### PR TITLE
Fix the `run.sh` problem

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -76,8 +76,8 @@ rec {
 
     nativeBuildInputs = [ nixpkgs.makeWrapper ];
 
-    buildInputs = commonBuildInputs ++
-      (if test-dsh then [ dsh ] else []);
+    buildInputs = commonBuildInputs;
+
 
     buildPhase = ''
       make -C src BUILD=native asc
@@ -88,11 +88,17 @@ rec {
       cp src/asc $out/bin
     '';
 
+    installCheckInputs =
+      commonBuildInputs ++
+      [ nixpkgs.bash ] ++
+      (if test-dsh then [ dsh ] else []);
+
     # The binary does not work until we use wrapProgram, which runs in
     # the install phase. Therefore, we use the installCheck phase to
     # run the test suite
     doInstallCheck = true;
     installCheckPhase = ''
+      patchShebangs test
       $out/bin/asc --version
       make -C samples ASC=$out/bin/asc all
       make -C test/run VERBOSE=1 ASC=$out/bin/asc all

--- a/test/async/Makefile
+++ b/test/async/Makefile
@@ -1,8 +1,8 @@
 all:
-	ASC_FLAGS=-a bash ../run.sh *.as
+	ASC_FLAGS=-a ../run.sh *.as
 
 accept:
-	ASC_FLAGS=-a bash ../run.sh -a *.as
+	ASC_FLAGS=-a ../run.sh -a *.as
 
 clean:
 	rm -rf _out

--- a/test/fail/Makefile
+++ b/test/fail/Makefile
@@ -1,8 +1,8 @@
 all:
-	bash ../run.sh *.as
+	../run.sh *.as
 
 accept:
-	bash ../run.sh -a *.as
+	../run.sh -a *.as
 
 clean:
 	rm -rf _out

--- a/test/run-dfinity/Makefile
+++ b/test/run-dfinity/Makefile
@@ -1,8 +1,8 @@
 all:
-	bash ../run.sh -d *.as
+	../run.sh -d *.as
 
 accept:
-	bash ../run.sh -d -a *.as
+	../run.sh -d -a *.as
 
 clean:
 	rm -rf _out

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A simple test runner. Synopsis:
 #

--- a/test/run/Makefile
+++ b/test/run/Makefile
@@ -1,8 +1,8 @@
 all:
-	bash ../run.sh *.as
+	../run.sh *.as
 
 accept:
-	bash ../run.sh -a *.as
+	../run.sh -a *.as
 
 clean:
 	rm -rf _out


### PR DESCRIPTION
After some more reading I learned the following:
 
 * NixOS has no `/bin/bash` or `/usr/bin/env`
 * Therefore, all scripts running on NixOS should have the full path to the “right” `bash` binary in the shebang, e.g. `#!/nix/store/nii7pk6pv4x4as7vsxbvwyzjn67vax6r-bash-4.4-p23/bin/bash`
 * For *installed* scripts, the default “post-installation fixup” phase does that, using `patchShebangs`
 * But in this case, I am running `run.sh` from the source directory, as part of the `installCheckPhase`.

The solution is to run `patchShebangs` as part of the test commands.