### PR TITLE
Add a failing test case for arrays and for loops

### DIFF
--- a/test/fail/array-not-iterable.as
+++ b/test/fail/array-not-iterable.as
@@ -1,0 +1,14 @@
+type Object = { name : Text };
+
+func f(objects : Object[]) {
+  /* type error, expected iterable type, but expression has type Object[] */
+  for (object in objects) {
+    print(object.name);
+  };
+};
+
+let xs : Object[] = [
+  new { name = "a"; }
+];
+
+f(xs);


### PR DESCRIPTION
Not sure if this is a bug or I'm missing something obvious but I expected this to work. 