### PR TITLE
Add failing test for func param/object label clash

### DIFF
--- a/test/fail/func-param-object-label-clash.as
+++ b/test/fail/func-param-object-label-clash.as
@@ -1,0 +1,8 @@
+type Object = { name : Text };
+
+func f(name : Text) : Object {
+  /* execution error, accessing identifier before its definition */
+  new { name = name; };
+};
+
+let _ : Object = f("a");


### PR DESCRIPTION
I assume this is a bug.