### PR TITLE
Add failing test case for array concatenation

### DIFF
--- a/test/fail/array-concat.as
+++ b/test/fail/array-concat.as
@@ -1,0 +1,2 @@
+/* type error, operator not defined for operand types Nat[] and Nat[] */
+let nats : Nat[] = [1] # [2];


### PR DESCRIPTION
Not sure if this is a bug or just not implemented yet.