### PR TITLE
Fix prelude parse error

### DIFF
--- a/src/prelude.ml
+++ b/src/prelude.ml
@@ -75,7 +75,7 @@ func new_async<T <: Shared>():(Async<T>,shared T->()) {
 	};
     };
     (enqueue,fullfill)
-
+};
 |}
 
 (* Primitives *)


### PR DESCRIPTION
This fixes `prelude:78.1: fatal error, parsing prelude failed: unexpected token`