### PR TITLE
Create a coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ To update the `dev` checkout and install `dvm` in one go, run `./update-dvm.sh`.
 By default, `dvm` is built using the V8 engine. To build with the Haskell
 engine, pass `--arg v8 false` to any of the above `nix-*` commands.
 
-
 ## Installation and development without Nix
 
 You do not have to use nix:
@@ -69,7 +68,7 @@ You do not have to use nix:
    [`opam`](https://opam.ocaml.org/doc/Install.html)
  * Install the packages listed as `OPAM_PACKAGES` in `src/Makefile`:
    ```
-   opam install num
+   opam install num vlq yojson bisect_ppx bisect_ppx-ocamlbuild
    ```
  * Install the `wasm` package in `vendor/wasm-spec/interpreter/` by running
    `make install` therein.
@@ -77,6 +76,19 @@ You do not have to use nix:
    the path to run the `run` tests.
  * Make sure `dvm` (a binary from the `hs-dfinity-dvm` package) is in the path
    to run the `run-dfinity` tests.
+
+## Create a coverage report
+
+Run
+
+    BISECT_COVERAGE=YES make -C src asc
+    make -C test coverage
+
+and open `test/coverage/index.html` in the browser, or run
+
+   nix-build -A coverage-report
+
+and open the path printed on the last line of that command.
 
 
 ## Introduction

--- a/nix/ocaml-bisect_ppx-ocamlbuild.nix
+++ b/nix/ocaml-bisect_ppx-ocamlbuild.nix
@@ -1,0 +1,32 @@
+pkgs:
+
+let version = "1.4.0"; in
+
+pkgs.stdenv.mkDerivation {
+  name = "ocaml${pkgs.ocaml.version}-bisect_ppx-ocamlbuild-${version}";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "aantron";
+    repo = "bisect_ppx";
+    rev = version;
+    sha256 = "1plhm4pvrhpapz5zaks194ji1fgzmp13y942g10pbn9m7kgkqg4h";
+  };
+
+  buildInputs = [
+    pkgs.ocaml
+    pkgs.dune
+    pkgs.ocamlPackages.findlib
+    pkgs.ocamlPackages.ocamlbuild
+  ];
+
+  buildPhase = "dune build -p bisect_ppx-ocamlbuild";
+
+  inherit (pkgs.dune) installPhase;
+
+  meta = {
+    homepage = https://github.com/aantron/bisect_ppx;
+    platforms = pkgs.ocaml.meta.platforms or [];
+    description = "Code coverage for OCaml";
+    license = pkgs.stdenv.lib.licenses.mpl20;
+  };
+}

--- a/nix/ocaml-bisect_ppx.nix
+++ b/nix/ocaml-bisect_ppx.nix
@@ -1,0 +1,33 @@
+pkgs:
+
+let version = "1.4.0"; in
+
+pkgs.stdenv.mkDerivation {
+  name = "ocaml${pkgs.ocaml.version}-bisect_ppx-${version}";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "aantron";
+    repo = "bisect_ppx";
+    rev = version;
+    sha256 = "1plhm4pvrhpapz5zaks194ji1fgzmp13y942g10pbn9m7kgkqg4h";
+  };
+
+  buildInputs = [
+    pkgs.ocaml
+    pkgs.dune
+    pkgs.ocamlPackages.findlib
+    pkgs.ocamlPackages.ocaml-migrate-parsetree
+    pkgs.ocamlPackages.ppx_tools_versioned
+  ];
+
+  buildPhase = "dune build -p bisect_ppx";
+
+  inherit (pkgs.dune) installPhase;
+
+  meta = {
+    homepage = https://github.com/aantron/bisect_ppx;
+    platforms = pkgs.ocaml.meta.platforms or [];
+    description = "Code coverage for OCaml";
+    license = pkgs.stdenv.lib.licenses.mpl20;
+  };
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,14 @@ MENHIR = menhir
 MENHIR_FLAGS = --infer --dump --explain
 
 OCAML_FLAGS = -cflags '-w +a-4-27-30-42-44-45 -warn-error +a'
-OCAMLBUILD = ocamlbuild $(OCAML_FLAGS) -use-ocamlfind -use-menhir -menhir "$(MENHIR) $(MENHIR_FLAGS)" -I src -I lib $(OPAM_PACKAGES:%=-pkg %) -tags debug
+OCAMLBUILD = ocamlbuild $(OCAML_FLAGS) \
+ -use-ocamlfind \
+ -plugin-tag 'package(bisect_ppx-ocamlbuild)' \
+ -use-menhir -menhir "$(MENHIR) $(MENHIR_FLAGS)" \
+ -I src \
+ -I lib \
+ $(OPAM_PACKAGES:%=-pkg %) \
+ -tags debug
 
 .PHONY: all clean test
 

--- a/src/_tags
+++ b/src/_tags
@@ -1,0 +1,1 @@
+<*>: coverage

--- a/src/myocamlbuild.ml
+++ b/src/myocamlbuild.ml
@@ -1,0 +1,2 @@
+open Ocamlbuild_plugin
+let () = dispatch Bisect_ppx_plugin.dispatch

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,6 +3,9 @@ _out
 new-asc
 old-asc
 
+coverage
+_coverage
+
 *.diff
 *.wat
 *.wat.stderr

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,6 +3,19 @@ all:
 	$(MAKE) -C run
 	$(MAKE) -C run-dfinity all
 
+coverage:
+	rm -rf _coverage
+	mkdir _coverage
+	export BISECT_FILE=$$PWD/_coverage/bisect; \
+	export SKIP_RUNNING=yes; \
+	$(MAKE) -C fail; \
+	$(MAKE) -C run; \
+	$(MAKE) -C run-dfinity || true
+	bisect-ppx-report -I ../src/_build/ -html coverage/ _coverage/bisect*.out
+	rm -rf _coverage
+
+
+
 accept:
 	$(MAKE) -C fail accept
 	$(MAKE) -C run accept
@@ -12,3 +25,5 @@ clean:
 	$(MAKE) -C fail clean
 	$(MAKE) -C run clean
 	$(MAKE) -C run-dfinity clean
+
+.PHONY: coverage

--- a/test/README.md
+++ b/test/README.md
@@ -14,6 +14,10 @@ Run these either in the top level directory, or in one of the subdirectories.
 
    Refreshes all output
 
+* `make coverage`
+
+   Creates a coverage report in `./coverage/`
+
 * `make clean`
 
    Cleans

--- a/test/run.sh
+++ b/test/run.sh
@@ -95,17 +95,20 @@ do
     then
       mv $base.wasm $base.wasm.map $out
 
-      if [ $DFINITY = 'yes' ];
+      if [ "$SKIP_RUNNING" != yes ]
       then
-        echo -n " [dvm]"
-        $DVM_WRAPPER $out/$base.wasm > $out/$base.dvm-run 2>&1
-        diff_files="$diff_files $base.dvm-run"
-      else
-        echo -n " [wasm-run]"
-        $WASM _out/$base.wasm  > $out/$base.wasm-run 2>&1
-        sed 's/wasm:0x[a-f0-9]*:/wasm:0x___:/g' $out/$base.wasm-run >$out/$base.wasm-run.temp
-        mv -f $out/$base.wasm-run.temp $out/$base.wasm-run
-        diff_files="$diff_files $base.wasm-run"
+        if [ $DFINITY = 'yes' ]
+        then
+          echo -n " [dvm]"
+          $DVM_WRAPPER $out/$base.wasm > $out/$base.dvm-run 2>&1
+          diff_files="$diff_files $base.dvm-run"
+        else
+          echo -n " [wasm-run]"
+          $WASM _out/$base.wasm  > $out/$base.wasm-run 2>&1
+          sed 's/wasm:0x[a-f0-9]*:/wasm:0x___:/g' $out/$base.wasm-run >$out/$base.wasm-run.temp
+          mv -f $out/$base.wasm-run.temp $out/$base.wasm-run
+          diff_files="$diff_files $base.wasm-run"
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
Run

    opam install bisect_ppx bisect_ppx-ocamlbuild
    BISECT_COVERAGE=YES make -C src asc
    make -C test coverage

and open `test/coverage/index.html` in the browser, or run

   nix-build -A coverage-report

and open the path printed on the last line of that command.