### PR TITLE
Introduce the Diag module

### DIFF
--- a/src/diag.ml
+++ b/src/diag.ml
@@ -1,0 +1,39 @@
+type severity = Warning | Error
+type message = {
+  sev : severity;
+  at : Source.region;
+  cat : string;
+  text : string
+}
+type messages = message list
+
+type 'a result = ('a * messages, messages) Pervasives.result
+
+let map_result f = function
+  | Pervasives.Error msgs -> Pervasives.Error msgs
+  | Ok (x, msgs) -> Ok (f x, msgs)
+
+type msg_store = messages ref
+let add_msg s m = s := m :: !s
+let get_msgs s = List.rev !s
+
+let has_errors : messages -> bool =
+  List.fold_left (fun b msg -> b || msg.sev == Error) false
+
+let fatal_error at text = { sev = Error; at; cat = "fatal"; text }
+
+let print_message msg =
+  let label = match msg.sev with
+    | Error -> Printf.sprintf "%s error"  msg.cat
+    | Warning -> "warning" in
+  Printf.eprintf "%s: %s, %s\n%!" (Source.string_of_region msg.at) label msg.text
+
+let print_messages = List.iter print_message
+
+let with_message_store f =
+  let s = ref [] in
+  let r = f s in
+  let msgs = get_msgs s in
+  match r with
+  | Some x when not (has_errors msgs) -> Ok (x, msgs)
+  | _ -> Error msgs

--- a/src/diag.mli
+++ b/src/diag.mli
@@ -1,0 +1,42 @@
+(* A common data type for diagnostic messages *)
+
+type severity = Warning | Error
+
+type message = {
+  sev : severity;
+  at : Source.region;
+  cat : string;
+  text : string
+}
+
+type messages = message list
+
+val fatal_error : Source.region -> string -> message
+
+val print_message : message -> unit
+val print_messages : messages -> unit
+
+(*
+An extension of the built-in result type that also reports diagnostic messages.
+Both success and failure can come with messages)
+*)
+
+type 'a result = ('a * messages, messages) Pervasives.result
+
+val map_result : ('a -> 'b) -> 'a result -> 'b result
+
+(*
+An impure, but more more convenient interface.
+
+The 'result' type above is a monad, and would be sufficient to model, e.g., the
+type checker. But since monadic style is cumbersome, the following definitions
+provide an impure way of tracking messages.
+
+The function with_message_store returns Error if its argument returns None or
+the reported messages contain an error.
+*)
+
+type msg_store (* abstract *)
+val add_msg : msg_store -> message -> unit
+val with_message_store : (msg_store -> 'a option) -> 'a result
+

--- a/src/js_main.ml
+++ b/src/js_main.ml
@@ -13,20 +13,20 @@ let range_of_region at =
     val _end = position_of_pos at.right
   end
 
-let diagnostics_of_error (sev, at, category, msg) =
-  object%js
-    val range = range_of_region at
-    val severity = match sev with Severity.Error -> 1 | Severity.Warning -> 2
+let diagnostics_of_error (msg : Diag.message) =
+  Diag.(object%js
     val source = Js.string "actorscript"
-    val message = Js.string msg
-  end
+    val severity = match msg.sev with Diag.Error -> 1 | Diag.Warning -> 2
+    val range = range_of_region msg.at
+    val message = Js.string msg.text
+  end)
 
 
 let js_check source =
   let msgs = match
     Pipeline.check_string Pipeline.initial_stat_env (Js.to_string source) "js-input" with
     | Error msgs -> msgs
-    | Ok (_, _, _,  msgs) -> msgs in
+    | Ok (_,  msgs) -> msgs in
   object%js
     val diagnostics = Js.array (Array.of_list (List.map diagnostics_of_error msgs))
     val code = Js.null

--- a/src/main.ml
+++ b/src/main.ml
@@ -57,7 +57,7 @@ let exit_on_none = function
 let exit_on_failure = function
   | Ok x -> x
   | Error errs ->
-    Pipeline.print_messages errs;
+    Diag.print_messages errs;
     exit 1
 
 let process_files files : unit =
@@ -71,8 +71,8 @@ let process_files files : unit =
     let env = exit_on_none Pipeline.(run_files initial_env files) in
     Pipeline.run_stdin env
   | Check ->
-    let (_,_,_,msgs) = exit_on_failure Pipeline.(check_files initial_stat_env files) in
-    Pipeline.print_messages msgs
+    let (_,msgs) = exit_on_failure Pipeline.(check_files initial_stat_env files) in
+    Diag.print_messages msgs
   | Compile ->
     if !out_file = "" then begin
       match files with

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -11,18 +11,8 @@ type env = stat_env * dyn_env
 let phase heading name =
   if !Flags.verbose then printf "-- %s %s:\n%!" heading name
 
-type message = Severity.t * Source.region * string * string
-type messages = message list
-
-let error at category msg =
-  Error (Severity.Error, at, category, msg)
-
-let print_message (sev, at, category, msg) =
-  match sev with
-  | Severity.Error -> eprintf "%s: %s error, %s\n%!" (Source.string_of_region at) category msg
-  | Severity.Warning -> eprintf "%s: warning, %s\n%!" (Source.string_of_region at) msg
-
-let print_messages = List.iter print_message
+let error at cat text =
+  Error { Diag.sev = Diag.Error; at; cat; text }
 
 let print_ce =
   Con.Env.iter (fun c k ->
@@ -61,7 +51,7 @@ let print_val _senv v t =
 
 (* Parsing *)
 
-type parse_result = (Syntax.prog, message) result
+type parse_result = (Syntax.prog, Diag.message) result
 
 let dump_prog flag prog =
     if !flag then
@@ -108,22 +98,21 @@ let parse_files filenames =
 
 (* Checking *)
 
-type check_result = (Syntax.prog * Type.typ * Typing.scope * messages, messages) result
-
-let messages_of_typing_messages = List.map (fun (sev, at, msg) -> (sev, at, "type", msg))
+type check_result = (Syntax.prog * Type.typ * Typing.scope) Diag.result
 
 let check_prog infer senv name prog
-  : ((Type.typ * Typing.scope) * messages, messages) result =
+  : (Type.typ * Typing.scope) Diag.result =
   phase "Checking" name;
-  match infer senv prog with
-  | Ok ((t, scope), msgs) ->
-    if !Flags.trace && !Flags.verbose then begin
+  let r = infer senv prog in
+  if !Flags.trace && !Flags.verbose then begin
+    match r with
+    | Ok ((_, scope), _) ->
       print_ce scope.Typing.con_env;
-      print_stat_ve scope.Typing.val_env
-    end;
-    dump_prog Flags.dump_tc prog;
-    Ok ((t, scope), messages_of_typing_messages msgs)
-  | Error msgs -> Error (messages_of_typing_messages msgs)
+      print_stat_ve scope.Typing.val_env;
+      dump_prog Flags.dump_tc prog;
+    | Error _ -> ()
+  end;
+  r
 
 let await_lowering flag prog name =
   if flag then
@@ -149,14 +138,12 @@ let check_with parse infer senv name : check_result =
   match parse name with
   | Error e -> Error [e]
   | Ok prog ->
-    match check_prog infer senv name prog with
-    | Error msgs -> Error msgs
-    | Ok ((t, scope), msgs) -> Ok (prog, t, scope, msgs)
+    Diag.map_result (fun (t, scope) -> (prog, t, scope))
+      (check_prog infer senv name prog)
 
 let infer_prog_unit senv prog =
-  match Typing.check_prog senv prog with
-  | Error msgs -> Error msgs
-  | Ok (scope, msgs) -> Ok ((Type.unit, scope), msgs)
+  Diag.map_result (fun (scope) -> (Type.unit, scope))
+    (Typing.check_prog senv prog)
 
 let check_string senv s = check_with (parse_string s) Typing.infer_prog senv
 let check_file senv n = check_with parse_file infer_prog_unit senv n
@@ -179,7 +166,7 @@ let interpret_prog denv name prog : (Value.value * Interpret.scope) option =
     | Some v -> Some (v, scope)
   with exn ->
     (* For debugging, should never happen. *)
-    print_message (Severity.Error, Interpret.get_last_region (), "fatal", Printexc.to_string exn);
+    Diag.print_message (Diag.fatal_error (Interpret.get_last_region ()) (Printexc.to_string exn));
     eprintf "\nLast environment:\n%!";
     eprint_dyn_ve_untyped Interpret.((get_last_env ()).vals);
     eprintf "\n";
@@ -190,10 +177,10 @@ let interpret_prog denv name prog : (Value.value * Interpret.scope) option =
 let interpret_with check (senv, denv) name : interpret_result =
   match check senv name with
   | Error msgs ->
-    print_messages msgs;
+    Diag.print_messages msgs;
     None
-  | Ok (prog, t, sscope, msgs) ->
-    print_messages msgs;
+  | Ok ((prog, t, sscope), msgs) ->
+    Diag.print_messages msgs;
     let prog = await_lowering (!Flags.await_lowering) prog name in
     let prog = async_lowering (!Flags.await_lowering && !Flags.async_lowering) prog name in
     match interpret_prog denv name prog with
@@ -212,18 +199,19 @@ let interpret_files env = function
 
 let prelude_name = "prelude"
 
-let prelude_error phase (sev, at, _, msg) =
-  print_message (sev, at, "fatal", phase ^ " prelude failed: " ^ msg);
+let prelude_error phase (msgs : Diag.messages) =
+  Printf.eprintf "%s prelude failed\n" phase;
+  Diag.print_messages msgs;
   exit 1
 
 let check_prelude () : Syntax.prog * stat_env =
   let lexer = Lexing.from_string Prelude.prelude in
   let parser = Parser.parse_prog in
   match parse_with Lexer.Privileged lexer parser prelude_name with
-  | Error e -> prelude_error "parsing" e
+  | Error e -> prelude_error "parsing" [e]
   | Ok prog ->
     match check_prog infer_prog_unit Typing.empty_scope prelude_name prog with
-    | Error es -> prelude_error "checking" (List.hd es)
+    | Error es -> prelude_error "checking" es
     | Ok ((_t, sscope), msgs) ->
       let senv = Typing.adjoin_scope Typing.empty_scope sscope in
       prog, senv
@@ -232,7 +220,7 @@ let prelude, initial_stat_env = check_prelude ()
 
 let run_prelude () : dyn_env =
   match interpret_prog Interpret.empty_env prelude_name prelude with
-  | None -> prelude_error "initializing" (Severity.Error, Source.no_region, "", "crashed")
+  | None -> prelude_error "initializing" []
   | Some (_v, dscope) ->
     Interpret.adjoin Interpret.empty_env dscope
 
@@ -289,13 +277,13 @@ let run_files env = function
 (* Compilation *)
 
 type compile_mode = Compile.mode = WasmMode | DfinityMode
-type compile_result = (CustomModule.extended_module, messages) result
+type compile_result = (CustomModule.extended_module, Diag.messages) result
 
 let compile_with check mode name : compile_result =
   match check initial_stat_env name with
   | Error msgs -> Error msgs
-  | Ok (prog, _t, _scope, msgs) ->
-    print_messages msgs;
+  | Ok ((prog, _t, _scope), msgs) ->
+    Diag.print_messages msgs;
     let prog = await_lowering true prog name in
     let prog = async_lowering true prog name in
     let prog = Desugar.prog prog in

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -2,21 +2,17 @@ type stat_env = Typing.scope
 type dyn_env = Interpret.env
 type env = stat_env * dyn_env
 
-type message = Severity.t * Source.region * string * string
-type messages = message list
-val print_messages : messages -> unit
-
 val initial_stat_env : stat_env
 val initial_dyn_env  : dyn_env
 val initial_env      : env
 
-type parse_result = (Syntax.prog, message) result
+type parse_result = (Syntax.prog, Diag.message) result
 val parse_file   : string -> parse_result
 val parse_files  : string list -> parse_result
 val parse_string : string -> string -> parse_result
 val parse_lexer  : Lexing.lexbuf -> string -> parse_result
 
-type check_result = (Syntax.prog * Type.typ * Typing.scope * messages, messages) result
+type check_result = (Syntax.prog * Type.typ * Typing.scope) Diag.result
 val check_file   : stat_env -> string -> check_result
 val check_files  : stat_env -> string list -> check_result
 val check_string : stat_env -> string -> string -> check_result
@@ -37,7 +33,7 @@ val run_lexer  : env -> Lexing.lexbuf -> string -> run_result
 val run_stdin  : env -> unit
 
 type compile_mode = WasmMode | DfinityMode
-type compile_result = (CustomModule.extended_module, messages) result
+type compile_result = (CustomModule.extended_module, Diag.messages) result
 val compile_file   : compile_mode -> string -> string -> compile_result
 val compile_files  : compile_mode -> string list -> string -> compile_result
 val compile_string : compile_mode -> string -> string -> compile_result

--- a/src/severity.ml
+++ b/src/severity.ml
@@ -1,1 +1,0 @@
-type t = Error | Warning

--- a/src/typing.mli
+++ b/src/typing.mli
@@ -4,11 +4,6 @@ type val_env = typ Env.t
 type typ_env = con Env.t
 type con_env = Type.con_env
 
-(* TODO: Move to a module together with Severity *)
-type message = Severity.t * Source.region * string
-type messages = message list
-type 'a messages_result = ('a * messages, messages) result
-
 type scope =
   { val_env : val_env;
     typ_env : typ_env;
@@ -18,5 +13,5 @@ type scope =
 val empty_scope : scope
 val adjoin_scope : scope -> scope -> scope
 
-val check_prog : scope -> Syntax.prog -> scope messages_result
-val infer_prog : scope -> Syntax.prog -> (typ * scope) messages_result
+val check_prog : scope -> Syntax.prog -> scope Diag.result
+val infer_prog : scope -> Syntax.prog -> (typ * scope) Diag.result


### PR DESCRIPTION
this combines the two different `message` types previously in `pipeline`
and `typing` and creates a nicer, more abstract interface into the mutable
tracking of diagnostic messages.

A review should probably begin with `diag.mli`.