### PR TITLE
Add blocks to the testcase for #103

### DIFF
--- a/test/fail/issue103.as
+++ b/test/fail/issue103.as
@@ -1,19 +1,27 @@
 // A (non-shared) function is not sharable
-func invalid1 (f : shared (() -> Nat) -> ()) {
-   f (func foo() : Nat = 1)
+{
+  func invalid1 (f : shared (() -> Nat) -> ()) {
+     f (func foo() : Nat = 1)
+  };
 };
 
 // An object with function fields is not sharable
-func invalid2 (f : shared {foo : () -> Nat} -> ()) {
-   f (new { foo() : Nat = 1; })
+{
+  func invalid2 (f : shared {foo : () -> Nat} -> ()) {
+     f (new { foo() : Nat = 1; })
+  };
 };
 
 // Cannot return a function in an async
-func invalid3 () : (async (() -> Nat)) {
-   async { func foo() : Nat = 1 }
+{
+  func invalid3 () : (async (() -> Nat)) {
+     async { func foo() : Nat = 1 }
+  };
 };
 
 // Cannot return an object with function fields in an async
-func invalid4 () : (async ({foo : () -> Nat})) {
-   async { new { foo() : Nat = 1; } }
+{
+  func invalid4 () : (async ({foo : () -> Nat})) {
+     async { new { foo() : Nat = 1; } }
+  };
 };

--- a/test/fail/ok/issue103.tc.ok
+++ b/test/fail/ok/issue103.tc.ok
@@ -1,2 +1,4 @@
-issue103.as:2.27-2.38: type error, shared function has non-shared parameter type
+issue103.as:3.29-3.40: type error, shared function has non-shared parameter type
+  () -> Nat
+issue103.as:17.29-17.40: type error, async type has non-shared parameter type
   () -> Nat


### PR DESCRIPTION
so that we see all error messages, and not just the first.