### PR TITLE
Fix array syntax explanation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ You do not have to use nix:
 
     The fields of an actor are all of function type with a return type of `async t` or `()`.
 
-* Array types: Java-like, but elements can be mutable or immutable
-  - `T[]`
-  - `var T[]`
+* Array types: elements can be mutable or immutable
+  - `[T]`
+  - `[var T]`
 
 * Option types: ML/Haskell-style option/maybe type, other types do not include null!
   - `T?`


### PR DESCRIPTION
I assume the memory layout is still Java-like (contiguous), but the syntax has been changed to resemble Haskell recently.