### PR TITLE
Base IR.typ_bound on `con`, not `var`.

### DIFF
--- a/src/arrange_ir.ml
+++ b/src/arrange_ir.ml
@@ -70,6 +70,8 @@ and dec d = match d.it with
   | TypD (c,k) ->
     "TypD" $$ [con c; kind k]
 
-and typ_bind (tb : typ_bind) = Arrange_type.open_typ_bind tb.it
+and typ_bind (tb : typ_bind) =
+  Con.to_string tb.it.con $$ [typ tb.it.bound]
+
 
 and prog prog = "BlockE"  $$ List.map dec prog.it

--- a/src/arrange_type.ml
+++ b/src/arrange_type.ml
@@ -52,9 +52,6 @@ let rec typ (t:Type.typ) = match t with
 and typ_bind (tb : Type.bind) =
   tb.var $$ [typ tb.bound]
 
-and open_typ_bind (tb : Type.open_bind) =
-  Con.to_string tb.con $$ [typ tb.con_bound]
-
 and typ_field (tf : Type.field) =
   tf.name $$ [typ tf.typ]
 

--- a/src/async.ml
+++ b/src/async.ml
@@ -317,12 +317,12 @@ and t_dec' dec' =
     begin
       match s with
       | T.Local  ->
-         FuncD (cc, id, t_typ_open_binds typbinds, t_pat pat, t_typ typT, t_exp exp)
+         FuncD (cc, id, t_typ_binds typbinds, t_pat pat, t_typ typT, t_exp exp)
       | T.Sharable ->
          begin
            match typ exp with
            | T.Tup [] ->
-              FuncD (cc, id, t_typ_open_binds typbinds, t_pat pat, t_typ typT, t_exp exp)
+              FuncD (cc, id, t_typ_binds typbinds, t_pat pat, t_typ typT, t_exp exp)
            | T.Async res_typ ->
              let cc' = Value.message_cc (cc.Value.n_args + 1) in
              let res_typ = t_typ res_typ in
@@ -331,7 +331,7 @@ and t_dec' dec' =
              let typ' = T.Tup []  in
              let k = fresh_id reply_typ in
              let pat',d = extendTupP pat (varP k) in
-             let typbinds' = t_typ_open_binds typbinds in
+             let typbinds' = t_typ_binds typbinds in
              let x = fresh_id res_typ in
              let exp' =
                match exp.it with
@@ -375,13 +375,13 @@ and t_pat' pat =
   | AltP (pat1, pat2) ->
     AltP (t_pat pat1, t_pat pat2)
 
-and t_open_bind {con; con_bound} =
-  {con; con_bound = t_typ con_bound}
+and t_typ_bind' {con; bound} =
+  {con; bound = t_typ bound}
 
-and t_typ_open_bind typ_bind =
-  { typ_bind with it = t_open_bind typ_bind.it }
+and t_typ_bind typ_bind =
+  { typ_bind with it = t_typ_bind' typ_bind.it }
 
-and t_typ_open_binds typbinds = List.map t_typ_open_bind typbinds
+and t_typ_binds typbinds = List.map t_typ_bind typbinds
 
 and t_prog prog:prog = { prog with it = t_decs prog.it }
 

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -239,8 +239,8 @@ module E = struct
        This shoulds be extracte into Type.add_open_typ_binds
        and maybe we need a type open_typ_bind that can be used inside the IR.
     *)
-    let cs = List.map (fun tp -> tp.it.Type.con) typ_binds in
-    let ks = List.map (fun tp -> Type.Abs([],tp.it.Type.con_bound)) typ_binds in
+    let cs = List.map (fun tp -> tp.it.con) typ_binds in
+    let ks = List.map (fun tp -> Type.Abs([],tp.it.bound)) typ_binds in
     let ce = List.fold_right2 Con.Env.add cs ks Con.Env.empty in
     { env with con_env = Con.Env.adjoin env.con_env ce }
 

--- a/src/desugar.ml
+++ b/src/desugar.ml
@@ -132,7 +132,7 @@ and typ_bind tb =
     | Some c -> c
     | _ -> assert false
   in
-  { it = { T.con = c; T.con_bound = tb.it.S.bound.note}
+  { it = { Ir.con = c; Ir.bound = tb.it.S.bound.note}
   ; at = tb.at
   ; note = ()
   }

--- a/src/ir.ml
+++ b/src/ir.ml
@@ -3,7 +3,8 @@ type type_note = Syntax.typ_note = {note_typ : Type.typ; note_eff : Type.eff}
 
 type 'a phrase = ('a, Syntax.typ_note) Source.annotated_phrase
 
-type typ_bind = Type.open_bind Source.phrase
+and typ_bind' = {con : Con.t; bound : Type.typ}
+type typ_bind = typ_bind' Source.phrase
 
 type pat = (pat', Type.typ) Source.annotated_phrase
 and pat' =

--- a/src/tailcall.ml
+++ b/src/tailcall.ml
@@ -65,7 +65,7 @@ let bind env i (info:func_info option) : env =
 let are_generic_insts tbs insts =
   List.for_all2 (fun tb inst ->
       match inst with
-      | Con(c2,[]) -> tb.it.Type.con = c2 (* conservative, but safe *)
+      | Con(c2,[]) -> tb.it.con = c2 (* conservative, but safe *)
       |  _ -> false
       ) tbs insts
 
@@ -210,7 +210,7 @@ and dec' env d =
       in
       let env3 = pat env2 p  in (* shadow id if necessary *)
       let exp0' = tailexp env3 exp0 in
-      let cs = List.map (fun tb -> Con (tb.it.Type.con, [])) tbs in
+      let cs = List.map (fun tb -> Con (tb.it.con, [])) tbs in
       if !tail_called then
         let ids = match typ d with
           | Func( _, _, _, dom, _) -> List.map (fun t -> fresh_id (open_ cs t)) dom

--- a/src/type.ml
+++ b/src/type.ml
@@ -38,7 +38,6 @@ and typ =
   | Pre                                       (* pre-type *)
 
 and bind = {var : string; bound : typ}
-and open_bind = {con : con; con_bound : typ}
 and field = {name : string; typ : typ}
 
 (* field ordering *)
@@ -173,9 +172,6 @@ let close cs t =
 let close_binds cs tbs =
   if cs = [] then tbs else
   List.map (fun {var; bound} -> {var; bound = close cs bound}) tbs
-
-let close_open_binds cs tbs =
-  List.map (fun {con; con_bound} -> {var = Con.name con; bound = close cs con_bound}) tbs
 
 
 let rec open' i ts t =

--- a/src/type.mli
+++ b/src/type.mli
@@ -38,7 +38,6 @@ and typ =
   | Pre                                       (* pre-type *)
 
 and bind = {var : string; bound : typ}
-and open_bind = {con : con; con_bound : typ}
 and field = {name : string; typ : typ}
 
 (* field ordering *)
@@ -130,7 +129,6 @@ val glb : con_env -> typ -> typ -> typ
 
 val close : con list -> typ -> typ
 val close_binds : con list -> bind list -> bind list
-val close_open_binds : con list -> open_bind list -> bind list
 
 val open_ : typ list -> typ -> typ
 val open_binds : con_env -> bind list -> typ list * con_env


### PR DESCRIPTION
Previously, `IR.typ_bound` would mirror `Syntax.typ_bound`, with a `var`
instead of a `con`. But post-typechecker, we only want to work with the
stamped `con`. Previously, this was hidden away in the annotations
(misusing `Type.typ` as `Con.t option).

This patch cleans this up a bit,
but introducting a `Type.open_bind` that binds a `Con.t` to its bound,
and using that as part of `FuncD`.