### PR TITLE
Run large-mem test case also in run-dfinity

### DIFF
--- a/test/run-dfinity/large-mem.as
+++ b/test/run-dfinity/large-mem.as
@@ -1,0 +1,1 @@
+ignore(Array_init<()>(64*1024, ()));

--- a/test/run-dfinity/ok/large-mem.dvm-run.ok
+++ b/test/run-dfinity/ok/large-mem.dvm-run.ok
@@ -1,0 +1,1 @@
+Top-level code done.


### PR DESCRIPTION
where it uncovers a problem with growing imported memory when combined
with orthogonal persistence:
https://dfinity.atlassian.net/projects/M1/issues/M1-396