### PR TITLE
`ClassD` now defines a type equality, no longer just a type inequality

### DIFF
--- a/src/typing.ml
+++ b/src/typing.ml
@@ -1134,7 +1134,7 @@ and infer_dec_typdecs env dec : con_env =
     let self_typ = T.Con(c, List.map (fun c -> T.Con (c, [])) cs) in
     let t = infer_obj (adjoin_vals env' ve) sort.it self_id (Some self_typ) fields in
     let tbs = List.map2 (fun c t -> {T.var = Con.name c; bound = T.close cs t}) cs ts in
-    let k = T.Abs (tbs, T.close cs t) in
+    let k = T.Def (tbs, T.close cs t) in
     con_id.note <- Some (c, k);
     Con.Env.singleton c k
 

--- a/test/fail/ok/type-inference.tc.ok
+++ b/test/fail/ok/type-inference.tc.ok
@@ -60,5 +60,3 @@ the previous produce type
   Text
 type-inference.as:78.13-78.16: type error, expected iterable type, but expression has type
   Non
-type-inference.as:85.3-90.4: type error, local class type C/5 is contained in inferred block type
-  C/5

--- a/test/fail/type-inference.as
+++ b/test/fail/type-inference.as
@@ -79,7 +79,9 @@ func bot(bot : Bot) {
 };
 };
 
-// This is an error.
+// This was an error when classes were subtypes of their
+// representation, but with structural typing throughout it is
+// no longer one
 {
   let _ =
   {


### PR DESCRIPTION
previously, `class D = ` would define a new type `D` that is bounded by
its representation type. With class types and like types gone, we can
simply treat this like a short-hand for a `TypD` (as we already do in
`desguar.ml`, for example.)