### PR TITLE
Introduce IR.FuncE (AST-26)

### DIFF
--- a/src/arrange_ir.ml
+++ b/src/arrange_ir.ml
@@ -40,6 +40,8 @@ let rec exp e = match e.it with
   | PrimE p             -> "PrimE"   $$ [Atom p]
   | DeclareE (i, t, e1) -> "DeclareE" $$ [id i; exp e1]
   | DefineE (i, m, e1)  -> "DefineE" $$ [id i; Arrange.mut m; exp e1]
+  | FuncE (x, cc, tp, p, t, e) ->
+    "FuncE" $$ [Atom x; call_conv cc] @ List.map typ_bind tp @ [pat p; typ t; exp e]
   | NewObjE (s, nameids, t)-> "NewObjE" $$ (Arrange.obj_sort' s ::
                                               List.fold_left (fun flds (n,i) ->
                                                   Atom (name n)::(id i):: flds) [typ t] nameids)
@@ -66,8 +68,6 @@ and dec d = match d.it with
   | ExpD e ->      "ExpD" $$ [exp e ]
   | LetD (p, e) -> "LetD" $$ [pat p; exp e]
   | VarD (i, e) -> "VarD" $$ [id i; exp e]
-  | FuncD (cc, i, tp, p, t, e) ->
-    "FuncD" $$ [call_conv cc; id i] @ List.map typ_bind tp @ [pat p; typ t; exp e]
   | TypD c ->
     "TypD" $$ [con c; kind (Con.kind c)]
 

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -169,6 +169,8 @@ module Ir =
         effect_exp exp1
       | DefineE (_, _, exp1) ->
         effect_exp exp1
+      | FuncE _ ->
+        T.Triv
       | NewObjE _ ->
         T.Triv
 
@@ -192,7 +194,6 @@ module Ir =
       | LetD (_,e)
       | VarD (_, e) ->
         effect_exp e
-      | TypD _
-      | FuncD _ ->
+      | TypD _ ->
         T.Triv
 end

--- a/src/freevars.ml
+++ b/src/freevars.ml
@@ -90,6 +90,7 @@ let rec exp e : f = match e.it with
   | OptE e              -> exp e
   | DeclareE (i, t, e)  -> exp e  // i.it
   | DefineE (i, m, e)   -> id i ++ exp e
+  | FuncE (x, cc, tp, p, t, e) -> under_lambda (exp e /// pat p)
   | NewObjE (_, ids, _) -> unions id (List.map (fun (lab,id) -> id) ids)
 
 and exps es : f = unions exp es
@@ -120,8 +121,6 @@ and dec d = match d.it with
   | LetD (p, e) -> pat p +++ exp e
   | VarD (i, e) ->
     (M.empty, S.singleton i.it) +++ exp e
-  | FuncD (cc, i, tp, p, t, e) ->
-    (M.empty, S.singleton i.it) +++ under_lambda (exp e /// pat p)
   | TypD c -> (M.empty, S.empty)
 
 (* The variables captured by a function. May include the function itself! *)

--- a/src/ir.ml
+++ b/src/ir.ml
@@ -58,6 +58,8 @@ and exp' =
   | AssertE of exp                             (* assertion *)
   | DeclareE of id * Type.typ * exp            (* local promise *)
   | DefineE of id * mut * exp                  (* promise fulfillment *)
+  | FuncE of                                   (* function *)
+      string * Value.call_conv * typ_bind list * pat * Type.typ * exp
   | NewObjE of                                 (* make an object, preserving mutable identity *)
       Type.obj_sort * (name * id) list * Type.typ
 
@@ -78,8 +80,6 @@ and dec' =
   | ExpD of exp                                (* plain expression *)
   | LetD of pat * exp                          (* immutable *)
   | VarD of id * exp                           (* mutable *)
-  | FuncD of                                   (* function *)
-      Value.call_conv * id * typ_bind list * pat * Type.typ * exp
   | TypD of Type.con                           (* type *)
 
 

--- a/src/rename.ml
+++ b/src/rename.ml
@@ -60,6 +60,10 @@ and exp' rho e  = match e with
   | DeclareE (i, t, e)  -> let i',rho' = id_bind rho i in
                            DeclareE (i', t, exp rho' e)
   | DefineE (i, m, e)   -> DefineE (id rho i, m, exp rho e)
+  | FuncE (x, s, tp, p, t, e) ->
+     let p', rho' = pat rho p in
+     let e' = exp rho' e in
+     FuncE (x, s, tp, p', t, e')
   | NewObjE (s, is, t)  -> NewObjE (s, List.map (fun (l,i) -> (l,id rho i)) is, t)
 
 and exps rho es  = List.map (exp rho) es
@@ -137,13 +141,6 @@ and dec' rho d = match d with
   | VarD (i, e) ->
      let i', rho = id_bind rho i in
      (fun rho' -> VarD (i',exp rho' e)),
-     rho
-  | FuncD (s, i, tp, p, t, e) ->
-     let i', rho = id_bind rho i in
-     (fun rho' ->
-       let p', rho'' = pat rho' p in
-       let e' = exp rho'' e in
-       FuncD (s, i', tp, p', t, e')),
      rho
   | TypD c -> (* we don't rename type names *)
      (fun rho -> d),

--- a/test/fail/ok/use-before-define5.wasm.stderr.ok
+++ b/test/fail/ok/use-before-define5.wasm.stderr.ok
@@ -2,14 +2,12 @@ non-closed actor: (ActorE
   a
   (foo
     foo
-    (BlockE
-      (FuncD
-        (shared  0 -> 0)
-        foo
-        (TupP)
-        ()
-        (AssertE (RelE Nat (VarE x) EqOp (LitE (NatLit 1))))
-      )
+    (FuncE
+      foo
+      (shared  0 -> 0)
+      (TupP)
+      ()
+      (AssertE (RelE Nat (VarE x) EqOp (LitE (NatLit 1))))
     )
     Const
     Public

--- a/test/run-dfinity/ok/counter-class.dvm-run.ok
+++ b/test/run-dfinity/ok/counter-class.dvm-run.ok
@@ -1,0 +1,1 @@
+W, hypervisor: call failed with trap message: Uncaught RuntimeError: unreachable

--- a/test/run-dfinity/ok/counter-class.wasm.stderr.ok
+++ b/test/run-dfinity/ok/counter-class.wasm.stderr.ok
@@ -3,16 +3,14 @@ non-closed actor: (ActorE
   (c c (VarE i) Var Private)
   (dec
     dec
-    (BlockE
-      (FuncD
-        (shared  0 -> 0)
-        dec
-        (TupP)
-        ()
-        (BlockE
-          (ExpD (CallE ( 1 -> 0) (VarE show) (VarE c)))
-          (ExpD (AssignE (VarE c) (BinE Int (VarE c) SubOp (LitE (IntLit 1)))))
-        )
+    (FuncE
+      dec
+      (shared  0 -> 0)
+      (TupP)
+      ()
+      (BlockE
+        (ExpD (CallE ( 1 -> 0) (VarE show) (VarE c)))
+        (ExpD (AssignE (VarE c) (BinE Int (VarE c) SubOp (LitE (IntLit 1)))))
       )
     )
     Const
@@ -20,35 +18,29 @@ non-closed actor: (ActorE
   )
   (read
     read
-    (BlockE
-      (FuncD
-        (shared  1 -> 0)
-        read
-        (VarP $1)
-        ()
-        (BlockE
-          (LetD (TupP) (TupE))
-          (ExpD
-            (CallE
+    (FuncE
+      read
+      (shared  1 -> 0)
+      (VarP $1)
+      ()
+      (BlockE
+        (LetD (TupP) (TupE))
+        (ExpD
+          (CallE
+            ( 1 -> 0)
+            (FuncE
+              $lambda
               ( 1 -> 0)
-              (BlockE
-                (FuncD
-                  ( 1 -> 0)
-                  $lambda
-                  (VarP $0)
-                  ()
-                  (CallE ( 1 -> 0) (VarE $0) (VarE c))
-                )
-              )
-              (BlockE
-                (FuncD
-                  ( 1 -> 0)
-                  $lambda
-                  (VarP $2)
-                  ()
-                  (CallE (shared  1 -> 0) (VarE $1) (VarE $2))
-                )
-              )
+              (VarP $0)
+              ()
+              (CallE ( 1 -> 0) (VarE $0) (VarE c))
+            )
+            (FuncE
+              $lambda
+              ( 1 -> 0)
+              (VarP $2)
+              ()
+              (CallE (shared  1 -> 0) (VarE $1) (VarE $2))
             )
           )
         )

--- a/test/run/last-dec-val.as
+++ b/test/run/last-dec-val.as
@@ -1,0 +1,2 @@
+assert ({let x = 5} == 5);
+assert (({let (x,y) = (1,2)}).1 == 2);


### PR DESCRIPTION
this turned out to be a bigger change, uncovering a few dirty spots in
`Check_ir` and other places.

This codifies also that, in the IR:
 * All `BlockE` expressions end with an `ExprE`
 * Only `ExpD` declarations return their type (this is differs from
    Source)