### PR TITLE
Check_ir: Check typ annotation in check_exp

### DIFF
--- a/src/typing.ml
+++ b/src/typing.ml
@@ -895,7 +895,6 @@ and pub_typ_id id (xs, ys) : region T.Env.t * region T.Env.t =
 and pub_val_id id (xs, ys) : region T.Env.t * region T.Env.t =
   (xs, T.Env.add id.it id.at ys)
 
-
 and infer_obj env s fields at : T.typ =
   let decs = List.map (fun (field : exp_field) -> field.it.dec) fields in
   let _, scope = infer_block env decs at in
@@ -916,13 +915,10 @@ and infer_obj env s fields at : T.typ =
     ) tfs
   end;
   let t = T.Obj (s, tfs) in
-  (try T.avoid scope.con_env t with T.Unavoidable c ->
-      error env at "local class type %s is contained in object or actor type\n  %s"
-        (Con.to_string c)
-        (T.string_of_typ_expand t)
-    )
-
-        
+  try T.avoid scope.con_env t with T.Unavoidable c ->
+    error env at "local class type %s is contained in object or actor type\n  %s"
+      (Con.to_string c)
+      (T.string_of_typ_expand t)
 
 
 (* Blocks and Declarations *)

--- a/test/run/ok/objects1.diff-ir.ok
+++ b/test/run/ok/objects1.diff-ir.ok
@@ -1,5 +1,0 @@
---- objects1.run
-+++ objects1.run-ir
-@@ -0,0 +1,2 @@
-+Ill-typed intermediate code after Tailcall optimization (use -v to see dumped IR):
-+(unknown location): IR type error, free type constructor T

--- a/test/run/ok/objects1.run-ir.ok
+++ b/test/run/ok/objects1.run-ir.ok
@@ -1,2 +1,0 @@
-Ill-typed intermediate code after Tailcall optimization (use -v to see dumped IR):
-(unknown location): IR type error, free type constructor T

--- a/test/run/ok/objects1.wasm.stderr.ok
+++ b/test/run/ok/objects1.wasm.stderr.ok
@@ -1,2 +1,0 @@
-Ill-typed intermediate code after desugaring (use -v to see dumped IR):
-(unknown location): IR type error, free type constructor T


### PR DESCRIPTION
as suggested by Claudio. Reveals a bug in `tailcall`. Did not investigate yet, but this is the failing output:
```
objects1: [tc] [run] [run-low] [run-ir] [wasm]
--- objects1.run-ir (expected)
+++ objects1.run-ir (actual)
@@ -0,0 +1,2 @@
+Ill-typed intermediate code after Tailcall optimization (use -v to see dumped IR):
+(unknown location): IR type error, free type constructor T
--- objects1.diff-ir (expected)
+++ objects1.diff-ir (actual)
@@ -0,0 +1,5 @@
+--- objects1.run
++++ objects1.run-ir
+@@ -0,0 +1,2 @@
++Ill-typed intermediate code after Tailcall optimization (use -v to see dumped IR):
++(unknown location): IR type error, free type constructor T
--- objects1.wasm.stderr (expected)
+++ objects1.wasm.stderr (actual)
@@ -0,0 +1,2 @@
+Ill-typed intermediate code after desugaring (use -v to see dumped IR):
+(unknown location): IR type error, free type constructor T
Some tests failed.
make[1]: *** [../quick.mk:9: _out/objects1.done] Fehler 1
```