### PR TITLE
Integer division miscompiled

### DIFF
--- a/src/compile.ml
+++ b/src/compile.ml
@@ -3210,8 +3210,8 @@ let compile_binop env t op =
   | Type.Prim Type.Int, AddOp -> G.i (Binary (Wasm.Values.I64 I64Op.Add))
   | Type.Prim Type.Int, SubOp -> G.i (Binary (Wasm.Values.I64 I64Op.Sub))
   | Type.Prim Type.Int, MulOp -> G.i (Binary (Wasm.Values.I64 I64Op.Mul))
-  | Type.Prim Type.Int, DivOp -> G.i (Binary (Wasm.Values.I64 I64Op.DivU))
-  | Type.Prim Type.Int, ModOp -> G.i (Binary (Wasm.Values.I64 I64Op.RemU))
+  | Type.Prim Type.Int, DivOp -> G.i (Binary (Wasm.Values.I64 I64Op.DivS))
+  | Type.Prim Type.Int, ModOp -> G.i (Binary (Wasm.Values.I64 I64Op.RemS))
   | Type.Prim Type.Text, CatOp -> Text.concat env
   | _ -> todo "compile_binop" (Arrange.binop op) (G.i Unreachable)
   )

--- a/test/run/ok/signed-div.wasm-run.ok
+++ b/test/run/ok/signed-div.wasm-run.ok
@@ -1,1 +1,0 @@
-_out/signed-div.wasm:0x___: runtime trap: unreachable executed


### PR DESCRIPTION
It is compiled as unsigned division, which I have now fixed. The interpreter was correct on both test steps.

The first commit adds a failing test case.
The second adds the fix, and removes the `.ok` file.

I have not written an `AST-xx` as I regard this as a trivial fix.