### PR TITLE
Extend testsuite to allow for FileCheck assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ installing all required tools without nix is out of scope).
    ```
    opam install num vlq yojson bisect_ppx bisect_ppx-ocamlbuild menhir
    ```
- * Install the `wasm` package. We use a newer version than is on opam, and a
+ * Install the `wasm` Ocaml package. We use a newer version than is on opam, and a
    fork that supports the multi-value extension. See `nix/ocaml-wasm.nix` for
    the precise repository and version. You can use `nix` to fetch the correct
    source for you, and run the manual installation inside:
@@ -73,9 +73,11 @@ installing all required tools without nix is out of scope).
    cd $(nix-build -Q -A wasm.src)/interpreter
    make install
    ```
- * Install the `wasm` tool, using
+ * Install various command line tools used by, in particuar, the test suite:
    ```
    nix-env -i -f . -A wasm
+   nix-env -i -f . -A filecheck
+   nix-env -i -f . -A wabt
    ```
  * Install the `dvm` tool, using
    ```

--- a/default.nix
+++ b/default.nix
@@ -106,6 +106,7 @@ rec {
         nixpkgs.wabt
         nixpkgs.bash
         nixpkgs.perl
+	filecheck
       ] ++
       (if test-dvm then [ real-dvm ] else []);
 
@@ -202,6 +203,9 @@ rec {
 
   wasm = ocaml_wasm;
   dvm = real-dvm;
+  filecheck = nixpkgs.linkFarm "FileCheck"
+    [ { name = "bin/FileCheck"; path = "${nixpkgs.llvm}/bin/FileCheck";} ];
+  wabt = nixpkgs.wabt;
 
   all-systems-go = nixpkgs.releaseTools.aggregate {
     name = "all-systems-go";

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -273,7 +273,7 @@ module E = struct
       let d = {
         materialize = (fun env -> (SR.Vanilla, materialize env));
         materialize_vanilla = (fun env -> materialize env) } in
-      { env with local_vars_env = NameEnv.add name (Deferred d) env.local_vars_env }
+      add_local_deferred env name d
 
   let add_direct_local (env : t) name =
       let i = add_anon_local env I32Type in

--- a/test/run.sh
+++ b/test/run.sh
@@ -78,7 +78,7 @@ do
   [ -d $out ] || mkdir $out
   [ -d $ok ] || mkdir $ok
 
-  rm -f $out/$base.{tc,wasm,wasm.map,wasm-run,dvm-run}
+  rm -f $out/$base.{tc,wasm,wasm.map,wasm-run,dvm-run,filecheck,diff-ir,diff-low}
 
   # First run all the steps, and remember what to diff
   diff_files=
@@ -131,6 +131,15 @@ do
     fi
     normalize $out/$base.wasm.stderr
     diff_files="$diff_files $base.wasm.stderr"
+
+    # Check filecheck
+    if grep -F -q CHECK $base.as
+    then
+      $ECHO -n " [Filecheck]"
+      wasm2wat --no-check --enable-multi-value $out/$base.wasm > $out/$base.wat
+      cat $out/$base.wat | FileCheck $base.as > $out/$base.filecheck 2>&1
+      diff_files="$diff_files $base.filecheck"
+    fi
 
     # Run compiled program
     if [ -e $out/$base.wasm ]

--- a/test/run/mutrec2.as
+++ b/test/run/mutrec2.as
@@ -1,18 +1,26 @@
-var sub = 1;
-
 func even(n : Nat) : Bool {
   if (n == 0) {
     return true;
   } else
-    return odd(n-sub);
+    return odd(n-1);
   };
 
 func odd(n : Nat) : Bool {
   if (n == 0) {
     return false;
   } else
-    return even(n-sub);
+    return even(n-1);
   };
+
+// There should be a bunch of calls to known functions here, but
+// no indirect calls
+// CHECK: func $start
+// CHECK: call $even
+// CHECK: call $even
+// CHECK: call $even
+// CHECK: call $even
+// CHECK: call $odd
+// CHECK: call $odd
 
 assert(even(0));
 assert(even(2));


### PR DESCRIPTION
[FileCheck](https://llvm.org/docs/CommandGuide/FileCheck.html) is a tool
created by the LLVM folks to embed textual assertions about the output
code in test cases. This comment sets up our test suite so that we can
put `CHECK` directives into the test files, and `run.sh` will use
`FileCheck` to see if the resulting `.wat` file matches the specs.

I am using this in one example to assert that the mutually recursive
functions in `mutrec2.as` are compiled to direct calls (and not
closures).

This requires you to have `FileCheck` in your PATH. The easiest way of
doing that is to run

    nix-env -i -f . -A filecheck