### PR TITLE
Emacs major mode for ActorScript

### DIFF
--- a/emacs/actorscript-mode.el
+++ b/emacs/actorscript-mode.el
@@ -55,14 +55,20 @@
                  "type"
                  "var"
                  "while"
-                 "prim" ))
+                 "prim"
+                 ))
+              ;; Braces introduce blocks; it's nice to make them stand
+              ;; out more than ordinary symbols
+              (x-braces
+               '( "{"
+                  "}"))
               (x-symbols
                '( "("
                   ")"
                   "["
                   "]"
-                  "{"
-                  "}"
+                  ;"{"
+                  ;"}"
                   ";"
                   ","
                   ":"
@@ -119,6 +125,7 @@
         (x-types-regexp (regexp-opt x-types 'words))
         (x-constant-regexp (regexp-opt x-constants 'words))
         (x-keywords-regexp (regexp-opt x-keywords 'words))
+        (x-braces-regexp (regexp-opt x-braces))
         (x-symbols-regexp (regexp-opt x-symbols))
         (x-symbols-more-regexp (regexp-opt x-symbols-more))
         )
@@ -127,6 +134,7 @@
           (,x-types-regexp . font-lock-type-face)
           (,x-constant-regexp . font-lock-constant-face)
           (,x-keywords-regexp . font-lock-keyword-face)
+          (,x-braces-regexp . font-lock-keyword-face)
           (,x-symbols-regexp . font-lock-builtin-face)
           (,x-symbols-more-regexp . font-lock-builtin-face)
           )))


### PR DESCRIPTION
Nice stuff:
 - associates `.as` files with ActorScript mode
 - highlights the correct keywords, constants and types of ActorScript
 - derives from Swift mode for its auto-indenting behavior, which is _mostly_ consistent with ActorScript

**Not** nice stuff, for now:
 - Because of how Swift and ActorScript's syntax for `switch` differs, tends to over-indent nested `switch` expressions quite badly.  This is no worse than the status quo, however, which is just to use Swift mode in place of this mode.

---------------------

To try this out yourself, open this file in emacs and
 -  do `M-x eval-buffer`, then open an ActorScript source file, or 
 - do `M-x actorscript-mode` on an already-open ActorScript source file.
  