### PR TITLE
Limit `make parallel` jobs to number of processors

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -3,12 +3,14 @@ all:
 	$(MAKE) -C run
 	$(MAKE) -C run-dfinity
 
+MAKE_PAR := $(MAKE) --no-print-directory --load-average -j $(shell getconf _NPROCESSORS_ONLN)
+
 quick:
-	$(MAKE) --no-print-directory --load-average -j -C fail quick
-	$(MAKE) --no-print-directory --load-average -j -C run quick
+	$(MAKE_PAR) -C fail quick
+	$(MAKE_PAR) -C run quick
 
 parallel: quick
-	$(MAKE) --no-print-directory --load-average -j -C run-dfinity quick
+	$(MAKE_PAR) -C run-dfinity quick
 
 coverage:
 	rm -rf _coverage

--- a/test/quick.mk
+++ b/test/quick.mk
@@ -10,6 +10,5 @@ _out:
 	@ mkdir -p $@
 
 # run single test, e.g. make _out/AST-56.done
-.SECONDEXPANSION:
-_out/%.done: %.as $$(wildcard $(ASC)) ../run.sh  | _out
+_out/%.done: %.as $(wildcard ../../src/asc) ../run.sh  | _out
 	@ (../run.sh $(RUNFLAGS) $< > $@.tmp && mv $@.tmp $@) || (cat $@.tmp; rm -f $@.tmp; false)


### PR DESCRIPTION
otherwise my system would come to a crawl while dozends of `dvm`
commands are trying to run in parallel.

Also fixes the dependency on `ASC`: When invoked manually, `ASC` is not
actually set (`run.sh` knows where to look).