### PR TITLE
Make shared functions invariant

### DIFF
--- a/src/type.ml
+++ b/src/type.ml
@@ -458,10 +458,15 @@ let rec rel_typ rel eq t1 t2 =
     rel_list rel_typ rel eq ts1 (List.map (fun _ -> Shared) ts1)
   | Func (s1, c1, tbs1, t11, t12), Func (s2, c2, tbs2, t21, t22) ->
     c1 = c2 && s1 = s2 &&
+    (* subtyping on shared functions needs to imply subtyping of the serialized
+       arguments, i.e. the IDL. Until we have a real IDL, we are conservative
+       here and assum no subtyping in the IDL. This makes shared functions invariant. *)
+    let rel_param =
+      if s1 = Sharable then eq_typ else rel_typ in
     (match rel_binds rel eq tbs1 tbs2 with
     | Some ts ->
-      rel_list rel_typ rel eq (List.map (open_ ts) t21) (List.map (open_ ts) t11) &&
-      rel_list rel_typ rel eq (List.map (open_ ts) t12) (List.map (open_ ts) t22)
+      rel_list rel_param rel eq (List.map (open_ ts) t21) (List.map (open_ ts) t11) &&
+      rel_list rel_param rel eq (List.map (open_ ts) t12) (List.map (open_ ts) t22)
     | None -> false
     )
   | Func (Sharable, _,  _, _, _), Shared when rel != eq ->

--- a/test/fail/argument-subtyping.as
+++ b/test/fail/argument-subtyping.as
@@ -1,0 +1,9 @@
+// Normal function allow subtyping
+{ func foo(h : Int -> ()) : (Nat -> ()) = h };
+
+// Shared functions are invariant for now
+{ func foo(h : shared Int -> ()) : (shared Nat -> ()) = h };
+
+// The same with abstract types
+{ func foo<A <: shared {}>(h : (shared {}) -> ()) : ((shared{x:Nat}) -> ()) = h };
+{ func foo<A <: shared {}>(h : shared (shared {}) -> ()) : (shared (shared {x:Nat}) -> ()) = h };

--- a/test/fail/ok/argument-subtyping.tc.ok
+++ b/test/fail/ok/argument-subtyping.tc.ok
@@ -1,0 +1,8 @@
+argument-subtyping.as:5.57-5.58: type error, expression of type
+  shared Int -> ()
+cannot produce expected type
+  shared Nat -> ()
+argument-subtyping.as:9.94-9.95: type error, expression of type
+  shared (shared {}) -> ()
+cannot produce expected type
+  shared (shared {x : Nat}) -> ()


### PR DESCRIPTION
so that we don’t claim to have a serialization format that commutes with
subtyping.

(Since #327 this was already true for the IR past the `Serialization`
pass, so this just makes the source type-checker catch up.)