### PR TITLE
Rename: Count stamps per name

### DIFF
--- a/src/con.ml
+++ b/src/con.ml
@@ -18,11 +18,7 @@ module Stamps = Env.Make(String)
 let stamps : int Stamps.t ref = ref Stamps.empty
 
 let fresh_stamp name =
-  let n =
-    match Stamps.find_opt name !stamps with
-    | Some n -> n
-    | None -> 0
-  in
+  let n = Lib.Option.get (Stamps.find_opt name !stamps) 0 in
   stamps := Stamps.add name (n + 1) !stamps;
   n
 

--- a/src/rename.ml
+++ b/src/rename.ml
@@ -6,12 +6,13 @@ module Renaming = Map.Make(String)
 
 (* One traversal for each syntactic category, named by that category *)
 
-let stamp = ref 0
+module Stamps = Map.Make(String)
+let stamps = ref Stamps.empty
 
 let fresh_id id =
-  let i' = Printf.sprintf "%s@%i" id.it (!stamp) in
-  stamp := !stamp+1;
-  i'
+  let n = Lib.Option.get (Stamps.find_opt id.it !stamps) 0 in
+  stamps := Stamps.add id.it (n + 1) !stamps;
+  Printf.sprintf "%s/%i" id.it n
 
 let id rho i =
   try {i with it = Renaming.find i.it rho}


### PR DESCRIPTION
this way, the IR dumps will hopefully vary less.

(It didn't fix what I hoped it would fix, but it is still useful, I
think.)