### PR TITLE
`Construct.fresh_var` requires a name base

### DIFF
--- a/src/async.ml
+++ b/src/async.ml
@@ -43,12 +43,12 @@ module Transform() = struct
 
   let replyT as_seq typ = T.Func(T.Sharable, T.Returns, [], as_seq typ, [])
 
-  let fullfillT as_seq typ = T.Func(T.Local, T.Returns, [], as_seq typ, [])
+  let fulfillT as_seq typ = T.Func(T.Local, T.Returns, [], as_seq typ, [])
 
   let t_async as_seq t =
     T.Func (T.Local, T.Returns, [], [T.Func(T.Local, T.Returns, [],as_seq t,[])], [])
 
-  let new_async_ret as_seq t = [t_async as_seq t;fullfillT as_seq t]
+  let new_async_ret as_seq t = [t_async as_seq t;fulfillT as_seq t]
 
   let new_asyncT =
     T.Func (
@@ -64,17 +64,17 @@ module Transform() = struct
 
   let new_async t1 =
     let call_new_async = callE new_asyncE [t1] (tupE []) in
-    let async = fresh_var (typ (projE call_new_async 0)) in
-    let fullfill = fresh_var (typ (projE call_new_async 1)) in
-    (async,fullfill),call_new_async
+    let async = fresh_var "async" (typ (projE call_new_async 0)) in
+    let fulfill = fresh_var "fulfill" (typ (projE call_new_async 1)) in
+    (async,fulfill),call_new_async
 
   let new_nary_async_reply t1 =
-    let (unary_async,unary_fullfill),call_new_async = new_async t1 in
-    let v' = fresh_var t1 in
+    let (unary_async,unary_fulfill),call_new_async = new_async t1 in
+    let v' = fresh_var "v" t1 in
     let ts1 = T.as_seq t1 in
     (* construct the n-ary async value, coercing the continuation, if necessary *)
     let nary_async =
-      let k' = fresh_var (contT t1) in
+      let k' = fresh_var "k" (contT t1) in
       match ts1 with
       | [t] ->
         unary_async
@@ -82,28 +82,28 @@ module Transform() = struct
         let seq_of_v' = tupE (List.mapi (fun i _ -> projE v' i) ts) in
         k' --> (unary_async -*- ([v'] -->* (k' -*- seq_of_v')))
     in
-    (* construct the n-ary reply message that sends a sequence of value to fullfill the async *)
+    (* construct the n-ary reply message that sends a sequence of value to fulfill the async *)
     let nary_reply =
       let vs,seq_of_vs =
         match ts1 with
         | [t] ->
-          let v = fresh_var t in
+          let v = fresh_var "rep" t in
           [v],v
         | ts ->
-          let vs = List.map fresh_var ts in
+          let vs = fresh_vars "rep" ts in
           vs, tupE vs
       in
-      vs -@>* (unary_fullfill -*-  seq_of_vs)
+      vs -@>* (unary_fulfill -*-  seq_of_vs)
     in
-    let async,reply = fresh_var (typ nary_async), fresh_var (typ nary_reply) in
-    (async,reply),blockE [letP (tupP [varP unary_async; varP unary_fullfill])  call_new_async]
+    let async,reply = fresh_var "async" (typ nary_async), fresh_var "fulfill" (typ nary_reply) in
+    (async,reply),blockE [letP (tupP [varP unary_async; varP unary_fulfill])  call_new_async]
                          (tupE [nary_async; nary_reply])
 
 
   let letEta e scope =
     match e.it with
     | VarE _ -> scope e (* pure, so reduce *)
-    | _  -> let f = fresh_var (typ e) in
+    | _  -> let f = fresh_var "x" (typ e) in
             letD f e :: (scope f) (* maybe impure; sequence *)
 
   let isAwaitableFunc exp =
@@ -123,11 +123,11 @@ module Transform() = struct
     | [] ->
       (expD e)::d_of_vs []
     | [t] ->
-      let x = fresh_var t in
+      let x = fresh_var "x" t in
       let p = varP x in
       (letP p e)::d_of_vs [x]
     | ts ->
-      let xs = List.map fresh_var ts in
+      let xs = fresh_vars "x" ts in
       let p = tupP (List.map varP xs) in
       (letP p e)::d_of_vs (xs)
 
@@ -246,10 +246,10 @@ module Transform() = struct
                []) -> (* TBR, why isn't this []? *)
           (t_typ (T.seq ts1),t_typ contT)
         | t -> assert false in
-      let k = fresh_var contT in
-      let v1 = fresh_var t1 in
-      let post = fresh_var (T.Func(T.Sharable,T.Returns,[],[],[])) in
-      let u = fresh_var T.unit in
+      let k = fresh_var "k" contT in
+      let v1 = fresh_var "v" t1 in
+      let post = fresh_var "post" (T.Func(T.Sharable,T.Returns,[],[],[])) in
+      let u = fresh_var "u" T.unit in
       let ((nary_async,nary_reply),def) = new_nary_async_reply t1 in
       (blockE [letP (tupP [varP nary_async; varP nary_reply]) def;
                funcD k v1 (nary_reply -*- v1);
@@ -323,10 +323,10 @@ module Transform() = struct
               let res_typ = t_typ res_typ in
               let reply_typ = replyT nary res_typ in
               let typ' = T.Tup []  in
-              let k = fresh_var reply_typ in
+              let k = fresh_var "k" reply_typ in
               let args' = t_args args @ [ arg_of_exp k ] in
               let typbinds' = t_typ_binds typbinds in
-              let y = fresh_var res_typ in
+              let y = fresh_var "y" res_typ in
               let exp' =
                 match exp.it with
                 | CallE(_, async,_,cps) ->

--- a/src/construct.ml
+++ b/src/construct.ml
@@ -42,20 +42,24 @@ let exp_of_arg a = idE {a with note = () } a.note
 
 (* Fresh id generation *)
 
-let id_stamp = ref 0
+module Stamps = Map.Make(String)
+let id_stamps = ref Stamps.empty
 
-let fresh () =
-  let name = Printf.sprintf "$%i" (!id_stamp) in
-  id_stamp := !id_stamp + 1;
-  name
+let fresh name_base () =
+  let n = Lib.Option.get (Stamps.find_opt name_base !id_stamps) 0 in
+  id_stamps := Stamps.add name_base (n + 1) !id_stamps;
+  Printf.sprintf "$%s/%i" name_base n
 
-let fresh_id () =
-  let name = fresh () in
+let fresh_id name_base () =
+  let name = fresh name_base () in
   name @@ no_region
 
-let fresh_var typ =
-  let name = fresh () in
+let fresh_var name_base typ =
+  let name = fresh name_base () in
   idE (name @@ no_region) typ
+
+let fresh_vars name_base ts =
+  List.mapi (fun i t -> fresh_var (Printf.sprintf "%s%i" name_base i) t) ts
 
 
 (* Patterns *)
@@ -307,7 +311,7 @@ let funcE name t x exp =
     then
       [ arg_of_exp x ], exp
     else
-      let vs = List.map fresh_var arg_tys in
+      let vs = fresh_vars "param" arg_tys in
       List.map arg_of_exp vs,
       blockE [letD x (tupE vs)] exp
   in
@@ -364,7 +368,7 @@ let answerT = T.unit
 let contT typ = T.Func (T.Local, T.Returns, [], T.as_seq typ, [])
 let cpsT typ = T.Func (T.Local, T.Returns, [], [contT typ], [])
 
-let fresh_cont typ = fresh_var (contT typ)
+let fresh_cont typ = fresh_var "cont" (contT typ)
 
 (* Sequence expressions *)
 
@@ -435,7 +439,7 @@ let whileE exp1 exp2 =
            if e1 then { e2 } else { break l }
          }
   *)
-  let lab = fresh_id () in
+  let lab = fresh_id "done" () in
   labelE lab T.unit (
       loopE (
           ifE exp1
@@ -452,7 +456,7 @@ let loopWhileE exp1 exp2 =
           if e2 { } else { break l }
         }
    *)
-  let lab = fresh_id () in
+  let lab = fresh_id "done" () in
   labelE lab T.unit (
       loopE (
           thenE exp1
@@ -474,11 +478,11 @@ let forE pat exp1 exp2 =
          case p    { e2 };
        }
      } *)
-  let lab = fresh_id () in
+  let lab = fresh_id "done" () in
   let ty1 = exp1.note.S.note_typ in
   let _, tfs  = Type.as_obj_sub "next" ty1 in
   let tnxt    = T.lookup_field "next" tfs in
-  let nxt = fresh_var tnxt in
+  let nxt = fresh_var "nxt" tnxt in
   letE nxt (dotE exp1 (nameN "next") tnxt) (
     labelE lab Type.unit (
       loopE (

--- a/src/construct.mli
+++ b/src/construct.mli
@@ -23,8 +23,9 @@ val nextN : name
 
 (* Identifiers *)
 
-val fresh_id : unit -> id
-val fresh_var : typ -> var
+val fresh_id : string -> unit -> id
+val fresh_var : string -> typ -> var
+val fresh_vars : string -> typ list -> var list
 
 val idE : id -> typ -> exp
 val id_of_exp : var -> id

--- a/src/desugar.ml
+++ b/src/desugar.ml
@@ -137,7 +137,7 @@ and block force_unit ds =
   | false, S.LetD ({it = S.VarP x; _}, e) ->
     (extra @ List.map dec ds, idE x e.note.S.note_typ)
   | false, S.LetD (p', e') ->
-    let x = fresh_var (e'.note.S.note_typ) in
+    let x = fresh_var "x" (e'.note.S.note_typ) in
     (extra @ List.map dec prefix @ [letD x (exp e'); letP (pat p') x], x)
   | _, _ ->
     (extra @ List.map dec ds, tupE [])
@@ -229,11 +229,11 @@ and to_arg p : (Ir.arg * (Ir.exp -> Ir.exp)) =
     { i with note = p.note },
     (fun e -> e)
   | S.WildP ->
-    let v = fresh_var p.note in
+    let v = fresh_var "param" p.note in
     arg_of_exp v,
     (fun e -> e)
   |  _ ->
-    let v = fresh_var p.note in
+    let v = fresh_var "param" p.note in
     arg_of_exp v,
     (fun e -> blockE [letP (pat p) v] e)
 
@@ -250,7 +250,7 @@ and to_args cc p0 : (Ir.arg list * (Ir.exp -> Ir.exp)) =
   let args, wrap =
     match n, p.it with
     | _, S.WildP ->
-      let vs = List.map fresh_var tys in
+      let vs = fresh_vars "param" tys in
       List.map arg_of_exp vs,
       (fun e -> e)
     | 1, _ ->
@@ -265,7 +265,7 @@ and to_args cc p0 : (Ir.arg list * (Ir.exp -> Ir.exp)) =
         (a::args, fun e -> wrap1 (wrap e))
       ) ps ([], (fun e -> e))
     | _, _ ->
-      let vs = List.map fresh_var tys in
+      let vs = fresh_vars "param" tys in
       List.map arg_of_exp vs,
       (fun e -> blockE [letP (pat p) (tupE vs)] e)
   in

--- a/src/serialization.ml
+++ b/src/serialization.ml
@@ -51,9 +51,9 @@ module Transform() = struct
     | _, _ ->
       let ts = T.as_tup e.note.note_typ in
       assert (List.length ts = n);
-      let vs = List.map fresh_var ts in
-        blockE [letP (seqP (List.map varP vs)) e]
-          (tupE (List.map f vs))
+      let vs = fresh_vars "tup" ts in
+      blockE [letP (seqP (List.map varP vs)) e]
+        (tupE (List.map f vs))
 
   let rec t_typ (t:T.typ) =
     match t with

--- a/src/tailcall.ml
+++ b/src/tailcall.ml
@@ -83,7 +83,7 @@ and assignEs vars exp : dec list =
   | _, TupE es when List.length es = List.length vars ->
        List.map expD (List.map2 assignE vars es)
   | _, _ ->
-    let tup = fresh_var (typ exp) in
+    let tup = fresh_var "tup" (typ exp) in
     letD tup exp ::
     List.mapi (fun i v -> expD (assignE v (projE v i))) vars
 
@@ -186,8 +186,8 @@ and dec' env d =
           ({it = FuncE (x, ({ Value.sort = Local; _} as cc), tbs, as_, typT, exp0);_} as funexp)) ->
     let env = bind env id None in
     begin fun env1 ->
-      let temps = List.map (fun a -> fresh_var (Mut a.note)) as_ in
-      let label = fresh_id () in
+      let temps = fresh_vars "temp" (List.map (fun a -> Mut a.note) as_) in
+      let label = fresh_id "tailcall" () in
       let tail_called = ref false in
       let env2 = { tail_pos = true;
                    info = Some { func = id;
@@ -201,7 +201,8 @@ and dec' env d =
       let cs = List.map (fun (tb : typ_bind) -> Con (tb.it.con, [])) tbs in
       if !tail_called then
         let ids = match typ funexp with
-          | Func( _, _, _, dom, _) -> List.map (fun t -> fresh_var (open_ cs t)) dom
+          | Func( _, _, _, dom, _) ->
+            fresh_vars "id" (List.map (fun t -> open_ cs t) dom)
           | _ -> assert false
         in
         let l_typ = Type.unit in

--- a/test/run-dfinity/ok/counter-class.wasm.stderr.ok
+++ b/test/run-dfinity/ok/counter-class.wasm.stderr.ok
@@ -18,31 +18,31 @@ non-closed actor: (ActorE
     (FuncE
       read
       (shared  1 -> 0)
-      (params $3/raw)
+      (params $k/0/raw)
       ()
       (BlockE
         (LetD
-          (TupP (VarP $3))
-          (TupE (CallE ( 1 -> 1) (PrimE @deserialize) (VarE $3/raw)))
+          (TupP (VarP $k/0))
+          (TupE (CallE ( 1 -> 1) (PrimE @deserialize) (VarE $k/0/raw)))
         )
         (CallE
           ( 1 -> 0)
           (FuncE
             $lambda
             ( 1 -> 0)
-            (params $2)
+            (params $cont/0)
             ()
-            (CallE ( 1 -> 0) (VarE $2) (VarE c))
+            (CallE ( 1 -> 0) (VarE $cont/0) (VarE c))
           )
           (FuncE
             $lambda
             ( 1 -> 0)
-            (params $4)
+            (params $y/0)
             ()
             (CallE
               (shared  1 -> 0)
-              (VarE $3)
-              (CallE ( 1 -> 1) (PrimE @serialize) (VarE $4))
+              (VarE $k/0)
+              (CallE ( 1 -> 1) (PrimE @serialize) (VarE $y/0))
             )
           )
         )


### PR DESCRIPTION
this way, the code is easier to read, because instead of just `$0`, we
have something like `$k.0`, which gives some indication where it came
from, and what it is. It also counts the stamps separately per name, so
it gives less churn in diffs.