### PR TITLE
Small IR refactor: Make FuncE return type explicitly n-ary

### DIFF
--- a/src/arrange_ir.ml
+++ b/src/arrange_ir.ml
@@ -36,8 +36,8 @@ let rec exp e = match e.it with
   | PrimE p             -> "PrimE"   $$ [Atom p]
   | DeclareE (i, t, e1) -> "DeclareE" $$ [id i; exp e1]
   | DefineE (i, m, e1)  -> "DefineE" $$ [id i; Arrange.mut m; exp e1]
-  | FuncE (x, cc, tp, as_, t, e) ->
-    "FuncE" $$ [Atom x; call_conv cc] @ List.map typ_bind tp @ args as_@ [ typ t; exp e]
+  | FuncE (x, cc, tp, as_, ts, e) ->
+    "FuncE" $$ [Atom x; call_conv cc] @ List.map typ_bind tp @ args as_@ [ typ (Type.seq ts); exp e]
   | ActorE (i, ds, fs, t) -> "ActorE"  $$ [id i] @ List.map dec ds @ fields fs @ [typ t]
   | NewObjE (s, fs, t)  -> "NewObjE" $$ (Arrange.obj_sort' s :: fields fs @ [typ t])
 

--- a/src/async.ml
+++ b/src/async.ml
@@ -312,17 +312,16 @@ module Transform() = struct
       begin
         match s with
         | T.Local  ->
-          FuncE (x, cc, t_typ_binds typbinds, t_args args, t_typ typT, t_exp exp)
+          FuncE (x, cc, t_typ_binds typbinds, t_args args, List.map t_typ typT, t_exp exp)
         | T.Sharable ->
           begin
             match typ exp with
             | T.Tup [] ->
-              FuncE (x, cc, t_typ_binds typbinds, t_args args, t_typ typT, t_exp exp)
+              FuncE (x, cc, t_typ_binds typbinds, t_args args, List.map t_typ typT, t_exp exp)
             | T.Async res_typ ->
               let cc' = Value.message_cc (cc.Value.n_args + 1) in
               let res_typ = t_typ res_typ in
               let reply_typ = replyT nary res_typ in
-              let typ' = T.Tup []  in
               let k = fresh_var "k" reply_typ in
               let args' = t_args args @ [ arg_of_exp k ] in
               let typbinds' = t_typ_binds typbinds in
@@ -337,7 +336,7 @@ module Transform() = struct
                   end
                 | _ -> assert false
               in
-              FuncE (x, cc', typbinds', args', typ', exp')
+              FuncE (x, cc', typbinds', args', [], exp')
             | _ -> assert false
           end
       end

--- a/src/construct.ml
+++ b/src/construct.ml
@@ -303,7 +303,7 @@ let ignoreE exp =
 (* Mono-morphic function expression *)
 let funcE name t x exp =
   let arg_tys, retty = match t with
-    | T.Func(_, _, _, ts1, ts2) -> ts1, T.seq ts2
+    | T.Func(_, _, _, ts1, ts2) -> ts1, ts2
     | _ -> assert false in
   let cc = Value.call_conv_of_typ t in
   let args, exp' =
@@ -330,7 +330,7 @@ let funcE name t x exp =
 
 let nary_funcE name t xs exp =
   let retty = match t with
-    | T.Func(_, _, _, _, ts2) -> T.seq ts2
+    | T.Func(_, _, _, _, ts2) -> ts2
     | _ -> assert false in
   let cc = Value.call_conv_of_typ t in
   assert (cc.Value.n_args = List.length xs);

--- a/src/desugar.ml
+++ b/src/desugar.ml
@@ -57,7 +57,7 @@ and exp' at note = function
   | S.FuncE (name, s, tbs, p, ty, e) ->
     let cc = Value.call_conv_of_typ note.S.note_typ in
     let args, wrap = to_args cc p in
-    I.FuncE (name, cc, typ_binds tbs, args, ty.note, wrap (exp e))
+    I.FuncE (name, cc, typ_binds tbs, args, Type.as_seq ty.note, wrap (exp e))
   | S.CallE (e1, inst, e2) ->
     let cc = Value.call_conv_of_typ e1.Source.note.S.note_typ in
     let inst = List.map (fun t -> t.Source.note) inst in
@@ -192,7 +192,7 @@ and dec' at n d = match d with
     let varPat = {it = I.VarP id'; at = at; note = fun_typ } in
     let args, wrap = to_args cc p in
     let fn = {
-      it = I.FuncE (id.it, cc, typ_binds tbs, args, obj_typ, wrap
+      it = I.FuncE (id.it, cc, typ_binds tbs, args, [obj_typ], wrap
          { it = obj at s (Some self_id) es obj_typ;
            at = at;
            note = { S.note_typ = obj_typ; S.note_eff = T.Triv } });

--- a/src/ir.ml
+++ b/src/ir.ml
@@ -59,7 +59,7 @@ and exp' =
   | DeclareE of id * Type.typ * exp            (* local promise *)
   | DefineE of id * mut * exp                  (* promise fulfillment *)
   | FuncE of                                   (* function *)
-      string * Value.call_conv * typ_bind list * arg list * Type.typ * exp
+      string * Value.call_conv * typ_bind list * arg list * Type.typ list * exp
   | ActorE of id * dec list * field list * Type.typ (* actor *)
   | NewObjE of  Type.obj_sort * field list * Type.typ  (* make an object *)
 

--- a/src/rename.ml
+++ b/src/rename.ml
@@ -64,10 +64,10 @@ and exp' rho e  = match e with
   | DeclareE (i, t, e)  -> let i',rho' = id_bind rho i in
                            DeclareE (i', t, exp rho' e)
   | DefineE (i, m, e)   -> DefineE (id rho i, m, exp rho e)
-  | FuncE (x, s, tp, p, t, e) ->
+  | FuncE (x, s, tp, p, ts, e) ->
      let p', rho' = args rho p in
      let e' = exp rho' e in
-     FuncE (x, s, tp, p', t, e')
+     FuncE (x, s, tp, p', ts, e')
   | NewObjE (s, fs, t)  -> NewObjE (s, fields rho fs, t)
 
 and exps rho es  = List.map (exp rho) es

--- a/src/serialization.ml
+++ b/src/serialization.ml
@@ -138,19 +138,19 @@ module Transform() = struct
           let exp2' = map_tuple cc.Value.n_args serialize (t_exp exp2) in
           CallE (cc, t_exp exp1, [], exp2')
       end
-    | FuncE (x, cc, typbinds, args, typT, exp) ->
+    | FuncE (x, cc, typbinds, args, ret_tys, exp) ->
       begin match cc.Value.sort with
       | T.Local ->
-        FuncE (x, cc, t_typ_binds typbinds, t_args args, t_typ typT, t_exp exp)
+        FuncE (x, cc, t_typ_binds typbinds, t_args args, List.map t_typ ret_tys, t_exp exp)
       | T.Sharable ->
-        assert (T.is_unit typT);
+        assert (ret_tys = []);
         let args' = t_args args in
         let raw_args = List.map serialized_arg args' in
         let body' =
           blockE [letP (tupP (List.map varP (List.map exp_of_arg args')))
                        (tupE (List.map deserialize (List.map exp_of_arg raw_args))) ]
             (t_exp exp) in
-        FuncE (x, cc, [], raw_args, T.unit, body')
+        FuncE (x, cc, [], raw_args, [], body')
       end
     | PrimE _
       | LitE _ -> exp'

--- a/src/tailcall.ml
+++ b/src/tailcall.ml
@@ -128,11 +128,11 @@ and exp' env e  : exp' = match e.it with
   | DeclareE (i, t, e)  -> let env1 = bind env i None in
                            DeclareE (i, t, tailexp env1 e)
   | DefineE (i, m, e)   -> DefineE (i, m, exp env e)
-  | FuncE (x, cc, tbs, as_, typT, exp0) ->
+  | FuncE (x, cc, tbs, as_, ret_tys, exp0) ->
     let env1 = { tail_pos = true; info = None} in
     let env2 = args env1 as_ in
     let exp0' = tailexp env2 exp0 in
-    FuncE (x, cc, tbs, as_, typT, exp0')
+    FuncE (x, cc, tbs, as_, ret_tys, exp0')
   | ActorE (i, ds, fs, t) -> ActorE (i, ds, fs, t) (* TODO: descent into ds *)
   | NewObjE (s,is,t)    -> NewObjE (s, is, t)
 


### PR DESCRIPTION
I think that every use of `Type.as_seq` is a bit fishy: Once we are in
the IR, we really should think in terms of n-ary types as far as
possible. So let’s store the list of return types in `FuncE`, making it
match the `Type.Func` constructor more closely. `Check_ir` is
simplified, which is a good thing.

This does not completely eliminate `Type.as_seq` from the IR phases
completely; especially the `async` translation (and hence parts of
`construct`) use it to flatten the return values of `T.Async`. Maybe
`T.Async` itself should take a list of arguments, so that we can deal
with that in the desgurarer, where we already deal with fuction
arguments and return values.