### PR TITLE
Add ci-pr

### DIFF
--- a/ci-pr.nix
+++ b/ci-pr.nix
@@ -1,0 +1,1 @@
+args@{...}: import ./default.nix (args)


### PR DESCRIPTION
Add a ci file for PRs to fix the issue with the build post https://github.com/dfinity-lab/hydra-jobsets/pull/6


Initially,  I was going for  a fix allowing different pr files, but after some discussion, it is more robust to keep a separate ci-pr that we *just* pass arguments in. 

(@nomeata  your thoughts here.)


cc @ninegua @nomeata 