### PR TITLE
Remove old Jenkins build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ActorScript
 
-[![Build Status](https://jenkins.london.dfinity.build/job/actorscript-multibranch/job/master/badge/icon)](https://jenkins.london.dfinity.build/job/actorscript-multibranch/job/master/)
-
 A simple language for writing Dfinity actors.
 
 


### PR DESCRIPTION
Jenkins is no longer used for CI.