### PR TITLE
Allow the last actor literal to be named

### DIFF
--- a/test/run-dfinity/hello-world-message2.as
+++ b/test/run-dfinity/hello-world-message2.as
@@ -1,0 +1,7 @@
+actor hello_world {
+  hello () {
+    print("Hello World!\n");
+  }
+}
+
+//CALL hello

--- a/test/run-dfinity/ok/hello-world-message2.dvm-run.ok
+++ b/test/run-dfinity/ok/hello-world-message2.dvm-run.ok
@@ -1,0 +1,2 @@
+DVM: Calling method hello
+Hello World!


### PR DESCRIPTION
by, in the compiler, recognizing the code that the earlier passes
produce. This is a hack in want of a more disciplined notion of an
“actor-defining file”, but we need this for @matthewhammer’s produce
exchange demo.

Makes #287 obsolete.