### PR TITLE
Add getUserInfo

### DIFF
--- a/stdlib/examples/produce-exchange/serverActor.as
+++ b/stdlib/examples/produce-exchange/serverActor.as
@@ -119,6 +119,16 @@ actor server = {
     getModel().userTable.allInfo()
   };
 
+  /**
+   `getUserInfo`
+   ---------------------------
+   Get the information associated with a user, based on its id.
+   */
+  getUserInfo(id:UserId) : async ?UserInfo {
+    getModel()
+      .userTable.getInfo(id)
+  };
+
  /**
  `TruckType`
  ==============


### PR DESCRIPTION
This relates to SDK-100. It may seem somewhat unnecessary because we already fetch `allUserInfo` but ignoring that it's closer to a real log in flow and forces us to deal with things like waiting for a response from the "log in" request.