### PR TITLE
Mergify: Remove tags

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,3 +33,12 @@ pull_request_rules:
         strict: smart
         strict_method: rebase
       delete_head_branch: {}
+  - name: Clean up automerge tags
+    conditions:
+      - closed
+    actions:
+      label:
+        remove:
+        - automerge
+        - automerge-squash
+        - automerge-rebase


### PR DESCRIPTION
once a PR is closed (merged or otherwise), the automerge tags are just
distracting. So let’s remove them.