### PR TITLE
Add `--strict` to `menhir` flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ OPAM_PACKAGES = wasm num vlq yojson
 JS_OPAM_PACKAGES = js_of_ocaml js_of_ocaml-ppx
 
 MENHIR = menhir
-MENHIR_FLAGS = --infer --dump --explain
+MENHIR_FLAGS = --infer --dump --explain --strict
 
 OCAML_FLAGS = -cflags '-w +a-4-27-30-42-44-45-58 -warn-error +a'
 OCAMLBUILD = ocamlbuild $(OCAML_FLAGS) \


### PR DESCRIPTION
so that
https://github.com/dfinity-lab/actorscript/pull/310#issuecomment-483186660
does not happen by accident again.

When developing, you can make it less strict, by passing

    make MENHIR_FLAGS="--infer --dump --explain"

similar to how you can make `ocaml` less pedantic by passing, say,

    make OCAML_FLAGS="-cflags '-w +a-4-27-30-42-44-45 -g'"

(which I usually do).