### PR TITLE
SDK-261 AS documentation generated by hydra should use URLs hosted by hydra

### DIFF
--- a/stdlib/markdown-of-actorscript.py
+++ b/stdlib/markdown-of-actorscript.py
@@ -46,12 +46,8 @@
 
 ## Stable links
 ## -----------
-## https://hydra.oregon.dfinity.build//job/dfinity-ci-build/actorscript.pr-234/stdlib-reference/latest/download/1/doc/
-##
-## (PR 234 is the current PR for the standard library and produce exchange)
-##
 
-DOCURL="https://hydra.oregon.dfinity.build//job/dfinity-ci-build/actorscript.pr-234/stdlib-reference/latest/download/1/doc/"
+DOCURL="https://hydra.oregon.dfinity.build//job/dfinity-ci-build/actorscript/stdlib-reference/latest/download/1/doc/"
 
 #############################################################################################################
 

--- a/stdlib/markdown-of-markdown.py
+++ b/stdlib/markdown-of-markdown.py
@@ -2,12 +2,8 @@
 
 ## Stable links
 ## -----------
-## https://hydra.oregon.dfinity.build//job/dfinity-ci-build/actorscript.pr-234/stdlib-reference/latest/download/1/doc/
-##
-## (PR 234 is the current PR for the standard library and produce exchange)
-##
 
-DOCURL="https://hydra.oregon.dfinity.build//job/dfinity-ci-build/actorscript.pr-234/stdlib-reference/latest/download/1/doc/"
+DOCURL="https://hydra.oregon.dfinity.build//job/dfinity-ci-build/actorscript/stdlib-reference/latest/download/1/doc/"
 
 #############################################################################################################
 


### PR DESCRIPTION
Originally, I had put URLs into the code that point at github.  Now, we have static URLs hosted on hydra. Also, we have recently merged into `master`.

To make the generated documentation consistent with these changes, I still need to do a few things:

- [x] use the correct base URL; we likely want to use `master` for this URL, consistently
- [ ] use the correct file names, with the correct extensions; these used to be `.md` but are now `.html`; this requires a lot of small, simple changes in a lot of files.

----------------

Some example doc links (note that they each refer to `master`, not the current state of this PR):

- [stdlib documentation hosted on hydra](https://hydra.oregon.dfinity.build//job/dfinity-ci-build/actorscript/stdlib-reference/latest/download/1/doc/README.html)
- [PX documentation hosted on hydra](https://hydra.oregon.dfinity.build//job/dfinity-ci-build/actorscript/stdlib-reference/latest/download/1/doc/examples/produce-exchange/README.html)