### PR TITLE
SDK-119 SDK-131 Add getRouteInfo to the Produce Exchange

### DIFF
--- a/stdlib/examples/produce-exchange/serverActor.as
+++ b/stdlib/examples/produce-exchange/serverActor.as
@@ -666,6 +666,20 @@ actor server = {
   };
 
   /**
+   `getRouteInfo`
+   ---------------------
+
+   See also: [server type `RouteInfo`]($DOCURL/examples/produce-exchange/serverTypes.md#routeinfo).
+
+   */
+
+  getRouteInfo(
+    id: RouteId
+  ) : async ?RouteInfo {
+    getModel().routeTable.getInfo(id)
+  };
+
+  /**
    `Retailer`-based ingress messages:
    ======================================
 


### PR DESCRIPTION
This branch is based on 4a3cc2516a30b9905e8751e7a3b93e196444d37c (an older commit) because the front end of the produce exchange needs the nixpkgs update from https://github.com/dfinity-lab/dev/pull/542 in order to support the latest from this repo.

This PR should still be compatible and mergeable though.