### PR TITLE
AST-80: Public actor fields must be functions

### DIFF
--- a/src/typing.ml
+++ b/src/typing.ml
@@ -967,6 +967,10 @@ and pub_typ_id id (xs, ys) : region T.Env.t * region T.Env.t =
 and pub_val_id id (xs, ys) : region T.Env.t * region T.Env.t =
   (xs, T.Env.add id.it id.at ys)
 
+and is_actor_method dec : bool = match dec.it with
+  | LetD ({ it = VarP _; _}, {it = FuncE _; _} ) -> true
+  | _ -> false
+
 and infer_obj env s fields at : T.typ =
   let decs = List.map (fun (field : exp_field) -> field.it.dec) fields in
   let _, scope = infer_block env decs at in
@@ -985,6 +989,12 @@ and infer_obj env s fields at : T.typ =
           "public shared object or actor field %s has non-shared type\n  %s"
           lab (T.string_of_typ_expand typ)
     ) tfs
+  end;
+  if not env.pre && s = T.Actor then begin
+    List.iter (fun ef ->
+      if ef.it.vis.it = Syntax.Public && not (is_actor_method ef.it.dec) then
+        local_error env ef.it.dec.at "public actor field needs to be a manifest function"
+    ) fields
   end;
   let t = T.Obj (s, tfs) in
   try T.avoid scope.con_env t with T.Unavoidable c ->

--- a/test/fail/actor-reexport.as
+++ b/test/fail/actor-reexport.as
@@ -1,0 +1,21 @@
+actor test {
+  exported() {
+    print("exported()\n");
+  };
+  let exported_too = exported;
+};
+
+actor test2 {
+  let exported_three = test.exported_too;
+  let (exported_four, exported_five) =
+    if (true)
+      (test.exported_too, test.exported_too)
+    else
+      (exported_three, exported_three)
+};
+
+test.exported();
+test.exported_too();
+test2.exported_three();
+test2.exported_four();
+test2.exported_five();

--- a/test/fail/ok/actor-reexport.tc.ok
+++ b/test/fail/ok/actor-reexport.tc.ok
@@ -1,0 +1,3 @@
+actor-reexport.as:5.3-5.30: type error, public actor field needs to be a manifest function
+actor-reexport.as:9.3-9.41: type error, public actor field needs to be a manifest function
+actor-reexport.as:10.3-14.39: type error, public actor field needs to be a manifest function


### PR DESCRIPTION
otherwise every message would go through a second, forwarding message
send, which is bad. Or we need to do some best-effort optimizations, but
that is also not nice. So let’s require a function here (the user can
still eta-expand they really have to, so no loss of expressivity).

The actual changes to the IR and backend will come in a separate PR.