### PR TITLE
Don’t make closures larger than they have to be

### DIFF
--- a/test/run/static-func-call.as
+++ b/test/run/static-func-call.as
@@ -1,0 +1,6 @@
+(func() = ()) ()
+
+// CHECK: func $start
+// CHECK-NOT: call_indirect
+// CHECK: call $anon-func-
+


### PR DESCRIPTION
previously, the size of the closure would be the number of free
variables. Since the introduction of static things (static functions,
variables allocated on a static heap) these slots were filled with `0`,
which is obviously stupid. This removes the stupidity (and surprisingly
simple at that).