### PR TITLE
Backend: Do not hardcode import ids

### DIFF
--- a/src/compile.ml
+++ b/src/compile.ml
@@ -299,11 +299,6 @@ module E = struct
     let l = env.local_vars_env in
     NameEnv.fold (fun k _ -> Freevars.S.add k) l Freevars.S.empty
 
-  let add_func_import (env : t) f =
-    if !(env.funcs) = []
-    then reg env.func_imports f
-    else assert false (* "add all imports before all functions!" *)
-
   let _add_other_import (env : t) m =
     let _ = reg env.other_imports m in ()
 
@@ -364,6 +359,21 @@ module E = struct
     go 0 !(env.func_types)
 
   let get_types (env : t) = !(env.func_types)
+
+  let add_func_import (env : t) modname funcname arg_tys ret_tys =
+    if !(env.funcs) = []
+    then
+      let i = {
+        module_name = Wasm.Utf8.decode modname;
+        item_name = Wasm.Utf8.decode funcname;
+        idesc = nr (FuncImport (nr (func_type env (FuncType (arg_tys, ret_tys)))))
+      } in
+      let fi = reg env.func_imports (nr i) in
+      let name = modname ^ "_" ^ funcname in
+      assert (not (NameEnv.mem name !(env.built_in_funcs)));
+      env.built_in_funcs := NameEnv.add name (Defined fi) !(env.built_in_funcs);
+    else assert false (* "add all imports before all functions!" *)
+
 
   let add_label (env : t) name (d : G.depth) =
       { env with ld = NameEnv.add name.it d env.ld }
@@ -2315,136 +2325,24 @@ end (* Tuple *)
 module Dfinity = struct
   (* Dfinity-specific stuff: System imports, databufs etc. *)
 
-  (* function ids for imported stuff *)
-  let test_print_i env = 0l
-  let test_show_i32_i env = 1l
-  let data_externalize_i env = 2l
-  let data_internalize_i env = 3l
-  let data_length_i env = 4l
-  let elem_externalize_i env = 5l
-  let elem_internalize_i env = 6l
-  let elem_length_i env = 7l
-  let module_new_i env = 8l
-  let actor_new_i env = 9l
-  let actor_self_i env = 10l
-  let actor_export_i env = 11l
-  let func_internalize_i env = 12l
-  let func_externalize_i env = 13l
-  let func_bind_i env = 14l
-
-  (* Based on http://caml.inria.fr/pub/old_caml_site/FAQ/FAQ_EXPERT-eng.html#strings *)
-  (* Ok to use as long as everything is ASCII *)
-  let explode s =
-    let rec exp i l =
-      if i < 0 then l else exp (i - 1) (Char.code s.[i] :: l) in
-    exp (String.length s - 1) []
-
   let system_imports env =
-    let i = E.add_func_import env (nr {
-      module_name = explode "test";
-      item_name = explode "print";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type],[])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (test_print_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "test";
-      item_name = explode "show_i32";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (test_show_i32_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "data";
-      item_name = explode "externalize";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type; I32Type],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (data_externalize_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "data";
-      item_name = explode "internalize";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type; I32Type; I32Type; I32Type],[])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (data_internalize_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "data";
-      item_name = explode "length";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (data_length_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "elem";
-      item_name = explode "externalize";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type; I32Type],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (elem_externalize_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "elem";
-      item_name = explode "internalize";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type; I32Type; I32Type; I32Type],[])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (elem_internalize_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "elem";
-      item_name = explode "length";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (elem_length_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "module";
-      item_name = explode "new";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (module_new_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "actor";
-      item_name = explode "new";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (actor_new_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "actor";
-      item_name = explode "self";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (actor_self_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "actor";
-      item_name = explode "export";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type; I32Type],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (actor_export_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "func";
-      item_name = explode "internalize";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type; I32Type],[])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (func_internalize_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "func";
-      item_name = explode "externalize";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type], [I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (func_externalize_i env));
-
-    let i = E.add_func_import env (nr {
-      module_name = explode "func";
-      item_name = explode "bind_i32";
-      idesc = nr (FuncImport (nr (E.func_type env (FuncType ([I32Type; I32Type],[I32Type])))))
-    }) in
-    assert (Int32.to_int i == Int32.to_int (func_bind_i env))
-
+    begin
+      E.add_func_import env "test" "print" [I32Type] [];
+      E.add_func_import env "test" "show_i32" [I32Type] [I32Type];
+      E.add_func_import env "data" "externalize" [I32Type; I32Type] [I32Type];
+      E.add_func_import env "data" "internalize" [I32Type; I32Type; I32Type; I32Type] [];
+      E.add_func_import env "data" "length" [I32Type] [I32Type];
+      E.add_func_import env "elem" "externalize" [I32Type; I32Type] [I32Type];
+      E.add_func_import env "elem" "internalize" [I32Type; I32Type; I32Type; I32Type] [];
+      E.add_func_import env "elem" "length" [I32Type] [I32Type];
+      E.add_func_import env "module" "new" [I32Type] [I32Type];
+      E.add_func_import env "actor" "new" [I32Type] [I32Type];
+      E.add_func_import env "actor" "self" [] [I32Type];
+      E.add_func_import env "actor" "export" [I32Type; I32Type] [I32Type];
+      E.add_func_import env "func" "internalize" [I32Type; I32Type] [];
+      E.add_func_import env "func" "externalize" [I32Type] [I32Type];
+      E.add_func_import env "func" "bind_i32" [I32Type; I32Type] [I32Type];
+    end
 
   let compile_databuf_of_text env  =
     Func.share_code1 env "databuf_of_text" ("string", I32Type) [I32Type] (fun env get_string ->
@@ -2457,7 +2355,7 @@ module Dfinity = struct
       Heap.load_field (Text.len_field) ^^
 
       (* Externalize *)
-      G.i (Call (nr (data_externalize_i env)))
+      G.i (Call (nr (E.built_in env "data_externalize")))
     )
 
   let compile_databuf_of_bytes env (bytes : string) =
@@ -2466,10 +2364,10 @@ module Dfinity = struct
   (* For debugging *)
   let compile_static_print env s =
       compile_databuf_of_bytes env s ^^
-      G.i (Call (nr (test_print_i env)))
+      G.i (Call (nr (E.built_in env "test_print")))
   let _compile_print_int env =
-      G.i (Call (nr (test_show_i32_i env))) ^^
-      G.i (Call (nr (test_print_i env))) ^^
+      G.i (Call (nr (E.built_in env "test_show_i32"))) ^^
+      G.i (Call (nr (E.built_in env "test_print"))) ^^
       compile_static_print env "\n"
 
   let trap_with env s =
@@ -2482,8 +2380,8 @@ module Dfinity = struct
     then
       BoxedInt.unbox env ^^
       G.i (Convert (Wasm.Values.I32 I32Op.WrapI64)) ^^
-      G.i (Call (nr (test_show_i32_i env))) ^^
-      G.i (Call (nr (test_print_i env)))
+      G.i (Call (nr (E.built_in env "test_show_i32"))) ^^
+      G.i (Call (nr (E.built_in env "test_print")))
     else
       G.i Unreachable
 
@@ -2491,19 +2389,18 @@ module Dfinity = struct
     if E.mode env = DfinityMode
     then
       compile_databuf_of_text env ^^
-      (* Call print *)
-      G.i (Call (nr (test_print_i env)))
+      G.i (Call (nr (E.built_in env "test_print")))
     else
       G.i Unreachable
 
   let default_exports env =
     (* these exports seem to be wanted by the hypervisor/v8 *)
     E.add_export env (nr {
-      name = explode "mem";
+      name = Wasm.Utf8.decode "mem";
       edesc = nr (MemoryExport (nr 0l))
     });
     E.add_export env (nr {
-      name = explode "table";
+      name = Wasm.Utf8.decode "table";
       edesc = nr (TableExport (nr 0l))
     })
 
@@ -2519,7 +2416,7 @@ module Dfinity = struct
       ) in
     let fi = E.add_fun env "start_stub" empty_f in
     E.add_export env (nr {
-      name = explode "start";
+      name = Wasm.Utf8.decode "start";
       edesc = nr (FuncExport (nr fi))
     })
 
@@ -2536,12 +2433,12 @@ module Dfinity = struct
     ElemHeap.recall_reference env
 
   let get_self_reference env =
-    G.i (Call (nr (actor_self_i env))) ^^
+    G.i (Call (nr (E.built_in env "actor_self"))) ^^
     box_reference env
 
   let static_message_funcref env fi =
     compile_unboxed_const fi ^^
-    G.i (Call (nr (func_externalize_i env)))
+    G.i (Call (nr (E.built_in env "func_externalize")))
 
 
 end (* Dfinity *)
@@ -2570,18 +2467,18 @@ module OrthogonalPersistence = struct
 
   let register env start_funid =
     E.add_export env (nr {
-      name = Dfinity.explode "datastore";
+      name = Wasm.Utf8.decode "datastore";
       edesc = nr (GlobalExport (nr mem_global))
     });
     E.add_export env (nr {
-      name = Dfinity.explode "elemstore";
+      name = Wasm.Utf8.decode "elemstore";
       edesc = nr (GlobalExport (nr elem_global))
     });
 
     Func.define_built_in env "restore_mem" [] [] (fun env1 ->
        let (set_i, get_i) = new_local env1 "len" in
        G.i (GlobalGet (nr mem_global)) ^^
-       G.i (Call (nr (Dfinity.data_length_i env1))) ^^
+       G.i (Call (nr (E.built_in env1 "data_length"))) ^^
        set_i ^^
 
        get_i ^^
@@ -2602,11 +2499,11 @@ module OrthogonalPersistence = struct
            get_i ^^
            G.i (GlobalGet (nr mem_global)) ^^
            compile_unboxed_zero ^^
-           G.i (Call (nr (Dfinity.data_internalize_i env1))) ^^
+           G.i (Call (nr (E.built_in env1 "data_internalize"))) ^^
 
            (* Load reference counter *)
            G.i (GlobalGet (nr elem_global)) ^^
-           G.i (Call (nr (Dfinity.elem_length_i env1))) ^^
+           G.i (Call (nr (E.built_in env1 "elem_length"))) ^^
            ElemHeap.set_ref_ctr ^^
 
            (* Load references *)
@@ -2614,7 +2511,7 @@ module OrthogonalPersistence = struct
            ElemHeap.get_ref_ctr ^^
            G.i (GlobalGet (nr elem_global)) ^^
            compile_unboxed_zero ^^
-           G.i (Call (nr (Dfinity.elem_internalize_i env1)))
+           G.i (Call (nr (E.built_in env1 "elem_internalize")))
         )
     );
     Func.define_built_in env "save_mem" [] [] (fun env1 ->
@@ -2623,13 +2520,13 @@ module OrthogonalPersistence = struct
        Heap.get_heap_ptr ^^
        compile_unboxed_const ElemHeap.table_end ^^
        G.i (Binary (Wasm.Values.I32 I32Op.Sub)) ^^
-       G.i (Call (nr (Dfinity.data_externalize_i env))) ^^
+       G.i (Call (nr (E.built_in env "data_externalize"))) ^^
        G.i (GlobalSet (nr mem_global)) ^^
 
        (* Store references *)
        compile_unboxed_const ElemHeap.ref_location ^^
        ElemHeap.get_ref_ctr ^^
-       G.i (Call (nr (Dfinity.elem_externalize_i env))) ^^
+       G.i (Call (nr (E.built_in env "elem_externalize"))) ^^
        G.i (GlobalSet (nr elem_global))
     )
 
@@ -3249,7 +3146,7 @@ module Serialization = struct
         get_refs_start ^^
         get_data_start ^^
         get_data_size ^^
-        G.i (Call (nr (Dfinity.data_externalize_i env))) ^^
+        G.i (Call (nr (E.built_in env "data_externalize"))) ^^
         store_unskewed_ptr  ^^
 
         if has_no_references t
@@ -3265,7 +3162,7 @@ module Serialization = struct
           (* Finally, create elembuf *)
           get_refs_start ^^
           get_refs_size ^^ compile_add_const 1l ^^
-          G.i (Call (nr (Dfinity.elem_externalize_i env)))
+          G.i (Call (nr (E.built_in env "elem_externalize")))
     )
 
   let deserialize_text env get_databuf =
@@ -3273,7 +3170,7 @@ module Serialization = struct
     let (set_x, get_x) = new_local env "x" in
 
     get_databuf ^^
-    G.i (Call (nr (Dfinity.data_length_i env))) ^^
+    G.i (Call (nr (E.built_in env "data_length"))) ^^
     set_data_size ^^
 
     get_data_size ^^
@@ -3284,7 +3181,7 @@ module Serialization = struct
     get_data_size ^^
     get_databuf ^^
     compile_unboxed_const 0l ^^
-    G.i (Call (nr (Dfinity.data_internalize_i env))) ^^
+    G.i (Call (nr (E.built_in env "data_internalize"))) ^^
 
     get_x
 
@@ -3312,7 +3209,7 @@ module Serialization = struct
         else
           (* Allocate space for the elem buffer *)
           get_elembuf ^^
-          G.i (Call (nr (Dfinity.elem_length_i env))) ^^
+          G.i (Call (nr (E.built_in env "elem_length"))) ^^
           set_refs_size ^^
 
           get_refs_size ^^
@@ -3326,7 +3223,7 @@ module Serialization = struct
           get_refs_size ^^
           get_elembuf ^^
           compile_unboxed_const 0l ^^
-          G.i (Call (nr (Dfinity.elem_internalize_i env))) ^^
+          G.i (Call (nr (E.built_in env "elem_internalize"))) ^^
 
           (* Get databuf *)
           get_refs_start ^^
@@ -3336,7 +3233,7 @@ module Serialization = struct
 
         (* Allocate space for the data buffer *)
         get_databuf ^^
-        G.i (Call (nr (Dfinity.data_length_i env))) ^^
+        G.i (Call (nr (E.built_in env "data_length"))) ^^
         set_data_size ^^
 
         get_data_size ^^
@@ -3352,7 +3249,7 @@ module Serialization = struct
         get_data_size ^^
         get_databuf ^^
         compile_unboxed_const 0l ^^
-        G.i (Call (nr (Dfinity.data_internalize_i env))) ^^
+        G.i (Call (nr (E.built_in env "data_internalize"))) ^^
 
         (* Go! *)
         get_data_start ^^
@@ -3694,7 +3591,7 @@ module FuncDec = struct
     if E.mode env <> DfinityMode then G.i Unreachable else
       compile_unboxed_const tmp_table_slot ^^ (* slot number *)
       get_ref ^^ (* the unboxed funcref *)
-      G.i (Call (nr (Dfinity.func_internalize_i env))) ^^
+      G.i (Call (nr (E.built_in env "func_internalize"))) ^^
 
       compile_unboxed_const tmp_table_slot ^^
       G.i (CallIndirect (nr (message_ty env cc)))
@@ -3703,9 +3600,9 @@ module FuncDec = struct
     Func.share_code1 env "export_self_message" ("name", I32Type) [I32Type] (fun env get_name ->
       Tagged.obj env Tagged.Reference [
         (* Create a funcref for the message *)
-        G.i (Call (nr (Dfinity.actor_self_i env))) ^^
+        G.i (Call (nr (E.built_in env "actor_self"))) ^^
         get_name ^^ (* the databuf with the message name *)
-        G.i (Call (nr (Dfinity.actor_export_i env))) ^^
+        G.i (Call (nr (E.built_in env "actor_export"))) ^^
         ElemHeap.remember_reference env
       ]
     )
@@ -3912,10 +3809,10 @@ module FuncDec = struct
         SR.UnboxedReference,
         code ^^
         compile_unboxed_const fi ^^
-        G.i (Call (nr (Dfinity.func_externalize_i env))) ^^
+        G.i (Call (nr (E.built_in env "func_externalize"))) ^^
         get_clos ^^
         ClosureTable.remember_closure env ^^
-        G.i (Call (nr (Dfinity.func_bind_i env)))
+        G.i (Call (nr (E.built_in env "func_bind_i32")))
 
   let lit env how name cc free_vars args mk_body at =
     let is_local = cc.Value.sort <> Type.Sharable in
@@ -4915,7 +4812,7 @@ and export_actor_field env (f : Ir.field) =
     ) ts
   );
   E.add_export env (nr {
-    name = Dfinity.explode name;
+    name = Wasm.Utf8.decode name;
     edesc = nr (FuncExport (nr fi))
   })
 
@@ -4956,8 +4853,8 @@ and actor_lit outer_env this ds fs at =
 
     Dfinity.compile_databuf_of_bytes outer_env wasm_binary ^^
     (* Create actorref *)
-    G.i (Call (nr (Dfinity.module_new_i outer_env))) ^^
-    G.i (Call (nr (Dfinity.actor_new_i outer_env)))
+    G.i (Call (nr (E.built_in outer_env "module_new"))) ^^
+    G.i (Call (nr (E.built_in outer_env "actor_new")))
 
 (* Main actor: Just return the initialization code, and export functions as needed *)
 and main_actor env this ds fs =
@@ -4976,7 +4873,7 @@ and main_actor env this ds fs =
 
 and actor_fake_object_idx env name =
     Dfinity.compile_databuf_of_bytes env (name.it) ^^
-    G.i (Call (nr (Dfinity.actor_export_i env)))
+    G.i (Call (nr (E.built_in env "actor_export")))
 
 and conclude_module env module_name start_fi_o =
 


### PR DESCRIPTION
this cleans up a very old wart, in preparation for importing functions
from a separate `rts` module.