### PR TITLE
Reverts incorrect changes to the design documents

### DIFF
--- a/design/FAQ.md
+++ b/design/FAQ.md
@@ -1,6 +1,6 @@
 > 1. Why would I want an `actor class` versus just a `class`?
 
-An actor is instantiated as a separate wasm instance, with isolated state. Classes can capture (mutable) free variables state, actors classes should not (but currently can because the typechecker is too liberal).
+An actor is instantiated as a separate wasm instance, with isolated state. Classes can capture (mutable) free variables state, actor classes should not (but currently can because the typechecker is too liberal).
 
 > 2. Where am I permitted to place `async` blocks?
 

--- a/design/Implementation.md
+++ b/design/Implementation.md
@@ -65,7 +65,7 @@
 
 * Definitions lifted to the surrounding actor.
 
-* Closed-over locals need indirection through heap if mutable or if defined-ness cannot be proven.
+* Closed-over locals need indirection through heap if mutable or if definedness cannot be proved.
 
 
 ## Actor Objects

--- a/design/TmpWireFormat.md
+++ b/design/TmpWireFormat.md
@@ -62,8 +62,7 @@ little endian format.
  * An empty tuple, the type `Null` and the type `Shared` are represented by
    zero bytes.
  * A `Variant` with `n` constructors sorted by constructor name is represented
-   <!-- TODO What's the Word's size? -->
-   by a single word indicating the constructor as a number `0..n-1`, followed
+   by a single 32-bit word indicating the constructor as a number `0..n-1`, followed
    by the payload of the constructor. (Yes, obviously no subtyping here.)
 
 *Example:* The ActorScript value


### PR DESCRIPTION
fixes one more typo

clarify the tag size for serialized variants

Follow-up to #354 