### PR TITLE
Remove repeated length field from text fields

### DIFF
--- a/design/IDL.md
+++ b/design/IDL.md
@@ -700,6 +700,7 @@ M((k,v) : <fieldtype>^*) = i32(k) leb128(|F(v : <datatype>)|) F(v : <datatype>) 
 M((k,v) : <fieldtype>^*) = .                          otherwise
 
 F(null : opt <datatype>) = .
+F(t : text)              = i8^*(utf8(t))
 F(v : opt <datatype>)    = M(v : <datatype>)
 F(v : <datatype>)        = M(v : <datatype>)          otherwise
 


### PR DESCRIPTION
We already “flatten” an `opt` field into record fields (using the presence of the record field for the tag), so why not flatten an `text` field (using the record lengths for the text length).

The change is really small, and I would be embarrassed to show a hex dump to someone and have to explain the duplicated length field there.