### PR TITLE
PX: Add IDs to ReservationInfo (SDK-158)

### DIFF
--- a/stdlib/examples/produce-exchange/serverModel.as
+++ b/stdlib/examples/produce-exchange/serverModel.as
@@ -1297,6 +1297,9 @@ than the MVP goals, however.
       date_begin   = route.start_date  :T.Date;
       date_end     = route.end_date    :T.Date;
       trans_cost   = route.cost:  T.Price;
+
+      inventoryId = item.id  : T.InventoryId;
+      routeId = route.id : T.RouteId;
     }
   };
 

--- a/stdlib/examples/produce-exchange/serverTypes.as
+++ b/stdlib/examples/produce-exchange/serverTypes.as
@@ -292,6 +292,8 @@ type ReservationInfo = shared {
   date_end:    Date;
   prod_cost:   PriceTotal;
   trans_cost:  PriceTotal;
+  inventoryId: InventoryId;
+  routeId:     RouteId;
 };
 
 


### PR DESCRIPTION
`retailerQueryAll` ultimately returns `[ReservationInfo]` but we are currently
unable to make reservations based on this information because values of type
`InventoryId` and `RouteId` are required.

This adds the missing IDs required by `retailerQueryAll` and similar functions.