### PR TITLE
Make IDL serialisation format self-describing by including types

### DIFF
--- a/design/IDL.md
+++ b/design/IDL.md
@@ -826,7 +826,7 @@ Deserialisation is the parallel application of the inverse functions of `T`, `M`
 
 * A serialised type may be headed by an opcode other than the ones defined above (i.e., less than -23). Any such opcode is followed by an LEB128-encoded count, and then a number of bytes corresponding to this count. A type represented that way is called a *future type*.
 
-* A value corresponding to a future type is called a *future value*. It is  represented by two LEB128-encoded counts, *m* and *n*, followed by a *m* bytes in the memory representation M and accompanied by *n* corresponding references in R.
+* A value corresponding to a future type is called a *future value*. It is represented by two LEB128-encoded counts, *m* and *n*, followed by a *m* bytes in the memory representation M and accompanied by *n* corresponding references in R.
 
 These measures allow the serialisation format to be extended with new types in the future, as long as their representation and the representation of the corresponding values include a length prefix matching the above scheme, and thereby allowing an older deserialiser not understanding them to skip over them. The subtyping rules ensure that upgradability is maintained in this situation, i.e., an old deserialiser has no need to understand the encoded data.
 


### PR DESCRIPTION
Include a serialisation of the data's type itself and thereby decouple serialisation from subtyping. Also, add extension hooks for "future types".