### PR TITLE
Nix: Inject the Git Revision in the finall all-systems-go derivation

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,16 +1,19 @@
+{ src ? { rev = null; } }:
 let
   nixpkgs = (import ./nix/nixpkgs.nix).nixpkgs { };
   nixpkgs-linux = (import ./nix/nixpkgs.nix).nixpkgs { system = "x86_64-linux"; };
   nixpkgs-darwin = (import ./nix/nixpkgs.nix).nixpkgs { system = "x86_64-darwin"; };
+
+  inject-rev = drv: drv.overrideAttrs (attrs: { rev = src.rev; });
 in
 rec {
   linux = import ./default.nix { nixpkgs = nixpkgs-linux; };
   darwin = import ./default.nix { nixpkgs = nixpkgs-darwin; };
-  all-systems-go = nixpkgs.releaseTools.aggregate {
+  all-systems-go = inject-rev (nixpkgs.releaseTools.aggregate {
     name = "all-systems-go";
     constituents = [
       linux.all-systems-go
       darwin.all-systems-go
     ];
-  };
+  });
 }


### PR DESCRIPTION
This way even rebases or pushes that don’t affect CI will get built and
reported by hydra.