### PR TITLE
AST-87 Prepare for BigNum implementation

### DIFF
--- a/src/compile.ml
+++ b/src/compile.ml
@@ -1774,7 +1774,7 @@ sig
    *)
   val compile_lit_pat : E.t -> G.t -> G.t
 
-  (* aritmetics *)
+  (* arithmetics *)
   val compile_abs : E.t -> G.t
   val compile_add : E.t -> G.t
   val compile_signed_sub : E.t -> G.t


### PR DESCRIPTION
https://dfinity.atlassian.net/browse/AST-87

See #359.

This PR establishes a signature `BigNumType` that bignum implementations must adhere to.

It implements `BigNumType` for the lossy 64-bit word implementation.

~Some of the utility methods necessary for efficient `Array` bounds checking are still missing from the `sig`, since it is not clear yet how to declare them. Does `libtommath` provide something like `test_unsigned_lt : BigInt -> Unsigned32 -> Bool`?~

- [x] ~Tests fail, also for me locally, investigating.~
- [x] Implement the bounds checking code that doesn't cons
- [x] Remove `bignum.ml`