### PR TITLE
Nix CI tweaks

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -3,12 +3,13 @@ let
   nixpkgs = (import ./nix/nixpkgs.nix).nixpkgs { };
   nixpkgs-linux = (import ./nix/nixpkgs.nix).nixpkgs { system = "x86_64-linux"; };
   nixpkgs-darwin = (import ./nix/nixpkgs.nix).nixpkgs { system = "x86_64-darwin"; };
-
   inject-rev = drv: drv.overrideAttrs (attrs: { rev = src.rev; });
-in
-rec {
+
   linux = import ./default.nix { nixpkgs = nixpkgs-linux; };
   darwin = import ./default.nix { nixpkgs = nixpkgs-darwin; };
+in
+linux // {
+  darwin = darwin.all-systems-go;
   all-systems-go = inject-rev (nixpkgs.releaseTools.aggregate {
     name = "all-systems-go";
     constituents = [


### PR DESCRIPTION
this recovers the old job names without the linux prefix (relevant for the stable links to users
guide on hydra), and reports only one job for the darwin check.