### PR TITLE
Various clean-ups in frontend

### DIFF
--- a/src/arrange.ml
+++ b/src/arrange.ml
@@ -50,7 +50,7 @@ let rec exp e = match e.it with
   | AssertE e           -> "AssertE" $$ [exp e]
   | AnnotE (e, t)       -> "AnnotE"  $$ [exp e; typ t]
   | OptE e              -> "OptE"    $$ [exp e]
-  | VariantE (i, e)     -> "VariantE" $$ [id i; exp e]
+  | TagE (i, e)         -> "TagE"    $$ [id i; exp e]
   | PrimE p             -> "PrimE"   $$ [Atom p]
   | ImportE (f, fp)     -> "ImportE" $$ [Atom (if !fp = "" then f else !fp)]
 
@@ -63,7 +63,7 @@ and pat p = match p.it with
   | LitP l          -> "LitP"       $$ [lit !l]
   | SignP (uo, l)   -> "SignP"      $$ [unop uo ; lit !l]
   | OptP p          -> "OptP"       $$ [pat p]
-  | VariantP (i, p) -> "VariantP"   $$ [tag i; pat p]
+  | TagP (i, p)     -> "TagP"       $$ [tag i; pat p]
   | AltP (p1,p2)    -> "AltP"       $$ [pat p1; pat p2]
   | ParP p          -> "ParP"       $$ [pat p]
 
@@ -143,8 +143,8 @@ and vis v = match v.it with
 and typ_field (tf : typ_field)
   = tf.it.id.it $$ [typ tf.it.typ; mut tf.it.mut]
 
-and typ_tag (c, t)
-  = c.it $$ [typ t]
+and typ_tag (tt : typ_tag)
+  = tt.it.tag.it $$ [typ tt.it.typ]
 
 and typ_bind (tb : typ_bind)
   = tb.it.var.it $$ [typ tb.it.bound]

--- a/src/arrange_ir.ml
+++ b/src/arrange_ir.ml
@@ -34,7 +34,7 @@ let rec exp e = match e.it with
   | AwaitE e            -> "AwaitE"  $$ [exp e]
   | AssertE e           -> "AssertE" $$ [exp e]
   | OptE e              -> "OptE"    $$ [exp e]
-  | VariantE (i, e)     -> "VariantE" $$ [id i; exp e]
+  | TagE (i, e)         -> "TagE" $$ [id i; exp e]
   | PrimE p             -> "PrimE"   $$ [Atom p]
   | DeclareE (i, t, e1) -> "DeclareE" $$ [id i; exp e1]
   | DefineE (i, m, e1)  -> "DefineE" $$ [id i; Arrange.mut m; exp e1]
@@ -58,7 +58,7 @@ and pat p = match p.it with
   | ObjP pfs        -> "ObjP"       $$ List.map pat_field pfs
   | LitP l          -> "LitP"       $$ [ Arrange.lit l ]
   | OptP p          -> "OptP"       $$ [ pat p ]
-  | VariantP (i, p) -> "VariantP"   $$ [ id i; pat p ]
+  | TagP (i, p)     -> "TagP"       $$ [ id i; pat p ]
   | AltP (p1,p2)    -> "AltP"       $$ [ pat p1; pat p2 ]
 
 and pat_field pf = name pf.it.name $$ [pat pf.it.pat]

--- a/src/arrange_type.ml
+++ b/src/arrange_type.ml
@@ -36,12 +36,12 @@ let con c = Atom (Con.to_string c)
 
 let rec typ (t:Type.typ) = match t with
   | Var (s, i)             -> "Var" $$ [Atom s; Atom (string_of_int i)]
-  | Con (c,ts)             -> "Con" $$ (con c::List.map typ ts)
+  | Con (c, ts)            -> "Con" $$ (con c::List.map typ ts)
   | Prim p                 -> "Prim" $$ [prim p]
-  | Obj (s, ts)            -> "Obj" $$ [obj_sort s] @ List.map typ_field ts
+  | Obj (s, tfs)           -> "Obj" $$ [obj_sort s] @ List.map typ_field tfs
   | Array t                -> "Array" $$ [typ t]
   | Opt t                  -> "Opt" $$ [typ t]
-  | Variant cts            -> "Variant" $$ List.map typ_summand cts
+  | Variant tfs            -> "Variant" $$ List.map typ_field tfs
   | Tup ts                 -> "Tup" $$ List.map typ ts
   | Func (s, c, tbs, at, rt) -> "Func" $$ [Atom (sharing s); Atom (control c)] @ List.map typ_bind tbs @ [ "" $$ (List.map typ at); "" $$ (List.map typ rt)]
   | Async t               -> "Async" $$ [typ t]
@@ -58,6 +58,3 @@ and typ_bind (tb : Type.bind) =
 
 and typ_field (tf : Type.field) =
   tf.lab $$ [typ tf.typ]
-
-and typ_summand (c, t) =
-  c $$ [typ t]

--- a/src/async.ml
+++ b/src/async.ml
@@ -158,7 +158,7 @@ module Transform() = struct
           Func (s, c, List.map t_bind tbs, List.map t_typ t1, List.map t_typ t2)
       end
     | Opt t -> Opt (t_typ t)
-    | Variant cts -> Variant (map_constr_typ t_typ cts)
+    | Variant fs -> Variant (List.map t_field fs)
     | Async t -> t_async nary (t_typ t)
     | Obj (s, fs) -> Obj (s, List.map t_field fs)
     | Mut t -> Mut (t_typ t)
@@ -224,8 +224,8 @@ module Transform() = struct
       TupE (List.map t_exp exps)
     | OptE exp1 ->
       OptE (t_exp exp1)
-    | VariantE (i, exp1) ->
-      VariantE (i, t_exp exp1)
+    | TagE (i, exp1) ->
+      TagE (i, t_exp exp1)
     | ProjE (exp1, n) ->
       ProjE (t_exp exp1, n)
     | DotE (exp1, id) ->
@@ -387,8 +387,8 @@ module Transform() = struct
       ObjP (map_obj_pat t_pat pfs)
     | OptP pat1 ->
       OptP (t_pat pat1)
-    | VariantP (i, pat1) ->
-      VariantP (i, t_pat pat1)
+    | TagP (i, pat1) ->
+      TagP (i, t_pat pat1)
     | AltP (pat1, pat2) ->
       AltP (t_pat pat1, t_pat pat2)
 

--- a/src/await.ml
+++ b/src/await.ml
@@ -73,8 +73,8 @@ and t_exp' context exp' =
     TupE (List.map (t_exp context) exps)
   | OptE exp1 ->
     OptE (t_exp context exp1)
-  | VariantE (id, exp1) ->
-    VariantE (id, t_exp context exp1)
+  | TagE (id, exp1) ->
+    TagE (id, t_exp context exp1)
   | ProjE (exp1, n) ->
     ProjE (t_exp context exp1, n)
   | DotE (exp1, id) ->
@@ -249,8 +249,8 @@ and c_exp' context exp k =
     nary context k (fun vs -> e (TupE vs)) exps
   | OptE exp1 ->
     unary context k (fun v1 -> e (OptE v1)) exp1
-  | VariantE (i, exp1) ->
-    unary context k (fun v1 -> e (VariantE (i, v1))) exp1
+  | TagE (i, exp1) ->
+    unary context k (fun v1 -> e (TagE (i, v1))) exp1
   | ProjE (exp1, n) ->
     unary context k (fun v1 -> e (ProjE (v1, n))) exp1
   | ActorE _ ->
@@ -411,7 +411,7 @@ and declare_pat pat exp : exp =
   | TupP pats -> declare_pats pats exp
   | ObjP pfs -> declare_pats (pats_of_obj_pat pfs) exp
   | OptP pat1
-  | VariantP (_, pat1) -> declare_pat pat1 exp
+  | TagP (_, pat1) -> declare_pat pat1 exp
   | AltP (pat1, pat2) -> declare_pat pat1 exp
 
 and declare_pats pats exp : exp =
@@ -442,9 +442,9 @@ and rename_pat' pat =
   | OptP pat1 ->
     let (patenv,pat1) = rename_pat pat1 in
     (patenv, OptP pat1)
-  | VariantP (i, pat1) ->
+  | TagP (i, pat1) ->
     let (patenv,pat1) = rename_pat pat1 in
-    (patenv, VariantP (i, pat1))
+    (patenv, TagP (i, pat1))
   | AltP (pat1,pat2) ->
     assert(Freevars.S.is_empty (snd (Freevars.pat pat1)));
     assert(Freevars.S.is_empty (snd (Freevars.pat pat2)));
@@ -468,7 +468,7 @@ and define_pat patenv pat : dec list =
   | TupP pats -> define_pats patenv pats
   | ObjP pfs -> define_pats patenv (pats_of_obj_pat pfs)
   | OptP pat1
-  | VariantP (_, pat1) -> define_pat patenv pat1
+  | TagP (_, pat1) -> define_pat patenv pat1
   | AltP (pat1, pat2) ->
     assert(Freevars.S.is_empty (snd (Freevars.pat pat1)));
     assert(Freevars.S.is_empty (snd (Freevars.pat pat2)));

--- a/src/check_ir.ml
+++ b/src/check_ir.ml
@@ -103,14 +103,6 @@ let disjoint_union env at fmt env1 env2 =
 
 (* Types *)
 
-let check_ids env ids = ignore (
-    List.fold_left (fun dom id ->
-      check env no_region (not (List.mem id dom))
-        "duplicate field name %s in object type" id;
-      id::dom
-    ) [] ids
-  )
-
 let check_sub env at t1 t2 =
   check env at (T.sub t1 t2) "subtype violation:\n  %s\n  %s\n"
     (T.string_of_typ_expand t1) (T.string_of_typ_expand t2)
@@ -177,26 +169,14 @@ let rec check_typ env typ : unit =
     let t' = T.promote typ in
     check_shared env no_region t'
   | T.Obj (sort, fields) ->
-    let rec strictly_sorted fields =
-      match fields with
-      | []
-      | [_] -> true
-      | f1::((f2::_) as fields') ->
-        T.compare_field f1 f2  < 0 && strictly_sorted fields'
-    in
-    List.iter (check_typ_field env sort) fields;
+    List.iter (check_typ_field env (Some sort)) fields;
     (* fields strictly sorted (and) distinct *)
-    if (not (strictly_sorted fields)) then
+    if not (Lib.List.is_strictly_ordered T.compare_field fields) then
       error env no_region "object type's fields are not distinct and sorted %s" (T.string_of_typ typ)
-  | T.Variant cts ->
-    let rec sorted = function
-      | [] | [_] -> true
-      | (c1, _)::(((c2, _)::_) as summands') ->
-        compare c1 c2  < 0 && sorted summands'
-    in
-    check_ids env (List.map fst cts);
-    List.iter (check_typ_summand env) cts;
-    check env no_region (sorted cts) "variant type's constructors are not sorted"
+  | T.Variant fields ->
+    List.iter (check_typ_field env None) fields;
+    if not (Lib.List.is_strictly_ordered T.compare_field fields) then
+      error env no_region "variant type's fields are not distinct and sorted %s" (T.string_of_typ typ)
   | T.Mut typ ->
     check_typ env typ
   | T.Serialized typ ->
@@ -224,14 +204,11 @@ and check_typ_field env s typ_field : unit =
   let T.{lab; typ} = typ_field in
   check_typ env typ;
   check env no_region
-     (s <> T.Actor || T.is_func (T.promote typ))
+     (s <> Some T.Actor || T.is_func (T.promote typ))
     "actor field has non-function type";
   check env no_region
-     (s = T.Object T.Local || s = T.Module || T.sub typ T.Shared)
+     ((s <> Some T.Actor && s <> Some (T.Object T.Sharable)) || T.sub typ T.Shared)
     "shared object or actor field has non-shared type"
-
-and check_typ_summand env (c, typ) : unit =
-  check_typ env typ
 
 and check_typ_binds env typ_binds : T.con list * con_env =
   let ts = Type.open_binds typ_binds in
@@ -323,7 +300,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
     check_exp env exp2;
     typ exp1 <: ot;
     typ exp2 <: ot;
-    ot <: t;
+    ot <: t
   | ShowE (ot, exp1) ->
     check env.flavor.has_show "show expression in non-show flavor";
     check (Show.can_show ot) "show is not defined for operand type";
@@ -336,18 +313,17 @@ let rec check_exp env (exp:Ir.exp) : unit =
     check_exp env exp2;
     typ exp1 <: ot;
     typ exp2 <: ot;
-    T.bool <: t;
+    T.bool <: t
   | TupE exps ->
     List.iter (check_exp env) exps;
-    T.Tup (List.map typ exps) <: t;
+    T.Tup (List.map typ exps) <: t
   | OptE exp1 ->
     check_exp env exp1;
-    T.Opt (typ exp1) <: t;
-  | VariantE (i, exp1) ->
+    T.Opt (typ exp1) <: t
+  | TagE (i, exp1) ->
     check_exp env exp1;
-    T.Variant [(i.it, typ exp1)] <: t;
+    T.Variant [{T.lab = i.it; typ = typ exp1}] <: t
   | ProjE (exp1, n) ->
-    begin
     check_exp env exp1;
     let t1 = T.promote (immute_typ exp1) in
     let ts = try T.as_tup_sub n t1
@@ -359,7 +335,6 @@ let rec check_exp env (exp:Ir.exp) : unit =
                error env exp.at "tuple projection %n is out of bounds for type\n  %s"
                  n (T.string_of_typ_expand t1) in
     tn <: t
-    end
   | ActorDotE(exp1,{it = Name n;_})
   | DotE (exp1, {it = Name n;_}) ->
     begin
@@ -375,7 +350,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
              | ActorDotE _ -> sort = T.Actor
              | DotE _ -> sort <> T.Actor
              | _ -> false) "sort mismatch";
-      match T.lookup_field n tfs with
+      match T.lookup_val_field n tfs with
       | Some tn ->
         tn <~ t
       | None ->
@@ -389,12 +364,12 @@ let rec check_exp env (exp:Ir.exp) : unit =
                Invalid_argument _ -> error env exp.at "expected mutable assignment target"
     in
     typ exp2 <: t2;
-    T.unit <: t;
+    T.unit <: t
   | ArrayE (mut, t0, exps) ->
     List.iter (check_exp env) exps;
     List.iter (fun e -> typ e <: t0) exps;
     let t1 = T.Array (match mut.it with Syntax.Const -> t0 | Syntax.Var -> T.Mut t0) in
-    t1 <: t;
+    t1 <: t
   | IdxE (exp1, exp2) ->
     check_exp env exp1;
     check_exp env exp2;
@@ -426,7 +401,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
       check_concrete env exp.at t_ret;
     end;
     typ exp2 <: t_arg;
-    t_ret <: t;
+    t_ret <: t
   | BlockE (ds, exp1) ->
     let scope = gather_block_decs env ds in
     let env' = adjoin env scope in
@@ -439,7 +414,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
     check_exp env exp2;
     typ exp2 <: t;
     check_exp env exp3;
-    typ exp3 <: t;
+    typ exp3 <: t
   | SwitchE (exp1, cases) ->
     check_exp env exp1;
     let t1 = T.promote (typ exp1) in
@@ -447,7 +422,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
       if not (Coverage.check_cases env.cons cases t1) then
         warn env exp.at "the cases in this switch do not cover all possible values";
  *)
-    check_cases env t1 t cases;
+    check_cases env t1 t cases
   | LoopE exp1 ->
     check_exp env exp1;
     typ exp1 <: T.unit;
@@ -457,7 +432,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
     check_typ env t0;
     check_exp (add_lab env id.it t0) exp1;
     typ exp1 <: t0;
-    t0 <: t;
+    t0 <: t
   | BreakE (id, exp1) ->
     begin
       match T.Env.find_opt id.it env.labs with
@@ -467,7 +442,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
         check_exp env exp1;
         typ exp1 <: t1;
     end;
-    T.Non <: t; (* vacuously true *)
+    T.Non <: t (* vacuously true *)
   | RetE exp1 ->
     begin
       match env.rets with
@@ -478,7 +453,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
         check_exp env exp1;
         typ exp1 <: t0;
     end;
-    T.Non <: t; (* vacuously true *)
+    T.Non <: t (* vacuously true *)
   | AsyncE exp1 ->
     check env.flavor.has_await "async expression in non-await flavor";
     let t1 = typ exp1 in
@@ -497,16 +472,16 @@ let rec check_exp env (exp:Ir.exp) : unit =
                error env exp1.at "expected async type, but expression has type\n  %s"
                  (T.string_of_typ_expand t1)
     in
-    t2 <: t;
+    t2 <: t
   | AssertE exp1 ->
     check_exp env exp1;
     typ exp1 <: T.bool;
-    T.unit <: t;
+    T.unit <: t
   | DeclareE (id, t0, exp1) ->
     check_typ env t0;
     let env' = adjoin_vals env (T.Env.singleton id.it t0) in
     check_exp env' exp1;
-    (typ exp1) <: t;
+    (typ exp1) <: t
   | DefineE (id, mut, exp1) ->
     check_exp env exp1;
     begin
@@ -554,7 +529,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
     let t1 = type_obj env'' T.Actor fs in
     check (T.is_obj t0) "bad annotation (object type expected)";
     t1 <: t0;
-    t0 <: t;
+    t0 <: t
   | NewObjE (s, fs, t0) ->
     check (T.is_obj t0) "bad annotation (object type expected)";
     let is_typ_field {T.lab;T.typ} =
@@ -568,6 +543,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
     let t1 = T.Obj(s, List.sort T.compare_field (typ_tfs0 @ tfs1)) in
     t1 <: t0;
     t0 <: t
+
 (* Cases *)
 
 and check_cases env t_pat t cases =
@@ -610,7 +586,7 @@ and gather_pat env ve0 pat : val_env =
     | AltP (pat1, pat2) ->
       ve
     | OptP pat1
-    | VariantP (_, pat1) ->
+    | TagP (_, pat1) ->
       go ve pat1
   in T.Env.adjoin ve0 (go T.Env.empty pat)
 
@@ -643,9 +619,9 @@ and check_pat env pat : val_env =
     let ve = check_pat env pat1 in
     T.Opt pat1.note <: t;
     ve
-  | VariantP (i, pat1) ->
+  | TagP (i, pat1) ->
     let ve = check_pat env pat1 in
-    T.Variant [(i.it, pat1.note)] <: t;
+    T.Variant [{T.lab = i.it; typ = pat1.note}] <: t;
     ve
   | AltP (pat1, pat2) ->
     let ve1 = check_pat env pat1 in
@@ -672,8 +648,8 @@ and check_pat_field env t (pf : pat_field) =
   let s, tfs = T.as_obj_sub lab t in
   let (<:) = check_sub env pf.it.pat.at in
   t <: T.Obj (s, [tf]);
-  if T.is_mut (match T.lookup_field lab tfs with Some t -> t | None -> assert false)
-  then error env pf.it.pat.at "cannot match mutable field %s" lab
+  if T.is_mut (Lib.Option.value (T.lookup_val_field lab tfs)) then
+    error env pf.it.pat.at "cannot match mutable field %s" lab
 
 (* Objects *)
 

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -1874,12 +1874,7 @@ module Object = struct
   (* Determines whether the field is mutable (and thus needs an indirection) *)
   let is_mut_field env obj_type ({it = Name s; _}) =
     let _, fields = Type.as_obj_sub "" obj_type in
-    let field_typ =
-      match Type.lookup_field s fields with
-      | Some t -> t
-      | None -> assert false in
-    let mut = Type.is_mut field_typ in
-    mut
+    Type.is_mut (Lib.Option.value (Type.lookup_val_field s fields))
 
   let idx env obj_type name =
     compile_unboxed_const (hash_field_name name) ^^
@@ -2803,7 +2798,7 @@ module Serialization = struct
           List.for_all go (List.map (open_ ts) ts1) &&
           List.for_all go (List.map (open_ ts) ts2)
         | Opt t -> go t
-        | Variant cts -> List.for_all (fun (_, t) -> go t) cts
+        | Variant fs -> List.for_all (fun f -> go f.typ) fs
         | Async t -> go t
         | Obj (Actor, fs) -> false
         | Obj (_, fs) -> List.for_all (fun f -> go f.typ) fs
@@ -2884,7 +2879,7 @@ module Serialization = struct
         G.if_ (ValBlockType None) (get_x ^^ Opt.project ^^ size env t) G.nop
       | Variant vs ->
         inc_data_size (compile_unboxed_const 4l) ^^ (* one word tag *)
-        List.fold_right (fun (l,t) continue ->
+        List.fold_right (fun {lab = l; typ = t} continue ->
             get_x ^^
             Variant.test_is env l ^^
             G.if_ (ValBlockType None)
@@ -2998,7 +2993,7 @@ module Serialization = struct
           ( write_byte (compile_unboxed_const 1l) ^^ get_x ^^ Opt.project ^^ write env t )
           ( write_byte (compile_unboxed_const 0l) )
       | Variant vs ->
-        List.fold_right (fun (i, (l,t)) continue ->
+        List.fold_right (fun (i, {lab = l; typ = t}) continue ->
             get_x ^^
             Variant.test_is env l ^^
             G.if_ (ValBlockType None)
@@ -3006,7 +3001,7 @@ module Serialization = struct
                 get_x ^^ Variant.project ^^ write env t)
               continue
           )
-          ( List.mapi (fun i x -> (i,x)) vs )
+          ( List.mapi (fun i f -> (i,f)) vs )
           ( E.trap_with env "serialize_go: unexpected variant" )
       | Prim Text ->
         let (set_len, get_len) = new_local env "len" in
@@ -3124,14 +3119,14 @@ module Serialization = struct
       | Variant vs ->
         let (set_tag, get_tag) = new_local env "tag" in
         read_word ^^ set_tag ^^
-        List.fold_right (fun (i, (l,t)) continue ->
+        List.fold_right (fun (i, {lab = l; typ = t}) continue ->
             get_tag ^^
             compile_eq_const (Int32.of_int i) ^^
             G.if_ (ValBlockType (Some I32Type))
               ( Variant.inject env l (read env t) )
               continue
           )
-          ( List.mapi (fun i x -> (i,x)) vs )
+          ( List.mapi (fun i f -> (i,f)) vs )
           ( E.trap_with env "deserialize_go: unexpected variant tag" )
       | Prim Text ->
         let (set_len, get_len) = new_local env "len" in
@@ -4507,7 +4502,7 @@ and compile_exp (env : E.t) exp =
   | OptE e ->
     SR.Vanilla,
     Opt.inject env (compile_exp_vanilla env e)
-  | VariantE (l, e) ->
+  | TagE (l, e) ->
     SR.Vanilla,
     Variant.inject env l.it (compile_exp_vanilla env e)
   | TupE es ->
@@ -4690,8 +4685,8 @@ and fill_pat env pat : patternCode =
           )
           fail_code
       )
-  | VariantP (l, p) ->
-      let (set_x, get_x) = new_local env "variant_scrut" in
+  | TagP (l, p) ->
+      let (set_x, get_x) = new_local env "tag_scrut" in
       CanFail (fun fail_code ->
         set_x ^^
         get_x ^^

--- a/src/definedness.ml
+++ b/src/definedness.ml
@@ -120,7 +120,7 @@ let rec exp msgs e : f = match e.it with
   | AssertE e           -> exp msgs e
   | AnnotE (e, t)       -> exp msgs e
   | OptE e              -> exp msgs e
-  | VariantE (_, e)     -> exp msgs e
+  | TagE (_, e)         -> exp msgs e
 
 and exps msgs es : f = unions (exp msgs) es
 
@@ -134,7 +134,7 @@ and pat msgs p : fd = match p.it with
   | LitP l        -> (M.empty, S.empty)
   | SignP (uo, l) -> (M.empty, S.empty)
   | OptP p
-  | VariantP (_, p) -> pat msgs p
+  | TagP (_, p)   -> pat msgs p
   | AltP (p1, p2) -> pat msgs p1 ++++ pat msgs p2
 
 and pats msgs ps : fd = union_binders (pat msgs) ps

--- a/src/desugar.ml
+++ b/src/desugar.ml
@@ -55,7 +55,7 @@ and exp' at note = function
   | S.OptE e -> I.OptE (exp e)
   | S.ObjE (s, es) ->
     obj at s None es note.S.note_typ
-  | S.VariantE (c, e) -> I.VariantE (c, exp e)
+  | S.TagE (c, e) -> I.TagE (c, exp e)
   | S.DotE (e, x) ->
     let n = {x with it = I.Name x.it} in
     begin match T.as_obj_sub x.it e.note.S.note_typ with
@@ -262,7 +262,7 @@ and pat' = function
   | S.ObjP pfs ->
     I.ObjP (pat_fields pfs)
   | S.OptP p -> I.OptP (pat p)
-  | S.VariantP (i, p) -> I.VariantP (i, pat p)
+  | S.TagP (i, p) -> I.TagP (i, pat p)
   | S.AltP (p1, p2) -> I.AltP (pat p1, pat p2)
   | S.AnnotP (p, _)
   | S.ParP p -> pat' p.it

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -35,7 +35,7 @@ let rec infer_effect_exp (exp:Syntax.exp) : T.eff =
   | ShowE (_, exp1)
   | ProjE (exp1, _)
   | OptE exp1
-  | VariantE (_, exp1)
+  | TagE (_, exp1)
   | DotE (exp1, _)
   | NotE exp1
   | AssertE exp1
@@ -132,7 +132,7 @@ module Ir =
       | ShowE (_, exp1)
       | ProjE (exp1, _)
       | OptE exp1
-      | VariantE (_, exp1)
+      | TagE (_, exp1)
       | DotE (exp1, _)
       | ActorDotE (exp1, _)
       | AssertE exp1

--- a/src/freevars.ml
+++ b/src/freevars.ml
@@ -85,7 +85,7 @@ let rec exp e : f = match e.it with
   | AwaitE e            -> exp e
   | AssertE e           -> exp e
   | OptE e              -> exp e
-  | VariantE (_, e)     -> exp e
+  | TagE (_, e)         -> exp e
   | DeclareE (i, t, e)  -> exp e  // i.it
   | DefineE (i, m, e)   -> id i ++ exp e
   | FuncE (x, cc, tp, as_, t, e) -> under_lambda (exp e /// args as_)
@@ -107,7 +107,7 @@ and pat p : fd = match p.it with
   | ObjP pfs        -> pats (pats_of_obj_pat pfs)
   | LitP l          -> (M.empty, S.empty)
   | OptP p          -> pat p
-  | VariantP (i, p) -> pat p
+  | TagP (i, p)     -> pat p
   | AltP (p1, p2)   -> pat p1 ++++ pat p2
 
 and pats ps : fd = union_binders pat ps

--- a/src/interpret.ml
+++ b/src/interpret.ml
@@ -142,14 +142,13 @@ let await at async k =
   if !Flags.trace then trace "=> await %s" (string_of_region at);
   decr trace_depth;
   get_async async (fun v ->
-      Scheduler.queue (fun () ->
-          if !Flags.trace then
-            trace "<- await %s%s" (string_of_region at) (string_of_arg v);
-          incr trace_depth;
-          k v
-        )
+    Scheduler.queue (fun () ->
+      if !Flags.trace then
+        trace "<- await %s%s" (string_of_region at) (string_of_arg v);
+      incr trace_depth;
+      k v
     )
-(*;  Scheduler.yield () *)
+  )
 
 let actor_msg id f v (k : V.value V.cont) =
   if !Flags.trace then trace "-> message %s%s" id (string_of_arg v);
@@ -167,9 +166,8 @@ let make_unit_message id v =
       actor_msg id f v (fun _ -> ());
       k V.unit
     )
-  | _ ->
+  | _ -> (* assert false *)
     failwith ("unexpected call_conv " ^ (V.string_of_call_conv call_conv))
-    (* assert (false) *)
 
 let make_async_message id v =
   let call_conv, f = V.as_func v in
@@ -182,18 +180,16 @@ let make_async_message id v =
       );
       k (V.Async async)
     )
-  | _ ->
+  | _ -> (* assert false *)
     failwith ("unexpected call_conv " ^ (V.string_of_call_conv call_conv))
-    (* assert (false) *)
 
 
 let make_message name t v : V.value =
   match t with
   | T.Func (_, _, _, _, []) -> make_unit_message name v
   | T.Func (_, _, _, _, [T.Async _]) -> make_async_message name v
-  | _ ->
+  | _ -> (* assert false *)
     failwith (Printf.sprintf "actorfield: %s %s" name (T.string_of_typ t))
-    (* assert false *)
 
 
 (* Literals *)
@@ -219,25 +215,31 @@ let interpret_lit env lit : V.value =
 let check_call_conv exp call_conv =
   let exp_call_conv = V.call_conv_of_typ exp.note.note_typ in
   if not (exp_call_conv = call_conv) then
-    failwith (Printf.sprintf "call_conv mismatch: function %s of type %s expecting %s, found %s"
+    failwith (Printf.sprintf
+      "call_conv mismatch: function %s of type %s expecting %s, found %s"
       (Wasm.Sexpr.to_string 80 (Arrange.exp exp))
       (T.string_of_typ exp.note.note_typ)
       (V.string_of_call_conv exp_call_conv)
-      (V.string_of_call_conv call_conv))
+      (V.string_of_call_conv call_conv)
+    )
 
 let check_call_conv_arg exp v call_conv =
   if call_conv.V.n_args <> 1 then
-  let es = try V.as_tup v
-    with Invalid_argument _ ->
-      failwith (Printf.sprintf "call %s: calling convention %s cannot handle non-tuple value %s"
-        (Wasm.Sexpr.to_string 80 (Arrange.exp exp))
-        (V.string_of_call_conv call_conv)
-        (V.string_of_val v)) in
+  let es = try V.as_tup v with Invalid_argument _ ->
+    failwith (Printf.sprintf
+      "call %s: calling convention %s cannot handle non-tuple value %s"
+      (Wasm.Sexpr.to_string 80 (Arrange.exp exp))
+      (V.string_of_call_conv call_conv)
+      (V.string_of_val v)
+    )
+  in
   if List.length es <> call_conv.V.n_args then
-    failwith (Printf.sprintf "call %s: calling convention %s got tuple of wrong length %s"
-        (Wasm.Sexpr.to_string 80 (Arrange.exp exp))
-        (V.string_of_call_conv call_conv)
-        (V.string_of_val v))
+    failwith (Printf.sprintf
+      "call %s: calling convention %s got tuple of wrong length %s"
+      (Wasm.Sexpr.to_string 80 (Arrange.exp exp))
+      (V.string_of_call_conv call_conv)
+      (V.string_of_val v)
+    )
 
 
 let rec interpret_exp env exp (k : V.value V.cont) =
@@ -286,7 +288,7 @@ and interpret_exp_mut env exp (k : V.value V.cont) =
     interpret_exp env exp1 (fun v1 -> k (List.nth (V.as_tup v1) n))
   | ObjE (sort, fields) ->
     interpret_obj env sort fields k
-  | VariantE (i, exp1) ->
+  | TagE (i, exp1) ->
     interpret_exp env exp1 (fun v1 -> k (V.Variant (i.it, v1)))
   | DotE (exp1, id) ->
     interpret_exp env exp1 (fun v1 ->
@@ -324,12 +326,11 @@ and interpret_exp_mut env exp (k : V.value V.cont) =
     in k v'
   | CallE (exp1, typs, exp2) ->
     interpret_exp env exp1 (fun v1 ->
-        interpret_exp env exp2 (fun v2 ->
-            let call_conv, f = V.as_func v1 in
-            check_call_conv exp1 call_conv;
-            check_call_conv_arg exp v2 call_conv;
-            f v2 k
-
+      interpret_exp env exp2 (fun v2 ->
+        let call_conv, f = V.as_func v1 in
+        check_call_conv exp1 call_conv;
+        check_call_conv_arg exp v2 call_conv;
+        f v2 k
 (*
         try
           let _, f = V.as_func v1 in f v2 k
@@ -460,7 +461,7 @@ and declare_pat pat : val_env =
   | TupP pats -> declare_pats pats V.Env.empty
   | ObjP pfs -> declare_pat_fields pfs V.Env.empty
   | OptP pat1
-  | VariantP (_, pat1)
+  | TagP (_, pat1)
   | AltP (pat1, _)    (* both have empty binders *)
   | AnnotP (pat1, _)
   | ParP pat1 -> declare_pat pat1
@@ -499,7 +500,7 @@ and define_pat env pat v =
       trap pat.at "value %s does not match pattern" (V.string_of_val v)
     | _ -> assert false
     )
-  | VariantP (_, pat1)
+  | TagP (_, pat1)
   | AnnotP (pat1, _)
   | ParP pat1 -> define_pat env pat1 v
 
@@ -550,7 +551,7 @@ and match_pat pat v : val_env option =
     | V.Null -> None
     | _ -> assert false
     )
-  | VariantP (i, pat1) ->
+  | TagP (i, pat1) ->
     let k, v1 = V.as_variant v in
     if i.it = k
     then match_pat pat1 v1
@@ -562,7 +563,7 @@ and match_pat pat v : val_env option =
     )
   | AnnotP (pat1, _)
   | ParP pat1 ->
-     match_pat pat1 v
+    match_pat pat1 v
 
 and match_pats pats vs ve : val_env option =
   match pats, vs with

--- a/src/interpret_ir.ml
+++ b/src/interpret_ir.ml
@@ -300,7 +300,7 @@ and interpret_exp_mut env exp (k : V.value V.cont) =
     interpret_exps env exps [] (fun vs -> k (V.Tup vs))
   | OptE exp1 ->
     interpret_exp env exp1 (fun v1 -> k (V.Opt v1))
-  | VariantE (i, exp1) ->
+  | TagE (i, exp1) ->
     interpret_exp env exp1 (fun v1 -> k (V.Variant (i.it, v1)))
   | ProjE (exp1, n) ->
     interpret_exp env exp1 (fun v1 -> k (List.nth (V.as_tup v1) n))
@@ -471,7 +471,7 @@ and declare_pat pat : val_env =
   | TupP pats -> declare_pats pats V.Env.empty
   | ObjP pfs -> declare_pats (pats_of_obj_pat pfs) V.Env.empty
   | OptP pat1
-  | VariantP (_, pat1) -> declare_pat pat1
+  | TagP (_, pat1) -> declare_pat pat1
   | AltP (pat1, pat2) -> declare_pat pat1
 
 and declare_pats pats ve : val_env =
@@ -502,7 +502,7 @@ and define_pat env pat v =
       trap pat.at "value %s does not match pattern" (V.string_of_val v)
     | _ -> assert false
     )
-  | VariantP (i, pat1) ->
+  | TagP (i, pat1) ->
     let lab, v1 = V.as_variant v in
     if lab = i.it
     then define_pat env pat1 v1
@@ -556,7 +556,7 @@ and match_pat pat v : val_env option =
     | V.Null -> None
     | _ -> assert false
     )
-  | VariantP (i, pat1) ->
+  | TagP (i, pat1) ->
     let tag, v1 = V.as_variant v in
     if i.it = tag
     then match_pat pat1 v1

--- a/src/ir.ml
+++ b/src/ir.ml
@@ -25,7 +25,7 @@ and pat' =
   | TupP of pat list                           (* tuple *)
   | ObjP of pat_field list                     (* object *)
   | OptP of pat                                (* option *)
-  | VariantP of id * pat                       (* variant *)
+  | TagP of id * pat                           (* variant *)
   | AltP of pat * pat                          (* disjunctive *)
 
 and pat_field = pat_field' Source.phrase
@@ -48,7 +48,7 @@ and exp' =
   | TupE of exp list                           (* tuple *)
   | ProjE of exp * int                         (* tuple projection *)
   | OptE of exp                                (* option injection *)
-  | VariantE of id * exp                       (* variant injection *)
+  | TagE of id * exp                           (* variant injection *)
   | DotE of exp * name                         (* object projection *)
   | ActorDotE of exp * name                    (* actor field access *)
   | AssignE of exp * exp                       (* assignment *)

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -219,7 +219,7 @@ rule token mode = parse
 
   | "prim" as s { if mode = Privileged then PRIM else ID s }
   | id as s { ID s }
-  | "#" (id as s) { VARIANT_TAG s }
+  | "#" (id as s) { TAG s }
   | privileged_id as s { if mode = Privileged then ID s else error lexbuf "privileged identifier" }
 
   | "//"utf8_no_nl*eof { EOF }

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -113,6 +113,22 @@ struct
       match f x y with
       | 0 -> compare f xs' ys'
       | n -> n
+
+  let rec is_ordered f xs =
+    match xs with
+    | [] | [_] -> true
+    | x1::x2::xs' ->
+      match f x1 x2 with
+      | -1 | 0 -> is_ordered f (x2::xs')
+      | _ -> false
+
+  let rec is_strictly_ordered f xs =
+    match xs with
+    | [] | [_] -> true
+    | x1::x2::xs' ->
+      match f x1 x2 with
+      | -1 -> is_strictly_ordered f (x2::xs')
+      | _ -> false
 end
 
 module List32 =

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -25,6 +25,8 @@ sig
   val map_filter : ('a -> 'b option) -> 'a list -> 'b list
 
   val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+  val is_ordered : ('a -> 'a -> int) -> 'a list -> bool
+  val is_strictly_ordered : ('a -> 'a -> int) -> 'a list -> bool
 end
 
 module List32 :

--- a/src/rename.ml
+++ b/src/rename.ml
@@ -62,7 +62,7 @@ and exp' rho e  = match e with
   | AwaitE e            -> AwaitE (exp rho e)
   | AssertE e           -> AssertE (exp rho e)
   | OptE e              -> OptE (exp rho e)
-  | VariantE (i, e)     -> VariantE (i, exp rho e)
+  | TagE (i, e)         -> TagE (i, exp rho e)
   | DeclareE (i, t, e)  -> let i',rho' = id_bind rho i in
                            DeclareE (i', t, exp rho' e)
   | DefineE (i, m, e)   -> DefineE (id rho i, m, exp rho e)
@@ -102,8 +102,8 @@ and pat' rho p = match p with
   | LitP l        -> (p, rho)
   | OptP p        -> let (p', rho') = pat rho p in
                      (OptP p', rho')
-  | VariantP (i, p) -> let (p', rho') = pat rho p in
-                       (VariantP (i, p'), rho')
+  | TagP (i, p)   -> let (p', rho') = pat rho p in
+                     (TagP (i, p'), rho')
   | AltP (p1, p2) -> assert(Freevars.S.is_empty (snd (Freevars.pat p1)));
                      assert(Freevars.S.is_empty (snd (Freevars.pat p2)));
                      let (p1', _) = pat rho p1 in

--- a/src/resolve_import.ml
+++ b/src/resolve_import.ml
@@ -55,7 +55,7 @@ let rec
   | ShowE (_, exp1)
   | ProjE (exp1, _)
   | OptE exp1
-  | VariantE (_, exp1)
+  | TagE (_, exp1)
   | DotE (exp1, _)
   | NotE exp1
   | AssertE exp1

--- a/src/serialization.ml
+++ b/src/serialization.ml
@@ -85,7 +85,7 @@ module Transform() = struct
     | T.Func (T.Local, c, tbs, t1, t2) ->
       T.Func (T.Local, c, List.map t_bind tbs, List.map t_typ t1, List.map t_typ t2)
     | T.Opt t -> T.Opt (t_typ t)
-    | T.Variant cts -> T.(Variant (map_constr_typ t_typ cts))
+    | T.Variant fs -> T.(Variant (List.map t_field fs))
     | T.Obj (s, fs) -> T.Obj (s, List.map t_field fs)
     | T.Mut t -> T.Mut (t_typ t)
     | T.Typ c -> T.Typ (t_con c) (* TBR *)
@@ -134,9 +134,9 @@ module Transform() = struct
         (* We should take the type to serialize at from the function, not the
            argument, as the latter could be a subtype *)
         let fun_ty = exp1.note.note_typ in
-        let t_arg, t_ret = T.inst_func_type fun_ty cc.Value.sort typs in
+        let _, _, t_arg, t_ret = T.as_func_sub cc.Value.sort (List.length typs) fun_ty in
         assert (T.is_unit t_ret);
-        let exp2' = map_tuple cc.Value.n_args serialize (t_exp exp2) (t_typ t_arg) in
+        let exp2' = map_tuple cc.Value.n_args serialize (t_exp exp2) (t_typ (T.open_ typs t_arg)) in
         CallE (cc, t_exp exp1, [], exp2')
       end
     | FuncE (x, cc, typbinds, args, ret_tys, exp) ->
@@ -168,8 +168,8 @@ module Transform() = struct
       TupE (List.map t_exp exps)
     | OptE exp1 ->
       OptE (t_exp exp1)
-    | VariantE (i, exp1) ->
-      VariantE (i, t_exp exp1)
+    | TagE (i, exp1) ->
+      TagE (i, t_exp exp1)
     | ProjE (exp1, n) ->
       ProjE (t_exp exp1, n)
     | DotE (exp1, id) ->
@@ -249,8 +249,8 @@ module Transform() = struct
       ObjP (map_obj_pat t_pat pfs)
     | OptP pat1 ->
       OptP (t_pat pat1)
-    | VariantP (id, pat1) ->
-      VariantP (id, t_pat pat1)
+    | TagP (id, pat1) ->
+      TagP (id, t_pat pat1)
     | AltP (pat1, pat2) ->
       AltP (t_pat pat1, t_pat pat2)
 

--- a/src/static.ml
+++ b/src/static.ml
@@ -34,7 +34,7 @@ let pat_err m at =
 let rec exp m e = match e.it with
   (* Plain values *)
   | (PrimE _ | LitE _ | FuncE _) -> ()
-  | (VariantE (_, exp1) | OptE exp1) -> exp m exp1
+  | (TagE (_, exp1) | OptE exp1) -> exp m exp1
   | (TupE es | ArrayE (_, es)) -> List.iter (exp m) es
   | ObjE (_, efs) -> List.iter (fun ef -> dec m ef.it.dec) efs
 

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -31,7 +31,7 @@ and typ' =
   | ObjT of obj_sort * typ_field list              (* object *)
   | ArrayT of mut * typ                            (* array *)
   | OptT of typ                                    (* option *)
-  | VariantT of (id * typ) list                    (* variant *)
+  | VariantT of typ_tag list                       (* variant *)
   | TupT of typ list                               (* tuple *)
   | FuncT of sharing * typ_bind list * typ * typ   (* function *)
   | AsyncT of typ                                  (* future *)
@@ -43,6 +43,9 @@ and typ' =
 
 and typ_field = typ_field' Source.phrase
 and typ_field' = {id : id; typ : typ; mut : mut}
+
+and typ_tag = typ_tag' Source.phrase
+and typ_tag' = {tag : id; typ : typ}
 
 and typ_bind = (typ_bind', Type.con option) Source.annotated_phrase
 and typ_bind' = {var : id; bound : typ}
@@ -108,7 +111,7 @@ and pat' =
   | TupP of pat list                           (* tuple *)
   | ObjP of pat_field list                     (* object *)
   | OptP of pat                                (* option *)
-  | VariantP of id * pat                       (* tagged variant *)
+  | TagP of id * pat                           (* tagged variant *)
   | AltP of pat * pat                          (* disjunctive *)
   | AnnotP of pat * typ                        (* type annotation *)
   | ParP of pat                                (* parenthesis *)
@@ -140,7 +143,7 @@ and exp' =
   | ProjE of exp * int                         (* tuple projection *)
   | OptE of exp                                (* option injection *)
   | ObjE of obj_sort * exp_field list          (* object *)
-  | VariantE of id * exp                       (* variant *)
+  | TagE of id * exp                           (* variant *)
   | DotE of exp * id                           (* object projection *)
   | AssignE of exp * exp                       (* assignment *)
   | ArrayE of mut * exp list                   (* array *)

--- a/src/tailcall.ml
+++ b/src/tailcall.ml
@@ -126,7 +126,7 @@ and exp' env e  : exp' = match e.it with
   | AwaitE e            -> AwaitE (exp env e)
   | AssertE e           -> AssertE (exp env e)
   | OptE e              -> OptE (exp env e)
-  | VariantE (i, e)     -> VariantE (i, exp env e)
+  | TagE (i, e)         -> TagE (i, exp env e)
   | DeclareE (i, t, e)  -> let env1 = bind env i None in
                            DeclareE (i, t, tailexp env1 e)
   | DefineE (i, m, e)   -> DefineE (i, m, exp env e)
@@ -156,7 +156,7 @@ and pat' env p = match p with
   | ObjP pfs      -> pats env (pats_of_obj_pat pfs)
   | LitP l        -> env
   | OptP p
-  | VariantP (_, p) -> pat env p
+  | TagP (_, p)   -> pat env p
   | AltP (p1, p2) -> assert(Freevars.S.is_empty (snd (Freevars.pat p1)));
                      assert(Freevars.S.is_empty (snd (Freevars.pat p2)));
                      env

--- a/src/type.mli
+++ b/src/type.mli
@@ -27,9 +27,9 @@ and typ =
   | Con of con * typ list                     (* constructor *)
   | Prim of prim                              (* primitive *)
   | Obj of obj_sort * field list              (* object *)
+  | Variant of field list                     (* variant *)
   | Array of typ                              (* array *)
   | Opt of typ                                (* option *)
-  | Variant of (lab * typ) list               (* variant *)
   | Tup of typ list                           (* tuple *)
   | Func of sharing * control * bind list * typ list * typ list  (* function *)
   | Async of typ                              (* future *)
@@ -48,7 +48,6 @@ and con = kind Con.t
 and kind =
   | Def of bind list * typ
   | Abs of bind list * typ
-
 
 
 (* Short-hands *)
@@ -79,7 +78,7 @@ val is_serialized : typ -> bool
 
 val as_prim : prim -> typ -> unit
 val as_obj : typ -> obj_sort * field list
-val as_variant : typ -> (lab * typ) list
+val as_variant : typ -> field list
 val as_array : typ -> typ
 val as_opt : typ -> typ
 val as_tup : typ -> typ list
@@ -102,28 +101,19 @@ val as_func_sub : sharing -> int -> typ -> sharing * bind list * typ * typ
 val as_mono_func_sub : typ -> typ * typ
 val as_async_sub : typ -> typ
 
-(* N-ary argument/result sequences *)
+
+(* Argument/result sequences *)
 
 val seq : typ list -> typ
 val as_seq : typ -> typ list
-val inst_func_type : typ -> sharing -> typ list -> (typ * typ)
 
-(* Field lookup, namespace sensitive *)
 
+(* Fields *)
+
+val lookup_val_field : string -> field list -> typ option
 val lookup_typ_field : string -> field list -> con option
 
-val lookup_field : string -> field list -> typ option
-
-(* Field ordering *)
-
 val compare_field : field -> field -> int
-
-val map_constr_typ : (typ -> typ) -> (lab * typ) list -> (lab * typ) list
-val compare_summand : (lab * typ) -> (lab * typ) -> int
-
-val span : typ -> int option
-
-
 
 
 (* Constructors *)
@@ -131,6 +121,7 @@ val span : typ -> int option
 val set_kind : con -> kind -> unit
 
 module ConSet : Dom.S with type elt = con
+
 
 (* Normalization and Classification *)
 
@@ -141,6 +132,9 @@ exception Unavoidable of con
 val avoid : ConSet.t -> typ -> typ (* raise Unavoidable *)
 
 val is_concrete : typ -> bool
+
+val span : typ -> int option
+
 
 (* Equivalence and Subtyping *)
 

--- a/src/value.ml
+++ b/src/value.ml
@@ -257,7 +257,7 @@ let as_char = function Char c -> c | _ -> invalid "as_char"
 let as_text = function Text s -> s | _ -> invalid "as_text"
 let as_array = function Array a -> a | _ -> invalid "as_array"
 let as_opt = function Opt v -> v | _ -> invalid "as_opt"
-let as_variant = function | Variant (i, v) -> i, v | _ -> invalid "as_variant"
+let as_variant = function Variant (i, v) -> i, v | _ -> invalid "as_variant"
 let as_tup = function Tup vs -> vs | _ -> invalid "as_tup"
 let as_unit = function Tup [] -> () | _ -> invalid "as_unit"
 let as_pair = function Tup [v1; v2] -> v1, v2 | _ -> invalid "as_pair"
@@ -337,6 +337,11 @@ let rec compare x1 x2 =
   | Tup vs1, Tup vs2 -> Lib.List.compare compare vs1 vs2
   | Array a1, Array a2 -> Lib.Array.compare compare a1 a2
   | Obj fs1, Obj fs2 -> Env.compare compare fs1 fs2
+  | Variant (l1, v1), Variant (l2, v2) ->
+    (match String.compare l1 l2 with
+    | 0 -> compare v1 v2
+    | i -> i
+    )
   | Mut r1, Mut r2 -> compare !r1 !r2
   | Async _, Async _ -> raise (Invalid_argument "Value.compare")
   | _ -> generic_compare x1 x2

--- a/test/fail/ok/modules-fwd.tc.ok
+++ b/test/fail/ok/modules-fwd.tc.ok
@@ -1,2 +1,2 @@
-modules-fwd.as:5.9-5.10: type error, field name v does not exist in type
+modules-fwd.as:5.9-5.10: type error, field v does not exist in type
   module {type T = ()}

--- a/test/fail/ok/modules-shadow.tc.ok
+++ b/test/fail/ok/modules-shadow.tc.ok
@@ -1,1 +1,1 @@
-modules-shadow.as:5.12-5.13: type error, cannot infer type of forward path X
+modules-shadow.as:5.12-5.13: type error, cannot infer type of forward variable reference X


### PR DESCRIPTION
This does a random batch of simplifications and cleanups:
* Rename VariantE/VariantP to TagE/TagP
* Make Type.Variant carry a proper field list, for uniformity and less code duplication
* Correctly define comparison on variant values
* Make coverage checking of variants use span
* Simplify path typing code somewhat
* Use Lib.Option.value in a couple of places
* Various naming and style inconsistencies
