### PR TITLE
Bump dev

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,7 +39,7 @@ let real-dvm =
       let dev = builtins.fetchGit {
         url = "ssh://git@github.com/dfinity-lab/dev";
         ref = "master";
-        rev = "aff35b2a015108f7d1d694471ccaf3ffd6f0340c";
+        rev = "8016991c399761c4d60571d0300426e8482ee1da";
       }; in
       (import dev { system = nixpkgs.system; }).dvm
     else null


### PR DESCRIPTION
mainly to get
 * https://github.com/dfinity-lab/dev/pull/953 and
 * https://github.com/dfinity-lab/dev/pull/954
which have the effect that downloading `dvm` from the cache is much
quicker (no accidential dependenciy on Haskell development libraries)
and the duplicate `wasm.cmi` warning when using `nix-shell` should be
gone now.