### PR TITLE
Named import sugar

### DIFF
--- a/design/Syntax.md
+++ b/design/Syntax.md
@@ -112,6 +112,8 @@ Productions marked * probably deferred to later versions.
   shared? func <id>? <typ-params>? <pat> (: <typ>)? =? <exp>  function
   type <id> <typ-params>? = <typ>                             type
   actor? class <id> <typ-params>? <pat> (: <typ>)? =? <exp>   class
+  module <id>? =? { <dec>* }                                  module
+  import <id>? =? <text>                                      import
 ```
 
 ## Programs

--- a/stdlib/examples/produce-exchange/serverActor.as
+++ b/stdlib/examples/produce-exchange/serverActor.as
@@ -4,12 +4,12 @@
  --------------------
 */
 
-let P = (import "../../prelude.as");
-let Option = (import "../../option.as");
-let T = (import "serverTypes.as");
-let L = (import "serverLang.as");
-let Model = (import "serverModel.as");
-let Result = (import "../../result.as");
+import P = "../../prelude.as";
+import Option = "../../option.as";
+import T = "serverTypes.as";
+import L = "serverLang.as";
+import Model = "serverModel.as";
+import Result = "../../result.as";
 
 type Result<Ok,Err> = Result.Result<Ok,Err>;
 

--- a/stdlib/examples/produce-exchange/serverLang.as
+++ b/stdlib/examples/produce-exchange/serverLang.as
@@ -7,9 +7,10 @@
 
 */
 
-let Result = (import "../../result.as");
+import Result = "../../result.as";
+import T = "serverTypes.as";
+
 type Result<Ok,Err> = Result.Result<Ok,Err>;
-let T = import "serverTypes.as";
 
 /**
  `Req`

--- a/stdlib/examples/produce-exchange/serverModel.as
+++ b/stdlib/examples/produce-exchange/serverModel.as
@@ -22,32 +22,32 @@ uses are is not.
 */
 
 
-let P = (import "../../prelude.as");
+import P = "../../prelude.as";
 
-let T = (import "serverTypes.as");
-let L = (import "serverLang.as");
-let M = (import "serverModelTypes.as");
+import T = "serverTypes.as";
+import L = "serverLang.as";
+import M = "serverModelTypes.as";
 
 let Hash = (import "../../hash.as").BitVec;
 type Hash = Hash.t;
 
-let Option = (import "../../option.as");
-let Trie = (import "../../trie.as");
+import Option = "../../option.as";
+import Trie = "../../trie.as";
 
 type Trie<K,V> = Trie.Trie<K,V>;
 type Key<K> = Trie.Key<K>;
 
 type Table<K,V> = Trie.Trie<K,V>;
-let Table = (import "../../trie.as");
+let Table = Trie;
 
 type Map<K,V> = Trie.Trie<K,V>;
-let Map = (import "../../trie.as");
+let Map = Trie;
 
-let DT = (import "../../docTable.as");
+import DT = "../../docTable.as";
 let DocTable = DT.DocTable;
 type DocTable<X,Y,Z> = DT.DocTable<X,Y,Z>;
 
-let Result = (import "../../result.as");
+import Result = "../../result.as";
 type Result<Ok,Err> = Result.Result<Ok,Err>;
 
 type RouteInventoryMap = Trie<(T.RouteId, T.InventoryId), (M.RouteDoc, M.InventoryDoc)>;

--- a/stdlib/examples/produce-exchange/serverModelTypes.as
+++ b/stdlib/examples/produce-exchange/serverModelTypes.as
@@ -32,9 +32,9 @@ Representation
 
 */
 
-let T = (import "serverTypes.as");
+import T = "serverTypes.as";
 
-let Trie = (import "../../trie.as");
+import Trie = "../../trie.as";
 type Trie<K,V> = Trie.Trie<K,V>;
 
 type Map<X, Y> = Trie<X, Y>;

--- a/test/fail/self-import.as
+++ b/test/fail/self-import.as
@@ -1,1 +1,1 @@
-import "self-import.as" : ()
+import "self-import.as";

--- a/test/run/import-module.as
+++ b/test/run/import-module.as
@@ -1,4 +1,3 @@
 let L = import "lib/ListM.as";
 type stack = L.List<Int>;
 let s = L.cons<Int>(1,L.nil<Int>());
-

--- a/test/run/import.as
+++ b/test/run/import.as
@@ -1,2 +1,2 @@
-assert (import "lib/hello-string.as" == "Hello!");
-assert (import "lib/dir" == "Hello!");
+assert ((import "lib/hello-string.as") == "Hello!");
+assert ((import "lib/dir") == "Hello!");

--- a/test/run/lib/ListM.as
+++ b/test/run/lib/ListM.as
@@ -1,4 +1,3 @@
 type List<T> = ?(T, List<T>);
 func nil<T>() : List<T> = null;
 func cons<T>(x : T, l : List<T>) : List<T> = ?(x, l);
-


### PR DESCRIPTION
For more natural looks, allow declarations of the form
```
import X = "..."
```
as sugar for
```
let X = import "...";
```
analogous to other forms.