### PR TITLE
AST-87 bignum relop datatype

### DIFF
--- a/src/compile.ml
+++ b/src/compile.ml
@@ -1730,7 +1730,7 @@ module UnboxedSmallWord = struct
 
 end (* UnboxedSmallWord *)
 
-type bignum_relop = Lt | Le | Ge | Gt
+type comparator = Lt | Le | Ge | Gt
 
 module type BigNumType =
 sig
@@ -1788,7 +1788,7 @@ sig
   (* comparisons *)
   val compile_eq : E.t -> G.t
   val compile_is_negative : E.t -> G.t
-  val compile_relop : E.t -> bignum_relop -> G.t
+  val compile_relop : E.t -> comparator -> G.t
 
   (* representation checks *)
   (* given a numeric object on the stack as skewed pointer, check whether


### PR DESCRIPTION
This excludes `Eq`, as we have `compile_eq` for that.

It could be worth getting rid of `compile_eq` and spinning all via `compile_relop`. Currently not, as the backend separates the two, later when the builtins get redone we can revisit. What do you think?

Oops, pushed too many commits! ff79ee9 is the relevant one.