### PR TITLE
Hypervisor user errors are no longer reported as log warnings

### DIFF
--- a/test/run-dfinity/ok/array-out-of-bounds.dvm-run.ok
+++ b/test/run-dfinity/ok/array-out-of-bounds.dvm-run.ok
@@ -1,4 +1,4 @@
-W, hypervisor: calling func$NNN failed with trap message: Uncaught RuntimeError: unreachable
-W, hypervisor: calling func$NNN failed with trap message: Uncaught RuntimeError: unreachable
+I, hypervisor: calling func$NNN failed with trap message: Uncaught RuntimeError: unreachable
+I, hypervisor: calling func$NNN failed with trap message: Uncaught RuntimeError: unreachable
 Array index out of bounds
 Array index out of bounds

--- a/test/run-dfinity/ok/counter-class.dvm-run.ok
+++ b/test/run-dfinity/ok/counter-class.dvm-run.ok
@@ -1,2 +1,2 @@
-W, hypervisor: calling start failed with trap message: Uncaught RuntimeError: unreachable
+I, hypervisor: calling start failed with trap message: Uncaught RuntimeError: unreachable
 TODO: non-closed actor

--- a/test/run-dfinity/ok/overflow.dvm-run.ok
+++ b/test/run-dfinity/ok/overflow.dvm-run.ok
@@ -1,5 +1,5 @@
-W, hypervisor: calling func$NNN failed with trap message: Uncaught RuntimeError: unreachable
-W, hypervisor: calling func$NNN failed with trap message: Uncaught RuntimeError: unreachable
+I, hypervisor: calling func$NNN failed with trap message: Uncaught RuntimeError: unreachable
+I, hypervisor: calling func$NNN failed with trap message: Uncaught RuntimeError: unreachable
 This is reachable.
 This is reachable.
 Natural subtraction underflow

--- a/test/run.sh
+++ b/test/run.sh
@@ -51,7 +51,7 @@ function normalize () {
     grep -a -E -v '^Raised by|Raised at|^Re-raised at|^Re-Raised at|^Called from' $1 |
     sed 's/\x00//g' |
     sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' |
-    sed 's/^.*W, hypervisor:/W, hypervisor:/g' |
+    sed 's/^.*I, hypervisor:/I, hypervisor:/g' |
     sed 's/wasm:0x[a-f0-9]*:/wasm:0x___:/g' |
     sed 's/^.*run-dfinity\/\.\.\/dvm.sh: line/dvm.sh: line/g' |
     sed 's/ *[0-9]* Illegal instruction.*dvm/ Illegal instruction dvm/g' |


### PR DESCRIPTION
This change is needed to support https://github.com/dfinity-lab/dev/pull/971.