### PR TITLE
Elaboration and some other tweaks

### DIFF
--- a/design/IDL.md
+++ b/design/IDL.md
@@ -352,7 +352,6 @@ record {
   num : nat;
   city : text;
   zip : nat;
-  state : reserved;  // removed since no longer needed
 }
 
 record { nat; nat }
@@ -517,8 +516,8 @@ To make these constraints as flexible as possible, two special rules apply:
 
  * An absent record field is considered equivalent to a present field with value `null`. Moreover, a record field of type `null` is a subtype of a field with type `opt <datatype>`. That way,	That way, a field of option (or null) type can always be added to a record type, no matter whether in co- or contra-variant position. If an optional field is added to an inbound record, and he client did not provide it, the service will read it as if its value was null.
 
-   - in an outbound record, a field of option (or null) type can also be removed in an upgrade, in which case the client will read it as if its value was null;	
-  - in an inbound record, a field of option (or null) type can also be added, in which case the service will read it as if its value was null.	
+  - in an outbound record, a field of option (or null) type can also be removed in an upgrade, in which case the client will read it as if its value was null;	
+  - in an inbound record, a field of option (or null) type can also be added, in which case the service will read it as if its value was null.
 
 Future extensions: defaults, including for variants?
 


### PR DESCRIPTION
Okay, this aims to address #364 and fix the transitivity issue by indexing the subtyping relation with a *polarity* that controls which record rules are applicable where:
- ordinary width subtyping (adding fields) is only available for records occurring in `+` polarity
- optional fields can only be removed (contra-variantly added) from records in `-` polarity

Admittedly, it is odd to have this on the side of co/contra-variance. The upshot is that extending a record type with an optional field creates both a co- and a contra-variant subtype! I'm not sure how else to achieve that.

Let me know what you think or whether I've been smoking crack.

Other changes:
- Untied subtyping `T <: opt T`, since we're no longer restricted to non-coercive subtyping.
- Renamed `unavailable` to `reserved`, which makes slightly more sense now.