### PR TITLE
Use faster mp_expt_d_ex

### DIFF
--- a/rts/Makefile
+++ b/rts/Makefile
@@ -4,7 +4,7 @@ WASM_LD ?= wasm-ld-9
 TOMMATHFILES=\
    mp_init mp_add mp_sub mp_mul mp_zero mp_cmp mp_init_set_int mp_set_long mp_set_int \
    mp_div mp_init_copy mp_get_int mp_get_long mp_set_long_long mp_get_long_long mp_neg mp_abs mp_2expt mp_expt_d_ex mp_set mp_sqr \
-   s_mp_add mp_cmp_mag s_mp_sub mp_grow mp_clamp mp_expt_d \
+   s_mp_add mp_cmp_mag s_mp_sub mp_grow mp_clamp \
    mp_init_size mp_exch mp_clear mp_copy mp_count_bits mp_mul_2d mp_rshd mp_mul_d mp_div_2d mp_mod_2d \
    s_mp_balance_mul s_mp_toom_mul s_mp_toom_sqr s_mp_karatsuba_sqr s_mp_sqr_fast s_mp_sqr s_mp_karatsuba_mul s_mp_mul_digs_fast s_mp_mul_digs mp_init_multi mp_clear_multi mp_mul_2 mp_div_2 mp_div_3 mp_lshd
 

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -304,7 +304,7 @@ export as_ptr bigint_pow(as_ptr a, as_ptr b) {
   as_ptr r = bigint_alloc();
   // Replace with mp_expt_long once available,
   // see https://github.com/libtom/libtommath/issues/243
-  CHECK(mp_expt_d(BIGINT_PAYLOAD(a), exp, BIGINT_PAYLOAD(r)));
+  CHECK(mp_expt_d_ex(BIGINT_PAYLOAD(a), exp, BIGINT_PAYLOAD(r), 1));
   return r;
 }
 


### PR DESCRIPTION
judging from the code, the slower one is interesting for more timing
resistance, which we don’t care about.