### PR TITLE
fix the interpreter to round div result towards zero AST-43

### DIFF
--- a/src/value.ml
+++ b/src/value.ml
@@ -153,8 +153,12 @@ struct
   let neg = minus_big_int
   let add = add_big_int
   let mul = mult_big_int
-  let div = div_big_int
-  let rem = mod_big_int (* Is rem and mod the same here? *)
+  let div a b =
+    let q, m = quomod_big_int a b in
+    if sign_big_int q < 0 && sign_big_int m > 0 then succ_big_int q else q
+  let rem a b =
+    let q, m = quomod_big_int a b in
+    if sign_big_int q < 0 && sign_big_int m > 0 then sub_big_int m b else m
   let eq = eq_big_int
   let ne x y = not (eq x y)
   let lt = lt_big_int


### PR DESCRIPTION
The AS reference interpreter inherits the `OCaml` semantics for division involving negative numbers (`Big_int`) :
```
$ ./asc
ActorScript 0.1 interpreter
> (-31)/10;
-4 : Int
```
As discussed in https://github.com/dfinity-lab/actorscript/issues/421#issuecomment-493384038 division should round towards zero. With the attached commit, we now have:
```
$ ./asc
ActorScript 0.1 interpreter
> (-31)/10;
-3 : Int
> (-31)%10;
-1 : Int
```
