### PR TITLE
Only run/interpret/compile individual files

### DIFF
--- a/src/compile.mli
+++ b/src/compile.mli
@@ -1,3 +1,3 @@
 type mode = WasmMode | DfinityMode
 
-val compile : mode -> string -> CustomModule.extended_module option -> Ir.prog -> Ir.prog list -> CustomModule.extended_module
+val compile : mode -> string -> CustomModule.extended_module option -> Ir.prog -> Ir.prog -> CustomModule.extended_module

--- a/src/desugar.ml
+++ b/src/desugar.ml
@@ -367,19 +367,16 @@ let declare_import imp_env (f, (prog:Syntax.prog))  =
      ; note = typ_note
      }
 
-let combine_files imp_env libraries progs : Syntax.prog =
+let combine_files imp_env libraries prog : Syntax.prog =
   (* This is a hack until the backend has explicit support for libraries *)
   let open Source in
-  { it = List.map (declare_import imp_env) libraries
-         @ List.concat (List.map (fun p -> p.it) progs)
+  { it = List.map (declare_import imp_env) libraries @ prog.Source.it
   ; at = no_region
-  ; note = match progs with
-           | [prog] -> prog.Source.note
-           | _ -> "all"
+  ; note = prog.Source.note
   }
 
 let transform p = prog p
 
-let transform_graph imp_env libraries progs =
-  prog (combine_files imp_env libraries progs)
+let transform_graph imp_env libraries p =
+  prog (combine_files imp_env libraries p)
 

--- a/src/desugar.mli
+++ b/src/desugar.mli
@@ -1,2 +1,2 @@
 val transform : Syntax.prog -> Ir.prog
-val transform_graph : Typing.lib_env -> Syntax.libraries -> Syntax.prog list -> Ir.prog
+val transform_graph : Typing.lib_env -> Syntax.libraries -> Syntax.prog -> Ir.prog

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -1,11 +1,11 @@
-val check_files  : string list -> unit Diag.result
+val check_file  : string -> unit Diag.result
 val check_string : string -> string -> unit Diag.result
 
-val run_files           : string list -> unit option
-val interpret_ir_files  : string list -> unit option
-val run_files_and_stdin : string list -> unit option
+val run_file           : string -> unit option
+val interpret_ir_file  : string -> unit option
+val run_file_and_stdin : string option -> unit option
 
 type compile_mode = WasmMode | DfinityMode
 type compile_result = CustomModule.extended_module Diag.result
 val compile_string : compile_mode -> string -> string -> compile_result
-val compile_files : compile_mode -> bool -> string list -> compile_result
+val compile_file : compile_mode -> bool -> string -> compile_result


### PR DESCRIPTION
this fixes #404 (issue not found).

The command line still accepts multiple files, but just handles then
independently and in sequence. In `pipeline.ml`, there is always only
ever one input file.

No change to generated WebAssembly output.