### PR TITLE
Add `-no-check-ir` flag

### DIFF
--- a/src/flags.ml
+++ b/src/flags.ml
@@ -10,3 +10,4 @@ let interpret_ir = ref false
 let source_map = ref false
 let prelude = ref true
 let link = ref true
+let check_ir = ref true

--- a/src/main.ml
+++ b/src/main.ml
@@ -50,6 +50,7 @@ let argspec = Arg.align
   "-dp", Arg.Set Flags.dump_parse, " dump parse";
   "-dt", Arg.Set Flags.dump_tc, " dump type-checked AST";
   "-dl", Arg.Set Flags.dump_lowering, " dump intermediate representation ";
+  "-no-check-ir", Arg.Clear Flags.check_ir, " do not check intermediate code";
   "--disable-prelude", Arg.Clear Flags.prelude, " disable prelude";
 ]
 

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -394,7 +394,7 @@ let transform transform_name trans env prog name =
   phase transform_name name;
   let prog_ir' : Ir.prog = trans env prog in
   dump_ir Flags.dump_lowering prog_ir';
-  Check_ir.check_prog env transform_name prog_ir';
+  if !Flags.check_ir then Check_ir.check_prog env transform_name prog_ir';
   prog_ir'
 
 let transform_if transform_name trans flag env prog name =
@@ -405,7 +405,7 @@ let desugar env lib_env libraries progs name =
   phase "Desugaring" name;
   let prog_ir' : Ir.prog = Desugar.transform_graph lib_env libraries progs in
   dump_ir Flags.dump_lowering prog_ir';
-  Check_ir.check_prog env "Desugaring" prog_ir';
+  if !Flags.check_ir then Check_ir.check_prog env "Desugaring" prog_ir';
   prog_ir'
 
 let await_lowering =


### PR DESCRIPTION
if someone wants high compilation speed and is not in the business of
debugging the compiler.

Eventually, I expect that should be the default, and we’ll just use
`-check-ir` in our test suite.