### PR TITLE
IR: Use Type.lab instead of Name

### DIFF
--- a/src/arrange_ir.ml
+++ b/src/arrange_ir.ml
@@ -17,8 +17,8 @@ let rec exp e = match e.it with
   | ShowE (t, e)        -> "ShowE"   $$ [typ t; exp e]
   | TupE es             -> "TupE"    $$ List.map exp es
   | ProjE (e, i)        -> "ProjE"   $$ [exp e; Atom (string_of_int i)]
-  | DotE (e, n)         -> "DotE"    $$ [exp e; Atom (name n)]
-  | ActorDotE (e, n)    -> "ActorDotE" $$ [exp e; Atom (name n)]
+  | DotE (e, n)         -> "DotE"    $$ [exp e; Atom n]
+  | ActorDotE (e, n)    -> "ActorDotE" $$ [exp e; Atom n]
   | AssignE (e1, e2)    -> "AssignE" $$ [exp e1; exp e2]
   | ArrayE (m, t, es)   -> "ArrayE"  $$ [Arrange.mut m; typ t] @ List.map exp es
   | IdxE (e1, e2)       -> "IdxE"    $$ [exp e1; exp e2]
@@ -43,7 +43,7 @@ let rec exp e = match e.it with
   | ActorE (i, ds, fs, t) -> "ActorE"  $$ [id i] @ List.map dec ds @ fields fs @ [typ t]
   | NewObjE (s, fs, t)  -> "NewObjE" $$ (Arrange.obj_sort' s :: fields fs @ [typ t])
 
-and fields fs = List.fold_left (fun flds (f : field) -> (name f.it.name $$ [ id f.it.var ]):: flds) [] fs
+and fields fs = List.fold_left (fun flds (f : field) -> (f.it.name $$ [ id f.it.var ]):: flds) [] fs
 
 and args = function
  | [] -> []
@@ -61,12 +61,9 @@ and pat p = match p.it with
   | TagP (i, p)     -> "TagP"       $$ [ id i; pat p ]
   | AltP (p1,p2)    -> "AltP"       $$ [ pat p1; pat p2 ]
 
-and pat_field pf = name pf.it.name $$ [pat pf.it.pat]
+and pat_field pf = pf.it.name $$ [pat pf.it.pat]
 
 and case c = "case" $$ [pat c.it.pat; exp c.it.exp]
-
-and name n = match n.it with
-  | Name l -> l
 
 and call_conv cc = Atom (Value.string_of_call_conv cc)
 

--- a/src/check_ir.ml
+++ b/src/check_ir.ml
@@ -337,8 +337,8 @@ let rec check_exp env (exp:Ir.exp) : unit =
                error env exp.at "tuple projection %n is out of bounds for type\n  %s"
                  n (T.string_of_typ_expand t1) in
     tn <: t
-  | ActorDotE(exp1,{it = Name n;_})
-  | DotE (exp1, {it = Name n;_}) ->
+  | ActorDotE(exp1, n)
+  | DotE (exp1, n) ->
     begin
       check_exp env exp1;
       let t1 = typ exp1 in
@@ -639,7 +639,7 @@ and check_pats at env pats ve : val_env =
 and check_pat_fields env t = List.iter (check_pat_field env t)
 
 and check_pat_field env t (pf : pat_field) =
-  let Name lab = pf.it.name.it in
+  let lab = pf.it.name in
   let tf = T.{lab; typ=pf.it.pat.note} in
   let s, tfs = T.as_obj_sub lab t in
   let (<:) = check_sub env pf.it.pat.at in
@@ -658,7 +658,7 @@ and type_exp_fields env s fs : T.field list =
   List.sort T.compare_field tfs
 
 and type_exp_field env s f : T.field =
-  let {name = {it = Name name; _}; var} = f.it in
+  let {name; var} = f.it in
   let t = try T.Env.find var.it env.vals with
           | Not_found -> error env f.at "field typing for %s not found" name
   in

--- a/src/construct.ml
+++ b/src/construct.ml
@@ -15,9 +15,9 @@ let constM = S.Const @@ no_region
 
 (* Field names *)
 
-let nameN s = Name s @@ no_region
+let nameN s = s
 
-let nextN = nameN "next"
+let nextN = "next"
 
 (* Identifiers *)
 

--- a/src/construct.mli
+++ b/src/construct.mli
@@ -18,8 +18,8 @@ val constM : mut
 
 (* Field names *)
 
-val nameN : string -> name
-val nextN : name
+val nameN : string -> Type.lab
+val nextN : Type.lab
 
 (* Identifiers *)
 
@@ -55,7 +55,7 @@ val boolE : bool -> exp
 val callE : exp -> typ list -> exp -> exp
 
 val ifE : exp -> exp -> exp -> typ -> exp
-val dotE : exp -> name -> typ -> exp
+val dotE : exp -> Type.lab -> typ -> exp
 val switch_optE : exp -> exp -> pat -> exp -> typ -> exp
 val switch_variantE : exp -> (id * pat * exp) list -> typ -> exp
 val tupE : exp list -> exp

--- a/src/desugar.ml
+++ b/src/desugar.ml
@@ -57,7 +57,7 @@ and exp' at note = function
     obj at s None es note.S.note_typ
   | S.TagE (c, e) -> I.TagE (c, exp e)
   | S.DotE (e, x) ->
-    let n = {x with it = I.Name x.it} in
+    let n = x.it in
     begin match T.as_obj_sub x.it e.note.S.note_typ with
     | Type.Actor, _ -> I.ActorDotE (exp e, n)
     | _ -> I.DotE (exp e, n)
@@ -108,7 +108,7 @@ and obj at s self_id es obj_typ =
   | Type.Actor -> build_actor at self_id es obj_typ
 
 and build_field {Type.lab; Type.typ} =
-  { it = { I.name = I.Name lab @@ no_region
+  { it = { I.name = lab
          ; I.var = lab @@ no_region
          }
   ; at = no_region
@@ -251,7 +251,7 @@ and pat' = function
 
 and pat_fields pfs = List.map pat_field pfs
 
-and pat_field pf = phrase (fun S.{id; pat=p} -> I.{name=phrase (fun s -> Name s) id; pat=pat p}) pf
+and pat_field pf = phrase (fun S.{id; pat=p} -> I.{name=id.it; pat=pat p}) pf
 
 and to_arg p : (Ir.arg * (Ir.exp -> Ir.exp)) =
   match p.it with

--- a/src/interpret_ir.ml
+++ b/src/interpret_ir.ml
@@ -304,8 +304,8 @@ and interpret_exp_mut env exp (k : V.value V.cont) =
     interpret_exp env exp1 (fun v1 -> k (V.Variant (i.it, v1)))
   | ProjE (exp1, n) ->
     interpret_exp env exp1 (fun v1 -> k (List.nth (V.as_tup v1) n))
-  | DotE (exp1, {it = Name n; _})
-  | ActorDotE (exp1, {it = Name n; _}) ->
+  | DotE (exp1, n)
+  | ActorDotE (exp1, n) ->
     interpret_exp env exp1 (fun v1 ->
       let fs = V.as_obj v1 in
       k (try find n fs with _ -> assert false)
@@ -424,8 +424,7 @@ and interpret_fields env fs =
     let ve =
       List.fold_left
         (fun ve (f : field) ->
-          let Name name = f.it.name.it in
-          V.Env.disjoint_add name (Lib.Promise.value (find f.it.var.it env.vals)) ve
+          V.Env.disjoint_add f.it.name (Lib.Promise.value (find f.it.var.it env.vals)) ve
         ) V.Env.empty fs in
     V.Obj ve
 
@@ -513,8 +512,7 @@ and define_pats env pats vs =
 
 and define_field_pats env pfs vs =
   let define_field (pf : pat_field) =
-    let Name key = pf.it.name.it in
-    define_pat env pf.it.pat (V.Env.find key vs) in
+    define_pat env pf.it.pat (V.Env.find pf.it.name vs) in
   List.iter define_field pfs
 
 
@@ -582,8 +580,7 @@ and match_pat_fields pfs vs ve : val_env option =
   | [] -> Some ve
   | pf::pfs' ->
     begin
-      let Name key = pf.it.name.it in
-      match match_pat pf.it.pat (V.Env.find key vs) with
+      match match_pat pf.it.pat (V.Env.find pf.it.name vs) with
       | Some ve' -> match_pat_fields pfs' vs (V.Env.adjoin ve ve')
       | None -> None
     end

--- a/src/ir.ml
+++ b/src/ir.ml
@@ -14,9 +14,6 @@ type relop = Syntax.relop
 type mut = Syntax.mut
 type vis = Syntax.vis
 
-type name = name' Source.phrase
-and name' = Name of string
-
 type pat = (pat', Type.typ) Source.annotated_phrase
 and pat' =
   | WildP                                      (* wildcard *)
@@ -29,7 +26,7 @@ and pat' =
   | AltP of pat * pat                          (* disjunctive *)
 
 and pat_field = pat_field' Source.phrase
-and pat_field' = {name : name; pat : pat}
+and pat_field' = {name : Type.lab; pat : pat}
 
 (* Like id, but with a type attached *)
 type arg = (string, Type.typ) Source.annotated_phrase
@@ -49,8 +46,8 @@ and exp' =
   | ProjE of exp * int                         (* tuple projection *)
   | OptE of exp                                (* option injection *)
   | TagE of id * exp                           (* variant injection *)
-  | DotE of exp * name                         (* object projection *)
-  | ActorDotE of exp * name                    (* actor field access *)
+  | DotE of exp * Type.lab                     (* object projection *)
+  | ActorDotE of exp * Type.lab                (* actor field access *)
   | AssignE of exp * exp                       (* assignment *)
   | ArrayE of mut * Type.typ * exp list        (* array *)
   | IdxE of exp * exp                          (* array indexing *)
@@ -74,7 +71,7 @@ and exp' =
   | NewObjE of Type.obj_sort * field list * Type.typ  (* make an object *)
 
 and field = (field', Type.typ) Source.annotated_phrase
-and field' = {name : name; var : id} (* the var is by reference, not by value *)
+and field' = {name : Type.lab; var : id} (* the var is by reference, not by value *)
 
 and case = case' Source.phrase
 and case' = {pat : pat; exp : exp}

--- a/src/show.ml
+++ b/src/show.ml
@@ -329,7 +329,7 @@ let show_for : T.typ -> Ir.dec * T.typ list = fun t ->
           catE
             (textE (f.Type.lab ^ " = "))
             (invoke_generated_show t'
-              { it = DotE (argE t, Ir.Name f.Type.lab @@ no_region )
+              { it = DotE (argE t, f.Type.lab)
               ; at = no_region
               ; note = { note_typ = t'; note_eff = T.Triv }
               }


### PR DESCRIPTION
In contrast to the source, the IR has a clear separation of what are
variables (can be renamed) and what are record labels (must not be
renamed). E.g. thanks to @crusso’s `NewObjE`.

And because the label in, say, `DotE`, directly refers to the
label in a type, it makes sense to use `Type.lab` instead of `Ir.name`
here.

This allows the backend to move the `open Ir` much further down, making
the structure of that file more obvious.

Currently, `Type.lab` is an alias for `string`, and it might be
desirable to make that a new type (as `Ir.name` was before), but that
can happen separately.