### PR TITLE
Fix func import oversight

### DIFF
--- a/src/aslib/compile.ml
+++ b/src/aslib/compile.ml
@@ -524,6 +524,7 @@ module RTS = struct
     E.add_func_import env "rts" "bigint_to_word64_signed_trap" [I32Type] [I64Type];
     E.add_func_import env "rts" "bigint_eq" [I32Type; I32Type] [I32Type];
     E.add_func_import env "rts" "bigint_isneg" [I32Type] [I32Type];
+    E.add_func_import env "rts" "bigint_count_bits" [I32Type] [I32Type];
     E.add_func_import env "rts" "bigint_2complement_bits" [I32Type] [I32Type];
     E.add_func_import env "rts" "bigint_lt" [I32Type; I32Type] [I32Type];
     E.add_func_import env "rts" "bigint_gt" [I32Type; I32Type] [I32Type];


### PR DESCRIPTION
This function `rts_bigint_count_bits` is actually used by the `Nat*` branch. It is also referenced by the backend code but probably not triggered.

Simple oversight, probably.

Thanks to @crusso for debugging this! Citing him from Slack here:
> I used the _s argument to reserve_promise to hunt this down...

@nomeata has this debug tag for such situations: https://github.com/dfinity-lab/actorscript/releases/tag/promise-debug