### PR TITLE
Ir/Frontent distangling: Define Ir.mut

### DIFF
--- a/src/as_ir/arrange_ir.ml
+++ b/src/as_ir/arrange_ir.ml
@@ -22,7 +22,7 @@ let rec exp e = match e.it with
   | DotE (e, n)         -> "DotE"    $$ [exp e; Atom n]
   | ActorDotE (e, n)    -> "ActorDotE" $$ [exp e; Atom n]
   | AssignE (e1, e2)    -> "AssignE" $$ [exp e1; exp e2]
-  | ArrayE (m, t, es)   -> "ArrayE"  $$ [Arrange.mut m; typ t] @ List.map exp es
+  | ArrayE (m, t, es)   -> "ArrayE"  $$ [mut m; typ t] @ List.map exp es
   | IdxE (e1, e2)       -> "IdxE"    $$ [exp e1; exp e2]
   | CallE (cc, e1, ts, e2) -> "CallE" $$ [call_conv cc; exp e1] @ List.map typ ts @ [exp e2]
   | BlockE (ds, e1)     -> "BlockE"  $$ List.map dec ds @ [exp e1]
@@ -39,7 +39,7 @@ let rec exp e = match e.it with
   | TagE (i, e)         -> "TagE" $$ [id i; exp e]
   | PrimE p             -> "PrimE"   $$ [Atom p]
   | DeclareE (i, t, e1) -> "DeclareE" $$ [id i; exp e1]
-  | DefineE (i, m, e1)  -> "DefineE" $$ [id i; Arrange.mut m; exp e1]
+  | DefineE (i, m, e1)  -> "DefineE" $$ [id i; mut m; exp e1]
   | FuncE (x, cc, tp, as_, ts, e) ->
     "FuncE" $$ [Atom x; call_conv cc] @ List.map typ_bind tp @ args as_@ [ typ (Type.seq ts); exp e]
   | ActorE (i, ds, fs, t) -> "ActorE"  $$ [id i] @ List.map dec ds @ fields fs @ [typ t]
@@ -52,6 +52,10 @@ and args = function
  | as_ -> ["params" $$ List.map arg as_]
 
 and arg a = Atom a.it
+
+and mut = function
+  | Const -> Atom "Const"
+  | Var   -> Atom "Var"
 
 and pat p = match p.it with
   | WildP           -> Atom "WildP"

--- a/src/as_ir/check_ir.ml
+++ b/src/as_ir/check_ir.ml
@@ -374,7 +374,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
   | ArrayE (mut, t0, exps) ->
     List.iter (check_exp env) exps;
     List.iter (fun e -> typ e <: t0) exps;
-    let t1 = T.Array (match mut.it with Syntax.Const -> t0 | Syntax.Var -> T.Mut t0) in
+    let t1 = T.Array (match mut with Const -> t0 | Var -> T.Mut t0) in
     t1 <: t
   | IdxE (exp1, exp2) ->
     check_exp env exp1;
@@ -494,10 +494,10 @@ let rec check_exp env (exp:Ir.exp) : unit =
       match T.Env.find_opt id.it env.vals with
       | None -> error env id.at "unbound variable %s" id.it
       | Some t0 ->
-        match mut.it with
-        | Syntax.Const ->
+        match mut with
+        | Const ->
           typ exp1 <: t0
-        | Syntax.Var ->
+        | Var ->
           let t0 = try T.as_mut t0 with
                    | Invalid_argument _ ->
                      error env exp.at "expected mutable %s" (T.string_of_typ t0)

--- a/src/as_ir/construct.ml
+++ b/src/as_ir/construct.ml
@@ -11,11 +11,6 @@ module T = As_types.Type
 
 type var = exp
 
-(* Mutabilities *)
-
-let varM = S.Var @@ no_region
-let constM = S.Const @@ no_region
-
 (* Field names *)
 
 let nameN s = s

--- a/src/as_ir/construct.mli
+++ b/src/as_ir/construct.mli
@@ -13,11 +13,6 @@ open Type
 
 type var = exp
 
-(* Mutabilities *)
-
-val varM : mut
-val constM : mut
-
 (* Field names *)
 
 val nameN : string -> Type.lab

--- a/src/as_ir/ir.ml
+++ b/src/as_ir/ir.ml
@@ -15,8 +15,8 @@ type lit = Syntax.lit
 type unop = Operator.unop
 type binop = Operator.binop
 type relop = Operator.relop
-type mut = Syntax.mut
-type vis = Syntax.vis
+
+type mut = Const | Var
 
 type pat = (pat', Type.typ) Source.annotated_phrase
 and pat' =

--- a/src/ir_interpreter/interpret_ir.ml
+++ b/src/ir_interpreter/interpret_ir.ml
@@ -339,9 +339,9 @@ and interpret_exp_mut env exp (k : V.value V.cont) =
   | ArrayE (mut, _, exps) ->
     interpret_exps env exps [] (fun vs ->
       let vs' =
-        match mut.it with
-        | Syntax.Var -> List.map (fun v -> V.Mut (ref v)) vs
-        | Syntax.Const -> vs
+        match mut with
+        | Var -> List.map (fun v -> V.Mut (ref v)) vs
+        | Const -> vs
       in k (V.Array (Array.of_list vs'))
     )
   | IdxE (exp1, exp2) ->
@@ -413,9 +413,9 @@ and interpret_exp_mut env exp (k : V.value V.cont) =
   | DefineE (id, mut, exp1) ->
     interpret_exp env exp1 (fun v ->
       let v' =
-        match mut.it with
-        | Syntax.Const -> v
-        | Syntax.Var -> V.Mut (ref v)
+        match mut with
+        | Const -> v
+        | Var -> V.Mut (ref v)
       in
       define_id env id v';
       k V.unit

--- a/src/ir_passes/await.ml
+++ b/src/ir_passes/await.ml
@@ -371,11 +371,11 @@ and c_dec context dec (k:kont) =
     begin
       match eff exp with
       | T.Triv ->
-        k -@- define_idE id varM (t_exp context exp)
+        k -@- define_idE id Var (t_exp context exp)
       | T.Await ->
         c_exp context exp
           (meta (typ exp)
-             (fun v -> k -@- define_idE id varM v))
+             (fun v -> k -@- define_idE id Var v))
     end
 
 
@@ -465,7 +465,7 @@ and define_pat patenv pat : dec list =
   | LitP _ ->
     []
   | VarP id ->
-    [ expD (define_idE id constM (PatEnv.find id.it patenv)) ]
+    [ expD (define_idE id Const (PatEnv.find id.it patenv)) ]
   | TupP pats -> define_pats patenv pats
   | ObjP pfs -> define_pats patenv (pats_of_obj_pat pfs)
   | OptP pat1

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -71,7 +71,7 @@ and exp' at note = function
   | S.AssignE (e1, e2) -> I.AssignE (exp e1, exp e2)
   | S.ArrayE (m, es) ->
     let t = T.as_array note.S.note_typ in
-    I.ArrayE (m, T.as_immut t, exps es)
+    I.ArrayE (mut m, T.as_immut t, exps es)
   | S.IdxE (e1, e2) -> I.IdxE (exp e1, exp e2)
   | S.FuncE (name, s, tbs, p, ty, e) ->
     let cc = Call_conv.call_conv_of_typ note.S.note_typ in
@@ -108,6 +108,10 @@ and exp' at note = function
   | S.ImportE (f, fp) ->
     if !fp = "" then assert false; (* unresolved import *)
     I.VarE (id_of_full_path !fp)
+
+and mut m = match m.it with
+  | S.Const -> Ir.Const
+  | S.Var -> Ir.Var
 
 and obj at s self_id es obj_typ =
   match s.it with


### PR DESCRIPTION
so that we don’t have to use Syntax.mut