### PR TITLE
Ir/Frontent distangling: Move lit to own module

### DIFF
--- a/src/as_frontend/arrange.ml
+++ b/src/as_frontend/arrange.ml
@@ -13,7 +13,7 @@ and tag i = Atom ("#" ^ i.it)
 
 let rec exp e = match e.it with
   | VarE x              -> "VarE"    $$ [id x]
-  | LitE l              -> "LitE"    $$ [lit !l]
+  | LitE l              -> "LitE"    $$ [Arrange_lit.lit !l]
   | UnE (ot, uo, e)     -> "UnE"     $$ [operator_type !ot; unop uo; exp e]
   | BinE (ot, e1, bo, e2) -> "BinE"  $$ [operator_type !ot; exp e1; binop bo; exp e2]
   | RelE (ot, e1, ro, e2) -> "RelE"  $$ [operator_type !ot; exp e1; relop ro; exp e2]
@@ -64,27 +64,12 @@ and pat p = match p.it with
   | TupP ps         -> "TupP"       $$ List.map pat ps
   | ObjP ps         -> "ObjP"       $$ List.map pat_field ps
   | AnnotP (p, t)   -> "AnnotP"     $$ [pat p; typ t]
-  | LitP l          -> "LitP"       $$ [lit !l]
-  | SignP (uo, l)   -> "SignP"      $$ [unop uo ; lit !l]
+  | LitP l          -> "LitP"       $$ [Arrange_lit.lit !l]
+  | SignP (uo, l)   -> "SignP"      $$ [unop uo ; Arrange_lit.lit !l]
   | OptP p          -> "OptP"       $$ [pat p]
   | TagP (i, p)     -> "TagP"       $$ [tag i; pat p]
   | AltP (p1,p2)    -> "AltP"       $$ [pat p1; pat p2]
   | ParP p          -> "ParP"       $$ [pat p]
-
-and lit (l:lit) = match l with
-  | NullLit       -> Atom "NullLit"
-  | BoolLit true  -> "BoolLit"   $$ [ Atom "true" ]
-  | BoolLit false -> "BoolLit"   $$ [ Atom "false" ]
-  | NatLit n      -> "NatLit"    $$ [ Atom (Value.Nat.to_string n) ]
-  | IntLit i      -> "IntLit"    $$ [ Atom (Value.Int.to_string i) ]
-  | Word8Lit w    -> "Word8Lit"  $$ [ Atom (Value.Word8.to_string_u w) ]
-  | Word16Lit w   -> "Word16Lit" $$ [ Atom (Value.Word16.to_string_u w) ]
-  | Word32Lit w   -> "Word32Lit" $$ [ Atom (Value.Word32.to_string_u w) ]
-  | Word64Lit w   -> "Word64Lit" $$ [ Atom (Value.Word64.to_string_u w) ]
-  | FloatLit f    -> "FloatLit"  $$ [ Atom (Value.Float.to_string f) ]
-  | CharLit c     -> "CharLit"   $$ [ Atom (string_of_int c) ]
-  | TextLit t     -> "TextLit"   $$ [ Atom t ]
-  | PreLit (s,p)  -> "PreLit"    $$ [ Atom s; Arrange_type.prim p ]
 
 and unop uo = match uo with
   | PosOp -> Atom "PosOp"

--- a/src/as_frontend/coverage.ml
+++ b/src/as_frontend/coverage.ml
@@ -44,7 +44,7 @@ let make_sets () =
   }
 
 
-let value_of_lit = function
+let value_of_lit = let open Lit in function
   | NullLit -> V.Null
   | BoolLit b -> V.Bool b
   | NatLit n -> V.Int n

--- a/src/as_frontend/parser.mly
+++ b/src/as_frontend/parser.mly
@@ -1,6 +1,7 @@
 %{
 open As_types
 open As_values.Operator
+open As_values.Lit
 open Syntax
 open Source
 

--- a/src/as_frontend/syntax.ml
+++ b/src/as_frontend/syntax.ml
@@ -1,6 +1,7 @@
 open As_types
 open As_values
 open As_values.Operator
+open As_values.Lit
 
 (* Notes *)
 
@@ -53,23 +54,6 @@ and typ_tag' = {tag : id; typ : typ}
 
 and typ_bind = (typ_bind', Type.con option) Source.annotated_phrase
 and typ_bind' = {var : id; bound : typ}
-
-
-(* Literals *)
-
-type lit =
-  | NullLit
-  | BoolLit of bool
-  | NatLit of Value.Nat.t
-  | IntLit of Value.Int.t
-  | Word8Lit of Value.Word8.t
-  | Word16Lit of Value.Word16.t
-  | Word32Lit of Value.Word32.t
-  | Word64Lit of Value.Word64.t
-  | FloatLit of Value.Float.t
-  | CharLit of Value.unicode
-  | TextLit of string
-  | PreLit of string * Type.prim
 
 
 (* Patterns *)

--- a/src/as_frontend/typing.ml
+++ b/src/as_frontend/typing.ml
@@ -312,6 +312,7 @@ let check_float env = check_lit_val env T.Float Value.Float.of_string
 
 
 let infer_lit env lit at : T.prim =
+  let open Lit in
   match !lit with
   | NullLit -> T.Null
   | BoolLit _ -> T.Bool
@@ -337,6 +338,7 @@ let infer_lit env lit at : T.prim =
     assert false
 
 let check_lit env t lit at =
+  let open Lit in
   match T.normalize t, !lit with
   | T.Opt _, NullLit -> ()
   | T.Prim T.Nat, PreLit (s, T.Nat) ->

--- a/src/as_ir/arrange_ir.ml
+++ b/src/as_ir/arrange_ir.ml
@@ -1,5 +1,6 @@
 open As_frontend
 open As_types
+open As_values
 open Source
 open Arrange_type
 open Ir
@@ -12,7 +13,7 @@ let kind k = Atom (Type.string_of_kind k)
 
 let rec exp e = match e.it with
   | VarE i              -> "VarE"    $$ [id i]
-  | LitE l              -> "LitE"    $$ [Arrange.lit l]
+  | LitE l              -> "LitE"    $$ [Arrange_lit.lit l]
   | UnE (t, uo, e)      -> "UnE"     $$ [typ t; Arrange.unop uo; exp e]
   | BinE (t, e1, bo, e2)-> "BinE"    $$ [typ t; exp e1; Arrange.binop bo; exp e2]
   | RelE (t, e1, ro, e2)-> "RelE"    $$ [typ t; exp e1; Arrange.relop ro; exp e2]
@@ -58,7 +59,7 @@ and pat p = match p.it with
   | VarP i          -> "VarP"       $$ [ id i ]
   | TupP ps         -> "TupP"       $$ List.map pat ps
   | ObjP pfs        -> "ObjP"       $$ List.map pat_field pfs
-  | LitP l          -> "LitP"       $$ [ Arrange.lit l ]
+  | LitP l          -> "LitP"       $$ [ Arrange_lit.lit l ]
   | OptP p          -> "OptP"       $$ [ pat p ]
   | TagP (i, p)     -> "TagP"       $$ [ id i; pat p ]
   | AltP (p1,p2)    -> "AltP"       $$ [ pat p1; pat p2 ]

--- a/src/as_ir/check_ir.ml
+++ b/src/as_ir/check_ir.ml
@@ -1,6 +1,6 @@
 open As_types
-open As_frontend
 open As_values
+open As_frontend
 
 open Source
 module T = Type
@@ -245,7 +245,7 @@ and check_inst_bounds env tbs typs at =
 (* Literals *)
 
 let type_lit env lit at : T.prim =
-  let open Syntax in
+  let open Lit in
   match lit with
   | NullLit -> T.Null
   | BoolLit _ -> T.Bool
@@ -602,7 +602,7 @@ and check_pat env pat : val_env =
   match pat.it with
   | WildP -> T.Env.empty
   | VarP id -> T.Env.singleton id.it pat.note
-  | LitP Syntax.NullLit ->
+  | LitP Lit.NullLit ->
     T.Prim T.Null <: t;
     T.Env.empty
   | LitP lit ->

--- a/src/as_ir/construct.ml
+++ b/src/as_ir/construct.ml
@@ -1,5 +1,6 @@
 open As_frontend
 open As_types
+open As_values
 
 (* WIP translation of syntaxops to use IR in place of Source *)
 open Source
@@ -133,7 +134,7 @@ let blockE decs exp =
     }
 
 let textE s =
-  { it = LitE (S.TextLit s);
+  { it = LitE (Lit.TextLit s);
     at = no_region;
     note = { S.note_typ = T.Prim T.Text;
              S.note_eff = T.Triv }
@@ -148,7 +149,7 @@ let unitE =
   }
 
 let boolE b =
-  { it = LitE (S.BoolLit b);
+  { it = LitE (Lit.BoolLit b);
     at = no_region;
     note = { S.note_typ = T.bool;
              S.note_eff = T.Triv}
@@ -183,7 +184,7 @@ let switch_optE exp1 exp2 pat exp3 typ1  =
   { it =
       SwitchE
         (exp1,
-         [{ it = {pat = {it = LitP S.NullLit;
+         [{ it = {pat = {it = LitP Lit.NullLit;
                          at = no_region;
                          note = typ exp1};
                   exp = exp2};

--- a/src/as_ir/ir.ml
+++ b/src/as_ir/ir.ml
@@ -11,7 +11,7 @@ type typ_bind' = {con : Type.con; bound : Type.typ}
 type typ_bind = typ_bind' Source.phrase
 
 type id = Syntax.id
-type lit = Syntax.lit
+type lit = Lit.lit
 type unop = Operator.unop
 type binop = Operator.binop
 type relop = Operator.relop

--- a/src/as_values/arrange_lit.ml
+++ b/src/as_values/arrange_lit.ml
@@ -1,0 +1,20 @@
+open As_types
+open Lit
+open Wasm.Sexpr
+
+let ($$) head inner = Node (head, inner)
+
+let lit (l:lit) = match l with
+  | NullLit       -> Atom "NullLit"
+  | BoolLit true  -> "BoolLit"   $$ [ Atom "true" ]
+  | BoolLit false -> "BoolLit"   $$ [ Atom "false" ]
+  | NatLit n      -> "NatLit"    $$ [ Atom (Value.Nat.to_string n) ]
+  | IntLit i      -> "IntLit"    $$ [ Atom (Value.Int.to_string i) ]
+  | Word8Lit w    -> "Word8Lit"  $$ [ Atom (Value.Word8.to_string_u w) ]
+  | Word16Lit w   -> "Word16Lit" $$ [ Atom (Value.Word16.to_string_u w) ]
+  | Word32Lit w   -> "Word32Lit" $$ [ Atom (Value.Word32.to_string_u w) ]
+  | Word64Lit w   -> "Word64Lit" $$ [ Atom (Value.Word64.to_string_u w) ]
+  | FloatLit f    -> "FloatLit"  $$ [ Atom (Value.Float.to_string f) ]
+  | CharLit c     -> "CharLit"   $$ [ Atom (string_of_int c) ]
+  | TextLit t     -> "TextLit"   $$ [ Atom t ]
+  | PreLit (s,p)  -> "PreLit"    $$ [ Atom s; Arrange_type.prim p ]

--- a/src/as_values/lit.ml
+++ b/src/as_values/lit.ml
@@ -1,0 +1,16 @@
+open As_types
+
+type lit =
+  | NullLit
+  | BoolLit of bool
+  | NatLit of Value.Nat.t
+  | IntLit of Value.Int.t
+  | Word8Lit of Value.Word8.t
+  | Word16Lit of Value.Word16.t
+  | Word32Lit of Value.Word32.t
+  | Word64Lit of Value.Word64.t
+  | FloatLit of Value.Float.t
+  | CharLit of Value.unicode
+  | TextLit of string
+  | PreLit of string * Type.prim
+

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -4361,7 +4361,8 @@ end (* AllocHow *)
 (* The actual compiler code that looks at the AST *)
 
 let compile_lit env lit =
-  try As_frontend.Syntax.(match lit with
+  let open Lit in
+  try match lit with
     (* Booleans are directly in Vanilla representation *)
     | BoolLit false -> SR.bool, Bool.lit false
     | BoolLit true ->  SR.bool, Bool.lit true
@@ -4375,8 +4376,7 @@ let compile_lit env lit =
     | CharLit c     -> SR.Vanilla, compile_unboxed_const Int32.(shift_left (of_int c) 8)
     | NullLit       -> SR.Vanilla, Opt.null
     | TextLit t     -> SR.Vanilla, Text.lit env t
-    | _ -> todo_trap_SR env "compile_lit" (As_frontend.Arrange.lit lit)
-    )
+    | _ -> todo_trap_SR env "compile_lit" (Arrange_lit.lit lit)
   with Failure _ ->
     Printf.eprintf "compile_lit: Overflow in literal %s\n" (As_frontend.Syntax.string_of_lit lit);
     SR.Unreachable, E.trap_with env "static literal overflow"
@@ -5002,7 +5002,7 @@ enabled mutual recursion.
 
 
 and compile_lit_pat env l =
-  let open As_frontend.Syntax in
+  let open Lit in
   match l with
   | NullLit ->
     compile_lit_as env SR.Vanilla l ^^
@@ -5018,7 +5018,7 @@ and compile_lit_pat env l =
   | (TextLit t) ->
     Text.lit env t ^^
     Text.compare env
-  | _ -> todo_trap env "compile_lit_pat" (As_frontend.Arrange.lit l)
+  | _ -> todo_trap env "compile_lit_pat" (Arrange_lit.lit l)
 
 and fill_pat env ae pat : patternCode =
   PatCode.with_region pat.at @@

--- a/src/interpreter/interpret.ml
+++ b/src/interpreter/interpret.ml
@@ -209,6 +209,7 @@ let make_message env name t v : V.value =
 (* Literals *)
 
 let interpret_lit env lit : V.value =
+  let open Lit in
   match !lit with
   | NullLit -> V.Null
   | BoolLit b -> V.Bool b
@@ -535,6 +536,7 @@ and define_pat_field env vs pf =
   define_pat env pf.it.pat v
 
 and match_lit lit v : bool =
+  let open Lit in
   match !lit, v with
   | NullLit, V.Null -> true
   | BoolLit b, V.Bool b' -> b = b'

--- a/src/ir_interpreter/interpret_ir.ml
+++ b/src/ir_interpreter/interpret_ir.ml
@@ -232,7 +232,7 @@ let extended_prim env s typ at =
 (* Literals *)
 
 let interpret_lit env lit : V.value =
-  let open Syntax in
+  let open Lit in
   match lit with
   | NullLit -> V.Null
   | BoolLit b -> V.Bool b
@@ -537,7 +537,7 @@ and define_field_pats env pfs vs =
 
 
 and match_lit lit v : bool =
-  let open Syntax in
+  let open Lit in
   match lit, v with
   | NullLit, V.Null -> true
   | BoolLit b, V.Bool b' -> b = b'

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -25,12 +25,13 @@ let id_of_full_path (fp : string) : Syntax.id =
 let trueE : Ir.exp = boolE true
 let falseE : Ir.exp = boolE false
 
-let apply_sign op l = Syntax.(match op, l with
+let apply_sign op l =
+  let open Lit in
+  match op, l with
   | PosOp, l -> l
   | NegOp, NatLit n -> NatLit (Value.Nat.sub Value.Nat.zero n)
   | NegOp, IntLit n -> IntLit (Value.Int.sub Value.Int.zero n)
   | _, _ -> raise (Invalid_argument "Invalid signed pattern")
-  )
 
 let phrase f x =  { x with it = f x.it }
 


### PR DESCRIPTION
removing a big chunck of mentions of As_frontend in IR-related code and
the backend.