### PR TITLE
Remove the --disable-prelude flags

### DIFF
--- a/src/exes/asc.ml
+++ b/src/exes/asc.ml
@@ -53,7 +53,6 @@ let argspec = Arg.align
   "-dt", Arg.Set Flags.dump_tc, " dump type-checked AST";
   "-dl", Arg.Set Flags.dump_lowering, " dump intermediate representation ";
   "-no-check-ir", Arg.Clear Flags.check_ir, " do not check intermediate code";
-  "--disable-prelude", Arg.Clear Flags.prelude, " disable prelude";
 ]
 
 

--- a/src/flags/flags.ml
+++ b/src/flags/flags.ml
@@ -8,6 +8,5 @@ let dump_tc = ref false
 let dump_lowering = ref false
 let interpret_ir = ref false
 let source_map = ref false
-let prelude = ref true
 let link = ref true
 let check_ir = ref true

--- a/src/wasm-exts/customModuleEncode.ml
+++ b/src/wasm-exts/customModuleEncode.ml
@@ -66,10 +66,8 @@ let encode (em : extended_module) =
     | h :: t -> if x = h then 0 else 1 + (add_source x t)
   in
 
-  if !Flags.prelude then begin
-    sources := !sources @ [ "prelude" ];
-    sourcesContent := !sourcesContent @ [ Prelude.prelude ]
-  end;
+  sources := !sources @ [ "prelude" ];
+  sourcesContent := !sourcesContent @ [ Prelude.prelude ];
 
   let add_to_map file il ic ol oc =
     let il = il - 1 in


### PR DESCRIPTION
it somehow affected the source map generation, but I see no problem in
simply always including the prelude in the source map.