### PR TITLE
Add `Any` back to `to_idl_prim`, to replace `Shared`

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -2797,6 +2797,7 @@ module Serialization = struct
       | Prim Int64 -> Some 12
       | Prim Float -> Some 14
       | Prim Text -> Some 15
+      | Any -> Some 16
       | Non -> Some 17
       | _ -> None
     in


### PR DESCRIPTION
slipped through the cracks in #560