### PR TITLE
Bump dev

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,7 @@ let ocaml_bisect_ppx-ocamlbuild = import ./nix/ocaml-bisect_ppx-ocamlbuild.nix n
 let dev = import (builtins.fetchGit {
   url = "ssh://git@github.com/dfinity-lab/dev";
   ref = "master";
-  rev = "49627900050b2db1b641cd402e832a165b8d47f5";
+  rev = "ad50bcea8db6d55decf2622ad836435aa36fa33f";
 }) { system = nixpkgs.system; }; in
 
 # Include dvm


### PR DESCRIPTION
this should finanlly get rid of the `gitSource.nix` warnign (this took
several PRs because we import `dev` with a pinned version which imports
`actorscript` with a pinned version.)