### PR TITLE
asc: -no-multi-value

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -186,6 +186,10 @@ rec {
     '';
   };
 
+  tests-no-mv = tests.overrideAttrs (oldAttrs: {
+    ASC_FLAGS = "-no-multi-value";
+  });
+
   unit-tests = stdenv.mkDerivation {
     name = "unit-tests";
 
@@ -409,6 +413,7 @@ rec {
       js
       didc
       tests
+      tests-no-mv
       unit-tests
       samples
       rts

--- a/src/codegen/flags.ml
+++ b/src/codegen/flags.ml
@@ -1,1 +1,2 @@
 let fake_orthogonal_persistence = ref true
+let multi_value = ref true

--- a/src/exes/asc.ml
+++ b/src/exes/asc.ml
@@ -69,6 +69,7 @@ let argspec = Arg.align
     Arg.Unit (fun () -> compile_mode := Pipeline.WasmMode),
       " do not import the DFINITY system API";
   "-no-fake-op", Arg.Clear Codegen.Flags.fake_orthogonal_persistence, " do not fake OP";
+  "-no-multi-value", Arg.Clear Codegen.Flags.multi_value, " avoid multi-value extension";
 
   "-dp", Arg.Set Pipeline.Flags.dump_parse, " dump parse";
   "-dt", Arg.Set Pipeline.Flags.dump_tc, " dump type-checked AST";


### PR DESCRIPTION
For some use-cases (e.g. processing the compiler output with analysis
tools) it is useful to avoid the multi-value extension.

This flag provides mostly transparent wrappers that put multiple values
in statically allocated globals (at most 10...) and pull them off again.

If the flag is not used, the code is unchanged.