### PR TITLE
IR.FuncE: Check calling convention against the parameter and return type list

### DIFF
--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -535,6 +535,10 @@ let rec check_exp env (exp:Ir.exp) : unit =
     check ((cc.Call_conv.sort = T.Shared && Type.is_async (T.seq ret_tys))
            ==> isAsyncE exp)
       "shared function with async type has non-async body";
+    check (cc.Call_conv.n_args = List.length args)
+      "calling convention arity does not match number of parameters";
+    check (cc.Call_conv.n_res = List.length ret_tys)
+      "calling convention arity does not match number of return types";
     if (cc.Call_conv.sort = T.Shared) then List.iter (check_concrete env exp.at) ret_tys;
     let env'' =
       {env' with labs = T.Env.empty; rets = Some (T.seq ret_tys); async = false} in

--- a/test/run-dfinity/idl-tuple.as
+++ b/test/run-dfinity/idl-tuple.as
@@ -1,0 +1,9 @@
+let a = actor {
+  public func len2() : async (Int,Int) {
+    (23, 42)
+  }
+};
+
+a.len2();
+
+//  CALL len2 0x4449444c016a027c7c00000100 [console:logAny]

--- a/test/run-dfinity/ok/idl-tuple.did.ok
+++ b/test/run-dfinity/ok/idl-tuple.did.ok
@@ -1,0 +1,4 @@
+type Int = int;
+service a {
+len2 : () -> (record {Int; Int});
+}


### PR DESCRIPTION
ever since
4efd91586f3cb3d5b8354186494a062353541353
and
4e67f89dac0a4dc3904374d206e29f3848abf222
the parameter list and return type list of `FuncE` should match the
Calling Convention field. This checks this fact.

Maybe it is time to get rid of the calling convention, now that we have
almost all relevant data in the other fields, moving `FuncE` closer to
`FuncT` again.

I wondered if this check breaks due to the way we put `[AyncT t]` in the
return type list for shared functions, but the test case I added says we
don’t. Maybe we just don't do n-ary returns in async these days.