### PR TITLE
State that natural storage types are submitted in little endian

### DIFF
--- a/design/IDL.md
+++ b/design/IDL.md
@@ -894,7 +894,7 @@ Note:
 
 #### Notation
 
-`T` and `M` create a byte sequence described below in terms of natural storage types (`i<N>` for `N = 8, 16, 32, 64`, `f<N>` for `N = 32, 64`).
+`T` and `M` create a byte sequence described below in terms of natural storage types (`i<N>` for `N = 8, 16, 32, 64`, `f<N>` for `N = 32, 64`). The bytes are sequenced according to increasing significance (least significant byte first, a.k.a. little-endian).
 
 The following notation is used:
 


### PR DESCRIPTION
I don't see this stated anywhere, and it is probably inherited from WASM. But better make it explicit.

No idea if this is true for floats. :-(