### PR TITLE
Test runner: Do not override node output

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -68,7 +68,7 @@ failures=no
 function normalize () {
   if [ -e "$1" ]
   then
-    grep -a -E -v '^Raised by|Raised at|^Re-raised at|^Re-Raised at|^Called from|^ *at ' $1 |
+    grep -a -E -v '^Raised by|^Raised at|^Re-raised at|^Re-Raised at|^Called from|^ *at ' $1 |
     sed 's/\x00//g' |
     sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' |
     sed 's/^.*[IW], hypervisor:/hypervisor:/g' |


### PR DESCRIPTION
`run.sh` was previously writing to `$base.js.out` twice. This fixes
this. It uncovers some regressions; committing the status quo here,
they will be fixed in #693.