### PR TITLE
render .as as swift on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# .gitattributes file which reclassifies `.as` files as Swift:
+*.as linguist-language=Swift


### PR DESCRIPTION
add .gitattributes file to render .as files as swift on GitHub. Not perfect, but better than nothing.