### PR TITLE
error out on parser conflicts

### DIFF
--- a/src/as_frontend/dune
+++ b/src/as_frontend/dune
@@ -4,7 +4,7 @@
 )
 (menhir
   (modules parser)
-  (flags -v)
+  (flags -v --strict)
   (infer false)
 )
 (ocamllex lexer)

--- a/src/idllib/dune
+++ b/src/idllib/dune
@@ -5,6 +5,7 @@
 
 (menhir
   (modules parser)
+  (flags -v --strict)
   (infer false)
 )
 (ocamllex lexer)


### PR DESCRIPTION
Looks like the `--strict` flag got lost in the `dune` transition.

For `idllib` it was never enabled.