### PR TITLE
deser: correct arg sequence and comments

### DIFF
--- a/src/exes/deser.ml
+++ b/src/exes/deser.ml
@@ -255,11 +255,16 @@ let output_text n froms tos =
 
 
 let output_arguments args : outputter * (unit -> int -> outputter -> outputter) =
+  let last i = i + 1 = args in
   let herald_arguments = function
-    | () when args = 0 -> output_string "# No arguments...\n"
-    | _ when args = 1 -> output_string "# 1 argument follows"
-    | _ -> Printf.printf "# %d arguments follow" args in
-  let herald_member () i f () = Printf.printf "\n# Argument #%d%s:\n" i (if i + 1 = args then " (last)" else ""); f () in
+    | () when args = 0 -> output_string "// No arguments...\n()"
+    | _ when args = 1 -> output_string "// 1 argument follows\n(\n"
+    | _ -> Printf.printf "// %d arguments follow\n(\n" args in
+  let herald_member () i f () =
+    Printf.printf "// Argument #%d%s:\n" i (if last i then " (last)" else "");
+    if i = 0 then print_string "  " else print_string ", ";
+    f ();
+    if last i then print_string "\n)" else print_string "\n" in
   herald_arguments, (*bracket args*) herald_member
 
 let start i = if i = 0 then output_string_space "{"

--- a/test/run-deser/ok/five.ok
+++ b/test/run-deser/ok/five.ok
@@ -4,15 +4,17 @@ DESER, to your service!
 ========================== Type section
 
 ========================== Value section
-# 5 arguments follow
-# Argument #0:
-"One"
-# Argument #1:
-"Two"
-# Argument #2:
-"Three"
-# Argument #3:
-"Four"
-# Argument #4 (last):
-"Five"
+// 5 arguments follow
+(
+// Argument #0:
+  "One"
+// Argument #1:
+, "Two"
+// Argument #2:
+, "Three"
+// Argument #3:
+, "Four"
+// Argument #4 (last):
+, "Five"
+)
 -------- DESER DONE

--- a/test/run-deser/ok/future.ok
+++ b/test/run-deser/ok/future.ok
@@ -5,9 +5,11 @@ DESER, to your service!
 read_type_table: 0
 
 ========================== Value section
-# 2 arguments follow
-# Argument #0:
-
-# Argument #1 (last):
-"Foo"
+// 2 arguments follow
+(
+// Argument #0:
+  
+// Argument #1 (last):
+, "Foo"
+)
 -------- DESER DONE


### PR DESCRIPTION
In `--idl` mode now output the correct comment characters, and form an argument sequence in parentheses.
