### PR TITLE
Exclude tests from stdlib tarball

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -478,7 +478,7 @@ rec {
     '';
     installPhase = ''
       mkdir -p $out
-      tar -rf $out/stdlib.tar -C $src *.as
+      tar -rf $out/stdlib.tar -C $src *.as --exclude="*Test.as"
       mkdir -p $out/nix-support
       echo "report stdlib $out/stdlib.tar" >> $out/nix-support/hydra-build-products
     '';


### PR DESCRIPTION
The contents of this tarball came up in https://github.com/dfinity-lab/sdk/pull/99. I'm assuming we don't want to include any tests files. This relies on a naming convention for now.