### PR TITLE
Adds utop to our nix-shell inputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -579,7 +579,7 @@ rec {
         deser.buildInputs ++
         tests.buildInputs ++
         users-guide.buildInputs ++
-        [ nixpkgs.ncurses nixpkgs.ocamlPackages.merlin ]
+        [ nixpkgs.ncurses nixpkgs.ocamlPackages.merlin nixpkgs.ocamlPackages.utop ]
       ));
 
     shellHook = llvmEnv;


### PR DESCRIPTION
This allows us to open a repl with our project loaded by executing `dune utop` from within the `src/` directory.