### PR TITLE
Make `large-array.mo` smaller

### DIFF
--- a/test/run-drun/large-array.mo
+++ b/test/run-drun/large-array.mo
@@ -1,3 +1,6 @@
 // Should allocate 1G
-ignore(Array_init<()>(1024*1024*1024/4, ()));
+// ignore(Array_init<()>(1024*1024*1024/4, ()));
+
+// Should allocate 50MB (easier on CI)
+ignore(Array_init<()>(50*1024*1024/4, ()));
 


### PR DESCRIPTION
Allocating a 1GB array was putting too much strain on CI, especially
during interpretation. Let's do 50MB instead.