### PR TITLE
Rename async to future

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1182,21 +1182,21 @@ module Tagged = struct
       | (Con _ | Any) -> true
       | (Array _ | Tup _) -> true
       | (Prim _ |  Obj _ | Opt _ | Variant _ | Func _ | Non) -> false
-      | (Pre | Async _ | Mut _ | Var _ | Typ _) -> assert false
+      | (Pre | Fut _ | Mut _ | Var _ | Typ _) -> assert false
       end
     | Blob ->
       begin match normalize ty with
       | (Con _ | Any) -> true
       | (Prim Text) -> true
       | (Prim _ | Obj _ | Array _ | Tup _ | Opt _ | Variant _ | Func _ | Non) -> false
-      | (Pre | Async _ | Mut _ | Var _ | Typ _) -> assert false
+      | (Pre | Fut _ | Mut _ | Var _ | Typ _) -> assert false
       end
     | Object ->
       begin match normalize ty with
       | (Con _ | Any) -> true
       | (Obj _) -> true
       | (Prim _ | Array _ | Tup _ | Opt _ | Variant _ | Func _ | Non) -> false
-      | (Pre | Async _ | Mut _ | Var _ | Typ _) -> assert false
+      | (Pre | Fut _ | Mut _ | Var _ | Typ _) -> assert false
       end
     | _ -> true
 
@@ -6413,7 +6413,7 @@ and compile_exp (env : E.t) ae exp =
           in
       let code2 = go env cs in
       code1 ^^ set_i ^^ orTrap env code2 ^^ get_j
-  (* Async-wait lowering support features *)
+  (* Future-await lowering support features *)
   | DeclareE (name, _, e) ->
     let (ae1, i) = VarEnv.add_local_with_offset env ae name 1l in
     let sr, code = compile_exp env ae1 e in

--- a/src/ir_def/arrange_ir.ml
+++ b/src/ir_def/arrange_ir.ml
@@ -23,7 +23,7 @@ let rec exp e = match e.it with
   | AssignE (e1, e2)    -> "AssignE" $$ [exp e1; exp e2]
   | ArrayE (m, t, es)   -> "ArrayE"  $$ [mut m; typ t] @ List.map exp es
   | IdxE (e1, e2)       -> "IdxE"    $$ [exp e1; exp e2]
-  | CallE (e1, ts, e2)  -> "CallE" $$ [exp e1] @ List.map typ ts @ [exp e2]
+  | CallE (e1, ts, e2)  -> "CallE"   $$ [exp e1] @ List.map typ ts @ [exp e2]
   | BlockE (ds, e1)     -> "BlockE"  $$ List.map dec ds @ [exp e1]
   | IfE (e1, e2, e3)    -> "IfE"     $$ [exp e1; exp e2; exp e3]
   | SwitchE (e, cs)     -> "SwitchE" $$ [exp e] @ List.map case cs
@@ -31,11 +31,11 @@ let rec exp e = match e.it with
   | LabelE (i, t, e)    -> "LabelE"  $$ [id i; typ t; exp e]
   | BreakE (i, e)       -> "BreakE"  $$ [id i; exp e]
   | RetE e              -> "RetE"    $$ [exp e]
-  | AsyncE e            -> "AsyncE"  $$ [exp e]
+  | FutE e              -> "FutE"    $$ [exp e]
   | AwaitE e            -> "AwaitE"  $$ [exp e]
   | AssertE e           -> "AssertE" $$ [exp e]
   | OptE e              -> "OptE"    $$ [exp e]
-  | TagE (i, e)         -> "TagE" $$ [id i; exp e]
+  | TagE (i, e)         -> "TagE"    $$ [id i; exp e]
   | DeclareE (i, t, e1) -> "DeclareE" $$ [id i; exp e1]
   | DefineE (i, m, e1)  -> "DefineE" $$ [id i; mut m; exp e1]
   | FuncE (x, s, c, tp, as_, ts, e) ->

--- a/src/ir_def/construct.ml
+++ b/src/ir_def/construct.ml
@@ -90,10 +90,10 @@ let primE prim es =
     note = { note_typ = ty; note_eff = e }
   }
 
-let asyncE typ e =
-  { it = PrimE (OtherPrim "@async", [e]);
+let futE typ e =
+  { it = PrimE (OtherPrim "@future", [e]);
     at = no_region;
-    note = { note_typ = T.Async typ; note_eff = eff e }
+    note = { note_typ = T.Fut typ; note_eff = eff e }
   }
 
 let assertE e =

--- a/src/ir_def/construct.mli
+++ b/src/ir_def/construct.mli
@@ -39,7 +39,7 @@ val seqP : pat list -> pat
 (* Expressions *)
 
 val primE : Ir.prim -> exp list -> exp
-val asyncE : typ -> exp -> exp
+val futE : typ -> exp -> exp
 val assertE : exp -> exp
 val awaitE : typ -> exp -> exp -> exp
 val ic_replyE : typ list -> exp -> exp

--- a/src/ir_def/freevars.ml
+++ b/src/ir_def/freevars.ml
@@ -75,7 +75,7 @@ let rec exp e : f = match e.it with
   | LabelE (i, t, e)    -> exp e
   | BreakE (i, e)       -> exp e
   | RetE e              -> exp e
-  | AsyncE e            -> exp e
+  | FutE e              -> exp e
   | AwaitE e            -> exp e
   | AssertE e           -> exp e
   | OptE e              -> exp e

--- a/src/ir_def/ir.ml
+++ b/src/ir_def/ir.ml
@@ -81,7 +81,7 @@ and exp' =
   | LabelE of id * Type.typ * exp              (* label *)
   | BreakE of id * exp                         (* break *)
   | RetE of exp                                (* return *)
-  | AsyncE of exp                              (* async *)
+  | FutE of exp                                (* future *)
   | AwaitE of exp                              (* await *)
   | AssertE of exp                             (* assertion *)
   | DeclareE of id * Type.typ * exp            (* local promise *)
@@ -154,15 +154,15 @@ should hold.
 *)
 
 type flavor = {
-  has_async_typ : bool; (* AsyncT *)
-  has_await : bool; (* AwaitE and AsyncE *)
+  has_fut_typ : bool; (* FutT *)
+  has_await : bool; (* AwaitE and FutE *)
   has_show : bool; (* ShowE *)
   serialized : bool; (* Shared function arguments are serialized *)
 }
 
 let full_flavor : flavor = {
   has_await = true;
-  has_async_typ = true;
+  has_fut_typ = true;
   has_show = true;
   serialized = false;
 }

--- a/src/ir_def/ir_effect.ml
+++ b/src/ir_def/ir_effect.ml
@@ -62,7 +62,7 @@ let rec infer_effect_exp (exp: exp) : T.eff =
     let e1 = effect_exp exp1 in
     let e2 = effect_cases cases in
     max_eff e1 e2
-  | AsyncE exp1 ->
+  | FutE exp1 ->
     T.Triv
   | ThrowE _
   | TryE _

--- a/src/ir_passes/await.ml
+++ b/src/ir_passes/await.ml
@@ -116,7 +116,7 @@ and t_exp' context exp' =
       | Some Label -> RetE (t_exp context exp1)
       | None -> assert false
     end
-  | AsyncE exp1 ->
+  | FutE exp1 ->
      let exp1 = R.exp R.Renaming.empty exp1 in (* rename all bound vars apart *)
      (* add the implicit return/throw label *)
      let k_ret = fresh_cont (typ exp1) in
@@ -126,7 +126,7 @@ and t_exp' context exp' =
          (LabelEnv.add Throw (Cont (ContVar k_fail)) LabelEnv.empty)
      in
      (* TODO: bind k_fail *)
-     (asyncE (typ exp1) ([k_ret; k_fail] -->*
+     (futE (typ exp1) ([k_ret; k_fail] -->*
                            c_exp context' exp1 (ContVar k_ret))).it
   | TryE _
   | ThrowE _
@@ -352,7 +352,7 @@ and c_exp' context exp k =
       | Some Label
       | None -> assert false
     end
-  | AsyncE exp1 ->
+  | FutE exp1 ->
      (* add the implicit return label *)
     let k_ret = fresh_cont (typ exp1) in
     let k_fail = fresh_err_cont () in
@@ -360,7 +360,7 @@ and c_exp' context exp k =
       LabelEnv.add Return (Cont (ContVar k_ret))
         (LabelEnv.add Throw (Cont (ContVar k_fail)) LabelEnv.empty)
     in
-    k -@- (asyncE (typ exp1) ([k_ret; k_fail] -->*
+    k -@- (futE (typ exp1) ([k_ret; k_fail] -->*
                                    (c_exp context' exp1 (ContVar k_ret))))
   | AwaitE exp1 ->
      let r = match LabelEnv.find_opt Throw context with

--- a/src/ir_passes/rename.ml
+++ b/src/ir_passes/rename.ml
@@ -54,7 +54,7 @@ and exp' rho e  = match e with
                            LabelE(i', t, exp rho' e)
   | BreakE (i, e)       -> BreakE(id rho i,exp rho e)
   | RetE e              -> RetE (exp rho e)
-  | AsyncE e            -> AsyncE (exp rho e)
+  | FutE e              -> FutE (exp rho e)
   | AwaitE e            -> AwaitE (exp rho e)
   | AssertE e           -> AssertE (exp rho e)
   | OptE e              -> OptE (exp rho e)

--- a/src/ir_passes/show.ml
+++ b/src/ir_passes/show.ml
@@ -124,7 +124,7 @@ and t_exp' env = function
     RetE (t_exp env exp1)
   | ThrowE exp1 ->
     ThrowE (t_exp env exp1)
-  | AsyncE e -> AsyncE (t_exp env e)
+  | FutE e -> FutE (t_exp env e)
   | AwaitE e -> AwaitE (t_exp env e)
   | AssertE exp1 ->
     AssertE (t_exp env exp1)

--- a/src/ir_passes/tailcall.ml
+++ b/src/ir_passes/tailcall.ml
@@ -123,7 +123,7 @@ and exp' env e  : exp' = match e.it with
   | RetE e              -> RetE (tailexp { env with tail_pos = true } e)
   (* NB:^ e is always in tailposition, regardless of fst env *)
   | ThrowE e            -> ThrowE (exp env e) (* TODO: make me a tail call *)
-  | AsyncE e            -> AsyncE (exp { tail_pos = true; info = None } e)
+  | FutE e              -> FutE (exp { tail_pos = true; info = None } e)
   | AwaitE e            -> AwaitE (exp env e)
   | AssertE e           -> AssertE (exp env e)
   | OptE e              -> OptE (exp env e)

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -131,7 +131,7 @@ and exp' at note = function
   | S.BreakE (l, e) -> I.BreakE (l.it, exp e)
   | S.RetE e -> I.RetE (exp e)
   | S.ThrowE e -> I.ThrowE (exp e)
-  | S.AsyncE e -> I.AsyncE (exp e)
+  | S.FutE e -> I.FutE (exp e)
   | S.AwaitE e -> I.AwaitE (exp e)
   | S.AssertE e -> I.AssertE (exp e)
   | S.AnnotE (e, _) -> assert false
@@ -402,14 +402,14 @@ and to_args typ p : Ir.arg list * (Ir.exp -> Ir.exp) * T.control * T.typ list =
       (fun e -> blockE [letP (pat p) (tupE vs)] e)
   in
 
-  let wrap_under_async e =
+  let wrap_under_fut e =
     if T.is_shared_sort sort && control <> T.Returns
     then match e.it with
-      | Ir.AsyncE e' -> { e with it = Ir.AsyncE (wrap e') }
+      | Ir.FutE e' -> { e with it = Ir.FutE (wrap e') }
       | _ -> assert false
     else wrap e in
 
-  args, wrap_under_async, control, res_tys
+  args, wrap_under_fut, control, res_tys
 
 and prog (p : Syntax.prog) : Ir.prog =
   begin match p.it with
@@ -417,7 +417,7 @@ and prog (p : Syntax.prog) : Ir.prog =
     | _ -> block false p.it
   end
   , { I.has_await = true
-    ; I.has_async_typ = true
+    ; I.has_fut_typ = true
     ; I.has_show = true
     ; I.serialized = false
     }

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -49,7 +49,7 @@ let rec exp e = match e.it with
   | DebugE e            -> "DebugE"  $$ [exp e]
   | BreakE (i, e)       -> "BreakE"  $$ [id i; exp e]
   | RetE e              -> "RetE"    $$ [exp e]
-  | AsyncE e            -> "AsyncE"  $$ [exp e]
+  | FutE e              -> "FutE"    $$ [exp e]
   | AwaitE e            -> "AwaitE"  $$ [exp e]
   | AssertE e           -> "AssertE" $$ [exp e]
   | AnnotE (e, t)       -> "AnnotE"  $$ [exp e; typ t]
@@ -147,7 +147,7 @@ and typ t = match t.it with
   | VariantT cts        -> "VariantT" $$ List.map typ_tag cts
   | TupT ts             -> "TupT" $$ List.map typ ts
   | FuncT (s, tbs, at, rt) -> "FuncT" $$ [func_sort s] @ List.map typ_bind tbs @ [ typ at; typ rt]
-  | AsyncT t            -> "AsyncT" $$ [typ t]
+  | FutT t              -> "FutT" $$ [typ t]
   | ParT t              -> "ParT" $$ [typ t]
 
 and dec d = match d.it with

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -40,7 +40,7 @@ and typ' =
   | VariantT of typ_tag list                       (* variant *)
   | TupT of typ list                               (* tuple *)
   | FuncT of func_sort * typ_bind list * typ * typ (* function *)
-  | AsyncT of typ                                  (* future *)
+  | FutT of typ                                    (* future *)
   | ParT of typ                                    (* parentheses, used to control function arity only *)
 
 and typ_field = typ_field' Source.phrase
@@ -141,7 +141,7 @@ and exp' =
   | BreakE of id * exp                         (* break *)
   | RetE of exp                                (* return *)
   | DebugE of exp                              (* debugging *)
-  | AsyncE of exp                              (* async *)
+  | FutE of exp                                (* future *)
   | AwaitE of exp                              (* await *)
   | AssertE of exp                             (* assertion *)
   | AnnotE of exp * typ                        (* type annotation *)

--- a/src/mo_frontend/definedness.ml
+++ b/src/mo_frontend/definedness.ml
@@ -119,7 +119,7 @@ let rec exp msgs e : f = match e.it with
   | ForE (p, e1, e2)    -> exp msgs e1 ++ (exp msgs e2 /// pat msgs p)
   | LabelE (i, t, e)    -> exp msgs e
   | DebugE e            -> exp msgs e
-  | AsyncE e            -> exp msgs e
+  | FutE e              -> exp msgs e
   | AwaitE e            -> exp msgs e
   | AssertE e           -> exp msgs e
   | AnnotE (e, t)       -> exp msgs e

--- a/src/mo_frontend/effect.ml
+++ b/src/mo_frontend/effect.ml
@@ -82,7 +82,7 @@ let rec infer_effect_exp (exp:Syntax.exp) : T.eff =
     let e1 = effect_exp exp1 in
     let e2 = effect_cases cases in
     max_eff e1 e2
-  | AsyncE exp1 ->
+  | FutE exp1 ->
     T.Triv
   | ThrowE _
   | TryE _

--- a/src/mo_frontend/lexer.mll
+++ b/src/mo_frontend/lexer.mll
@@ -191,7 +191,6 @@ rule token mode = parse
   *)
   | "actor" { ACTOR }
   | "and" { AND }
-  | "async" { ASYNC }
   | "assert" { ASSERT }
   | "await" { AWAIT }
   | "break" { BREAK }
@@ -204,6 +203,7 @@ rule token mode = parse
   | "false" { BOOL false }
   | "for" { FOR }
   | "func" { FUNC }
+  | "future" { FUTURE }
   | "if" { IF }
   | "in" { IN }
   | "import" { IMPORT }

--- a/src/mo_frontend/static.ml
+++ b/src/mo_frontend/static.ml
@@ -60,7 +60,7 @@ let rec exp m e = match e.it with
   | LabelE _
   | BreakE _
   | RetE _
-  | AsyncE _
+  | FutE _
   | AwaitE _
   | LoopE _
   | BinE _

--- a/src/mo_idl/mo_to_idl.ml
+++ b/src/mo_idl/mo_to_idl.ml
@@ -106,7 +106,7 @@ let rec typ vs t =
          fs1, tuple vs ts)
      | _ -> assert false)
   | Func _ -> assert false
-  | Async t -> assert false
+  | Fut t -> assert false
   | Mut t -> assert false
   | Pre -> assert false
   ) @@ no_region

--- a/src/mo_interpreter/interpret.ml
+++ b/src/mo_interpreter/interpret.ml
@@ -34,7 +34,7 @@ type env =
     libs : lib_env;
     rets : ret_env;
     throws : throw_env;
-    async : bool
+    fut : bool
   }
 
 let adjoin_scope scope1 scope2 =
@@ -56,7 +56,7 @@ let env_of_scope flags scope =
     labs = V.Env.empty;
     rets = None;
     throws = None;
-    async = false;
+    fut = false;
   }
 
 
@@ -120,46 +120,46 @@ struct
 end
 
 
-(* Async auxiliary functions *)
+(* Future auxiliary functions *)
 
-let make_async () : V.async =
+let make_fut () : V.fut =
   {V.result = Lib.Promise.make (); waiters = []}
 
-let get_async async (k : V.value V.cont) (r : V.value V.cont) =
-  match Lib.Promise.value_opt async.V.result with
+let get_fut fut (k : V.value V.cont) (r : V.value V.cont) =
+  match Lib.Promise.value_opt fut.V.result with
   | Some (V.Ok v) -> k v
   | Some (V.Error v) -> r v
-  | None -> async.V.waiters <- (k,r)::async.V.waiters
+  | None -> fut.V.waiters <- (k,r)::fut.V.waiters
 
-let set_async async v =
-  List.iter (fun (k,_) -> Scheduler.queue (fun () -> k v)) async.V.waiters;
-  Lib.Promise.fulfill async.V.result (V.Ok v);
-  async.V.waiters <- []
+let set_fut fut v =
+  List.iter (fun (k,_) -> Scheduler.queue (fun () -> k v)) fut.V.waiters;
+  Lib.Promise.fulfill fut.V.result (V.Ok v);
+  fut.V.waiters <- []
 
-let reject_async async v =
-  List.iter (fun (_,k) -> Scheduler.queue (fun () -> k v)) async.V.waiters;
-  Lib.Promise.fulfill async.V.result (V.Error v);
-  async.V.waiters <- []
+let reject_fut fut v =
+  List.iter (fun (_,k) -> Scheduler.queue (fun () -> k v)) fut.V.waiters;
+  Lib.Promise.fulfill fut.V.result (V.Error v);
+  fut.V.waiters <- []
 
-let reply async v =
-  Scheduler.queue (fun () -> set_async async v)
+let reply fut v =
+  Scheduler.queue (fun () -> set_fut fut v)
 
-let reject async v =
+let reject fut v =
   match v with
   | V.Tup [ _code; message ] ->
     (* mask the error code before rejecting *)
     Scheduler.queue
-      (fun () -> reject_async async (V.Tup [V.Variant("error", V.unit); message]))
+      (fun () -> reject_fut fut (V.Tup [V.Variant("error", V.unit); message]))
   | _ -> assert false
 
-let async env at (f: (V.value V.cont) -> (V.value V.cont) -> unit) (k : V.value V.cont) =
-    let async = make_async () in
-    (*    let k' = fun v1 -> set_async async v1 in *)
-    let k' = reply async in
-    let r  = reject async in
-    if env.flags.trace then trace "-> async %s" (string_of_region at);
+let fut env at (f: (V.value V.cont) -> (V.value V.cont) -> unit) (k : V.value V.cont) =
+    let fut = make_fut () in
+    (*    let k' = fun v1 -> set_fut fut v1 in *)
+    let k' = reply fut in
+    let r  = reject fut in
+    if env.flags.trace then trace "-> fututr %s" (string_of_region at);
     Scheduler.queue (fun () ->
-      if env.flags.trace then trace "<- async %s" (string_of_region at);
+      if env.flags.trace then trace "<- future %s" (string_of_region at);
       incr trace_depth;
       f (fun v ->
         if env.flags.trace then trace "<= %s" (string_of_val env v);
@@ -167,12 +167,12 @@ let async env at (f: (V.value V.cont) -> (V.value V.cont) -> unit) (k : V.value 
         k' v)
         r
     );
-    k (V.Async async)
+    k (V.Fut fut)
 
-let await env at async k =
+let await env at fut k =
   if env.flags.trace then trace "=> await %s" (string_of_region at);
   decr trace_depth;
-  get_async async (fun v ->
+  get_fut fut (fun v ->
     Scheduler.queue (fun () ->
       if env.flags.trace then
         trace "<- await %s%s" (string_of_region at) (string_of_arg env v);
@@ -209,17 +209,17 @@ let make_unit_message env id v =
   | _ -> (* assert false *)
     failwith ("unexpected call_conv " ^ (string_of_call_conv call_conv))
 
-let make_async_message env id v =
+let make_fut_message env id v =
   let open CC in
   let call_conv, f = V.as_func v in
   match call_conv with
   | {sort = T.Shared s; control = T.Promises; _} ->
-    Value.async_func s call_conv.n_args call_conv.n_res (fun v k ->
-      let async = make_async () in
-      actor_msg env id f v (fun v_async ->
-        get_async (V.as_async v_async) (set_async async) (reject_async async)
+    Value.fut_func s call_conv.n_args call_conv.n_res (fun v k ->
+      let fut = make_fut () in
+      actor_msg env id f v (fun v_fut ->
+        get_fut (V.as_fut v_fut) (set_fut fut) (reject_fut fut)
       );
-      k (V.Async async)
+      k (V.Fut fut)
     )
   | _ -> (* assert false *)
     failwith ("unexpected call_conv " ^ (string_of_call_conv call_conv))
@@ -228,7 +228,7 @@ let make_async_message env id v =
 let make_message env name t v : V.value =
   match t with
   | T.Func (_, T.Returns, _, _, _) -> make_unit_message env name v
-  | T.Func (_, T.Promises, _, _, _) -> make_async_message env name v
+  | T.Func (_, T.Promises, _, _, _) -> make_fut_message env name v
   | _ -> (* assert false *)
     failwith (Printf.sprintf "actorfield: %s %s" name (T.string_of_typ t))
 
@@ -556,17 +556,17 @@ and interpret_exp_mut env exp (k : V.value V.cont) =
     interpret_exp env exp1 (Lib.Option.value env.rets)
   | ThrowE exp1 ->
     interpret_exp env exp1 (Lib.Option.value env.throws)
-  | AsyncE exp1 ->
-    async env
+  | FutE exp1 ->
+    fut env
       exp.at
       (fun k' r ->
-        let env' = {env with labs = V.Env.empty; rets = Some k'; throws = Some r; async = true}
+        let env' = {env with labs = V.Env.empty; rets = Some k'; throws = Some r; fut = true}
         in interpret_exp env' exp1 k')
       k
 
   | AwaitE exp1 ->
     interpret_exp env exp1
-      (fun v1 -> await env exp.at (V.as_async v1) k)
+      (fun v1 -> await env exp.at (V.as_fut v1) k)
   | AssertE exp1 ->
     interpret_exp env exp1 (fun v ->
       if V.as_bool v
@@ -853,7 +853,7 @@ and interpret_func env name pat f v (k : V.value V.cont) =
         libs = env.libs;
         labs = V.Env.empty;
         rets = Some k';
-        async = false
+        fut = false
       }
     in f env' k'
 

--- a/src/mo_types/arrange_type.ml
+++ b/src/mo_types/arrange_type.ml
@@ -51,7 +51,7 @@ let rec typ (t:Type.typ) = match t with
   | Variant tfs            -> "Variant" $$ List.map typ_field tfs
   | Tup ts                 -> "Tup" $$ List.map typ ts
   | Func (s, c, tbs, at, rt) -> "Func" $$ [Atom (func_sort s); Atom (control c)] @ List.map typ_bind tbs @ [ "" $$ (List.map typ at); "" $$ (List.map typ rt)]
-  | Async t               -> "Async" $$ [typ t]
+  | Fut t                 -> "Fut" $$ [typ t]
   | Mut t                 -> "Mut" $$ [typ t]
   | Any                   -> Atom "Any"
   | Non                   -> Atom "Non"

--- a/src/mo_types/type.mli
+++ b/src/mo_types/type.mli
@@ -42,7 +42,7 @@ and typ =
   | Opt of typ                                (* option *)
   | Tup of typ list                           (* tuple *)
   | Func of func_sort * control * bind list * typ list * typ list  (* function *)
-  | Async of typ                              (* future *)
+  | Fut of typ                                (* future *)
   | Mut of typ                                (* mutable type *)
   | Any                                       (* top *)
   | Non                                       (* bottom *)
@@ -93,7 +93,7 @@ val is_tup : typ -> bool
 val is_unit : typ -> bool
 val is_pair : typ -> bool
 val is_func : typ -> bool
-val is_async : typ -> bool
+val is_fut : typ -> bool
 val is_mut : typ -> bool
 val is_typ : typ -> bool
 
@@ -106,7 +106,7 @@ val as_tup : typ -> typ list
 val as_unit : typ -> unit
 val as_pair : typ -> typ * typ
 val as_func : typ -> func_sort * control * bind list * typ list * typ list
-val as_async : typ -> typ
+val as_fut : typ -> typ
 val as_mut : typ -> typ
 val as_immut : typ -> typ
 val as_typ : typ -> con
@@ -121,7 +121,7 @@ val as_unit_sub : typ -> unit
 val as_pair_sub : typ -> typ * typ
 val as_func_sub : func_sort -> int -> typ -> func_sort * bind list * typ * typ
 val as_mono_func_sub : typ -> typ * typ
-val as_async_sub : typ -> typ
+val as_fut_sub : typ -> typ
 
 
 (* Argument/result sequences *)

--- a/src/mo_values/value.mli
+++ b/src/mo_values/value.mli
@@ -100,11 +100,11 @@ and value =
   | Array of value array
   | Obj of value Env.t
   | Func of Call_conv.t * func
-  | Async of async
+  | Fut of fut
   | Mut of value ref
 
 and res = Ok of value | Error of value
-and async = {result : res Lib.Promise.t ; mutable waiters : (value cont * value cont) list}
+and fut = {result : res Lib.Promise.t ; mutable waiters : (value cont * value cont) list}
 
 and def = value Lib.Promise.t
 and 'a cont = 'a -> unit
@@ -116,7 +116,7 @@ val unit : value
 
 val local_func : int -> int -> func -> value
 val message_func : Type.shared_sort -> int -> func -> value
-val async_func : Type.shared_sort -> int -> int -> func -> value
+val fut_func : Type.shared_sort -> int -> int -> func -> value
 
 
 (* Projections *)
@@ -147,7 +147,7 @@ val as_opt : value -> value
 val as_obj : value -> value Env.t
 val as_variant : value -> string * value
 val as_func : value -> Call_conv.t * func
-val as_async : value -> async
+val as_fut : value -> fut
 val as_mut : value -> value ref
 
 

--- a/src/pipeline/resolve_import.ml
+++ b/src/pipeline/resolve_import.ml
@@ -155,7 +155,7 @@ let rec
   | BreakE (_, exp1)
   | RetE exp1
   | AnnotE (exp1, _)
-  | AsyncE exp1
+  | FutE exp1
   | AwaitE exp1
   | ThrowE exp1
   | LoopE (exp1, None) ->

--- a/src/prelude/prelude.ml
+++ b/src/prelude/prelude.ml
@@ -351,11 +351,10 @@ func @int32ToErrorCode(i : Int32) : ErrorCode {
 };
 
 type Cont<T> = T -> () ;
-type Async<T> = (Cont<T>,Cont<Error>) -> ();
-
+type Fut<T> = (Cont<T>, Cont<Error>) -> ();
 type Result<T> = {#ok : T; #error : Error};
 
-func @new_async<T <: Any>() : (Async<T>, Cont<T>, Cont<Error>) {
+func @new_future<T <: Any>() : (Fut<T>, Cont<T>, Cont<Error>) {
   let k_null = func(_ : T) {};
   let r_null = func(_ : Error) {};
   var result : ?(Result<T>) = null;

--- a/src/profiler/profiler.ml
+++ b/src/profiler/profiler.ml
@@ -12,7 +12,7 @@ let process_prog_result result =
   if !ProfilerFlags.profile then
     try
       match result with
-        Some(Value.Async a,_) -> begin
+        Some(Value.Fut a,_) -> begin
           match Lib.Promise.value_opt a.Value.result with
           | Some (Value.Ok v) -> Counters.dump counters (Value.as_obj v)
           | Some _

--- a/stdlib/examples/produce-exchange/serverActor.mo
+++ b/stdlib/examples/produce-exchange/serverActor.mo
@@ -81,7 +81,7 @@ actor class Server () {
     isProducer: Bool,
     isRetailer: Bool,
     isTransporter: Bool
-  ) : async Result<T.UserId,T.IdErr> {
+  ) : future Result<T.UserId,T.IdErr> {
     Result.fromOption<T.UserId,T.IdErr>(
       getModel().addUser(
         public_key,
@@ -102,7 +102,7 @@ actor class Server () {
    -------------
    Get info for all users.
    */
-  public func allUserInfo() : async [T.UserInfo] {
+  public func allUserInfo() : future [T.UserInfo] {
     getModel().userTable.allInfo()
   };
 
@@ -111,7 +111,7 @@ actor class Server () {
    ---------------------------
    Get the information associated with a user, based on its id.
    */
-  public func getUserInfo(id:T.UserId) : async Result<T.UserInfo, T.IdErr> {
+  public func getUserInfo(id:T.UserId) : future Result<T.UserInfo, T.IdErr> {
     Result.fromOption<T.UserInfo, T.IdErr>(
       getModel().userTable.getInfo(id),
       #idErr null
@@ -123,7 +123,7 @@ actor class Server () {
    ---------------------------
    Returns true if the user id matches the public key.
    */
-  public func validateUser(public_key: T.PublicKey, id: T.UserId) : async Bool {
+  public func validateUser(public_key: T.PublicKey, id: T.UserId) : future Bool {
     getModel().isValidPublicKey(#user(id), public_key);
   };
 
@@ -146,7 +146,7 @@ actor class Server () {
     capacity_ : T.Weight,
     isFridge_ : Bool,
     isFreezer_ : Bool,
-  ) : async Result<T.TruckTypeId,None> {
+  ) : future Result<T.TruckTypeId,None> {
     Result.fromSome<T.TruckTypeId>(
       getModel()
         .truckTypeTable.addInfoGetId(
@@ -177,7 +177,7 @@ actor class Server () {
 
   public func registrarRemTruckType(
     id: T.TruckTypeId
-  ) : async Result<(),T.ServerErr> {
+  ) : future Result<(),T.ServerErr> {
     Result.fromOption<(),T.IdErr>(
       getModel().truckTypeTable.remGetUnit(id),
       #idErr null
@@ -191,7 +191,7 @@ actor class Server () {
 
   public func getTruckTypeInfo(
     id: T.TruckTypeId
-  ) : async Result<T.TruckTypeInfo,T.IdErr> {
+  ) : future Result<T.TruckTypeInfo,T.IdErr> {
     Result.fromOption<T.TruckTypeInfo,T.IdErr>(
       getModel().truckTypeTable.getInfo(id),
       #idErr null
@@ -203,7 +203,7 @@ actor class Server () {
    ---------------------
    */
 
-  public func allTruckTypeInfo() : async [T.TruckTypeInfo] {
+  public func allTruckTypeInfo() : future [T.TruckTypeInfo] {
     getModel().truckTypeTable.allInfo()
   };
 
@@ -225,7 +225,7 @@ actor class Server () {
   public func registrarAddRegion(
     short_name_:  Text,
     description_: Text,
-  ) : async Result<T.RegionId,None> {
+  ) : future Result<T.RegionId,None> {
     Result.fromSome<T.RegionId>(
       getModel().regionTable.addInfoGetId(
         func (id_:T.RegionId) : T.RegionInfo =
@@ -246,7 +246,7 @@ actor class Server () {
 
   public func registrarRemRegion(
     id: T.RegionId
-  ) : async Result<(),T.IdErr> {
+  ) : future Result<(),T.IdErr> {
     Result.fromOption<(),T.IdErr>(
       getModel().regionTable.remGetUnit(id),
       #idErr null,
@@ -263,7 +263,7 @@ actor class Server () {
 
   public func getRegionInfo(
     id: T.RegionId
-  ) : async Result<T.RegionInfo,T.IdErr> {
+  ) : future Result<T.RegionInfo,T.IdErr> {
     Result.fromOption<T.RegionInfo,T.IdErr>(
       getModel().regionTable.getInfo(id),
       #idErr null
@@ -279,7 +279,7 @@ actor class Server () {
 
    */
 
-  public func allRegionInfo() : async [T.RegionInfo] {
+  public func allRegionInfo() : future [T.RegionInfo] {
     getModel().regionTable.allInfo()
   };
 
@@ -302,7 +302,7 @@ actor class Server () {
     short_name_:  Text,
     description_: Text,
     grade_: T.Grade,
-  ) : async Result<T.ProduceId,None> {
+  ) : future Result<T.ProduceId,None> {
     Result.fromSome<T.ProduceId>(
       getModel().produceTable.addInfoGetId(
         func (id_:T.ProduceId) : T.ProduceInfo =
@@ -324,7 +324,7 @@ actor class Server () {
 
   public func registrarRemProduce(
     id: T.ProduceId
-  ) : async Result<(),T.IdErr> {
+  ) : future Result<(),T.IdErr> {
     Result.fromOption<(),T.IdErr>(
       getModel().produceTable.remGetUnit(id),
       #idErr null,
@@ -339,7 +339,7 @@ actor class Server () {
 
   public func getProduceInfo(
     id: T.ProduceId
-  ) : async Result<T.ProduceInfo,T.IdErr> {
+  ) : future Result<T.ProduceInfo,T.IdErr> {
     Result.fromOption<T.ProduceInfo,T.IdErr>(
       getModel().produceTable.getInfo(id),
       #idErr null
@@ -351,7 +351,7 @@ actor class Server () {
    ---------------------
    */
 
-  public func allProduceInfo() : async [T.ProduceInfo] {
+  public func allProduceInfo() : future [T.ProduceInfo] {
     getModel().produceTable.allInfo()
   };
 
@@ -374,7 +374,7 @@ actor class Server () {
     short_name_:  Text,
     description_: Text,
     region_: T.RegionId,
-  ) : async Result<T.ProducerId,T.IdErr> {
+  ) : future Result<T.ProducerId,T.IdErr> {
     Result.fromOption<T.ProduceId,T.IdErr>(
       getModel().producerTable.addInfoGetId(
         func(id_:T.ProducerId):T.ProducerInfo {
@@ -401,7 +401,7 @@ actor class Server () {
 
   public func registrarRemProducer(
     id: T.ProducerId
-  ) : async Result<(),T.IdErr> {
+  ) : future Result<(),T.IdErr> {
     Result.fromOption<(),T.IdErr>(
       getModel().producerTable.remGetUnit(id),
       #idErr null
@@ -416,7 +416,7 @@ actor class Server () {
 
   public func getProducerInfo(
     id: T.ProducerId
-  ) : async Result<T.ProducerInfo,T.IdErr> {
+  ) : future Result<T.ProducerInfo,T.IdErr> {
     Result.fromOption<T.ProducerInfo,T.IdErr>(
       getModel().producerTable.getInfo(id),
       #idErr null
@@ -428,7 +428,7 @@ actor class Server () {
    ---------------------
    */
 
-  public func allProducerInfo() : async [T.ProducerInfo] {
+  public func allProducerInfo() : future [T.ProducerInfo] {
     getModel().producerTable.allInfo()
   };
 
@@ -451,7 +451,7 @@ actor class Server () {
     short_name_:  Text,
     description_: Text,
     region_: T.RegionId,
-  ) : async Result<T.RetailerId,T.IdErr> {
+  ) : future Result<T.RetailerId,T.IdErr> {
     Result.fromOption<T.RetailerId,T.IdErr>(
       getModel().retailerTable.addInfoGetId(
         func(id_:T.RetailerId):T.RetailerInfo {
@@ -476,7 +476,7 @@ actor class Server () {
 
   public func registrarRemRetailer(
     id: T.RetailerId
-  ) : async Result<(),T.IdErr> {
+  ) : future Result<(),T.IdErr> {
     Result.fromOption<(),T.IdErr>(
       getModel().retailerTable.remGetUnit(id),
       #idErr null
@@ -490,7 +490,7 @@ actor class Server () {
 
   public func getRetailerInfo(
     id: T.RetailerId
-  ) : async Result<T.RetailerInfo,T.IdErr> {
+  ) : future Result<T.RetailerInfo,T.IdErr> {
     Result.fromOption<T.RetailerInfo,T.IdErr>(
       getModel().retailerTable.getInfo(id),
       #idErr null
@@ -502,7 +502,7 @@ actor class Server () {
    ---------------------
    */
 
-  public func allRetailerInfo() : async [T.RetailerInfo] {
+  public func allRetailerInfo() : future [T.RetailerInfo] {
     getModel().retailerTable.allInfo()
   };
 
@@ -522,7 +522,7 @@ actor class Server () {
     transporter_public_key: T.PublicKey,
     short_name_:  Text,
     description_: Text,
-  ) : async Result<T.TransporterId,()> {
+  ) : future Result<T.TransporterId,()> {
     Result.fromOption<T.TransporterId,()>(
       getModel().transporterTable.addInfoGetId(
         func(id_:T.TransporterId):T.TransporterInfo {
@@ -547,7 +547,7 @@ actor class Server () {
 
   public func registrarRemTransporter(
     id: T.TransporterId
-  ) : async Result<(),T.IdErr> {
+  ) : future Result<(),T.IdErr> {
     Result.fromOption<(),T.IdErr>(
       getModel().transporterTable.remGetUnit(id),
       #idErr null
@@ -561,7 +561,7 @@ actor class Server () {
 
   public func getTransporterInfo(
     id: T.TransporterId
-  ) : async Result<T.TransporterInfo,T.IdErr> {
+  ) : future Result<T.TransporterInfo,T.IdErr> {
     Result.fromOption<T.TransporterInfo,T.IdErr>(
       getModel().transporterTable.getInfo(id),
       #idErr null
@@ -574,7 +574,7 @@ actor class Server () {
    ---------------------
    */
 
-  public func allTransporterInfo() : async [T.TransporterInfo] {
+  public func allTransporterInfo() : future [T.TransporterInfo] {
     getModel().transporterTable.allInfo()
   };
 
@@ -600,7 +600,7 @@ actor class Server () {
     begin:T.Date,
     end:  T.Date,
     comments: Text,
-  ) : async Result<T.InventoryId,T.ServerErr> {
+  ) : future Result<T.InventoryId,T.ServerErr> {
     if (not getModel().isValidPublicKey(#producer(id), public_key)) {
       return (#err(#publicKeyErr))
     };
@@ -625,7 +625,7 @@ actor class Server () {
     begin:T.Date,
     end:  T.Date,
     comments: Text,
-  ) : async Result<(),T.ServerErr> {
+  ) : future Result<(),T.ServerErr> {
     if (not getModel().isValidPublicKey(#producer(id), public_key)) {
       return (#err(#publicKeyErr))
     };
@@ -638,7 +638,7 @@ actor class Server () {
    `producerRemInventory`
    ---------------------------
    */
-  public func producerRemInventory(public_key: T.PublicKey, id:T.InventoryId) : async Result<(),T.ServerErr> {
+  public func producerRemInventory(public_key: T.PublicKey, id:T.InventoryId) : future Result<(),T.ServerErr> {
     if (not getModel().isValidPublicKey(#producer(id), public_key)) {
       return (#err(#publicKeyErr))
     };
@@ -649,7 +649,7 @@ actor class Server () {
    `producerAllInventoryInfo`
    ---------------------------
    */
-  public func producerAllInventoryInfo(public_key: T.PublicKey, id:T.UserId) : async Result<[T.InventoryInfo],T.IdErr> {
+  public func producerAllInventoryInfo(public_key: T.PublicKey, id:T.UserId) : future Result<[T.InventoryInfo],T.IdErr> {
     Result.fromOption<[T.InventoryInfo],T.IdErr>(
       getModel()
         .producerAllInventoryInfo(id),
@@ -661,7 +661,7 @@ actor class Server () {
    `producerAllReservationInfo`
    ---------------------------
    */
-  public func producerReservations(public_key: T.PublicKey, id:T.UserId) : async Result<[T.ReservedInventoryInfo],T.IdErr> {
+  public func producerReservations(public_key: T.PublicKey, id:T.UserId) : future Result<[T.ReservedInventoryInfo],T.IdErr> {
     Result.fromOption<[T.ReservedInventoryInfo],T.IdErr>(
       getModel()
         .producerAllReservationInfo(id),
@@ -682,7 +682,7 @@ actor class Server () {
    ---------------------------
    The last sales price for produce within a given geographic area; null region id means "all areas."
    */
-  public func produceMarketInfo(public_key: T.PublicKey, id:T.ProduceId, reg:?T.RegionId) : async Result<[T.ProduceMarketInfo],T.IdErr> {
+  public func produceMarketInfo(public_key: T.PublicKey, id:T.ProduceId, reg:?T.RegionId) : future Result<[T.ProduceMarketInfo],T.IdErr> {
     Result.fromOption<[T.ProduceMarketInfo],T.IdErr>(
       getModel()
         .produceMarketInfo(id, reg),
@@ -696,7 +696,7 @@ actor class Server () {
    ---------------------------
    Get the information for all known inventory.
    */
-  public func allInventoryInfo() : async [T.InventoryInfo] {
+  public func allInventoryInfo() : future [T.InventoryInfo] {
     getModel()
       .inventoryTable.allInfo()
   };
@@ -706,7 +706,7 @@ actor class Server () {
    ---------------------------
    Get the information associated with inventory, based on its id.
    */
-  public func getInventoryInfo(id:T.InventoryId) : async Result<T.InventoryInfo,T.IdErr> {
+  public func getInventoryInfo(id:T.InventoryId) : future Result<T.InventoryInfo,T.IdErr> {
     Result.fromOption<T.InventoryInfo,T.IdErr>(
       getModel()
         .inventoryTable.getInfo(id),
@@ -733,7 +733,7 @@ actor class Server () {
     end:    T.Date,
     cost:   T.Price,
     ttid:   T.TruckTypeId
-  ) : async Result<T.RouteId,T.ServerErr> {
+  ) : future Result<T.RouteId,T.ServerErr> {
     if (not getModel().isValidPublicKey(#transporter(id), public_key)) {
       return (#err(#publicKeyErr))
     };
@@ -754,7 +754,7 @@ actor class Server () {
     end:    T.Date,
     cost:   T.Price,
     ttid:   T.TruckTypeId
-  ) : async Result<(),T.ServerErr> {
+  ) : future Result<(),T.ServerErr> {
     if (not getModel().isValidPublicKey(#transporter(id), public_key)) {
       return (#err(#publicKeyErr))
     };
@@ -765,7 +765,7 @@ actor class Server () {
    `transporterRemRoute`
    ---------------------------
    */
-  public func transporterRemRoute(public_key: T.PublicKey, id:T.RouteId) : async Result<(),T.ServerErr> {
+  public func transporterRemRoute(public_key: T.PublicKey, id:T.RouteId) : future Result<(),T.ServerErr> {
     if (not getModel().isValidPublicKey(#transporter(id), public_key)) {
       return (#err(#publicKeyErr))
     };
@@ -776,7 +776,7 @@ actor class Server () {
    `transporterAllRouteInfo`
    ---------------------------
    */
-  public func transporterAllRouteInfo(public_key: T.PublicKey, id:T.UserId) : async Result<[T.RouteInfo],T.IdErr> {
+  public func transporterAllRouteInfo(public_key: T.PublicKey, id:T.UserId) : future Result<[T.RouteInfo],T.IdErr> {
     Result.fromOption<[T.RouteInfo],T.IdErr>(
       getModel()
         .transporterAllRouteInfo(id),
@@ -788,7 +788,7 @@ actor class Server () {
    `transporterAllReservationInfo`
    ---------------------------
    */
-  public func transporterAllReservationInfo(public_key: T.PublicKey, id:T.UserId) : async Result<[T.ReservedRouteInfo],T.IdErr> {
+  public func transporterAllReservationInfo(public_key: T.PublicKey, id:T.UserId) : future Result<[T.ReservedRouteInfo],T.IdErr> {
     Result.fromOption<[T.ReservedRouteInfo],T.IdErr>(
       getModel()
         .transporterAllReservationInfo(id),
@@ -801,7 +801,7 @@ actor class Server () {
    ---------------------------
    Get the information for all known routes.
    */
-  public func allRouteInfo() : async [T.RouteInfo] {
+  public func allRouteInfo() : future [T.RouteInfo] {
     getModel()
       .routeTable.allInfo()
   };
@@ -811,7 +811,7 @@ actor class Server () {
    ---------------------------
    Get the information for all reserved routes.
    */
-  public func allReservedRouteInfo() : async [T.ReservedRouteInfo] {
+  public func allReservedRouteInfo() : future [T.ReservedRouteInfo] {
     getModel()
       .reservedRouteTable.allInfo()
   };
@@ -826,7 +826,7 @@ actor class Server () {
 
   public func getRouteInfo(
     id: T.RouteId
-  ) : async Result<T.RouteInfo,T.IdErr> {
+  ) : future Result<T.RouteInfo,T.IdErr> {
     Result.fromOption<T.RouteInfo,T.IdErr>(
       getModel().routeTable.getInfo(id),
       #idErr null
@@ -846,7 +846,7 @@ actor class Server () {
     id:T.RetailerId,
     queryProduce:?T.ProduceId,
     queryDate:?T.Date
-  ) : async Result<T.QueryAllResults,T.IdErr> {
+  ) : future Result<T.QueryAllResults,T.IdErr> {
     Result.fromOption<T.QueryAllResults,T.IdErr>(
       getModel().
         retailerQueryAll(id, queryProduce, queryDate),
@@ -862,7 +862,7 @@ actor class Server () {
     public_key: T.PublicKey,
     id:T.RetailerId,
     inventory:T.InventoryId,
-    route:T.RouteId) : async Result<(T.ReservedInventoryId, T.ReservedRouteId),T.ServerErr>
+    route:T.RouteId) : future Result<(T.ReservedInventoryId, T.ReservedRouteId),T.ServerErr>
   {
     if (not getModel().isValidPublicKey(#retailer(id), public_key)) {
       return (#err(#publicKeyErr))
@@ -880,7 +880,7 @@ actor class Server () {
     id: T.RetailerId,
     list: [(T.InventoryId, T.RouteId)]
   )
-    : async Result<[Result<(T.ReservedInventoryId, T.ReservedRouteId), T.ServerErr>], T.ServerErr>
+    : future Result<[Result<(T.ReservedInventoryId, T.ReservedRouteId), T.ServerErr>], T.ServerErr>
   {
     if (not getModel().isValidPublicKey(#retailer(id), public_key)) {
       return (#err(#publicKeyErr))
@@ -894,7 +894,7 @@ actor class Server () {
 
   */
   public func retailerReservations(public_key: T.PublicKey, id:T.RetailerId) :
-    async Result<[(T.ReservedInventoryInfo,
+    future Result<[(T.ReservedInventoryInfo,
                    T.ReservedRouteInfo)],T.ServerErr>
   {
     Result.fromOption<[(T.ReservedInventoryInfo,
@@ -921,7 +921,7 @@ actor class Server () {
    ----------
    */
 
-  public func getCounts() : async T.ProduceExchangeCounts {
+  public func getCounts() : future T.ProduceExchangeCounts {
     let m = getModel();
     {
       hash_bit_length          = 0;
@@ -953,7 +953,7 @@ actor class Server () {
 been processed
 */
 
-  public func devViewGMV() : async ?Nat {
+  public func devViewGMV() : future ?Nat {
     P.nyi()
   };
 
@@ -967,7 +967,7 @@ been processed
 
    */
 
-  public func devViewQueries() : async ?Nat {
+  public func devViewQueries() : future ?Nat {
     ?getModel().retailerQueryCount;
   };
 
@@ -982,7 +982,7 @@ been processed
 
    */
 
-  public func devViewReservations() : async Nat {
+  public func devViewReservations() : future Nat {
     getModel().reservedInventoryTable.count()
   };
 
@@ -998,7 +998,7 @@ been processed
 
    */
 
-  public func devViewProducers() : async [T.ProducerInfo] {
+  public func devViewProducers() : future [T.ProducerInfo] {
     getModel().producerTable.allInfo()
   };
 
@@ -1015,7 +1015,7 @@ been processed
 
    */
 
-  public func devViewTransporters() : async [T.TransporterInfo] {
+  public func devViewTransporters() : future [T.TransporterInfo] {
     getModel().transporterTable.allInfo()
   };
 
@@ -1031,7 +1031,7 @@ been processed
 
    */
 
-  public func devViewRetailers() : async [T.RetailerInfo] {
+  public func devViewRetailers() : future [T.RetailerInfo] {
     getModel().retailerTable.allInfo()
   };
 
@@ -1042,7 +1042,7 @@ been processed
    evaluate a collection of API calls (a "bulk request"), represented as an AS datatype.
    */
 
-  public func evalBulkArray(reqs:[L.BulkReq]) : async [L.BulkResp] {
+  public func evalBulkArray(reqs:[L.BulkReq]) : future [L.BulkResp] {
     getModel().evalBulkArray(reqs)
   };
 

--- a/stdlib/examples/produce-exchange/test/evalBulk.mo
+++ b/stdlib/examples/produce-exchange/test/evalBulk.mo
@@ -17,7 +17,7 @@ func printLabeledCost(lab:Text, cost:Nat) {
 
 actor class Test() = this {
   public func go() {
-    ignore(async
+    ignore(future
     {
       let s = A.Server();
 
@@ -144,7 +144,7 @@ actor class Test() = this {
 };
 
 
-func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : async () {
+func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : future () {
 
   print "\nRetailer ";
   let retailerId: T.UserId = Option.unwrap<T.UserId>(r);
@@ -168,7 +168,7 @@ func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : async () {
   }
 };
 
-func debugDumpAll(server:A.Server) : async () {
+func debugDumpAll(server:A.Server) : future () {
 
   print "\nTruck type info\n----------------\n";
   for ( info in ((await server.allTruckTypeInfo()).vals()) ) {

--- a/stdlib/examples/produce-exchange/test/loadWorkloadAndQuery.mo
+++ b/stdlib/examples/produce-exchange/test/loadWorkloadAndQuery.mo
@@ -14,7 +14,7 @@ func scaledParams(region_count_:Nat, factor:Nat) : T.WorkloadParams = {
 
 actor class Test() = this {
   go() {
-    ignore(async
+    ignore(future
     {
       // Vary the choice of region count and scaling factor here;
       // Each choice leads to a different count of (InventoryCount, RouteCount), and load time:

--- a/stdlib/examples/produce-exchange/test/loadWorkloadAndQueryBig.mo
+++ b/stdlib/examples/produce-exchange/test/loadWorkloadAndQueryBig.mo
@@ -16,7 +16,7 @@ func scaledParams(region_count_:Nat, factor:Nat) : T.WorkloadParams = shared {
 
 actor class Test() = this {
   go() {
-    ignore(async
+    ignore(future
     {
       // Vary the choice of region count and scaling factor here;
       // Each choice leads to a different count of (InventoryCount, RouteCount), and load time:
@@ -58,8 +58,8 @@ actor class Test() = this {
 };
 
 
-//func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : async () {
-func retailerQueryAll(pk:Text, retailerId:T.RetailerId) : async () {
+//func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : future () {
+func retailerQueryAll(pk:Text, retailerId:T.RetailerId) : future () {
 
   print "\nRetailer ";
   printInt retailerId;
@@ -82,8 +82,8 @@ func retailerQueryAll(pk:Text, retailerId:T.RetailerId) : async () {
   }
 };
 
-//func debugDumpAll(server:A.Server) : async () {
-func debugDumpAll() : async () {
+//func debugDumpAll(server:A.Server) : future () {
+func debugDumpAll() : future () {
 
   print "\nTruck type info\n----------------\n";
   for ( info in ((await server.allTruckTypeInfo()).vals()) ) {

--- a/stdlib/examples/produce-exchange/test/producerRemInventory.mo
+++ b/stdlib/examples/produce-exchange/test/producerRemInventory.mo
@@ -17,7 +17,7 @@ func printLabeledCost(lab:Text, cost:Nat) {
 
 actor class Test() = this {
   public func go() {
-    ignore(async
+    ignore(future
     {
       let s = A.Server();
 
@@ -147,7 +147,7 @@ actor class Test() = this {
   };
 };
 
-func debugDumpInventory(server:A.Server, pk:T.PublicKey, p:T.ProducerId) : async () {
+func debugDumpInventory(server:A.Server, pk:T.PublicKey, p:T.ProducerId) : future () {
   print "\nProducer ";
   printInt p;
   print "'s inventory:\n--------------------------------\n";
@@ -161,7 +161,7 @@ func debugDumpInventory(server:A.Server, pk:T.PublicKey, p:T.ProducerId) : async
   }
 };
 
-func debugDumpAll(server:A.Server) : async () {
+func debugDumpAll(server:A.Server) : future () {
 
   print "\nTruck type info\n----------------\n";
   for ( info in ((await server.allTruckTypeInfo()).vals()) ) {

--- a/stdlib/examples/produce-exchange/test/retailerReserveMany.mo
+++ b/stdlib/examples/produce-exchange/test/retailerReserveMany.mo
@@ -17,7 +17,7 @@ func printLabeledCost(lab:Text, cost:Nat) {
 
 actor class Test() = this {
   public func go() {
-    ignore(async
+    ignore(future
     {
       let s = A.Server();
 
@@ -182,7 +182,7 @@ actor class Test() = this {
   };
 };
 
-func debugDumpInventory(server:A.Server, pk:T.PublicKey, p:T.ProducerId) : async Nat {
+func debugDumpInventory(server:A.Server, pk:T.PublicKey, p:T.ProducerId) : future Nat {
   print "\nProducer ";
   printInt p;
   print "'s inventory:\n--------------------------------\n";
@@ -198,7 +198,7 @@ func debugDumpInventory(server:A.Server, pk:T.PublicKey, p:T.ProducerId) : async
   items.len()
 };
 
-func debugDumpRoutes(server:A.Server, pk:T.PublicKey, t:T.TransporterId) : async Nat {
+func debugDumpRoutes(server:A.Server, pk:T.PublicKey, t:T.TransporterId) : future Nat {
   print "\nTransporter ";
   printInt t;
   print "'s routes:\n--------------------------------\n";
@@ -214,7 +214,7 @@ func debugDumpRoutes(server:A.Server, pk:T.PublicKey, t:T.TransporterId) : async
   items.len()
 };
 
-func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : async () {
+func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : future () {
 
   print "\nRetailer ";
   let retailerId: T.UserId = Option.unwrap<T.UserId>(r);
@@ -238,7 +238,7 @@ func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : async () {
   }
 };
 
-func debugDumpAll(server:A.Server) : async () {
+func debugDumpAll(server:A.Server) : future () {
 
   print "\nTruck type info\n----------------\n";
   for ( info in ((await server.allTruckTypeInfo()).vals()) ) {

--- a/stdlib/examples/produce-exchange/test/simpleSetupAndQuery.mo
+++ b/stdlib/examples/produce-exchange/test/simpleSetupAndQuery.mo
@@ -17,7 +17,7 @@ func printLabeledCost(lab:Text, cost:Nat) {
 
 actor class Test() = this {
   public func go() {
-    ignore(async
+    ignore(future
     {
       let s = A.Server();
 
@@ -335,7 +335,7 @@ actor class Test() = this {
 };
 
 
-func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : async () {
+func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : future () {
 
   print "\nRetailer ";
   let retailerId: T.UserId = Option.unwrap<T.UserId>(r);
@@ -359,7 +359,7 @@ func retailerQueryAll(server:A.Server, pk:Text, r:?T.UserId) : async () {
   }
 };
 
-func debugDumpAll(server:A.Server) : async () {
+func debugDumpAll(server:A.Server) : future () {
 
   print "\nTruck type info\n----------------\n";
   for ( info in ((await server.allTruckTypeInfo()).vals()) ) {

--- a/test/as-idl/counter.mo
+++ b/test/as-idl/counter.mo
@@ -10,12 +10,12 @@ actor class Counter(i : Int) {
   };
 
   // Read counter, asynchronous
-  public func read() : async Int { c };
+  public func read() : future Int { c };
 };
 
 // Dummy functions to show intermediate value in trace.
 func show(note : Text, c : Int) {};
-func showAsync(note : Text, a : async Int) {};
+func showFuture(note : Text, a : future Int) {};
 
 // Create an actor.
 let c = Counter(10);
@@ -34,13 +34,13 @@ testDec();
 // Issue ten `dec` & `read` messages.
 func testRead() {
   var i : Int = 10;
-  let _ = async {
+  let _ = future {
     while (i > 0) {
       c.dec();
       let t = c.read();
-      showAsync("before", t);
+      showFuture("before", t);
       show("await", await t);
-      showAsync("after", t);
+      showFuture("after", t);
       i -= 1;
     }
   }

--- a/test/as-idl/fields.mo
+++ b/test/as-idl/fields.mo
@@ -7,6 +7,6 @@ type Info = {
 };
 type Tup = (Text, Info, Text, Nat);
 actor Server {
-    public func f_(user1 : Info, user2 : Tup) : async () {
+    public func f_(user1 : Info, user2 : Tup) : future () {
     };
 }

--- a/test/as-idl/inline_result.mo
+++ b/test/as-idl/inline_result.mo
@@ -3,13 +3,13 @@ actor {
   #ok:Ok;
   #err:Err;
  };
- public func f(x:?Nat):async Result<Nat,Text> {
+ public func f(x:?Nat):future Result<Nat,Text> {
   switch x {
     case (? x) {#ok x};
     case null {#err "error"};
   }
  };
- public func g(x:Result<Nat,Text>):async Result<Int,()> {
+ public func g(x:Result<Nat,Text>):future Result<Int,()> {
   #ok(1);
  };
 }

--- a/test/as-idl/pa_cars.mo
+++ b/test/as-idl/pa_cars.mo
@@ -8,7 +8,7 @@
 // - Client: Pick a parking spot from a Google Map like interface + time
 // - Server: Register the parking spot for the user
 type Car = { model : Text; plate : Text };
-type DMV = actor { check : Car -> async CarInfo };
+type DMV = actor { check : Car -> future CarInfo };
 type CarInfo = {
   model : Text;
   plate : Text;
@@ -18,10 +18,10 @@ type CarInfo = {
 };
 
 actor class PACars(dmv : DMV) {
-  public func verifyCarInformation(user : User, car : Car) : async ?(shared (Location, TimeSpan) -> async Result) {
+  public func verifyCarInformation(user : User, car : Car) : future ?(shared (Location, TimeSpan) -> future Result) {
     let carInfo = await dmv.check(car);
     if (carInfo.isValid and not carInfo.wasStolen) {
-      return ?(shared func (location, time) : async Result {
+      return ?(shared func (location, time) : future Result {
         return reserveSpot(user, carInfo, location, time);
       })
     } else {

--- a/test/as-idl/recursion.mo
+++ b/test/as-idl/recursion.mo
@@ -3,10 +3,10 @@ type List<A> = {
   tail:?List<A>;
 };
 actor {
- public func f(x:Nat):async List<Nat> {
+ public func f(x:Nat):future List<Nat> {
    {head=x; tail=null};
  };
- public func g(x:Int):async List<Int> {
+ public func g(x:Int):future List<Int> {
    {head=x; tail=null};
  };
 }

--- a/test/as-idl/result.mo
+++ b/test/as-idl/result.mo
@@ -11,13 +11,13 @@ type Result3<Ok> = {
   #err:Result2<Ok>;
 };
 actor {
- public func f(x:?Nat):async Result<Nat,Text> {
+ public func f(x:?Nat):future Result<Nat,Text> {
   switch x {
     case (? x) {#ok x};
     case null {#err "error"};
   }
  };
- public func g(x:Result3<()>):async Result2<Nat> {
+ public func g(x:Result3<()>):future Result2<Nat> {
   #ok(1);
  };
 }

--- a/test/bugs/aritybug.mo
+++ b/test/bugs/aritybug.mo
@@ -9,11 +9,11 @@
 
 {
 let t = "u_u\n";
-shared func fu_u(a:Int,) : async (Int,) {
+shared func fu_u(a:Int,) : future (Int,) {
    return (2*a,);
 };
 
-let _ : async (Int,)  = async {
+let _ : future (Int,)  = future {
   let (x,) = await fu_u(1); // *
   assert(x==2);
   print t;

--- a/test/bugs/sharingbug.mo
+++ b/test/bugs/sharingbug.mo
@@ -1,10 +1,10 @@
-type post = shared Text -> async ();
+type post = shared Text -> future ();
 
 type IServer = actor {
-  post: Text -> async ();
-  subscribe: IClient -> async post;
+  post: Text -> future ();
+  subscribe: IClient -> future post;
 };
 
 type IClient = actor {
-   send: shared Text -> async ();
+   send: shared Text -> future ();
 };

--- a/test/fail/abstract-msgs.mo
+++ b/test/fail/abstract-msgs.mo
@@ -3,18 +3,18 @@
 { shared func foo<A <: Any>() : ?A = null; };
 { func foo<A <: Any>() : () = {
   { shared func bar( x : A ) : () = (); };
-  { shared func bar() : async ?A { null } };
+  { shared func bar() : future ?A { null } };
 }};
 
 // In function calls, parameters with abstract types are not fine
 { func foo<A <: Any>( f : shared A -> (), x : A )  = (f x); };
-{ func foo<A <: Any>( f : shared () -> async A ) : async A = async { await (f ())}; };
+{ func foo<A <: Any>( f : shared () -> future A ) : future A = future { await (f ())}; };
 
 // Just in types, away from definitinos and calls, parameters with abstract types are fine
 { let x : ?(shared <A <: Any>A -> ()) = null; };
-{ let x : ?(shared <A <: Any>() -> async A) = null; };
+{ let x : ?(shared <A <: Any>() -> future A) = null; };
 { let x : ?(<A <: Any>(shared A -> ()) -> ()) = null; };
-{ let x : ?(<A <: Any>(shared () -> async A) -> ()) = null; };
+{ let x : ?(<A <: Any>(shared () -> future A) -> ()) = null; };
 
 
 // Phantom parameters are fine

--- a/test/fail/ast81-clash.mo
+++ b/test/fail/ast81-clash.mo
@@ -2,7 +2,7 @@ func foo() { }; // <-- removing this definition avoids the compiler exception
 
 actor class Test() = this { // <-- removing this stuff around the inner block avoids compiler exception
   public func go() {
-    ignore(async
+    ignore(future
     {
       let x = 123;
       let x = 123;

--- a/test/fail/asyncret2.mo
+++ b/test/fail/asyncret2.mo
@@ -1,1 +1,1 @@
-func call3(f : shared () -> async Int) : async Int { f(); };
+func call3(f : shared () -> future Int) : future Int { f(); };

--- a/test/fail/asyncret3.mo
+++ b/test/fail/asyncret3.mo
@@ -1,1 +1,1 @@
-shared func call4(f : shared () -> async Int) : async Int = f();
+shared func call4(f : shared () -> future Int) : future Int = f();

--- a/test/fail/await-in-actor.mo
+++ b/test/fail/await-in-actor.mo
@@ -1,7 +1,7 @@
-let _ = async {
+let _ = future {
   let a = actor {
-    let x = await { async 1 };
-    public func getX() : async Nat { x };
+    let x = await { future 1 };
+    public func getX() : future Nat { x };
   };
   ()
 }

--- a/test/fail/issue103.mo
+++ b/test/fail/issue103.mo
@@ -12,16 +12,16 @@
   };
 };
 
-// Cannot return a function in an async
+// Cannot return a function in a future
 {
-  func invalid3 () : (async (() -> Nat)) {
-     async { func foo() : Nat = 1 }
+  func invalid3 () : (future (() -> Nat)) {
+     future { func foo() : Nat = 1 }
   };
 };
 
-// Cannot return an object with function fields in an async
+// Cannot return an object with function fields in a future
 {
-  func invalid4 () : (async ({foo : () -> Nat})) {
-     async { object { public func foo() : Nat = 1; } }
+  func invalid4 () : (future ({foo : () -> Nat})) {
+     future { object { public func foo() : Nat = 1; } }
   };
 };

--- a/test/fail/objpat-infer.mo
+++ b/test/fail/objpat-infer.mo
@@ -12,7 +12,7 @@ func foo({}) : Int = 42;
 
 // infers
 
-shared func baz(a : actor {}) : async Int { 42 };
+shared func baz(a : actor {}) : future Int { 42 };
 
 // call it
 
@@ -20,7 +20,7 @@ ignore (foo({}));
 ignore (foo(object {}));
 ignore (foo(actor {}));
 
-let a = actor { public func bar({}) : async Nat = async 25 };
+let a = actor { public func bar({}) : future Nat = future 25 };
 ignore (foo a);
 
 

--- a/test/fail/ok/abstract-msgs.tc.ok
+++ b/test/fail/ok/abstract-msgs.tc.ok
@@ -1,6 +1,6 @@
 abstract-msgs.mo:2.28-2.37: type error, shared function has non-shared parameter type
   A/9
-abstract-msgs.mo:3.33-3.35: type error, shared function must have syntactic return type `()` or `async <typ>`
+abstract-msgs.mo:3.33-3.35: type error, shared function must have syntactic return type `()` or `future <typ>`
 abstract-msgs.mo:5.20-5.29: type error, shared function has non-shared parameter type
   A/10
 abstract-msgs.mo:6.25-6.33: type error, shared function has non-shared return type

--- a/test/fail/ok/asyncret1.tc.ok
+++ b/test/fail/ok/asyncret1.tc.ok
@@ -1,1 +1,1 @@
-asyncret1.mo:1.39-1.40: type error, shared function must have syntactic return type `()` or `async <typ>`
+asyncret1.mo:1.39-1.40: type error, shared function must have syntactic return type `()` or `future <typ>`

--- a/test/fail/ok/asyncret2.tc.ok
+++ b/test/fail/ok/asyncret2.tc.ok
@@ -1,4 +1,4 @@
 asyncret2.mo:1.54-1.57: type error, expression of type
-  async Int
+  future Int
 cannot produce expected type
   Int

--- a/test/fail/ok/asyncret3.tc.ok
+++ b/test/fail/ok/asyncret3.tc.ok
@@ -1,1 +1,1 @@
-asyncret3.mo:1.61-1.64: type error, shared function with async result type has non-async body
+asyncret3.mo:1.61-1.64: type error, shared function with future return type has non-future body

--- a/test/fail/ok/issue103.tc.ok
+++ b/test/fail/ok/issue103.tc.ok
@@ -10,13 +10,13 @@ type
   {foo : () -> Nat}
 is or contains non-shared type
   () -> Nat
-issue103.mo:17.29-17.40: type error, async has non-shared content type
+issue103.mo:17.29-17.40: type error, future has non-shared content type
   () -> Nat
 type
   () -> Nat
 is or contains non-shared type
   () -> Nat
-issue103.mo:24.29-24.48: type error, async has non-shared content type
+issue103.mo:24.29-24.48: type error, future has non-shared content type
   {foo : () -> Nat}
 type
   {foo : () -> Nat}

--- a/test/fail/ok/objpat-infer.tc.ok
+++ b/test/fail/ok/objpat-infer.tc.ok
@@ -5,7 +5,7 @@ objpat-infer.mo:21.13-21.21: type error, expression of type
 cannot produce expected type
   {}
 objpat-infer.mo:24.13-24.14: type error, expression of type
-  actor {bar : shared {} -> async Nat}
+  actor {bar : shared {} -> future Nat}
 cannot produce expected type
   {}
 objpat-infer.mo:27.13-27.15: type error, expression of type

--- a/test/random/Main.hs
+++ b/test/random/Main.hs
@@ -191,7 +191,7 @@ prop_matchInActor (Matching a) = mobile a
 
 mobile :: (AnnotLit t, ASValue t) => (ASTerm t, t) -> Property
 mobile (tm, v) = monadicIO $ do
-  let testCase = "/*let a = actor { public func match (b : " <> typed <> ") : async Bool = async { true } };*/ assert (switch (" <> expr <> " : " <> typed <> ") { case (" <> eval'd <> ") true; case _ false })"
+  let testCase = "/*let a = actor { public func match (b : " <> typed <> ") : future Bool = future { true } };*/ assert (switch (" <> expr <> " : " <> typed <> ") { case (" <> eval'd <> ") true; case _ false })"
 
       eval'd = unparse v
       typed = unparseType v

--- a/test/repl/ok/type-lub-repl.stdout.ok
+++ b/test/repl/ok/type-lub-repl.stdout.ok
@@ -28,5 +28,5 @@ Motoko 0.1 interpreter
 > 25 : Int
 > 42 : Int
 >   func : (C, D) -> [C]
-> [async (?4), async (?(-42))] : [(async (?Int))]
+> [future (?4), future (?(-42))] : [(future (?Int))]
 > 

--- a/test/run-dfinity/AST-66.mo
+++ b/test/run-dfinity/AST-66.mo
@@ -1,13 +1,13 @@
-// test cps conversion of async blocks with type decs
+// test cps conversion of future blocks with type decs
 
-let _ = async{
+let _ = future{
   type T = Null;
-  await { async (null:T) };
+  await { future (null:T) };
 };
 
-let _ = async{
+let _ = future{
   type T = U;
-  let _ = await { async (null:T) };
+  let _ = await { future (null:T) };
   type U = Null;
-  await { async (null:T) };
+  await { future (null:T) };
 };

--- a/test/run-dfinity/array-out-of-bounds.mo
+++ b/test/run-dfinity/array-out-of-bounds.mo
@@ -1,11 +1,11 @@
 let a = [0, 1, 2, 3, 4];
 let b = [];
 
-ignore(async {
+ignore(future {
   ignore(a[5]);
   print("Unreachable code reached\n");
 });
-ignore(async {
+ignore(future {
   ignore(b[0]);
   print("Unreachable code reached\n");
 });

--- a/test/run-dfinity/async-any.mo
+++ b/test/run-dfinity/async-any.mo
@@ -1,1 +1,1 @@
-async { ():Any };
+future { ():Any };

--- a/test/run-dfinity/async-loop-while.mo
+++ b/test/run-dfinity/async-loop-while.mo
@@ -1,5 +1,5 @@
 let _ =
-async {
+future {
 
 { var i = 0;
   var j = 0;
@@ -21,7 +21,7 @@ async {
     assert(j == i);
     i += 1;
     j += 1;
-  } while (await async (i < 11));
+  } while (await future (i < 11));
   assert(i == 11);
 };
 
@@ -31,7 +31,7 @@ async {
   loop {
    printNat(j);
    assert(j == i);
-   await (async (i += 1));
+   await (future (i += 1));
    j += 1;
   } while (i < 11);
   assert(i == 11);
@@ -48,7 +48,7 @@ async {
    };
    printNat(j);
    assert(j == i);
-   await (async (i += 1));
+   await (future (i += 1));
    j += 1;
    continue l;
    assert(false);

--- a/test/run-dfinity/async-loop.mo
+++ b/test/run-dfinity/async-loop.mo
@@ -1,5 +1,5 @@
 let _ =
-async {
+future {
 
 { var i = 0;
   var j = 0;
@@ -24,7 +24,7 @@ async {
     assert(j == i);
     i += 1;
     j += 1;
-    if (await async (j == 11)) break l else continue l;
+    if (await future (j == 11)) break l else continue l;
     assert(false);
   };
   assert(i == 11);
@@ -37,7 +37,7 @@ async {
   loop {
    printNat(j);
    assert(j == i);
-   await (async (i += 1));
+   await (future (i += 1));
    j += 1;
    if (j == 11) break l else continue l;
    assert(false);
@@ -56,7 +56,7 @@ async {
    };
    printNat(j);
    assert(j == i);
-   await (async (i += 1));
+   await (future (i += 1));
    j += 1;
    continue l;
    assert(false);

--- a/test/run-dfinity/async-new-obj.mo
+++ b/test/run-dfinity/async-new-obj.mo
@@ -1,6 +1,6 @@
 /* Test asynchronous construction of an object */
 
-let a = async {
+let a = future {
   let o = object {
     let a = "aa";
     let b = "ab";
@@ -13,9 +13,9 @@ let a = async {
   print "\n";
 };
 
-let b = async {
+let b = future {
   let o = object {
-    let a = await (async "ba") ;
+    let a = await (future "ba") ;
     let b = "bb";
     public func get_a() : Text { a };
     public func get_b() : Text { b };
@@ -26,10 +26,10 @@ let b = async {
   print "\n";
 };
 
-let c = async {
+let c = future {
   let o = object {
-    let a = await (async "ca") ;
-    let b = await (async "cb");
+    let a = await (future "ca") ;
+    let b = await (future "cb");
     public func get_a() : Text { a };
     public func get_b() : Text { b };
   };
@@ -39,10 +39,10 @@ let c = async {
   print "\n";
 };
 
-let d = async {
+let d = future {
   let o = object {
     let a = "da";
-    let b = await (async "db");
+    let b = await (future "db");
     public func get_a() : Text { a };
     public func get_b() : Text { b };
   };
@@ -52,10 +52,10 @@ let d = async {
   print "\n";
 };
 
-let e = async {
+let e = future {
   let o = object this {
     let a = "ea";
-    let b = await (async "eb");
+    let b = await (future "eb");
     public func get_a() : Text { a };
     public func get_b() : Text { b };
     public func get_ab() : (Text, Text) {

--- a/test/run-dfinity/async-obj-mut.mo
+++ b/test/run-dfinity/async-obj-mut.mo
@@ -1,8 +1,8 @@
-let _ = async {
+let _ = future {
   let o = object {
-    public var x = await { async { 1 } };
+    public var x = await { future { 1 } };
     let a = printNat(x);
-    // private b = (x := await { async (x + 1) });
+    // private b = (x := await { future (x + 1) });
     let b = (x := x + 1);
     let c = printNat(x);
     public func foo() = { x := x + 1 };

--- a/test/run-dfinity/async-while.mo
+++ b/test/run-dfinity/async-while.mo
@@ -1,5 +1,5 @@
 let _ =
-async {
+future {
 
 { var i = 0;
   var j = 0;
@@ -16,7 +16,7 @@ async {
 {
   var i = 0;
   var j = 0;
-  while (await async (j <= 10)) {
+  while (await future (j <= 10)) {
     printNat(j);
     assert(j == i);
     i += 1;
@@ -31,7 +31,7 @@ async {
   while (j <= 10) {
    printNat(j);
    assert(j == i);
-   await (async (i += 1));
+   await (future (i += 1));
    j += 1;
   };
   assert(i == 11);
@@ -48,7 +48,7 @@ async {
    };
    printNat(j);
    assert(j == i);
-   await (async (i += 1));
+   await (future (i += 1));
    j += 1;
    continue l;
    assert(false);

--- a/test/run-dfinity/await.mo
+++ b/test/run-dfinity/await.mo
@@ -1,6 +1,6 @@
 var cnt : Nat = 0;
 
-func f(i:Nat) : async Nat {
+func f(i:Nat) : future Nat {
     print "cnt: ";
     printNat cnt;
     print " i: ";
@@ -12,26 +12,26 @@ func f(i:Nat) : async Nat {
 
 print "a";
 
-let a = async await f(0);
+let a = future await f(0);
 
 print "b";
 
-let b = async { await f(1); };
+let b = future { await f(1); };
 
 print "c";
 
-let c = async {
+let c = future {
     let _ = await f(2);
     await f(3);
 };
 
 print "d";
 
-let d  = (async { return await f(4); }) : async Int; 
+let d  = (future { return await f(4); }) : future Int; 
 
 print "e";
 
-let e = async {
+let e = future {
     var i = 5;
     print "e-while";
     while (i < 10) {
@@ -43,7 +43,7 @@ let e = async {
 
 print "g";
 
-let g = async {
+let g = future {
     var i = 10;
     print "g-label";
     label lp
@@ -61,8 +61,8 @@ let g = async {
 
 print "holy";
 
-func p():async (Text,Text) { ("fst","snd"); };
-let h = async {
+func p():future (Text,Text) { ("fst","snd"); };
+let h = future {
    let (a,b) = ("a","b"); /* await p(a,b);*/
    print a;
    print b;

--- a/test/run-dfinity/block.mo
+++ b/test/run-dfinity/block.mo
@@ -1,34 +1,34 @@
-let a = async {
+let a = future {
    let (a,b) = ("a1","b1"); 
    print a;
    print b;
 };
 
-let b = async {
-   let (a,b) = await (async ("a2","b2"));
+let b = future {
+   let (a,b) = await (future ("a2","b2"));
    print a;
    print b;
 };
 
-let c = async {
+let c = future {
    func f(a:Text,b:Text):(){ print a; print b;};
-   let (a,b) = await (async ("a3","b3"));
+   let (a,b) = await (future ("a3","b3"));
    let _ = f(a,b);
 };
 
-let d = async {
+let d = future {
    var f = 1;
    printNat (f);
-   let (a,b) = await (async ("a4","b4"));
+   let (a,b) = await (future ("a4","b4"));
    f += 2;
    printNat (f);
 };
 
 
-let e = async {
-   var f = await (async 5);
+let e = future {
+   var f = await (future 5);
    printNat (f);
-   let (a,b) = await (async ("a5","b5"));
+   let (a,b) = await (future ("a5","b5"));
    f += 1;
    printNat (f);
 };

--- a/test/run-dfinity/chat.mo
+++ b/test/run-dfinity/chat.mo
@@ -18,7 +18,7 @@ actor class Server() = {
     };
   };
 
-  public func subscribe(client : Client) : async Post {
+  public func subscribe(client : Client) : future Post {
     let cs = {head = client; var tail = clients};
     clients := ?cs;
     return broadcast;
@@ -34,7 +34,7 @@ actor class Client() = this {
   public func go(n : Text, s : Server) {
     name := n;
     server := ?s;
-    ignore(async {
+    ignore(future {
       let post = await s.subscribe(this);
       post("hello from " # name);
       post("goodbye from " # name);
@@ -57,7 +57,7 @@ charlie.go("charlie", server);
 
 
 /* design flaws:
-     - we can't (synchronously) subscribe in the Client constructor as its async, need a separate 'go' method.
+     - we can't (synchronously) subscribe in the Client constructor as it's async, need a separate 'go' method.
    tc: reordering IServer and IClient leads to a complaint that subscribe has non-sharable argument type - we probably need to normalize while checking.
    compiler:
      - parameterising Client on s:IServer argument complains about non-closed actor (expected acc. to Joachim, pending system changes)

--- a/test/run-dfinity/chatpp.mo
+++ b/test/run-dfinity/chatpp.mo
@@ -28,7 +28,7 @@ actor class Server() = {
     };
   };
 
-  public func subscribe(aclient : Client) : async Subscription {
+  public func subscribe(aclient : Client) : future Subscription {
     let c = {id = nextId; client = aclient; var revoked = false};
     nextId += 1;
     let cs = {head = c; var tail = clients};
@@ -72,7 +72,7 @@ actor class Client() = this {
   public func go(n : Text, s : Server) {
     name := n;
     server := ?s;
-    ignore(async {
+    ignore(future {
       let sub = await s.subscribe(this);
       sub.post("hello from " # name);
       sub.post("goodbye from " # name);

--- a/test/run-dfinity/counter-class.mo
+++ b/test/run-dfinity/counter-class.mo
@@ -6,7 +6,7 @@ actor class Counter(i : Int) {
    j -= 1;
   };
 
-  public func read() : async Int { j };
+  public func read() : future Int { j };
 };
 
 func showCounter(c : Int) {};

--- a/test/run-dfinity/flatten-awaitables.mo
+++ b/test/run-dfinity/flatten-awaitables.mo
@@ -1,40 +1,40 @@
 // test flattening of awaitable, shared function arguments
 
 let a = actor {
-    public func m0():async() {};
-    public func m1(x:Int):async Int {return x;};
-    public func m2(x:Int,y:Bool):async(Int,Bool) {return (x,y);};
-    public func m3(x:Int,y:Bool,z:Text):async(Int,Bool,Text) {return (x,y,z);};
+    public func m0():future() {};
+    public func m1(x:Int):future Int {return x;};
+    public func m2(x:Int,y:Bool):future(Int,Bool) {return (x,y);};
+    public func m3(x:Int,y:Bool,z:Text):future(Int,Bool,Text) {return (x,y,z);};
 
-    public func n0(u:()):async() {return u};
-    public func n1(x:Int):async Int {return x;};
-    public func n2(xy:(Int,Bool)):async(Int,Bool) {return xy;};
-    public func n3(xyz:(Int,Bool,Text)):async(Int,Bool,Text) {return xyz;};
+    public func n0(u:()):future() {return u};
+    public func n1(x:Int):future Int {return x;};
+    public func n2(xy:(Int,Bool)):future(Int,Bool) {return xy;};
+    public func n3(xyz:(Int,Bool,Text)):future(Int,Bool,Text) {return xyz;};
 
     // higher-order cases
-    public func h0 (f0:shared () -> async (),u:()) : async ()
+    public func h0 (f0:shared () -> future (),u:()) : future ()
        { await f0 u;};
-    public func h1 (f1:shared (Int) -> async Int,x:Int)  : async Int
+    public func h1 (f1:shared (Int) -> future Int,x:Int)  : future Int
        { await f1 x;};
-    public func h2 (f2:shared (Int,Bool) -> async (Int,Bool), xy:(Int,Bool)) : async (Int,Bool)
+    public func h2 (f2:shared (Int,Bool) -> future (Int,Bool), xy:(Int,Bool)) : future (Int,Bool)
        { await f2 xy; };
-    public func h3 (f3:shared (Int,Bool,Text) -> async (Int,Bool,Text), xyz:(Int,Bool,Text)) : async (Int,Bool,Text)
+    public func h3 (f3:shared (Int,Bool,Text) -> future (Int,Bool,Text), xyz:(Int,Bool,Text)) : future (Int,Bool,Text)
        { await f3 xyz; };
 
-    public func g0 (f0:shared (()) -> async (),u:()) : async ()
+    public func g0 (f0:shared (()) -> future (),u:()) : future ()
        { await f0 u;};
-    public func g1 (f1:shared (Int) -> async Int,x:Int)  : async Int
+    public func g1 (f1:shared (Int) -> future Int,x:Int)  : future Int
        { await f1 x;};
-    public func g2 (f2:shared ((Int,Bool)) -> async (Int,Bool), xy:(Int,Bool)) : async (Int,Bool)
+    public func g2 (f2:shared ((Int,Bool)) -> future (Int,Bool), xy:(Int,Bool)) : future (Int,Bool)
        { await f2 xy; };
-    public func g3 (f3:shared ((Int,Bool,Text)) -> async (Int,Bool,Text), xyz:(Int,Bool,Text)) : async (Int,Bool,Text)
+    public func g3 (f3:shared ((Int,Bool,Text)) -> future (Int,Bool,Text), xyz:(Int,Bool,Text)) : future (Int,Bool,Text)
        { await f3 xyz; };
 
 };
 
 func println(s:Text) {print s;print ",";};
 
-let _ = async {
+let _ = future {
 
     println "\nfirst-order\n";
 

--- a/test/run-dfinity/for-await.mo
+++ b/test/run-dfinity/for-await.mo
@@ -1,5 +1,5 @@
 let _ =
-async {
+future {
 
 {
   var i = 0;
@@ -7,7 +7,7 @@ async {
   for (j in range(0, 10)) {
    printNat(j);
    assert(j == i);
-   await (async (i += 1));
+   await (future (i += 1));
   };
   assert(i == 11);
 };

--- a/test/run-dfinity/hello-world-await.mo
+++ b/test/run-dfinity/hello-world-await.mo
@@ -1,11 +1,11 @@
 let a = actor {
-  public func hello() : async Text {
+  public func hello() : future Text {
     "Hello ";
   };
-  public func world() : async Text {
+  public func world() : future Text {
     "World!\n"
   };
-  public func go() : async () {
+  public func go() : future () {
     print((await hello()) # (await world()));
   };
 };

--- a/test/run-dfinity/idl-tuple.mo
+++ b/test/run-dfinity/idl-tuple.mo
@@ -1,5 +1,5 @@
 let a = actor {
-  public func len2() : async (Int,Int) {
+  public func len2() : future (Int,Int) {
     (23, 42)
   }
 };

--- a/test/run-dfinity/local-throw.mo
+++ b/test/run-dfinity/local-throw.mo
@@ -1,7 +1,7 @@
 // This file only exercises local throws that don't cross function boundaries.
 // In principle, it should run on all targets.
 
-shared func t2() : async () {
+shared func t2() : future () {
    try {
      throw error("t2");
      assert(false);
@@ -14,7 +14,7 @@ shared func t2() : async () {
    }
 };
 
-shared func t3() : async () {
+shared func t3() : future () {
   try {
     try {
       throw error("t3");
@@ -47,7 +47,7 @@ shared func t3() : async () {
 };
 
 
-async {
+future {
 
   try {
     await t2();

--- a/test/run-dfinity/nary-async.mo
+++ b/test/run-dfinity/nary-async.mo
@@ -1,10 +1,10 @@
-/* test n-ary async/await */
+/* test n-ary future/await */
 
 /* n-ary args */
 {
 let t = "0_0\n";
-shared func f0_0() : async () {};
-let _ : async () = async {
+shared func f0_0() : future () {};
+let _ : future () = future {
   await f0_0();
   print t;
 };
@@ -12,10 +12,10 @@ let _ : async () = async {
 
 {
 let t = "1_0\n";
-shared func f1_0(x:Int) : async () {
+shared func f1_0(x:Int) : future () {
   assert(x == 1);
 };
-let _ : async () = async {
+let _ : future () = future {
   await f1_0(1);
   print t;
 };
@@ -23,11 +23,11 @@ let _ : async () = async {
 
 {
 let t = "2_0\n";
-shared func f2_0(x:Int,y:Bool) : async () {
+shared func f2_0(x:Int,y:Bool) : future () {
   assert(x==1);
   assert(y==true);
 };
-let _ : async () = async {
+let _ : future () = future {
   await f2_0(1,true);
   print t;
 };
@@ -35,12 +35,12 @@ let _ : async () = async {
 
 {
 let t = "3_0\n";
-shared func f3_0(x:Int,y:Bool,z:Text) : async () {
+shared func f3_0(x:Int,y:Bool,z:Text) : future () {
   assert(x == 1);
   assert(y == true);
   assert(z == "a");
 };
-let _ : async () = async {
+let _ : future () = future {
   await f3_0(1,true,"a");
   print t;
 };
@@ -50,8 +50,8 @@ let _ : async () = async {
 
 {
 let t = "0_0\n";
-shared func f0_0() : async () {};
-let _ : async () = async {
+shared func f0_0() : future () {};
+let _ : future () = future {
   await f0_0();
   print t;
 };
@@ -59,11 +59,11 @@ let _ : async () = async {
 
 {
 let t = "0_1\n";
-shared func f0_1() : async Int {
+shared func f0_1() : future Int {
    1;
 };
 
-let _ : async Int = async {
+let _ : future Int = future {
   let x = await f0_1();
   assert(x == 1);
   print t;
@@ -73,10 +73,10 @@ let _ : async Int = async {
 
 {
 let t = "0_2\n";
-shared func f0_2() : async (Int,Bool) {
+shared func f0_2() : future (Int,Bool) {
    (1,true);
 };
-let _ : async (Int,Bool) = async {
+let _ : future (Int,Bool) = future {
   let (x,y) = await f0_2();
   assert(x==1);
   assert(y==true);
@@ -88,10 +88,10 @@ let _ : async (Int,Bool) = async {
 
 {
 let t = "0_3\n!!";
-shared func f0_3() : async (Int,Bool,Text) {
+shared func f0_3() : future (Int,Bool,Text) {
    (1,true,"a");
 };
-let _ : async (Int,Bool,Text)  = async {
+let _ : future (Int,Bool,Text)  = future {
   let (x,y,z) = await f0_3();
   assert(x==1);
   assert(y==true);
@@ -107,11 +107,11 @@ let _ : async (Int,Bool,Text)  = async {
 /*
 {
 let t = "(1)-(1)\n";
-shared func fu_u(a:Int,) : async (Int,) {
+shared func fu_u(a:Int,) : future (Int,) {
    return (2*a,);
 };
 
-let _ : async (Int,)  = async {
+let _ : future (Int,)  = future {
   let (x,) = await fu_u(1);
   assert(x==2);
   print t;
@@ -124,11 +124,11 @@ let _ : async (Int,)  = async {
 /* Disabled: No generic messages are supported
 func Generic<T <: Shared>(t:Text, x:T,eq:(T,T)->Bool)  {
 
-shared func fu_u(x:T) : async T {
+shared func fu_u(x:T) : future T {
    return x;
 };
 
-let _ : async T  = async {
+let _ : future T  = future {
   let y = await fu_u(x);
   assert(eq(x,y));
   print t;

--- a/test/run-dfinity/overflow.mo
+++ b/test/run-dfinity/overflow.mo
@@ -2,33 +2,33 @@
 // traps are happening, and a good way to test this is if a message gets
 // aborted.
 
-ignore(async {
+ignore(future {
     ignore ((0-1):Int);
     print("This is reachable.\n");
 });
-ignore(async {
+ignore(future {
     ignore ((1-1):Nat);
     print("This is reachable.\n");
 });
-ignore(async {
+ignore(future {
     ignore ((0-1):Nat);
     print("This should be unreachable.\n");
 });
-ignore(async {
+ignore(future {
     ignore ((0-1):Nat);
     print("This should be unreachable.\n");
 });
 /*
-ignore(async {
+ignore(future {
     ignore ((18446744073709551615 + 0):Nat);
     print("This is reachable.\n");
 });
 */
-ignore(async {
+ignore(future {
     ignore ((9223372036854775806 + 9223372036854775806 + 1):Nat);
     print("This is reachable.\n");
 });
-ignore(async {
+ignore(future {
     ignore ((9223372036854775806 + 9223372036854775806 + 2):Nat);
     print("This is reachable.\n");
 });

--- a/test/run-dfinity/query.mo
+++ b/test/run-dfinity/query.mo
@@ -7,10 +7,10 @@ actor counter = {
   public func printCounter () {
     printNat c; print "\n";
   };
-  public func get() : async Nat {
+  public func get() : future Nat {
     return c
   };
-  public query func read() : async Nat {
+  public query func read() : future Nat {
     let tmp = c;
     c += 1;
     printNat c; print "(read)\n";
@@ -22,11 +22,11 @@ actor counter = {
 
 { // fully explicit syntax
 
-let _ : actor { read : shared query () -> async Nat } = counter;
+let _ : actor { read : shared query () -> future Nat } = counter;
 
-shared query func f () : async Nat { 666; };
+shared query func f () : future Nat { 666; };
 
-type Query = shared query () -> async Nat;
+type Query = shared query () -> future Nat;
 
 let _ : Query = counter.read;
 
@@ -36,17 +36,17 @@ let _ : Query = counter.read;
 
 // sugar, surpressing shared
 
-let _ : actor { read: query () -> async Nat } = counter;
+let _ : actor { read: query () -> future Nat } = counter;
 
-query func f () : async Nat { 666; };
+query func f () : future Nat { 666; };
 
-type Query = query () -> async Nat;
+type Query = query () -> future Nat;
 
 let _ : Query = counter.read;
 
 };
 
-async {
+future {
  counter.inc();
  counter.inc();
  counter.inc();

--- a/test/run-dfinity/shared-object.mo
+++ b/test/run-dfinity/shared-object.mo
@@ -4,12 +4,12 @@ let foo : Shob = { a = 17; b = { c = ?25 } };
 
 // check whether we can pattern match shared objects
 
-shared func baz(sh : Shob) : async Int = async (switch sh {
+shared func baz(sh : Shob) : future Int = future (switch sh {
   case {a; b = {c = null}} a;
   case {a; b = {c = ?c}} (a + c)
 });
 
-async {
+future {
   let b = await (baz foo);
   assert (b == 42);
 };

--- a/test/run-dfinity/simple-throw.mo
+++ b/test/run-dfinity/simple-throw.mo
@@ -1,7 +1,7 @@
 // This file only exercises local throws that don't cross function boundaries.
 // In principle, it should run on all targets.
 
-async {
+future {
    print "1";
    try {
      print "2";

--- a/test/run-dfinity/tiny.mo
+++ b/test/run-dfinity/tiny.mo
@@ -1,7 +1,7 @@
 // This file only exercises local throws that don't cross function boundaries.
 // In principle, it should run on all targets.
 
-async {
+future {
 };
 
 

--- a/test/run-dfinity/transpose.mo
+++ b/test/run-dfinity/transpose.mo
@@ -1,5 +1,5 @@
 actor foo {
-  public func transpose (data : [(Int,Text)]) : async {ints: [Int]; txts: [Text]} {
+  public func transpose (data : [(Int,Text)]) : future {ints: [Int]; txts: [Text]} {
     return {
       ints = Array_tabulate<Int>(data.len(), func (i:Nat) : Int = (data[i].0));
       txts = Array_tabulate<Text>(data.len(), func (i:Nat) : Text = (data[i].1))
@@ -7,7 +7,7 @@ actor foo {
   }
 };
 
-async {
+future {
   let x = await foo.transpose([(1,"Hi"), (2, "Ho")]);
   assert (x.ints[0] == 1);
   assert (x.ints[1] == 2);

--- a/test/run-dfinity/type-lub.mo
+++ b/test/run-dfinity/type-lub.mo
@@ -50,11 +50,11 @@ let shared_funcs = [ func (a : Int) : Int = a
                    , func (a : Nat) : Nat = 42
                    ];
 
-type C = async(?Int);
-type D = async(?Nat);
+type C = future(?Int);
+type D = future(?Nat);
 
 func c0(c : C, d : D) : [C] { ignore([c, d]); [c, d] };
-let c1s = [async ?4, async ?-42];
+let c1s = [future ?4, future ?-42];
 
 
 // recursive objects

--- a/test/run-drun/counter.mo
+++ b/test/run-drun/counter.mo
@@ -7,7 +7,7 @@ actor {
   public func printCounter () {
     printNat c; print "\n";
   };
-  public func get() : async Nat {
+  public func get() : future Nat {
     return c
   };
 }

--- a/test/run-drun/hello-world-return.mo
+++ b/test/run-drun/hello-world-return.mo
@@ -1,8 +1,8 @@
 actor {
-  public query func hello(who : Text) : async Text {
+  public query func hello(who : Text) : future Text {
     "Hello " # who # "!";
   };
-  public query func hello2(who : Text) : async Text {
+  public query func hello2(who : Text) : future Text {
     return ("Hello " # who # "!");
   }
 }

--- a/test/run-drun/idl-any.mo
+++ b/test/run-drun/idl-any.mo
@@ -1,7 +1,7 @@
 // This tests checks that the IDL decoder properly
 // zooms past the any argument and finds the beginning of the string
 actor {
-  public func any(_ : Any, x : Text) : async () {
+  public func any(_ : Any, x : Text) : future () {
      print ("ok: " # x);
   };
 }

--- a/test/run-drun/idl-bad.mo
+++ b/test/run-drun/idl-bad.mo
@@ -1,5 +1,5 @@
 actor {
-  public query func foo() : async () {
+  public query func foo() : future () {
   };
 }
 

--- a/test/run-drun/idl-field-escape.mo
+++ b/test/run-drun/idl-field-escape.mo
@@ -4,20 +4,20 @@ actor {
   type R = {
     _0_ : Int;
     _1_ : Nat;
-    async_ : Text
+    future_ : Text
   };
 
-  public func out() : async R {
+  public func out() : future R {
     { _0_ = 0xFFFF;
       _1_ = 0x1000;
-      async_ = "XXX"
+      future_ = "XXX"
     }
   };
 
-  public func foo1() : async {foo_ : ()} { { foo_ = () } };
-  public func foo2() : async {foo : ()} { { foo = () } };
+  public func foo1() : future {foo_ : ()} { { foo_ = () } };
+  public func foo2() : future {foo : ()} { { foo = () } };
 
-  public func input(r : R) : async () {
+  public func input(r : R) : future () {
   };
 }
 

--- a/test/run-drun/idl-func.mo
+++ b/test/run-drun/idl-func.mo
@@ -1,10 +1,10 @@
-type Func = shared Int -> async Func;
+type Func = shared Int -> future Func;
 
 actor {
-  public query func fun() : async ?Func {
+  public query func fun() : future ?Func {
         null
   };
-  public query func fun2(arg : ?Func) : async () {
+  public query func fun2(arg : ?Func) : future () {
   };
 }
 

--- a/test/run-drun/idl-nary.mo
+++ b/test/run-drun/idl-nary.mo
@@ -1,34 +1,34 @@
 actor {
-  public func two(x:Text, y:Text) : async (Text, Text) {
+  public func two(x:Text, y:Text) : future (Text, Text) {
     (x, y)
   };
 
-  public func three(x:Text, y:Text, z: Text) : async (Text, Text, Text) {
+  public func three(x:Text, y:Text, z: Text) : future (Text, Text, Text) {
     (x, y, z)
   };
 
-  public func four(x:Text, y:Text, z: Text, w: Text) : async (Text, Text, Text, Text) {
+  public func four(x:Text, y:Text, z: Text, w: Text) : future (Text, Text, Text, Text) {
     (x, y, z, w)
   };
 
-  public func mkRecord() : async ((Text, Text, Text, Text)) {
+  public func mkRecord() : future ((Text, Text, Text, Text)) {
     ("One", "Two", "Three", "Four")
   };
 
-  public func unary1((x:Text, y:Text, z: Text, w: Text)) : async ((Text, Text, Text, Text)) {
+  public func unary1((x:Text, y:Text, z: Text, w: Text)) : future ((Text, Text, Text, Text)) {
     (x, y, z, w)
   };
 
-  public func unary2(xyzw : (Text, Text, Text, Text)) : async ((Text, Text, Text, Text)) {
+  public func unary2(xyzw : (Text, Text, Text, Text)) : future ((Text, Text, Text, Text)) {
     xyzw
   };
 
-  public func unary3(xyzw : (Text, Text, Text, Text)) : async ((Text, Text, Text, Text)) {
+  public func unary3(xyzw : (Text, Text, Text, Text)) : future ((Text, Text, Text, Text)) {
     xyzw
   };
 
   type T = (Text, Text, Text, Text);
-  public func unary4(xyzw : (Text, Text, Text, Text)) : async T  {
+  public func unary4(xyzw : (Text, Text, Text, Text)) : future T  {
     xyzw
   }
 

--- a/test/run-drun/idl-nat-int.mo
+++ b/test/run-drun/idl-nat-int.mo
@@ -1,8 +1,8 @@
 actor {
-  public query func absolute(x:Int) : async Nat {
+  public query func absolute(x:Int) : future Nat {
     abs x
   };
-  public query func absolutes(xs:[Int]) : async [Nat] {
+  public query func absolutes(xs:[Int]) : future [Nat] {
     Array_tabulate<Nat>(xs.len(), func (i:Int) : Nat = abs(xs[i]))
   };
 }

--- a/test/run-drun/idl-option.mo
+++ b/test/run-drun/idl-option.mo
@@ -1,7 +1,7 @@
 // This test checks that the IDL decoder can
 // do the subtyping from null to option
 actor {
-  public func any(o : ?Text) : async () {
+  public func any(o : ?Text) : future () {
      switch o {
        case null print ("ok: null");
        case (?x) print ("ok: " # x);

--- a/test/run-drun/idl-pair.mo
+++ b/test/run-drun/idl-pair.mo
@@ -1,6 +1,6 @@
 type Pair = (Int,Int);
 actor {
-  public func len2(x:Text, y:Text) : async Pair {
+  public func len2(x:Text, y:Text) : future Pair {
     (x.len(), y.len())
   }
 }

--- a/test/run-drun/idl-record.mo
+++ b/test/run-drun/idl-record.mo
@@ -2,22 +2,22 @@
 // do the subtyping from received many-field record
 // to a double-field one (field names are in hash order)
 actor {
-    public func pair(o : (Text, Int)) : async () {
+    public func pair(o : (Text, Int)) : future () {
      switch o {
        case (content, num) print ("ok: " # debug_show num);
      }
   };
-  public func record(o : {content: Text; value : Int}) : async () {
+  public func record(o : {content: Text; value : Int}) : future () {
      switch o {
        case {content} print ("ok: " # content);
      }
   };
-  public func record1(o : {value : Int; byte : Int8}) : async () {
+  public func record1(o : {value : Int; byte : Int8}) : future () {
      switch o {
        case {byte} print ("ok: " # debug_show byte);
      }
   };
-    public func record2(o : {content: Text; value : Int}, follower : Int8) : async Int8 {
+    public func record2(o : {content: Text; value : Int}, follower : Int8) : future Int8 {
      switch o {
        case {content} { print ("ok: " # " " # content # " " # debug_show follower); follower };
      }

--- a/test/run-drun/idl-tuple.mo
+++ b/test/run-drun/idl-tuple.mo
@@ -1,10 +1,10 @@
 actor {
   // top-level tuple
-  public query func len2(x:Text, y:Text) : async (Int,Int) {
+  public query func len2(x:Text, y:Text) : future (Int,Int) {
     (x.len(), y.len())
   };
   // a pair embedded in top-level tuple
-  public query func len3((x:Text, i:Int32), y:Text) : async (Int,Int,Int) {
+  public query func len3((x:Text, i:Int32), y:Text) : future (Int,Int,Int) {
     (x.len(), y.len(), int32ToInt i)
   }
 }

--- a/test/run-drun/idl-unit.mo
+++ b/test/run-drun/idl-unit.mo
@@ -1,5 +1,5 @@
 actor {
-  public query func unit_id() : async () {
+  public query func unit_id() : future () {
     ()
   }
 }

--- a/test/run-drun/idl-variant.mo
+++ b/test/run-drun/idl-variant.mo
@@ -8,7 +8,7 @@ func to_left(e : Either) : Either
     };
 
 actor {
-  public query func numify(t: Either) : async Either {
+  public query func numify(t: Either) : future Either {
     to_left t
   }
 }

--- a/test/run-drun/idl-vector.mo
+++ b/test/run-drun/idl-vector.mo
@@ -4,7 +4,7 @@ type MayRose = ?[MayRose];
 func may(r : Rose) : MayRose = ?Array_tabulate<MayRose>(r.len(), func (i : Nat) = may(r[i]));
 
 actor {
-  public query func rose(r : Rose) : async MayRose {
+  public query func rose(r : Rose) : future MayRose {
     may r
   }
 }

--- a/test/run-drun/ok/idl-func.tc.ok
+++ b/test/run-drun/ok/idl-func.tc.ok
@@ -1,8 +1,8 @@
 idl-func.mo:1.13-1.37: type error, shared function has non-shared return type
-  Func = shared Int -> async Func
+  Func = shared Int -> future Func
 type
-  Func = shared Int -> async Func
+  Func = shared Int -> future Func
 is or contains non-shared type
-  shared Int -> async Func
+  shared Int -> future Func
 idl-func.mo:1.13-1.37: type error, shared function types are non-shared.
   (This is a limitation of the current version.)

--- a/test/run-drun/ok/unsupported.tc.ok
+++ b/test/run-drun/ok/unsupported.tc.ok
@@ -7,26 +7,26 @@ is or contains non-shared type
 unsupported.mo:6.28-6.39: type error, actor types are non-shared.
   (This is a limitation of the current version.)
 unsupported.mo:8.31-8.53: type error, shared function has non-shared parameter type
-  shared () -> async ()
+  shared () -> future ()
 type
-  shared () -> async ()
+  shared () -> future ()
 is or contains non-shared type
-  shared () -> async ()
+  shared () -> future ()
 unsupported.mo:8.31-8.53: type error, shared function types are non-shared.
   (This is a limitation of the current version.)
-unsupported.mo:19.19-19.21: type error, shared, async function must be called within an await expression
+unsupported.mo:19.19-19.21: type error, shared function with future return type must be called within an await expression
   (This is a limitation of the current version.)
 unsupported.mo:23.16-23.18: type error, calling a shared function not yet supported
   (This is a limitation of the current version.)
 unsupported.mo:28.8-28.9: type error, argument to await must be a call expression
   (This is a limitation of the current version.)
-unsupported.mo:32.17-32.29: type error, unsupported async block
+unsupported.mo:32.17-32.29: type error, unsupported future expression
   (This is a limitation of the current version.)
 unsupported.mo:4.5-4.41: type error, a shared function cannot be private
   (This is a limitation of the current version.)
 unsupported.mo:38.26-38.29: type error, a shared function is only allowed as a public field of an actor
   (This is a limitation of the current version.)
-unsupported.mo:41.10-41.18: type error, unsupported async block
+unsupported.mo:41.10-41.18: type error, unsupported future expression
   (This is a limitation of the current version.)
 unsupported.mo:46.31-46.48: type error, shared function has non-shared parameter type
   shared () -> ()
@@ -50,5 +50,5 @@ unsupported.mo:66.45-66.53: type error, non-toplevel actor; an actor can only be
   (This is a limitation of the current version.)
 unsupported.mo:70.29-70.37: type error, non-toplevel actor; an actor can only be declared at the toplevel of a program
   (This is a limitation of the current version.)
-unsupported.mo:76.34-76.37: type error, freestanding async expression not yet supported
+unsupported.mo:76.34-76.37: type error, freestanding future expression not yet supported
   (This is a limitation of the current version.)

--- a/test/run-drun/query.mo
+++ b/test/run-drun/query.mo
@@ -7,10 +7,10 @@ actor {
   public func printCounter () {
     printNat c; print "\n";
   };
-  public func get() : async Nat {
+  public func get() : future Nat {
     return c
   };
-  public query func read() : async Nat {
+  public query func read() : future Nat {
     let tmp = c;
     c += 1;
     printNat c; print "\n";

--- a/test/run-drun/reject.mo
+++ b/test/run-drun/reject.mo
@@ -1,18 +1,18 @@
 actor {
-  public func reject1() : async () {
+  public func reject1() : future () {
      print "1";
      throw (error("Error"));
      print "wrong";
   };
 
-  public func reject2() : async () {
+  public func reject2() : future () {
      print "1";
      try { throw (error("Error")) }
      catch e {};
      print "ok";
   };
 
-  public func reject3() : async () {
+  public func reject3() : future () {
      print "1";
      try { throw (error("Error")) }
      catch e {

--- a/test/run-drun/unsupported.mo
+++ b/test/run-drun/unsupported.mo
@@ -3,33 +3,33 @@ actor Counter {
 
     shared func bad_private_shared() { }; // not  public
 
-    public func badactorarg(a:actor{}) : async () {};
+    public func badactorarg(a:actor{}) : future () {};
 
-    public func badfunctionarg(f:shared()->async ()) : async () {};
+    public func badfunctionarg(f:shared()->future ()) : future () {};
 
     /* TODO
     public func badoneway(){}; // unsupported oneway
     */
 
-    public func ok() : async () {};
+    public func ok() : future () {};
 
-    public func ok_explicit() : async () = async {};
+    public func ok_explicit() : future () = future {};
 
-    public func bad_call() : async () {
+    public func bad_call() : future () {
         ignore (ok()); // unsupported intercanister messaging
     };
 
-    public func bad_await_call() : async () {
+    public func bad_await_call() : future () {
         await (ok()); // unsupported intercanister messaging
     };
 
-    public func bad_await() : async () {
-        let t : async Int = loop {};
+    public func bad_await() : future () {
+        let t : future Int = loop {};
 	await t; // unsupported general await
     };
 
-    public func badasync() : async () {
-        let a = async { 1; }; // unsupported async
+    public func badfuture() : future () {
+        let a = future { 1; }; // unsupported future
     };
 
 }
@@ -38,17 +38,17 @@ actor Counter {
 shared func bad_shared() { }; // not actor enclosed
 
 func local_spawn() {
-  ignore(async ()); // not yet supported
+  ignore(future ()); // not yet supported
 };
 
 {
     // shared function types aren't sharable
-    type illformed_1 = shared (shared () -> ()) -> async ();
+    type illformed_1 = shared (shared () -> ()) -> future ();
 };
 
 {
     // actors aren't shareable
-    type illformed_2 = shared (actor {}) -> async ();
+    type illformed_2 = shared (actor {}) -> future ();
 };
 
 /* TODO
@@ -73,4 +73,4 @@ func local_spawn() {
 
 actor BadSecondActor { };
 
-func implicit_async() : async () { }; // async functions not supported
+func implicit_future() : future () { }; // future functions not supported


### PR DESCRIPTION
This renames `async` to `future`, in an attempt of clarifying the concept and the role of the keyword.

However, after having done this and converting all the tests and examples, I am no longer convinced that it's actually an improvement overall. Uploading  it anyway, in case anybody wants to comment.