### PR TITLE
Parses package paths passed to the LSP server just like the compiler

### DIFF
--- a/src/exes/mo_ide.ml
+++ b/src/exes/mo_ide.ml
@@ -13,6 +13,18 @@ let argspec =
     ; "--canister-main",
       Arg.String set_entry_point,
       " specifies the entry point for the current project"
+    ; "--package",
+      (let package_name_ref = ref "DEADBEEF" in
+       Arg.Tuple [
+           Arg.Set_string package_name_ref ;
+           Arg.String begin fun package_url ->
+             (* push (package_name, package_url) onto the list. *)
+             Mo_config.Flags.package_urls := (
+               !package_name_ref,
+               package_url
+             ) :: ! Mo_config.Flags.package_urls
+             end
+      ]), "<args> Specify a package-name-package-URL pair, separated by a space" ;
     ]
 
 let () =


### PR DESCRIPTION
For consistency I'm reading this exactly like the compiler binary and didlc.