### PR TITLE
Tmp; don't use (Class that tracks the history of a variable)

### DIFF
--- a/stdlib/array.mo
+++ b/stdlib/array.mo
@@ -1,4 +1,22 @@
 module {
+  public func fromEnd<A>(a : [A], i : Nat) : A {
+    a[a.len()-1-i];
+  };
+  
+  public func equals<A>(a : [A], b : [A], eq : (A,A) -> Bool) : Bool {
+    if (a.len() != b.len()) { 
+      return false 
+    };
+    var i = 0;
+    while (i < a.len()) {
+      if (not eq(a[i],b[i])) { 
+        return false 
+      };
+      i += 1
+    };
+    return true; 
+  };
+
   public func append<A>(xs : [A], ys : [A]) : [A] {
     switch(xs.len(), ys.len()) {
       case (0, 0) { []; };

--- a/stdlib/cell.mo
+++ b/stdlib/cell.mo
@@ -1,0 +1,29 @@
+import E "../stdlib/env.mo";
+import A "../stdlib/array.mo";
+
+module {
+  /*  
+    A Cell can be thought of as a database cell that holds a single value which can be read and written. On top of that a cell:
+    a) saves the entire history of changes made to the value, and
+    b) saves environmental state with each write (e.g. time).
+
+    Todo: This is currently implemented using arrays, but should probably be switched to lists at some point. 
+  */
+  public class Cell<T>(env : E.Env, init : T) {
+    // The journal (history) of writes.
+    var j : [E.Event<T>] = [env.wrap<T>(init)]; 
+  
+    // The write function.
+    public func write(v : T) : () { j := A.append<E.Event<T>>(j, [env.wrap<T>(v)]) };
+  
+    // Read functions.
+    // The current value (i.e. the last one written). 
+    public func read() : T = env.unwrap<T>(A.fromEnd<E.Event<T>>(j, 0)) ;
+
+    // The entire raw journal.
+    public func journal() : [E.Event<T>] = j ;
+
+    // The history of written values as an array.
+    public func values() : [T] = A.map<E.Event<T>,T>(func(e){env.unwrap<T>(e)}, j) ;
+  };
+}

--- a/stdlib/cellTest.mo
+++ b/stdlib/cellTest.mo
@@ -1,0 +1,23 @@
+import E "../stdlib/env.mo";
+import C "../stdlib/cell.mo";
+import A "../stdlib/array.mo";
+import P "prelude.mo";
+
+P.printLn("Cell");
+
+{
+  P.printLn("  all functions");
+	let env = E.Env();
+  let b = C.Cell<Bool>(env, true);
+
+  assert(b.read() == true);
+  b.write(false);
+  assert(b.journal().len() == 2);
+  assert(A.equals<Bool>(b.values(), [true,false], func(x,y){x==y}));
+
+  let a = C.Cell<Nat>(env, 3);
+  assert(a.read() == 3);
+  a.write(2);
+  assert(a.journal().len() == 2);
+  assert(A.equals<Nat>(a.values(), [3,2], func(x,y){x==y}));
+};

--- a/stdlib/env.mo
+++ b/stdlib/env.mo
@@ -1,0 +1,32 @@
+/*
+  Mocking an environment that can include time, caller id, etc.
+*/
+
+module {
+  public type Time = Nat; 
+   
+  public class Env() {
+    // Environmental state. Currently, this is only time.
+    var t : Time = 0;
+
+    // Access functions.
+    // Currently, we make the time advance with every access.
+    public func currentTime() : Time { t += 10; t };
+
+    // Wrap value plus environmental state into an "event".
+    public func wrap<T>(v : T) : Event<T> = Event<T>(v, currentTime()); 
+    public func unwrap<T>(e : Event<T>) : T = e.value();
+  };
+
+  // The Event class bundles a value with environmental state.
+  // The class is static, i.e. has no write functions besides the constructor.
+  public type EventRep<T> = (Time, T);
+  public class Event<T>(value_ : T, time_ : Time) {
+    let t : Time = time_;
+    let v : T = value_;
+  
+    public func time() : Time = t ;
+    public func value() : T = v ;
+    public func rep() : EventRep<T> = (t,v) ; 
+  };
+}

--- a/stdlib/envTest.mo
+++ b/stdlib/envTest.mo
@@ -1,0 +1,38 @@
+import E "env.mo";
+import P "prelude.mo";
+
+P.printLn("Env");
+
+{
+  P.printLn("  Env.time");
+
+  let env = E.Env();        // time is initialized to 0
+  assert(env.currentTime() == 10); // time advances before reading it 
+  assert(env.currentTime() == 20);
+  assert(env.currentTime() == 30);
+};
+
+{
+  P.printLn("  Event");
+ 
+  let e = E.Event<Bool>(true, 42);
+  assert(e.time() == 42); 
+  assert(e.value() == true); 
+  assert(e.rep().0 == 42); 
+  assert(e.rep().1 == true); 
+}; 
+
+{
+  P.printLn("  (un)wrap");
+ 
+  let env = E.Env();
+  let e1 = env.wrap<Bool>(true);
+  assert(env.unwrap<Bool>(e1) == true); 
+  assert(e1.time() == env.currentTime()-10); 
+  assert(e1.value() == true); 
+
+  let e2 = env.wrap<Bool>(false);
+  assert(env.unwrap<Bool>(e2) == false); 
+  assert(e2.time() == env.currentTime()-10); 
+  assert(e2.value() == false); 
+};


### PR DESCRIPTION
This is code in anticipation of canisters that need to track the history of changes made to a variable and maintain that history in their current state,
e.g., for audit purposes.

Current sample code uses arrays, not lists, which may be wasteful but should be enough to play with applications.

The changes are tracked along with the times when changes occurred. For this, a mock module called "environment" is used in place of a real sys calls to obtain the time.