### PR TITLE
Clean up prelude

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -18,6 +18,7 @@ TESTS=\
 	Array \
 	ArrayTest \
 	AssocList \
+	Debug \
 	DocTable \
   Function \
   FunctionTest \

--- a/stdlib/arrayTest.mo
+++ b/stdlib/arrayTest.mo
@@ -1,11 +1,11 @@
 import Array "array.mo";
-import Prelude "prelude.mo";
+import Debug "debug.mo";
 import Text "text.mo";
 
-Prelude.printLn("Array");
+Debug.printLn("Array");
 
 {
-  Prelude.printLn("  append");
+  Debug.printLn("  append");
 
   let actual = Array.append<Int>([ 1, 2, 3 ], [ 4, 5, 6 ]);
   let expected = [ 1, 2, 3, 4, 5, 6 ];
@@ -18,7 +18,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  apply");
+  Debug.printLn("  apply");
 
   let ask = func (x : Text) : Text {
     x # "?";
@@ -39,7 +39,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  bind");
+  Debug.printLn("  bind");
 
   let purePlusOne = func (x : Int) : [Int] {
     [ x + 1 ];
@@ -56,7 +56,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  enumerate");
+  Debug.printLn("  enumerate");
 
   let xs = [ "a", "b", "c" ];
   let ys = Array.enumerate<Text>(xs);
@@ -74,7 +74,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  filter");
+  Debug.printLn("  filter");
 
   let isEven = func (x : Int) : Bool {
     x % 2 == 0;
@@ -91,7 +91,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  find");
+  Debug.printLn("  find");
 
   type Element = {
     key : Text;
@@ -119,7 +119,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  foldl");
+  Debug.printLn("  foldl");
 
   let xs = [ "a", "b", "c" ];
 
@@ -130,7 +130,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  foldr");
+  Debug.printLn("  foldr");
 
   let xs = [ "a", "b", "c" ];
 
@@ -141,7 +141,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  freeze");
+  Debug.printLn("  freeze");
 
   var xs : [var Int] = [ var 1, 2, 3 ];
 
@@ -156,7 +156,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  join");
+  Debug.printLn("  join");
 
   let xs = [ [ 1, 2, 3 ] ];
 
@@ -171,7 +171,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  map");
+  Debug.printLn("  map");
 
   let isEven = func (x : Int) : Bool {
     x % 2 == 0;
@@ -188,7 +188,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  mapWithIndex");
+  Debug.printLn("  mapWithIndex");
 
   let isEven = func (x : Int) : Bool {
     x % 2 == 0;
@@ -221,7 +221,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  pure");
+  Debug.printLn("  pure");
 
   let actual = Array.pure<Int>(0);
   let expected = [0];
@@ -234,7 +234,7 @@ Prelude.printLn("Array");
 };
 
 {
-  Prelude.printLn("  thaw");
+  Debug.printLn("  thaw");
 
   let xs : [Int] = [ 1, 2, 3 ];
 

--- a/stdlib/debug.mo
+++ b/stdlib/debug.mo
@@ -1,0 +1,29 @@
+module {
+  public func print(x : Text) {
+    debugPrint(x);
+  };
+
+  public func printLn(x : Text) {
+    print (x # "\n");
+  };
+
+  public func printNat(x : Nat) {
+    printLn (show x);
+  };
+
+  public func printInt(x : Int) {
+    printLn (show x);
+  };
+
+  public func printChar(x : Char) {
+    printLn (show x);
+  };
+
+  // FIXME: how to express types that can be shown?
+  // public func show(x : FIXME) : Text {
+  //   debug_show x;
+  // };
+
+  // This doesn't parse
+  // public let show = debug_show;
+};

--- a/stdlib/functionTest.mo
+++ b/stdlib/functionTest.mo
@@ -1,11 +1,11 @@
+import Debug "debug.mo";
 import Function "function.mo";
-import Prelude "prelude.mo";
 import Text "text.mo";
 
-Prelude.printLn("Function");
+Debug.printLn("Function");
 
 {
-  Prelude.printLn("  compose");
+  Debug.printLn("  compose");
 
   func isEven(x : Int) : Bool { x % 2 == 0; };
   func not_(x : Bool) : Bool { not x; };
@@ -16,21 +16,21 @@ Prelude.printLn("Function");
 };
 
 {
-  Prelude.printLn("  const");
+  Debug.printLn("  const");
 
   assert(Function.const<Bool, Text>(true)("abc"));
   assert(Function.const<Bool, Text>(false)("abc") == false);
 };
 
 {
-  Prelude.printLn("  const2");
+  Debug.printLn("  const2");
 
   assert(Function.const2<Bool, Int, Text>(true)(0, "abc"));
   assert(Function.const2<Bool, Int, Text>(false)(0, "abc") == false);
 };
 
 {
-  Prelude.printLn("  lift");
+  Debug.printLn("  lift");
 
   let appendPair = Function.lift<Text, Text, Text>(Text.append);
   let pair = ("Hello, ", "World!");
@@ -39,7 +39,7 @@ Prelude.printLn("Function");
 };
 
 {
-  Prelude.printLn("  lower");
+  Debug.printLn("  lower");
 
   func appendPair(pair : (Text, Text)) : Text {
     pair.0 # pair.1;

--- a/stdlib/intTest.mo
+++ b/stdlib/intTest.mo
@@ -1,10 +1,10 @@
-import Prelude "prelude.mo";
+import Debug "debug.mo";
 import Int "int.mo";
 
-Prelude.printLn("Int");
+Debug.printLn("Int");
 
 {
-  Prelude.printLn("  add");
+  Debug.printLn("  add");
 
   assert(Int.add(1, Int.add(2, 3)) == Int.add(1, Int.add(2, 3)));
   assert(Int.add(0, 1) == 1);
@@ -14,7 +14,7 @@ Prelude.printLn("Int");
 };
 
 {
-  Prelude.printLn("  toText");
+  Debug.printLn("  toText");
 
   assert(Int.toText(0) == "0");
   assert(Int.toText(-0) == "0");

--- a/stdlib/iterTest.mo
+++ b/stdlib/iterTest.mo
@@ -1,10 +1,10 @@
+import Debug "debug.mo";
 import Iter "iter.mo";
-import Prelude "prelude.mo";
 
-Prelude.printLn("Iter");
+Debug.printLn("Iter");
 
 {
-  Prelude.printLn("  forIn");
+  Debug.printLn("  forIn");
 
   let xs = [ "a", "b", "c", "d", "e", "f" ];
 

--- a/stdlib/natTest.mo
+++ b/stdlib/natTest.mo
@@ -1,10 +1,10 @@
-import Prelude "prelude.mo";
+import Debug "debug.mo";
 import Nat "nat.mo";
 
-Prelude.printLn("Nat");
+Debug.printLn("Nat");
 
 {
-  Prelude.printLn("  add");
+  Debug.printLn("  add");
 
   assert(Nat.add(1, Nat.add(2, 3)) == Nat.add(1, Nat.add(2, 3)));
   assert(Nat.add(0, 1) == 1);
@@ -14,7 +14,7 @@ Prelude.printLn("Nat");
 };
 
 {
-  Prelude.printLn("  toText");
+  Debug.printLn("  toText");
 
   assert(Nat.toText(0) == "0");
   assert(Nat.toText(1234) == "1234");

--- a/stdlib/noneTest.mo
+++ b/stdlib/noneTest.mo
@@ -1,11 +1,11 @@
 import Array "array.mo";
+import Debug "debug.mo";
 import None "none.mo";
-import Prelude "prelude.mo";
 
-Prelude.printLn("None");
+Debug.printLn("None");
 
 {
-  Prelude.printLn("  absurd");
+  Debug.printLn("  absurd");
 
   func showNone(x : None) : Text {
     None.absurd<Text>(x);

--- a/stdlib/optionTest.mo
+++ b/stdlib/optionTest.mo
@@ -1,13 +1,13 @@
+import Debug "debug.mo";
 import Option "option.mo";
-import Prelude "prelude.mo";
 
-Prelude.printLn("Option");
+Debug.printLn("Option");
 
 {
-  Prelude.printLn("  apply");
+  Debug.printLn("  apply");
 
   {
-    Prelude.printLn("    null function, null value");
+    Debug.printLn("    null function, null value");
 
     let actual = Option.apply<Int, Bool>(null, null);
     let expected : ?Bool = null;
@@ -23,7 +23,7 @@ Prelude.printLn("Option");
   };
 
   {
-    Prelude.printLn("    null function, non-null value");
+    Debug.printLn("    null function, non-null value");
 
      let actual = Option.apply<Int, Bool>(null, ?0);
     let expected : ?Bool = null;
@@ -39,7 +39,7 @@ Prelude.printLn("Option");
   };
 
   {
-    Prelude.printLn("    non-null function, null value");
+    Debug.printLn("    non-null function, null value");
 
      let isEven = func (x : Int) : Bool {
       x % 2 == 0;
@@ -59,7 +59,7 @@ Prelude.printLn("Option");
   };
 
   {
-    Prelude.printLn("    non-null function, non-null value");
+    Debug.printLn("    non-null function, non-null value");
 
    let isEven = func (x : Int) : Bool {
       x % 2 == 0;
@@ -81,10 +81,10 @@ Prelude.printLn("Option");
  };
 
 {
-  Prelude.printLn("  bind");
+  Debug.printLn("  bind");
 
   {
-    Prelude.printLn("    null value to null value");
+    Debug.printLn("    null value to null value");
 
     let safeInt = func (x : Int) : ?Int {
       if (x > 9007199254740991) {
@@ -108,7 +108,7 @@ Prelude.printLn("Option");
   };
 
   {
-    Prelude.printLn("    non-null value to null value");
+    Debug.printLn("    non-null value to null value");
 
     let safeInt = func (x : Int) : ?Int {
       if (x > 9007199254740991) {
@@ -132,7 +132,7 @@ Prelude.printLn("Option");
   };
 
   {
-    Prelude.printLn("    non-null value to non-null value");
+    Debug.printLn("    non-null value to non-null value");
 
     let safeInt = func (x : Int) : ?Int {
       if (x > 9007199254740991) {
@@ -158,10 +158,10 @@ Prelude.printLn("Option");
 };
 
 {
-  Prelude.printLn("  join");
+  Debug.printLn("  join");
 
   {
-    Prelude.printLn("    null value");
+    Debug.printLn("    null value");
 
     let actual = Option.join<Int>(?null);
     let expected : ?Int = null;
@@ -177,7 +177,7 @@ Prelude.printLn("Option");
   };
 
   {
-    Prelude.printLn("    non-null value");
+    Debug.printLn("    non-null value");
     let actual = Option.join<Int>(??0);
     let expected = ?0;
 
@@ -194,10 +194,10 @@ Prelude.printLn("Option");
 };
 
 {
-  Prelude.printLn("  map");
+  Debug.printLn("  map");
 
   {
-    Prelude.printLn("    null value");
+    Debug.printLn("    null value");
 
     let isEven = func (x : Int) : Bool {
       x % 2 == 0;
@@ -217,7 +217,7 @@ Prelude.printLn("Option");
   };
 
   {
-    Prelude.printLn("    non-null value");
+    Debug.printLn("    non-null value");
 
     let isEven = func (x : Int) : Bool {
       x % 2 == 0;
@@ -239,7 +239,7 @@ Prelude.printLn("Option");
 };
 
 {
-  Prelude.printLn("  pure");
+  Debug.printLn("  pure");
 
   let actual = Option.pure<Int>(0);
   let expected = ?0;

--- a/stdlib/prelude.mo
+++ b/stdlib/prelude.mo
@@ -12,18 +12,6 @@ some further experience and discussion.  Until then, they live here.
 
 /***
 
-  `printLn`
-  ---------
-
-  Print text followed by a newline.
-
-*/
-public func printLn(x : Text) {
-  debugPrint(x # "\n");
-};
-
-/***
-
  `nyi`: Not yet implemented
  -----------------------------
 

--- a/stdlib/textTest.mo
+++ b/stdlib/textTest.mo
@@ -1,10 +1,10 @@
-import Prelude "prelude.mo";
+import Debug "debug.mo";
 import Text "text.mo";
 
-Prelude.printLn("Text");
+Debug.printLn("Text");
 
 {
-  Prelude.printLn("  append");
+  Debug.printLn("  append");
 
   let actual = Text.append("x", "y");
   let expected = "xy";


### PR DESCRIPTION
I noticed that we now have `debug_show`, `debugPrint`, etc and figured it might be better to have these in a `Debug` module. Is this a good idea?

`Debug.show` is a bit of a cheat because it's not actually part of the module.

Some of the tests for the standard library examples are now failing to compile and I'm not sure why yet. Help appreciated.