### PR TITLE
IDL-Motoko: Pass actor and func references as data

### DIFF
--- a/design/IDL-Motoko.md
+++ b/design/IDL-Motoko.md
@@ -307,3 +307,15 @@ just suggestions.
 
   is treated by `moc` by reading `foo.did` as if  the developer had
   run `didc path/to/foo.did -o path/to/foo.mo`.
+
+## Provisional Scaffolding adjustments
+
+At the time of writing, the underlying transport mechanism on the Internet Computer has no notion of a “sequence of references”, as expected by the IDL spec. This means that the IDL types `service …` and `func …` are not usable.
+
+To work around this and at least support passing references to _public_ canister and to _public_ canister methods, and until this mismatch is resolved, we implement `e` as follows:
+
+```
+e(actor { <typ-field>;* }) = blob
+e(shared <typ1> -> <typ2>) = (blob, text)
+```
+where the `blob` is an actor id, and the `text` a method name.


### PR DESCRIPTION
The status quo is:

* Motoko assumes that we can pass around references to actors (public,
  anonymous, and non-closed) and functions (also public, anonymous and
  non-closed).

* The IDL type system has service and function references, and assumes
  the transport supports a “sequence of platform-specific references”

* The system has _no_ such concept, but obviously _public_ canister ids
  and id/method name pairs can be used to reference public canister and
  their public entry points.

This eventually needs consolidation.

But as a scaffolding measure, let’s at least support the lowest common
denominator, i.e. passing around public actors and public functions.

There are two points where we can implement that:

 * In the IDL (the “big” solution):

   We extend the IDL wire format so
   that a value of type `serivce {…}` is tagged (in `M`).
   One tag indicates “reference” and means there is a reference in `R`
   (as specified now).
   Another tag indicates “id” and means that in the _data_ section a
   public id follows.

   Nice side effect: This is future-proof with adding refernces, and we
   can add more tags later.

 * In the IDL-Motoko mapping (the “small” solution):

   We (temporarily) change `e(actor {…}) = blob` and do not use the
   IDL types that require system support for the reference sequence.

   This does not affect other IDL implementations.

This PR proposes the “small” solution, as it seems the easiest first
step.