### PR TITLE
run.sh -a: Delete ok files later

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -159,10 +159,6 @@ do
   [ -d $ok ] || mkdir $ok
 
   rm -f $out/$base.*
-  if [ $ACCEPT = yes ]
-  then
-    rm -f $ok/$base.*
-  fi
 
   # First run all the steps, and remember what to diff
   diff_files=
@@ -322,6 +318,8 @@ do
 
   if [ $ACCEPT = yes ]
   then
+    rm -f $ok/$base.*
+
     for outfile in $diff_files
     do
       if [ -s $out/$outfile ]


### PR DESCRIPTION
so that during a run of `make accept`, `git status` doesn't always show
some files as deleted. (It’s not completely atomic, just more
ergonomical).