### PR TITLE
Store reply and reject callbacks together in the table

### DIFF
--- a/test/run-stub/ok/count-callbacks.ic-stub-run.ok
+++ b/test/run-stub/ok/count-callbacks.ic-stub-run.ok
@@ -2,16 +2,16 @@
 ← completed: canister-id = 0x0000000000000400
 → install
 go 1: 0
+go 1: 1
 go 1: 2
+go 1: 3
 go 1: 4
-go 1: 6
-go 1: 8
-ping! 8
-ping! 8
-ping! 8
-ping! 8
-go 2: 7
-go 3: 6
-go 4: 5
-go 5: 4
+ping! 4
+ping! 4
+ping! 4
+ping! 4
+go 2: 3
+go 3: 2
+go 4: 1
+go 5: 0
 ← completed


### PR DESCRIPTION
because when one is called, we want to free both. Note how now the count
goes down to zero in the text:

```diff
diff --git a/test/run-stub/ok/count-callbacks.ic-stub-run.ok b/test/run-stub/ok/count-callbacks.ic-stub-run.ok
index 27667f29..2fbc3c6f 100644
--- a/test/run-stub/ok/count-callbacks.ic-stub-run.ok
+++ b/test/run-stub/ok/count-callbacks.ic-stub-run.ok
@@ -2,16 +2,16 @@
 ← completed: canister-id = 0x0000000000000400
 → install
 go 1: 0
+go 1: 1
 go 1: 2
+go 1: 3
 go 1: 4
-go 1: 6
-go 1: 8
-ping! 8
-ping! 8
-ping! 8
-ping! 8
-go 2: 7
-go 3: 6
-go 4: 5
-go 5: 4
+ping! 4
+ping! 4
+ping! 4
+ping! 4
+go 2: 3
+go 3: 2
+go 4: 1
+go 5: 0
 ← completed
```