### PR TITLE
Pull in hex decoding and CRC calculation

### DIFF
--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,5 +1,6 @@
 (library
  (name lib)
  (libraries bigarray)
- (preprocess (pps bisect_ppx -conditional))
+ (inline_tests)
+ (preprocess (pps ppx_inline_test bisect_ppx -conditional))
 )

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -46,7 +46,7 @@ struct
     else Int32.compare i1 i2
 end
 
-module Hex =
+module CRC =
 struct
   let crc8 (bs : bytes) : int =
     let inner _ = function
@@ -55,7 +55,10 @@ struct
     let outer crc b =
       List.fold_right inner [0;1;2;3;4;5;6;7] (Char.code b lxor crc) land 0xFF in
     Seq.fold_left outer 0 (Bytes.to_seq bs)
+end
 
+module Hex =
+struct
   let hexdigit = let open Char in function
     | c when c >= '0' && c <= '9' -> code c - code '0'
     | c when c >= 'A' && c <= 'F' -> code c - code 'A' + 10
@@ -403,3 +406,29 @@ struct
   let value_opt p = !p
   let value p = match !p with Some x -> x | None -> raise Promise
 end
+
+[@@@warning "-60"]
+module Test =
+struct
+(* need to put tests in this file because
+   dune does not like it if other files in lib depend on Lib
+   Maybe we should break up lib into its components, now that
+   it is a dune library.
+*)
+  let%test "bytes_of_hex DEADBEEF" =
+    Hex.bytes_of_hex "DEADBEEF" = Bytes.of_string "\xDE\xAD\xBE\xEF"
+  let%test "bytes_of_hex 0000" =
+    Hex.bytes_of_hex "0000" = Bytes.of_string "\x00\x00"
+  let%test "bytes_of_hex empty" =
+    Hex.bytes_of_hex "" = Bytes.of_string ""
+
+  let%test "int_of_hex_byte 00" = Hex.int_of_hex_byte "00" = 0
+  let%test "int_of_hex_byte AB" = Hex.int_of_hex_byte "AB" = 0xAB
+  let%test "int_of_hex_byte FF" = Hex.int_of_hex_byte "FF" = 0xFF
+
+  (* see https://crccalc.com/ *)
+  let %test "crc8 DEADBEEF" = CRC.crc8 (Bytes.of_string "\xDE\xAD\xBE\xEF") = 0xCA
+  let %test "crc8 empty" = CRC.crc8 (Bytes.of_string "") = 0x00
+  let %test "crc8 0000" = CRC.crc8 (Bytes.of_string "\x00\x00") = 0x00
+end
+

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -138,9 +138,13 @@ sig
   val lightweight_escaped : string -> string
 end
 
-module Hex :
+module CRC :
 sig
   val crc8 : bytes -> int
+end
+
+module Hex :
+sig
   val hexdigit : char -> int
   val bytes_of_hex : string -> bytes
   val int_of_hex_byte : string -> int


### PR DESCRIPTION
cherry-picked from #1001, with a bit of unit tests added, and `crc8` moved to
its own module.