### PR TITLE
IC Stub: Query methods can be responded to

### DIFF
--- a/ic-stub/src/IC/Canister/Imp.hs
+++ b/ic-stub/src/IC/Canister/Imp.hs
@@ -364,6 +364,9 @@ rawInvoke esref (CI.Callback cb ex responded res) =
 cantRespond :: Responded
 cantRespond = Responded True
 
+canRespond :: Responded
+canRespond = Responded False
+
 rawInitializeMethod :: ImpState s -> ExistingCanisters -> Module -> EntityId -> Blob -> ST s (TrapOr InitResult)
 rawInitializeMethod (esref, cid, inst) ex wasm_mod caller dat = do
   result <- runExceptT $ do
@@ -390,7 +393,7 @@ rawInitializeMethod (esref, cid, inst) ex wasm_mod caller dat = do
 
 rawQueryMethod :: ImpState s -> MethodName -> EntityId -> Blob -> ST s (TrapOr Response)
 rawQueryMethod (esref, cid, inst) method caller dat = do
-  let es = (initalExecutionState cid inst [] cantRespond)
+  let es = (initalExecutionState cid inst [] canRespond)
             { params = Params
                 { param_dat    = Just dat
                 , param_caller = Just caller


### PR DESCRIPTION
I made a mistake in #1017, breaking query methods on `ic-stub`. We
didn’t notice because all tests using query methods are only run on
`drun`.

More evidence that #1018 is the right way to go.