### PR TITLE
Move URL parsing from lib to pipeline

### DIFF
--- a/src/languageServer/declaration_index.ml
+++ b/src/languageServer/declaration_index.ml
@@ -57,7 +57,7 @@ let lookup_module
       (path : path)
       (index : t)
     : ide_decl list option =
-  let open Lib.URL in
+  let open Pipeline.URL in
   match parse path with
   | Ok (Relative path) -> Index.find_opt path index
   | Ok (Package (pkg, path)) ->

--- a/src/languageServer/source_file.ml
+++ b/src/languageServer/source_file.ml
@@ -40,13 +40,13 @@ let cursor_target_at_pos
   try loop (next ()) with _ -> None
 
 let is_package_path (path : string) =
-  let open Lib.URL in
+  let open Pipeline.URL in
   match parse path with
   | Ok (Package _) -> true
   | _ -> false
 
 let uri_for_package (path : string) =
-  let open Lib.URL in
+  let open Pipeline.URL in
   match parse path with
   | Ok (Package (pkg, path)) ->
      begin match

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -74,6 +74,11 @@ sig
   end
 end
 
+module Seq :
+sig
+  val for_all : ('a -> bool) -> 'a Seq.t -> bool
+end
+
 module Option :
 sig
   val equal : ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
@@ -168,14 +173,4 @@ sig
    * relative_to "foo/bar" "foo/bar/project" = Some "project"
    *)
   val relative_to : string -> string -> string option
-end
-
-module URL :
-sig
-  type parsed =
-    | Package of (string * string)
-    | Relative of string
-    | Ic of string
-
-  val parse : string -> (parsed, string) result
 end

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -148,11 +148,7 @@ and exp' at note = function
     begin match !ir with
     | S.Unresolved -> raise (Invalid_argument ("Unresolved import " ^ f))
     | S.LibPath fp -> I.VarE (id_of_full_path fp).it
-    | S.IDLPath fp ->
-      match Lib.URL.parse f with
-      | Ok (Lib.URL.Ic blob_id) ->
-        I.(PrimE (ActorOfIdBlob note.note_typ, [blobE blob_id]))
-      | _ -> raise (Invalid_argument ("Invalid import URL during desugaring"))
+    | S.IDLPath (fp, blob_id) -> I.(PrimE (ActorOfIdBlob note.note_typ, [blobE blob_id]))
     end
   | S.PrimE s -> raise (Invalid_argument ("Unapplied prim " ^ s))
 

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -15,7 +15,7 @@ let empty_typ_note = {note_typ = Type.Pre; note_eff = Type.Triv}
 type resolved_import =
   | Unresolved
   | LibPath of string
-  | IDLPath of string
+  | IDLPath of (string * string) (* filepath * bytes *)
 
 (* Identifiers *)
 

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -176,7 +176,7 @@ let check_import env at f ri =
     match !ri with
     | Unresolved -> error env at "unresolved import %s" f
     | LibPath fp -> fp
-    | IDLPath fp -> fp
+    | IDLPath (fp, _) -> fp
   in
   match T.Env.find_opt full_path env.libs with
   | Some T.Pre ->

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -11,6 +11,7 @@ open Mo_config
 open Printf
 
 module ResolveImport = Resolve_import
+module URL = Url
 
 type stat_env = Scope.t
 type dyn_env = Interpret.scope
@@ -247,7 +248,7 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
         Diag.return ()
         )))))
       end
-    | Syntax.IDLPath f ->
+    | Syntax.IDLPath (f, _) ->
       let sscope = Scope.lib f Type.(Obj (Actor, [])) in
       senv := Scope.adjoin !senv sscope;
       Diag.warn ri.Source.at "import" "imported actors assumed to have type actor {}"

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -3,6 +3,7 @@ open Mo_config
 open Mo_types
 
 module ResolveImport = Resolve_import
+module URL = Url
 
 type parse_fn = string -> (Syntax.prog * string) Diag.result
 val parse_file: parse_fn

--- a/src/pipeline/resolve_import.ml
+++ b/src/pipeline/resolve_import.ml
@@ -107,9 +107,9 @@ let add_lib_import msgs imported ri_ref at full_path =
   end else
     err_file_does_not_exist msgs at full_path
 
-let add_idl_import msgs imported ri_ref at full_path =
-  ri_ref := IDLPath full_path;
-  imported := RIM.add (IDLPath full_path) at !imported
+let add_idl_import msgs imported ri_ref at full_path bytes =
+  ri_ref := IDLPath (full_path, bytes);
+  imported := RIM.add (IDLPath (full_path, bytes)) at !imported
   (*
   if Sys.file_exists full_path
   then begin
@@ -127,19 +127,19 @@ let in_base base f =
   else Filename.concat base f
 
 let resolve_import_string msgs base packages imported (f, ri_ref, at)  =
-  match Lib.URL.parse f with
-    | Ok (Lib.URL.Relative path) ->
+  match Url.parse f with
+    | Ok (Url.Relative path) ->
       add_lib_import msgs imported ri_ref at (in_base base path)
-    | Ok (Lib.URL.Package (pkg,path)) ->
+    | Ok (Url.Package (pkg,path)) ->
       begin match M.find_opt pkg packages with
       | Some pkg_path ->
         add_lib_import msgs imported ri_ref at (in_base pkg_path path)
       | None ->
         err_package_not_defined msgs at pkg
       end
-    | Ok (Lib.URL.Ic bytes) ->
+    | Ok (Url.Ic bytes) ->
       let full_path = (* in_base actor_base *) bytes in
-      add_idl_import msgs imported ri_ref at full_path
+      add_idl_import msgs imported ri_ref at full_path bytes
     | Error msg ->
       err_unrecognized_url msgs at f msg
 

--- a/src/pipeline/url.ml
+++ b/src/pipeline/url.ml
@@ -1,0 +1,65 @@
+(* Parsing known URLs from mo: and ic: URLs *)
+
+(*
+   parse "mo:std/list"    = Ok (Package ("std", "list"))
+   parse "mo:std/foo/bar" = Ok (Package ("std", "foo/bar"))
+   parse "mo:foo/bar"     = Ok (Package ("foo", "bar"))
+   parse "mo:foo"         = Ok (Package ("foo", ""))
+
+   parse "ic:DEADBEEF"    = Ok (Ic "\DE\AD\BE\EF")
+   parse "ic:alias"       = (not yet supported)
+
+   parse "std/foo"        = Ok (Relative "std/foo")
+   parse "foo"            = Ok (Relative "foo")
+   parse "./foo"          = Ok (Relative "foo")
+
+   parse "something:else" = Error …
+
+   TODO: This could be the place to reject things like
+     ic: mo: http:std/foo
+  *)
+
+
+(* helper (only to be used on "ic:…" urls) *)
+let decode_actor_url url : (string, string) result =
+  let open Stdlib.String in
+  let hex = Lib.Option.value (Lib.String.chop_prefix "ic:" url) in
+
+  if equal hex "" then Error "principal ID must not be empty" else
+  if uppercase_ascii hex <> hex then Error "principal ID must be uppercase" else
+  let isHex c = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') in
+  if not (Lib.Seq.for_all isHex (to_seq hex)) then Error "principal ID must contain uppercase hexadecimal digits" else
+  if length hex mod 2 = 1 then Error "principal ID must contain an even number of hexadecimal digits" else
+  let blob, crc = sub hex 0 (length hex - 2), sub hex (length hex - 2) 2 in
+  let bs = Lib.Hex.bytes_of_hex blob in
+  let checksum = Lib.CRC.crc8 bs in
+  if checksum <> Lib.Hex.int_of_hex_byte crc then Error "invald checksum in principal ID, please check for typos" else
+  Ok bs
+
+type parsed =
+  | Package of (string * string)
+  | Relative of string
+  | Ic of string
+
+
+let parse (f: string) : (parsed, string) result =
+  match Lib.String.chop_prefix "mo:" f with
+  | Some suffix ->
+    begin match Stdlib.String.index_opt suffix '/' with
+    | None -> Ok (Package (suffix, ""))
+    | Some i ->
+      let pkg = Stdlib.String.sub suffix 0 i in
+      let path = Stdlib.String.sub suffix (i+1) (Stdlib.String.length suffix - (i+1)) in
+      Ok (Package (pkg, path))
+    end
+  | None ->
+    match Lib.String.chop_prefix "ic:" f with
+    | Some _suffix -> begin match decode_actor_url f with
+      | Ok bytes -> Ok (Ic bytes)
+      | Error err -> Error err
+      end
+    | None ->
+      begin match Stdlib.String.index_opt f ':' with
+      | Some _ -> Error "Unrecognized URL"
+      | None -> Ok (Relative (Lib.FilePath.normalise f))
+      end

--- a/src/pipeline/url.mli
+++ b/src/pipeline/url.mli
@@ -1,0 +1,6 @@
+type parsed =
+  | Package of (string * string)
+  | Relative of string
+  | Ic of string
+
+val parse : string -> (parsed, string) result


### PR DESCRIPTION
and do not parse any URLs in the desugarer, but instead extend
`resolved_import` to carry both the full path to the IDL _and_ the blob
id of the actor.

Maybe import resolution should move out of pipeline into its own
library, for cleaner access from `languageServer`.