### PR TITLE
ci-pr.nix: introduce the job diff-from-base.produce-exchange

### DIFF
--- a/ci-pr.nix
+++ b/ci-pr.nix
@@ -1,1 +1,40 @@
-import ./ci.nix
+{ src ? { rev = null; }, base ? null }:
+let
+  nixpkgs = (import ./nix/nixpkgs.nix).nixpkgs { };
+  prJobs = import ./ci.nix { inherit src; };
+in
+prJobs // nixpkgs.lib.optionalAttrs (base != null) (
+  let
+    baseJobs = import "${base}/ci.nix" { src = base; };
+  in {
+    diff-from-base = {
+      produce-exchange = nixpkgs.runCommandNoCC "produce-exchange-diff-from-base" {
+        base = baseJobs.produce-exchange;
+        pr = prJobs.produce-exchange;
+        nativeBuildInputs = [nixpkgs.coreutils nixpkgs.gawk];
+      } ''
+        size() {
+          du $1 | awk '{print $1}'
+        }
+
+        sizeBase=$(size "$base/ProduceExchange.wasm")
+        sizePr=$(size "$pr/ProduceExchange.wasm")
+        diff=$(($sizePr - $sizeBase))
+
+        mkdir -p $out/nix-support
+
+        (cat <<EOI
+        base = "$base"
+        pr   = "$pr"
+        size "\$base/ProduceExchange.wasm" = $sizeBase
+        size "\$pr/ProduceExchange.wasm"   = $sizePr
+        diff = $diff
+        EOI
+        ) > $out/produce-exchange-diff-from-base
+
+        echo "report produce-exchange-diff-from-base $out produce-exchange-diff-from-base" >> \
+          $out/nix-support/hydra-build-products
+      '';
+    };
+  }
+)


### PR DESCRIPTION
The new job `diff-from-base.produce-exchange` produces a report that lists the difference in size between the `ProduceExchange.wasm` of the PR and the `ProduceExchange.wasm` of the base branch of the PR.

This job depends on the new `inputForBaseBranch` feature (https://github.com/dfinity-lab/hydra-jobsets/pull/30) which is currently only active on https://zh-hydra-int.dfinity.systems/project/motoko. This will be active on the current hydra when that PR gets merged.

Context: https://dfinity.slack.com/archives/CGXFE1VMW/p1576678475007400?thread_ts=1576673945.007100&cid=CGXFE1VMW