### PR TITLE
Do not treat package paths relative to file

### DIFF
--- a/test/run/ok/pkg-import-relative.tc.ok
+++ b/test/run/ok/pkg-import-relative.tc.ok
@@ -1,1 +1,0 @@
-(unknown location): package error, file "pkg-import-relative.mo/lib/pkg" (for package `pkg`) does not exist

--- a/test/run/ok/pkg-import-relative.tc.ret.ok
+++ b/test/run/ok/pkg-import-relative.tc.ret.ok
@@ -1,1 +1,0 @@
-Return code 1

--- a/test/run/ok/pkg-missing.tc.ok
+++ b/test/run/ok/pkg-missing.tc.ok
@@ -1,1 +1,1 @@
-(unknown location): package error, file "pkg-missing.mo/does-not-exist" (for package `pkg`) does not exist
+(unknown location): package error, file "does-not-exist" (for package `pkg`) does not exist

--- a/test/run/pkg-import-relative.mo
+++ b/test/run/pkg-import-relative.mo
@@ -1,5 +1,5 @@
 //MOC-FLAG --package pkg lib/pkg
-import P "mo:pkg";
-import P "mo:pkg/other-module.mo";
+import P1 "mo:pkg";
+import P2 "mo:pkg/other-module.mo";
 P1.foo();
 P2.bar();


### PR DESCRIPTION
The code was buggy (it would not take the dirname of the file, as it
does for relative imports), and I also think it is wrong: If you write
`moc --package pkg pkg-dir foo/bar.mo`, and `bar` imports `mo:pkg/a`,
then you want that to resolve to `./pkg-dir/a.mo`, not
`./foo/pkg-dir/a.mo`.