### PR TITLE
IR Interpreter: Support actor ids

### DIFF
--- a/src/ir_interpreter/interpret_ir.mli
+++ b/src/ir_interpreter/interpret_ir.mli
@@ -10,11 +10,13 @@ type flags = {
   print_depth : int
 }
 
-type scope = V.def V.Env.t
+type state
+val initial_state : unit -> state
 
+type scope
 val empty_scope : scope
 val adjoin_scope : scope -> scope -> scope
 
 exception Trap of Source.region * string
 
-val interpret_prog : flags -> scope -> Ir.prog -> scope
+val interpret_prog : flags -> state -> scope -> Ir.prog -> scope

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -605,10 +605,11 @@ let interpret_ir_prog libs progs =
   phase "Interpreting" name;
   let open Interpret_ir in
   let flags = { trace = !Flags.trace; print_depth = !Flags.print_depth } in
+  let interpreter_state = initial_state () in 
   let denv0 = empty_scope in
-  let dscope = interpret_prog flags denv0 prelude_ir in
+  let dscope = interpret_prog flags interpreter_state denv0 prelude_ir in
   let denv1 = adjoin_scope denv0 dscope in
-  let _ = interpret_prog flags denv1 prog_ir in
+  let _ = interpret_prog flags interpreter_state denv1 prog_ir in
   ()
 
 let interpret_ir_files files =


### PR DESCRIPTION
this changes the value representation of an `actor …` to use `Text`,
i.e. a blob. This matches the RTS.

When accessing an actor field, we look up the actor in a global actor
map (representing, in a way, the state of the Internet Computer).

We trap more eagerly upon missing actors or fields than the platform,
but this is ok.

This implemented `ActorOfIdBlob` (now trivial), and unblocks #1104.