### PR TITLE
Stdlib bug fix: Buf module

### DIFF
--- a/stdlib/src/buf.mo
+++ b/stdlib/src/buf.mo
@@ -110,7 +110,7 @@ public class Buf<X> (initCapacity : Nat) {
   public func toVarArray() : [var X] = {
     if (count == 0) { [var] } else {
       let a = A.init<X>(count, elems[0]);
-      for (i in elems.keys()) {
+      for (i in I.range(0, count - 1)) {
         a[i] := elems[i]
       };
       a

--- a/stdlib/test/bufTest.mo
+++ b/stdlib/test/bufTest.mo
@@ -18,16 +18,23 @@ for (i in I.range(0, 123)) {
   b.append(a);
 };
 
-// regression test: buffers with extra space are converted to arrays of the correct length
-let bigLen = 100;
-let len = 3;
-let c = B.Buf<Nat>(bigLen);
-assert (len < bigLen)
-for (i in I.range(0, len)) {
-  b.append(c);
-};
-assert (b.toArray().len() == len);
-assert (b.toVarArray().len() == len);
-
 Prim.debugPrint(debug_show(a.toArray()));
 Prim.debugPrint(debug_show(b.toArray()));
+
+// regression test: buffers with extra space are converted to arrays of the correct length
+{
+  let bigLen = 100;
+  let len = 3;
+  let c = B.Buf<Nat>(bigLen);
+  assert (len < bigLen);
+  for (i in I.range(0, len - 1)) {
+    Prim.debugPrint(debug_show(i));
+    c.add(i);
+  };
+  Prim.debugPrint(debug_show(c.len()));
+  assert (c.len() == len);
+  Prim.debugPrint(debug_show(c.len()));
+  assert (c.toArray().len() == len);
+  Prim.debugPrint(debug_show(c.len()));
+  assert (c.toVarArray().len() == len);
+}


### PR DESCRIPTION
The conversions to arrays were buggy, and confused the capacity and the length.

This PR fixes those bugs, and adds a regression test for each.