### PR TITLE
nix/sources.json: use the same nixpkgs as dfinity & sdk

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -32,15 +32,15 @@
         "version": "v1.2.0"
     },
     "nixpkgs": {
-        "branch": "master",
+        "branch": "dfinity-release-19.09",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
+        "owner": "dfinity-lab",
         "repo": "nixpkgs",
-        "rev": "82875a20ba444110396f95537b18247898e40e22",
-        "sha256": "1xy2zn3hkcv66ddvscr3l32jcx1qg9h14zvhmy5zf0pcfb8gn42i",
+        "rev": "f678f769505147b0889739019763e68d30655eaf",
+        "sha256": "000mkqs3k5vclmagkhsfqxz03s6lp4cp2b30mknq3fj070nm5sj1",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/82875a20ba444110396f95537b18247898e40e22.tar.gz",
+        "url": "https://github.com/dfinity-lab/nixpkgs/archive/f678f769505147b0889739019763e68d30655eaf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ocaml-vlq": {


### PR DESCRIPTION
This is an experiment to see if motoko builds with this revision of
nixpkgs. It's needed because this nixpkgs builds on our new zh-hydra
which has access to the upstream cache.nixos.org disabled.

This setting has the advantage that our cache gets populated with
everything needed to build DFINITY. Secondly we reduce an attack
vector where an attacker can install a trojan in the cache.

If motoko really requires nixpkgs master than we can cherry-pick the
needed patches on top of nixpkgs master.