### PR TITLE
nix/sources.json: upgrade nixpkgs to the latest master

### DIFF
--- a/nix/haskell-packages.nix
+++ b/nix/haskell-packages.nix
@@ -1,11 +1,13 @@
 nix: subpath:
   let stdenv = nix.stdenv; in
   self: super: {
-  haskell-lsp-types = self.haskell-lsp-types_0_19_0_0;
+  haskell-lsp-types = self.haskell-lsp-types_0_20_0_0;
 
-  haskell-lsp = self.haskell-lsp_0_19_0_0;
+  haskell-lsp = self.haskell-lsp_0_20_0_1;
 
-  lsp-test = nix.haskell.lib.dontCheck self.lsp-test_0_9_0_0;
+  parser-combinators = self.parser-combinators_1_2_1;
+
+  lsp-test = nix.haskell.lib.dontCheck self.lsp-test_0_10_1_0;
 
   lsp-int = self.callCabal2nix "lsp-int" (subpath "test/lsp-int") { };
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -2,13 +2,13 @@
     "common": {
         "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "233f63f23f0a207f291693fc1983a92a53e28b59",
+        "rev": "7cf0a0864bf0670a7cad441067af0178fe51d506",
         "type": "git"
     },
     "dfinity": {
-        "ref": "master",
+        "ref": "v0.5.0",
         "repo": "ssh://git@github.com/dfinity-lab/dfinity",
-        "rev": "c9459e781f5b4b77452949f1e63725612b2201c3",
+        "rev": "fc1706faada19c3bcf0eee941b0468bf0c312d00",
         "type": "git"
     },
     "esm": {
@@ -32,15 +32,15 @@
         "version": "v1.2.0"
     },
     "nixpkgs": {
-        "branch": "master",
+        "branch": "dfinity-motoko",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
+        "owner": "dfinity-lab",
         "repo": "nixpkgs",
-        "rev": "82875a20ba444110396f95537b18247898e40e22",
-        "sha256": "1xy2zn3hkcv66ddvscr3l32jcx1qg9h14zvhmy5zf0pcfb8gn42i",
+        "rev": "a4e23f32f8d7006e217125a9123b53597b9c0c24",
+        "sha256": "1afpk1w6akfpvyj3n0wmlydpmxzb6khcgl4vhi7qkgg9bp6rngg4",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/82875a20ba444110396f95537b18247898e40e22.tar.gz",
+        "url": "https://github.com/dfinity-lab/nixpkgs/archive/a4e23f32f8d7006e217125a9123b53597b9c0c24.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ocaml-vlq": {

--- a/test/ld/ok/representative.linked.wat.ok
+++ b/test/ld/ok/representative.linked.wat.ok
@@ -28,4 +28,4 @@
   (table (;0;) 0 0 funcref)
   (memory (;0;) 2)
   (global (;0;) i32 (i32.const 65536))
-  (start 8))
+  (start $link_start))

--- a/test/lsp-int/lsp-int.cabal
+++ b/test/lsp-int/lsp-int.cabal
@@ -23,6 +23,6 @@ executable lsp-int
                      , lens
                      , data-default
                      , haskell-lsp-types
-                     , lsp-test ^>=0.9
+                     , lsp-test ^>=0.10
   -- hs-source-dirs:
   default-language:    Haskell2010

--- a/test/run-drun/ok/caller.drun-run.ok
+++ b/test/run-drun/ok/caller.drun-run.ok
@@ -4,7 +4,7 @@ ingress Completed: Canister: Payload: 0x4449444c0000
 ingress Completed: Canister: Payload: 0x4449444c0000
 ingress Completed: Canister: Payload: 0x4449444c0000
 Ok: Payload: 0x4449444c0000
-ingress Completed: Canister: Payload: 0x4449444c016d7b010021000000000000000000000000000000000000000000000000000000000000000000
-Ok: Payload: 0x4449444c0001798d3a7c7a
-Ok: Payload: 0x4449444c00017d21
-Ok: Payload: 0x4449444c016e7b01000100
+ingress Completed: Canister: Payload: 0x4449444c016d7b0100020101
+Ok: Payload: 0x4449444c0001792813c52f
+Ok: Payload: 0x4449444c00017d02
+Ok: Payload: 0x4449444c016e7b01000101


### PR DESCRIPTION
This upgrades `nixpkgs` to DFINITY's fork of nixpkgs which tracks the
`master` branch. There're only two patches on top of `master`:

```
commit a4e23f32f8d7006e217125a9123b53597b9c0c24 (HEAD -> dfinity-motoko, dfinity-lab/dfinity-motoko)
Author: Bas van Dijk <v.dijk.bas@gmail.com>
Date:   Wed Feb 12 16:08:05 2020 +0100

    expect: remove autoreconfHook since that causes a wrong path to stty

    See: https://github.com/NixOS/nixpkgs/issues/79863

commit f359aea057db81c51e55d7250283a0b2201bd6b6
Author: Bas van Dijk <v.dijk.bas@gmail.com>
Date:	Thu Feb 6 19:14:09 2020 +0100

    libuv: 1.34.1 -> 1.34.2

    (cherry picked from commit 21ad5c123b8e76ab241b89acbc8db24925244d63)
```

We need these patches in order to build `motoko` without using the
upstream `cache.nixos.org`. It would be good not to use an external
cache to decrease the chance an attacker can infect the cache with a
trojan and to ensure DFINITY can always build their own code without
depending on an external cache.