### PR TITLE
[INF-975] Disable packager

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -101,7 +101,7 @@ let ocaml_exe = name: bin:
   in
     # Make standalone on darwin (nothing to do on linux, is static)
     if nixpkgs.stdenv.isDarwin
-    then darwin_standalone { inherit drv; exename = bin; }
+    then darwin_standalone { inherit drv; usePackager = false; exename = bin; }
     else drv;
 in
 


### PR DESCRIPTION
Packager unpacks the binary into a tmpdir and runs it from there. Only needed if we have external dependencies, like replica, which needs `ld`. moc-bin doesn't.