### PR TITLE
Make sure cabal2nix is used also at build time

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -150,7 +150,7 @@ rec {
   # “our” Haskell packages
   inherit (haskellPackages) lsp-int qc-motoko ic-stub;
   # populate our nix cache with the right version of cabal2nix that
-  # is used by self.callCabal2nix
+  # is used by self.callCabal2nix at evalution time
   inherit (nixpkgs) cabal2nix;
 
   tests =


### PR DESCRIPTION
see https://github.com/dfinity-lab/motoko/pull/1189#issuecomment-585921319

My hope is that by adding `cabal2nix` to the build products, it will
reliably be available on our nix cache.