### PR TITLE
INF-996 .github: Add action for updating niv-dependencies

### DIFF
--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -1,0 +1,27 @@
+name: Automatically update niv-managed dependencies
+on:
+  # Manual override, one can start the workflow by running:
+  # curl -H "Accept: application/vnd.github.everest-preview+json" \
+  #  -H "Authorization: token <your-token-here>" \
+  #  --request POST \
+  #  --data '{"event_type": "niv-updater-nudge", "client_payload": {}}' \
+  #  https://api.github.com/repos/dfinity-lab/motoko/dispatches
+  # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
+  repository_dispatch:
+    types: niv-updater-nudge
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run every 20min, as we like it that way (but it should be hourly)
+    - cron:  '*/20 * * * *'
+jobs:
+  niv-updater:
+    name: 'Check for updates'
+    runs-on: ubuntu-latest
+    steps:
+      - name: niv-updater-action
+        uses: knl/niv-updater-action@v3
+        with:
+          # might be too noisy
+          blacklist: 'nixpkgs,dfinity'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIV_UPDATER_TOKEN }}


### PR DESCRIPTION
Bye, bye, manual PR creation everytime common changes.

This will create a PR for each dependency listed in `nix/sources.json`, except `nixpkgs`, and `dfinity`, as these might create too much noise. There will be just one PR per dependency, and it will not be updated if there are new updates. This is a feature that might be added in the future.