### PR TITLE
Nix: Include sources.nix in repo

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,13 +1,12 @@
 { system ? builtins.currentSystem }:
 let
-  sourcesnix = builtins.fetchurl https://raw.githubusercontent.com/nmattia/niv/506b896788d9705899592a303de95d8819504c55/nix/sources.nix;
-  nixpkgs_src = (import sourcesnix { sourcesFile = ./sources.json; inherit pkgs; }).nixpkgs;
+  nixpkgs_src = (import ./sources.nix { sourcesFile = ./sources.json; inherit pkgs; }).nixpkgs;
 
   pkgs =
     import nixpkgs_src {
       inherit system;
       overlays = [
-        (self: super: { sources = import sourcesnix { sourcesFile = ./sources.json; pkgs = super; }; })
+        (self: super: { sources = import ./sources.nix { sourcesFile = ./sources.json; pkgs = super; }; })
         # Selecting the ocaml version
         (self: super: { ocamlPackages = self.ocaml-ng.ocamlPackages_4_08; })
         # Additional ocaml package

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,0 +1,139 @@
+# This file has been fetched from
+# https://raw.githubusercontent.com/nmattia/niv/506b896788d9705899592a303de95d8819504c55/nix/sources.nix
+
+let
+
+  #
+  # The fetchers. fetch_<type> fetches specs of type <type>.
+  #
+
+  fetch_file = pkgs: spec:
+    if spec.builtin or true then
+      builtins_fetchurl { inherit (spec) url sha256; }
+    else
+      pkgs.fetchurl { inherit (spec) url sha256; };
+
+  fetch_tarball = pkgs: spec:
+    if spec.builtin or true then
+      builtins_fetchTarball { inherit (spec) url sha256; }
+    else
+      pkgs.fetchzip { inherit (spec) url sha256; };
+
+  fetch_git = spec:
+    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+
+  fetch_builtin-tarball = spec:
+    builtins.trace
+      ''
+        WARNING:
+          The niv type "builtin-tarball" will soon be deprecated. You should
+          instead use `builtin = true`.
+
+          $ niv modify <package> -a type=tarball -a builtin=true
+      ''
+      builtins_fetchTarball { inherit (spec) url sha256; };
+
+  fetch_builtin-url = spec:
+    builtins.trace
+      ''
+        WARNING:
+          The niv type "builtin-url" will soon be deprecated. You should
+          instead use `builtin = true`.
+
+          $ niv modify <package> -a type=file -a builtin=true
+      ''
+      (builtins_fetchurl { inherit (spec) url sha256; });
+
+  #
+  # Various helpers
+  #
+
+  # The set of packages used when specs are fetched using non-builtins.
+  mkPkgs = sources:
+    if hasNixpkgsPath
+    then
+      if hasThisAsNixpkgsPath
+      then import (builtins_fetchTarball { inherit (mkNixpkgs sources) url sha256; }) {}
+      else import <nixpkgs> {}
+    else
+      import (builtins_fetchTarball { inherit (mkNixpkgs sources) url sha256; }) {};
+
+  mkNixpkgs = sources:
+    if builtins.hasAttr "nixpkgs" sources
+    then sources.nixpkgs
+    else abort
+      ''
+        Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
+        add a package called "nixpkgs" to your sources.json.
+      '';
+
+  hasNixpkgsPath = (builtins.tryEval <nixpkgs>).success;
+  hasThisAsNixpkgsPath =
+    (builtins.tryEval <nixpkgs>).success && <nixpkgs> == ./.;
+
+  # The actual fetching function.
+  fetch = pkgs: name: spec:
+
+    if ! builtins.hasAttr "type" spec then
+      abort "ERROR: niv spec ${name} does not have a 'type' attribute"
+    else if spec.type == "file" then fetch_file pkgs spec
+    else if spec.type == "tarball" then fetch_tarball pkgs spec
+    else if spec.type == "git" then fetch_git spec
+    else if spec.type == "builtin-tarball" then fetch_builtin-tarball spec
+    else if spec.type == "builtin-url" then fetch_builtin-url spec
+    else
+      abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+
+  # Ports of functions for older nix versions
+
+  # a Nix version of mapAttrs if the built-in doesn't exist
+  mapAttrs = builtins.mapAttrs or (
+    f: set: with builtins;
+    listToAttrs (map (attr: { name = attr; value = f attr set.${attr}; }) (attrNames set))
+  );
+
+  # fetchTarball version that is compatible between all the versions of Nix
+  builtins_fetchTarball = { url, sha256 }@attrs:
+    let
+      inherit (builtins) lessThan nixVersion fetchTarball;
+    in
+      if lessThan nixVersion "1.12" then
+        fetchTarball { inherit url; }
+      else
+        fetchTarball attrs;
+
+  # fetchurl version that is compatible between all the versions of Nix
+  builtins_fetchurl = { url, sha256 }@attrs:
+    let
+      inherit (builtins) lessThan nixVersion fetchurl;
+    in
+      if lessThan nixVersion "1.12" then
+        fetchurl { inherit url; }
+      else
+        fetchurl attrs;
+
+  # Create the final "sources" from the config
+  mkSources = config:
+    mapAttrs (
+      name: spec:
+        if builtins.hasAttr "outPath" spec
+        then abort
+          "The values in sources.json should not have an 'outPath' attribute"
+        else
+          spec // { outPath = fetch config.pkgs name spec; }
+    ) config.sources;
+
+  # The "config" used by the fetchers
+  mkConfig =
+    { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
+    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
+    , pkgs ? mkPkgs sources
+    }: rec {
+      # The sources, i.e. the attribute set of spec name to spec
+      inherit sources;
+
+      # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
+      inherit pkgs;
+    };
+in
+mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }


### PR DESCRIPTION
the fact that since #1113, the `sources.nix`, which is central to any
nix evaluation, is fetched remotely almost prevented me from doing work
offline. (Luckily I knew about `--option tarball-ttl 100000`).

But even offline, it seems silly for nix to check github every hour if
this file has changed (it will not, because it is pinned using a git
revision.) Copying to the repo seems to make more sense.

(Alternatively, it would make sense to fetch it in a way that specifies
the expected file hash, so that nix will download it exactly once, maybe
using `builtins.path` somehow.)

Unfortunately, other repos that we pull in still fetch that file
remotely, so you still need to pass `--option tarball-ttl 100000` to
work offline. I’ll use this PR to notify our nix gurus of this issue.