### PR TITLE
ci-pr.nix: use the src.mergeBase input instead of base

### DIFF
--- a/ci-pr.nix
+++ b/ci-pr.nix
@@ -1,4 +1,4 @@
-{ src ? { rev = null; }, base ? null }:
+{ src ? { rev = null; } }:
 let
   nixpkgs = import ./nix { };
 
@@ -15,10 +15,10 @@ let
   };
 
 in
-import ./ci.nix { inherit src; } // nixpkgs.lib.optionalAttrs (base != null) {
+import ./ci.nix { inherit src; } // nixpkgs.lib.optionalAttrs (src ? mergeBase) {
   perf-delta =
     let
-      baseJobs = import "${base}/default.nix" { system = "x86_64-linux"; };
+      baseJobs = import (src.mergeBase + "/default.nix") { system = "x86_64-linux"; };
       prJobs = import ./default.nix { system = "x86_64-linux"; };
     in
     nixpkgs.runCommandNoCC "perf-delta" {


### PR DESCRIPTION
The `base` input will track the HEAD of the base branch while `src.mergeBase` will track the merge-base of your PR with its base branch.