### PR TITLE
Claudio/parser lc tidy

### DIFF
--- a/samples/lambda-calculus.mo
+++ b/samples/lambda-calculus.mo
@@ -74,19 +74,19 @@ let rparen = P.token(func (t:Token) : ?() { switch t {
 module LCParser = {
 
     type LCParser = P.Parser<Token, LC>;
-    
-    func parseVar() : LCParser { 
+
+    func parseVar() : LCParser {
         P.map(ident, lcvar)
     };
-    
+
     func parseParens() : LCParser {
         P.between(lparen, P.delay parseLC, rparen);
     };
-    
+
     func parseLambda(): LCParser {
         P.map(P.pair(P.between(lam, ident, dot), P.delay parseLC),
             func ((v, lc) : (Text,LC)) : LC { lclam(v,lc) });
-    };          
+    };
 
     public func parseAtom(): LCParser  {
         P.choice(List.fromArray([


### PR DESCRIPTION
@kritzcreek I've tidied up the parser to avoid using bind by introducing a pair combinator and exploiting then - that means the productions are much shorted and look like proper grammar productions. I've also introduce delay combinator to support this.
I've also exploited a few more of the combinators and re-ordered the args to between to make more sense.

God know what happens to the complexity by doing this. Any idea?

I think it looks nicer though..