### PR TITLE
Test case: capturing top-level variables in local function

### DIFF
--- a/test/run/static-call-rec.mo
+++ b/test/run/static-call-rec.mo
@@ -1,0 +1,13 @@
+var FOO = 1;
+func go (x:Nat) {
+  func rec(x:Nat) {
+    ignore(FOO);
+  };
+  rec(x);
+};
+go(1000);
+
+// CHECK: func $go
+// CHECK-NOT: call_indirect
+// CHECK: call $rec
+


### PR DESCRIPTION
on `master`, this correctly leads to a statically allocated `rec`, but
with #1336 this breaks.

It seems we need to be able to distinguish “location statically known”
(true for all top-level bindings, and required for free variables of a
`FuncE` for it to be constant) and “value constant” (required to
put a value pre-compiled into static memory).

The test case is a minized version of `fromList` in `Trie.mo` which uses
a global constant.