### PR TITLE
nixpkgs: Update to 20.03

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -57,10 +57,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d63f95896ca8c5480629ef59fd46d6c50e3f98d0",
-        "sha256": "1nq65cczxjcvfy0m4hxyl4hbcxdqsqhdnr58n9h30zbsdv6vl6b4",
+        "rev": "e79d1e83f91b6c7a92f899b0a356ea6d770fb426",
+        "sha256": "1qh0sl3szadxpnvp1baby2zw10lsbpkynyjhy2d4kf6qzj95v2nl",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d63f95896ca8c5480629ef59fd46d6c50e3f98d0.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e79d1e83f91b6c7a92f899b0a356ea6d770fb426.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ocaml-vlq": {


### PR DESCRIPTION
20.03 has been released, so update nixpkgs.

This mirrors https://github.com/dfinity-lab/common/pull/178