### PR TITLE
INF-1227: .mergify.yml: also require evaluation success for merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
+      - status-success=hydra:dfinity-ci-build:evaluation
       - status-success=hydra:dfinity-ci-build:motoko:all-systems-go
       - base=master
       - label=automerge-squash
@@ -27,4 +28,3 @@ pull_request_rules:
       review:
         type: APPROVE
         message: This bot trusts that bot
-


### PR DESCRIPTION
It seems that when evaluation fails, github/mergify still waits for
`hydra:dfinity-ci-build:motoko:all-jobs`. This commit configures mergify
to also require that `hydra:dfinity-ci-build:evaluation` succeeds, so
that it doesn’t get stuck on this.