### PR TITLE
life-mut: upgrade involving mutable stable state

### DIFF
--- a/test/run-drun/life-mut.drun
+++ b/test/run-drun/life-mut.drun
@@ -1,0 +1,22 @@
+# like life.drun, but using mutable stable state
+# too slow for ic-ref:
+# SKIP ic-ref-run
+
+install ic:2A012B life-mut/life-v1.mo ""
+ingress ic:2A012B advance "DIDL\x00\x01\x7d\x0F"
+query ic:2A012B show "DIDL\x00\x00"
+# self-upgrade from life-v1
+upgrade ic:2A012B life-mut/life-v1.mo ""
+query ic:2A012B show "DIDL\x00\x00"
+ingress ic:2A012B advance "DIDL\x00\x01\x7d\x0F"
+query ic:2A012B show "DIDL\x00\x00"
+# upgrade from life-v1 to life-v2
+upgrade ic:2A012B life-mut/life-v2.mo ""
+query ic:2A012B show "DIDL\x00\x00"
+ingress ic:2A012B advance "DIDL\x00\x01\x7d\x01"
+query ic:2A012B show "DIDL\x00\x00"
+# self-upgrade from life-v2
+upgrade ic:2A012B life-mut/life-v2.mo ""
+query ic:2A012B show "DIDL\x00\x00"
+ingress ic:2A012B advance "DIDL\x00\x01\x7d\x0F"
+query ic:2A012B show "DIDL\x00\x00"

--- a/test/run-drun/life-mut/life-v1.mo
+++ b/test/run-drun/life-mut/life-v1.mo
@@ -1,0 +1,124 @@
+import P = "mo:prim";
+
+object Random {
+  var state = 1;
+  public func next() : Bool {
+    state := (123138118391*state + 133489131) % 9999;
+    (state % 2 == 0)
+  };
+};
+
+type Cell = Bool;
+
+type State = {
+   #v1 : [[var Cell]];
+};
+
+class Grid((#v1 state) : State) {
+
+  let n = state.len();
+
+  public func size() : Nat { n };
+
+  let grid = P.Array_tabulate(n, func (i : Nat) : [var Cell] {
+    let a = P.Array_init(n, false);
+    let si = state[i];
+    assert (si.len() == n);
+    for (j in si.keys()) {
+      a[j] := si[j];
+    };
+    a
+  });
+
+  public func get(i : Nat, j : Nat) : Cell { grid[i][j] };
+
+  public func set(i : Nat, j : Nat, v : Cell) { grid[i][j] := v };
+
+  func pred(i : Nat) : Nat { (n + i - 1) % n };
+
+  func succ(i : Nat) : Nat { (i + 1) % n };
+
+  func count(i : Nat, j : Nat) : Nat { if (grid[i][j]) 1 else 0 };
+
+  func living(i : Nat, j : Nat) : Nat {
+    count(pred i, pred j) + count(pred i, j) + count(pred i, succ j) +
+    count(     i, pred j)                    + count(     i, succ j) +
+    count(succ i, pred j) + count(succ i, j) + count(succ i, succ j)
+  };
+
+  func nextCell(i : Nat, j : Nat) : Cell {
+    let l : Nat = living(i, j);
+    if (get(i, j))
+      l == 2 or l == 3
+    else
+      l == 3;
+  };
+
+  public func next(dst : Grid) {
+    for (i in grid.keys()) {
+      for (j in grid[i].keys()) {
+        dst.set(i, j, nextCell(i, j));
+      };
+    };
+  };
+
+  public func toState() :  State {
+    #v1 grid
+  };
+
+  public func toText() : Text {
+    var t = "\n";
+    for (i in grid.keys()) {
+      for (j in grid[i].keys()) {
+        t #= if (get(i, j)) "O" else " ";
+      };
+      t #= "\n";
+    };
+    t
+  };
+};
+
+actor Life {
+
+  stable var state : State =
+    { let n = 32;
+      #v1 (
+      	 P.Array_tabulate<[var Cell]>(n,
+           func i { 
+             let ai = P.Array_init(n,false);
+             for (j in ai.keys()) { ai[j] := Random.next() };
+             ai })
+      )
+    };
+
+  flexible var src = Grid(state);
+  flexible var dst = Grid(state);
+
+  func update(c : Nat) {
+    var i = c;
+    while (i > 0) {
+      src.next(dst);
+      let temp = src;
+      src := dst;
+      dst := temp;
+      i -= 1;
+    };
+  };
+
+  system func preupgrade() {
+   state := src.toState();
+  };
+
+  system func postupgrade() {
+    P.debugPrint("upgraded!");
+  };
+
+  public func advance(n : Nat) : async () {
+    update(n);
+  };
+
+  public query func show() : async () {
+    P.debugPrint(src.toText());
+  };
+
+};

--- a/test/run-drun/life-mut/life-v2.mo
+++ b/test/run-drun/life-mut/life-v2.mo
@@ -1,0 +1,164 @@
+import P = "mo:prim";
+
+object Random {
+  var state = 1;
+  public func next() : Bool {
+    state := (123138118391*state + 133489131) % 9999;
+    (state % 2 == 0)
+  };
+};
+
+class below(u : Nat) {
+  var i = 0;
+  public func next() : ?Nat { if (i >= u) null else {let j = i; i += 1; ?j} };
+};
+
+func readBit(bits : [var Word64], index : Nat) : Bool {
+  let bit = P.natToWord64(index);
+  let mask : Word64 = 1 << (bit % 64);
+  (bits[P.word64ToNat(bit >> 6)] & mask) == mask
+};
+
+func writeBit(bits : [var Word64], index : Nat, v : Bool) {
+  let bit = P.natToWord64(index);
+  let mask : Word64 = 1 << (bit % 64);
+  let i = P.word64ToNat(bit >> 6);
+  if v {
+    bits[i] |= mask
+  }
+  else {
+    bits[i] &= ^mask;
+  }
+};
+
+type Cell = Bool;
+
+type State = {
+  #v1 : [[var Cell]];
+  #v2 : {size : Nat; bits : [var Word64]}
+};
+
+class Grid(state : State) {
+
+  let (n : Nat, bits : [var Word64]) =
+    switch state {
+      case (#v1 css) {
+        let n = css.len();
+        let len = (n * n) / 64 + 1;
+        let bits = P.Array_init<Word64>(len, 0);
+        for (i in css.keys()) {
+          for (j in css[i].keys()) {
+            writeBit(bits, i * n + j, css[i][j]);
+          };
+        };
+        (n, bits)
+      };
+      case (#v2 {size; bits}) {
+        (size,bits)
+      }
+    };
+
+  public func size() : Nat { n };
+
+  public func get(i : Nat, j : Nat) : Cell {
+    readBit(bits, i * n + j);
+  };
+
+  public func set(i : Nat, j : Nat, v : Cell) {
+    writeBit(bits, i * n + j, v);
+  };
+
+  func pred(i : Nat) : Nat { (n + i - 1) % n };
+
+  func succ(i : Nat) : Nat { (i + 1) % n };
+
+  func count(i : Nat, j : Nat) : Nat { if (get(i, j)) 1 else 0 };
+
+  func living(i : Nat, j : Nat) : Nat {
+    count(pred i, pred j) + count(pred i, j) + count(pred i, succ j) +
+    count(     i, pred j)                    + count(     i, succ j) +
+    count(succ i, pred j) + count(succ i, j) + count(succ i, succ j)
+  };
+
+  func nextCell(i : Nat, j : Nat) : Cell {
+    let l : Nat = living(i, j);
+    if (get(i, j))
+      l == 2 or l == 3
+    else
+      l == 3;
+  };
+
+  public func next(dst : Grid) {
+    for (i in below(n)) {
+      for (j in below(n)) {
+        dst.set(i, j, nextCell(i, j));
+      };
+    };
+  };
+
+  public func toState() : State {
+    let ws = bits;
+    #v2 { size = n; bits = ws }
+  };
+
+  public func toText() : Text {
+    var t = "\n";
+    for (i in below(n)) {
+      for (j in below(n)) {
+        t #= if (get(i, j)) "O" else " ";
+      };
+      t #= "\n";
+    };
+    t
+  };
+};
+
+actor Life {
+
+  stable var state : State = {
+    let n = 32;
+    let len = (n * n) / 64 + 1;
+    let words = P.Array_init(len, 0 : Word64);
+    for (i in words.keys()) {
+      var word : Word64 = 0;
+      for (j in below(64)) {
+        let bit : Word64 = if (Random.next()) 0 else 1;
+        word |= bit;
+        word <<= 1;
+      };
+      words[i] := word;
+    };
+    #v2 { size = n; bits = words };
+  };
+
+  flexible var src = Grid(state);
+  flexible var dst = Grid(state);
+
+  func update(c : Nat) {
+    var i = c;
+    while (i > 0) {
+      src.next(dst);
+      let temp = src;
+      src := dst;
+      dst := temp;
+      i -= 1;
+    };
+  };
+
+  system func preupgrade() {
+    state := src.toState();
+  };
+
+  system func postupgrade() {
+    P.debugPrint("upgraded!");
+  };
+
+  public func advance(n : Nat) : async () {
+     update(n);
+  };
+
+  public query func show() : async () {
+     P.debugPrint(src.toText());
+  };
+
+};

--- a/test/run-drun/ok/life-mut.drun.ok
+++ b/test/run-drun/ok/life-mut.drun.ok
@@ -1,0 +1,256 @@
+ingress System
+ingress Completed: Canister: Reply: 0x4449444c0000
+debug.print: 
+    O OO          O             
+  O    O          O             
+ O    OO                        
+     OOO O                      
+   OO                           
+       O  O                     
+O     OOO               O     OO
+O    OO                O O     O
+OO   OO                O OO  O O
+  O                     O     OO
+OO                            OO
+O                  OOO          
+                  OO O          
+                 O     O        
+       OOO     O O O   O        
+     O    OOOO O  O OOO         
+           O O  O               
+         O    O                 
+     O                          
+                                
+    O                           
+                          O O  O
+O                         O   O 
+ O                    OO       O
+O                    OOO OO  O  
+ O             OOO   OOO O O O  
+O             OOOOO OOO    OO  O
+O      O     O     O O O       O
+      OOO     OOO  O OO         
+     O   O      OO   OO         
+     OO OO        OOO           
+    O O OO       O              
+
+Ok: Reply: 0x4449444c0000
+debug.print: upgraded!
+ingress System
+debug.print: 
+    O OO          O             
+  O    O          O             
+ O    OO                        
+     OOO O                      
+   OO                           
+       O  O                     
+O     OOO               O     OO
+O    OO                O O     O
+OO   OO                O OO  O O
+  O                     O     OO
+OO                            OO
+O                  OOO          
+                  OO O          
+                 O     O        
+       OOO     O O O   O        
+     O    OOOO O  O OOO         
+           O O  O               
+         O    O                 
+     O                          
+                                
+    O                           
+                          O O  O
+O                         O   O 
+ O                    OO       O
+O                    OOO OO  O  
+ O             OOO   OOO O O O  
+O             OOOOO OOO    OO  O
+O      O     O     O O O       O
+      OOO     OOO  O OO         
+     O   O      OO   OO         
+     OO OO        OOO           
+    O O OO       O              
+
+Ok: Reply: 0x4449444c0000
+ingress Completed: Canister: Reply: 0x4449444c0000
+debug.print: 
+     O O  O    O                
+      OOOOO             OOO     
+     OO  O              O  O    
+      O O              O   O    
+       O               O O OO   
+                        OO OO   
+                         OOO    
+                                
+                                
+                   O  O         
+                   O  O         
+                   O            
+                      OO        
+                                
+                OO              
+               OOO              
+               O  OO            
+               OO OO            
+                O OO            
+                 O              
+                                
+                                
+                                
+                                
+                                
+ O                              
+OOO                             
+ O                      O       
+O O            O       OO   O OO
+ OOO  OO      OO        O   O OO
+ O  O     O  O  O            O  
+    O O  O O  OO                
+
+Ok: Reply: 0x4449444c0000
+debug.print: upgraded!
+ingress System
+debug.print: 
+     O O  O    O                
+      OOOOO             OOO     
+     OO  O              O  O    
+      O O              O   O    
+       O               O O OO   
+                        OO OO   
+                         OOO    
+                                
+                                
+                   O  O         
+                   O  O         
+                   O            
+                      OO        
+                                
+                OO              
+               OOO              
+               O  OO            
+               OO OO            
+                O OO            
+                 O              
+                                
+                                
+                                
+                                
+                                
+ O                              
+OOO                             
+ O                      O       
+O O            O       OO   O OO
+ OOO  OO      OO        O   O OO
+ O  O     O  O  O            O  
+    O O  O O  OO                
+
+Ok: Reply: 0x4449444c0000
+ingress Completed: Canister: Reply: 0x4449444c0000
+debug.print: 
+     O     O  OO         O      
+          O             OOO     
+     O    O            OO  O    
+     OO O              O   O    
+       O               O O      
+                                
+                        OO OO   
+                          O     
+                                
+                                
+                  OOO           
+                      OO        
+                                
+                                
+               O O              
+               O                
+              O    O            
+               OO   O           
+               OO  O            
+                 OO             
+                                
+                                
+                                
+                                
+                                
+OOO                             
+O O                             
+                       OO       
+   O          OO       OOO    O 
+   O          OOO      OO   O   
+OO  O OO  O  O  O            OO 
+    O O  O O  OOO               
+
+Ok: Reply: 0x4449444c0000
+debug.print: upgraded!
+ingress System
+debug.print: 
+     O     O  OO         O      
+          O             OOO     
+     O    O            OO  O    
+     OO O              O   O    
+       O               O O      
+                                
+                        OO OO   
+                          O     
+                                
+                                
+                  OOO           
+                      OO        
+                                
+                                
+               O O              
+               O                
+              O    O            
+               OO   O           
+               OO  O            
+                 OO             
+                                
+                                
+                                
+                                
+                                
+OOO                             
+O O                             
+                       OO       
+   O          OO       OOO    O 
+   O          OOO      OO   O   
+OO  O OO  O  O  O            OO 
+    O O  O O  OOO               
+
+Ok: Reply: 0x4449444c0000
+ingress Completed: Canister: Reply: 0x4449444c0000
+debug.print: 
+O O               O   O O   O O 
+O OOO    OOOOO     OO O O OO  O 
+OO    O O    O     O  O  O   O  
+  OOO O  OOO         OOO  OO O O
+OO    OO             O     O O O
+ O  O O                  O O O  
+OO   OO OOO              O     O
+ O O O  O O OO            OO O O
+  OOO        O            OO    
+   OO       O            O      
+            O O        O   O    
+             OO       O O OO    
+                      O O O     
+                      O O OO    
+                     OOOO O OO  
+                      O  OO     
+                          O OO  
+               OO          O O  
+               O O              
+O OOOOOO        O O            O
+ O     OO        OO           O 
+O   OO   O                   OO 
+ O O O OOO                     O
+ O O  O    OO                  O
+ O  O O OOO O               OO O
+   OO   O   O              O O O
+ O     OO O               O O  O
+  OO      O  OO OO         O  O 
+O  O   OO O O O OO              
+  O  O  O O O O   O          OOO
+O O O  OO O     O O O  OOO O O  
+O O OOOOO OOOOOOO O O O   OO  O 
+
+Ok: Reply: 0x4449444c0000


### PR DESCRIPTION
Build on #1483, adding variant of run-drun/life.drun that exploits mutable stable store for less copying 