### PR TITLE
ci-pr.nix: accept all arguments in preparation for `labels` argument

### DIFF
--- a/ci-pr.nix
+++ b/ci-pr.nix
@@ -1,4 +1,4 @@
-{ src ? { rev = null; } }:
+{ src ? { rev = null; }, ... }:
 let
   nixpkgs = import ./nix { };
 


### PR DESCRIPTION
In https://github.com/dfinity-lab/hydra-jobsets/pull/54 I would like to start forwarding GitHub PR labels to jobsets such that we can optionally enable jobs based on the presence of labels.

For this to work the `ci-pr.nix` jobset specification needs to accept this extra `labels` argument.

To prepare for this we accept all arguments (`...`) such that evaluation won't fail when Hydra starts passing `labels`.