### PR TITLE
Candid: Make services self-describing

### DIFF
--- a/design/IDL.md
+++ b/design/IDL.md
@@ -534,6 +534,18 @@ An *interface description* consists of a sequence of imports and type definition
 
 The optional name given to the service in an interface description is immaterial; it only serves as documentation.
 
+## Self-describing services
+
+A service providing a Candid-based interface should expose that interface by way of an implicit method
+
+```
+  candid_interface : () -> (Text) query
+```
+
+which returns the current interface of the service in textual form.
+
+The `candid_interface` method is typically _not_ explicitly listed in the interface.
+
 
 ## Upgrading and Subtyping
 


### PR DESCRIPTION
We always had the vision that you can just take a canister ID and find
out what it's interface is. This is crucial for use-cases like
 * importing external canisters in your code (where `dfx` would fetch
   the `.did` file and provide it to `moc`)
 * @chenyan-dfinity’s Candid interface should work for all canisters
 * command line tools can provide an interface for all canisters
   with auto-complete etc.

Why don’t we have this already since months? The main reason is that for
a long while I expected this to fall under “static front-end assets”,
which I imagined would be uploaded by `dfx`, separately from the
`.wasm`, and served by the system, independent of WasmCode, in a special
“static content serving mode”, and the IDL would just be one of these
files (with a well-known name). One reason for this design was that we
thought this was the only way to make access to these assets
trustworthy.

The feature of front-end assets has been contentious, prone to feature
creep, and got entangled with other issues (like, how to return data
from queries in trustworthy ways). So nothing moved.

But recently things started to move there again. We have a vision for
how general queries can actually be trustworthy, and are leaning towards
moving the frontend handling into the canister, and allow canisters to
somehow fuel [HTTP endpoints](https://github.com/dfinity-lab/notes/pull/3).

And this led me to the conclusion that the candid definition is _not_ a
ront-end asset, and we can and should just design the “canister can
indicate its own interface” separately.

This proposal is a very simple idea: A canister, by convention, reports
its IDL via

    candid_interface : () -> (Text) query

For Motoko, this would happen automatically.

Benefits of this design:

 * We can implement it right away.

 * The interface is bundled with the `.wasm`. No more complex steps to
   be taken by `dfx` to create the `.did` file, keep it in sync, and
   somehow bundle it with the `.wasm` upon uploading.

   (We still want `moc --idl` for local development though, lest we
   write a tool that simulates the IC System API and locally calls
   `candid_interface()`.)

 * It _can_ be dynamic, if a canister changes its interface without
   redeployment.
   - Maybe some methods only become available after some flag got set?
   - Or we have a completely dynamic canister – I recently played around
     with a Python canister, and there I would expect to
     upload some code using an regular call, and the interface should
     match the installed code.
   - Or maybe we have a proxy canister that fetches its candid from the
     canister it proxies.

 * As @rossberg points out: Candid is not actually tied to the IC
   system, and could be used in other “service RPC” contexts as well.

   The presented design will neatly apply to other environments as well.

 * Treating this different from front-end assets is sensible:

   - Front-end assets need to be reachable via HTTP, it seems. But the
     candid interface not: Any tool that cares about Candid is able to
     speak Candid and IC.

   - Front-end assets may be developed and deployed independently from
     the backend. The Candid interface is tied to the canister.

  * Candid messages are self-describing, so Candid services ought to be too.