### PR TITLE
ci-pr.nix: introduce the all-jobs job that includes all jobs

### DIFF
--- a/ci-pr.nix
+++ b/ci-pr.nix
@@ -72,8 +72,14 @@ let
       echo "comment manifest $out/comment" >> $out/nix-support/hydra-build-products
     '';
 
+  jobs = import ./ci.nix { inherit src; } //
+    nixpkgs.lib.optionalAttrs (src ? mergeBase) {
+      inherit perf-delta;
+    };
 in
-import ./ci.nix { inherit src; } //
-nixpkgs.lib.optionalAttrs (src ? mergeBase) {
-  inherit perf-delta;
+jobs // {
+  all-jobs = nixpkgs.releaseTools.aggregate {
+    name = "all-jobs";
+    constituents = nixpkgs.lib.collect (drv: nixpkgs.lib.isDerivation drv) jobs;
+  };
 }


### PR DESCRIPTION
The following originated from [this](https://dfinity.slack.com/archives/CH4CADCJX/p1589811951414600) slack thread.

Infra is planning to deploy a change to Hydra that will reduce the
number of notifications sent to GitHub. At the moment PRs will get a
"pending" and a "success" or "failure" notification for every CI
job. Note that we currently have almost 150 jobs (for the `dfinity`
repo). We just discovered that GitHub takes between 3 and 6 seconds to
process a notification. Unfortunately these notifications are sent in
sequence resulting in the all-jobs "success" notification (the one
that makes a PR green) to be sent 15m after the all-jobs job has
finished. If there are more concurrent PRs that time will be even
higher.

We're going to work on sending these notifications in parallel but in
the mean time we'll reduce the number of notifications sent to GitHub
to just the "evaluation" and "all-jobs" / "all-systems-go"
notifications.

This means you won't see individual jobs failures on your PRs
anymore. However the "all-jobs" job will still fail in case there's a
bug and clicking on it will show the failing job.

The `motoko` repo only had the `all-systems-go` aggregate job that
includes a subset of all jobs. This PR adds the `all-jobs` job which
includes all job such that PRs will still receive a build failure in
case one of the jobs not in `all-systems-go` fail.