### PR TITLE
Bring back polarities

### DIFF
--- a/design/IDL.md
+++ b/design/IDL.md
@@ -537,7 +537,7 @@ For upgrading data structures passed between service and client, it is important
 
 * *Outbound* data returned from service to client as message results is *provided* by the service; an upgrade may provide *more* or more refined data without breaking clients. For example, an outbound record may provide additional fields after an upgrade.
 
-* *Inbound* data passed from client to service as message parameters is *required* by the service; an upgrade may only require *less* or less specific data without breaking clients. For example, an inbound record may accept additional variant cases after an upgrade.
+* *Inbound* data passed from client to service as message parameters is *required* by the service; an upgrade may only require *less* or less specific data without breaking clients. For example, an inbound variant may accept additional cases after an upgrade.
 
 That is, outbound message results can only be replaced with a subtype (more fields) in an upgrade, while inbound message parameters can only be replaced with a supertype (fewer fields). This corresponds to the notions of co-variance and contra-variance in type systems.
 


### PR DESCRIPTION
This time hopefully sound and with transitivity. The main difference to https://github.com/dfinity-lab/motoko/commit/3376b150b92050eed1e5029e4448833ae72a1fa3 is that it is no longer possible to invoke regular width subtyping in negative position, so record fields can never be removed and the transitivity conflict cannot arise.

Also adds the dual rules for variants (although I'm less sure about their practical utility -- you'll need to know ahead of time that you might want to upgrade a variant and make all uses optional).