### PR TITLE
docs: Comment out the empty Advanced discussion section

### DIFF
--- a/modules/language-guide/lang-nav.adoc
+++ b/modules/language-guide/lang-nav.adoc
@@ -11,6 +11,6 @@
 ** xref:sharing.adoc[Sharing among distinct actors]
 ** xref:modules-and-imports.adoc[Modules and imports]
 ** xref:control-flow.adoc[Imperative control flow]
-** xref:advanced-discussion.adoc[Advanced discussion topics]
+//** xref:advanced-discussion.adoc[Advanced discussion topics]
 ** xref:language-manual.adoc[Language quick reference]
 ** xref:compiler-ref.adoc[Compiler reference]


### PR DESCRIPTION
The file has a to-do list of topics but no content, so I'm removing it from the navigation for now.