### PR TITLE
refactor: orTrap in terms of with_fail

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -5842,9 +5842,7 @@ module PatCode = struct
           G.if_ [] G.nop is2
         )
 
-  let orTrap env : patternCode -> G.t = function
-    | CannotFail is -> is
-    | CanFail is -> is (E.trap_with env "pattern failed")
+  let orTrap env = with_fail (E.trap_with env "pattern failed")
 
   let with_region at = function
     | CannotFail is -> CannotFail (G.with_region at is)


### PR DESCRIPTION
Minor simplification: `orTrap` is just `with_fail` with failure code that traps.