### PR TITLE
refactor: teach Freevars.pat to return a name-to-type mapping

### DIFF
--- a/src/ir_passes/await.ml
+++ b/src/ir_passes/await.ml
@@ -477,8 +477,8 @@ and rename_pat' pat =
     let (patenv,pat1) = rename_pat pat1 in
     (patenv, TagP (i, pat1))
   | AltP (pat1,pat2) ->
-    assert(Freevars.S.is_empty (snd (Freevars.pat pat1)));
-    assert(Freevars.S.is_empty (snd (Freevars.pat pat2)));
+    assert(Freevars.(M.is_empty (pat pat1)));
+    assert(Freevars.(M.is_empty (pat pat2)));
     (PatEnv.empty,pat.it)
 
 and rename_pats pats =
@@ -501,8 +501,8 @@ and define_pat patenv pat : dec list =
   | OptP pat1
   | TagP (_, pat1) -> define_pat patenv pat1
   | AltP (pat1, pat2) ->
-    assert(Freevars.S.is_empty (snd (Freevars.pat pat1)));
-    assert(Freevars.S.is_empty (snd (Freevars.pat pat2)));
+    assert(Freevars.(M.is_empty (pat pat1)));
+    assert(Freevars.(M.is_empty (pat pat2)));
     []
 
 and define_pats patenv (pats : pat list) : dec list =

--- a/src/ir_passes/rename.ml
+++ b/src/ir_passes/rename.ml
@@ -102,8 +102,8 @@ and pat' rho p = match p with
                      (OptP p', rho')
   | TagP (i, p)   -> let (p', rho') = pat rho p in
                      (TagP (i, p'), rho')
-  | AltP (p1, p2) -> assert(Freevars.S.is_empty (snd (Freevars.pat p1)));
-                     assert(Freevars.S.is_empty (snd (Freevars.pat p2)));
+  | AltP (p1, p2) -> assert(Freevars.(M.is_empty (pat p1)));
+                     assert(Freevars.(M.is_empty (pat p2)));
                      let (p1', _) = pat rho p1 in
                      let (p2' ,_) = pat rho p2 in
                      (AltP (p1', p2'), rho)

--- a/src/ir_passes/tailcall.ml
+++ b/src/ir_passes/tailcall.ml
@@ -155,8 +155,8 @@ and pat' env p = match p with
   | LitP l        -> env
   | OptP p
   | TagP (_, p)   -> pat env p
-  | AltP (p1, p2) -> assert(Freevars.S.is_empty (snd (Freevars.pat p1)));
-                     assert(Freevars.S.is_empty (snd (Freevars.pat p2)));
+  | AltP (p1, p2) -> assert(Freevars.(M.is_empty (pat p1)));
+                     assert(Freevars.(M.is_empty (pat p2)));
                      env
 
 and pats env ps  =


### PR DESCRIPTION
pulling this out of #1163, as it makes sense standalone
and the previously returned pair was bogus anyway