### PR TITLE
Nix: Run mo-doc on motoko-base’s next-moc branch

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -402,6 +402,24 @@ rec {
     '';
   };
 
+  base-doc = stdenv.mkDerivation {
+    name = "base-doc";
+    src = nixpkgs.sources.motoko-base;
+    phases = "unpackPhase buildPhase installPhase";
+    doCheck = true;
+    buildInputs = [ mo-doc nixpkgs.asciidoctor nixpkgs.perl ];
+    buildPhase = ''
+      make -C doc
+    '';
+    installPhase = ''
+      mkdir -p $out
+      cp -rv doc/_out/* $out/
+
+      mkdir -p $out/nix-support
+      echo "report docs $out index.html" >> $out/nix-support/hydra-build-products
+    '';
+  };
+
   check-generated = nixpkgs.runCommandNoCC "check-generated" {
       nativeBuildInputs = [ nixpkgs.diffutils ];
       expected = import ./nix/generate.nix { pkgs = nixpkgs; };
@@ -424,6 +442,7 @@ rec {
       rts
       base-src
       base-tests
+      base-doc
       users-guide
       ic-ref
       shell

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -40,7 +40,7 @@
     "motoko-base": {
         "ref": "next-moc",
         "repo": "ssh://git@github.com/dfinity-lab/motoko-base",
-        "rev": "db9c494dc344f5de182061bbde3aa68c1a117802",
+        "rev": "758096adf709a72c20680ae84cb73df342a9d107",
         "type": "git"
     },
     "musl-wasi": {


### PR DESCRIPTION
and ship the result via hydra for showing off in RPs.

Builds on top of https://github.com/dfinity-lab/motoko-base/pull/32