### PR TITLE
Makefile: remove [grammar] dependency in [all] target until [grammar] works on Linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ ALL_TARGETS = $(MO_IDE_TARGET) $(MO_LD_TARGET) $(MO_DOC_TARGET) $(MOC_TARGET) $(
 
 # This targets is spelled out so that `make`
 # only invokes `dune` once, much faster
-all: grammar
+all:
 	dune build $(DUNE_OPTS) $(ALL_TARGETS)
 	@ln -fs $(MOC_TARGET) moc
 	@ln -fs $(MO_IDE_TARGET) mo-ide


### PR DESCRIPTION
 see #1570 for the problem