### PR TITLE
prelude: add arctan2

### DIFF
--- a/rts/Makefile
+++ b/rts/Makefile
@@ -17,7 +17,7 @@ TOMMATHFILES = \
    s_mp_balance_mul s_mp_toom_mul s_mp_toom_sqr s_mp_karatsuba_sqr s_mp_sqr_fast s_mp_sqr s_mp_karatsuba_mul s_mp_mul_digs_fast s_mp_mul_digs mp_init_multi mp_clear_multi mp_mul_2 mp_div_2 mp_div_3 mp_lshd mp_incr mp_decr mp_add_d mp_sub_d
 
 MUSLFILES = \
-  exp_data pow_data pow sin cos tan asin acos atan __math_invalid \
+  exp_data pow_data pow sin cos tan asin acos atan atan2 __math_invalid \
   floor scalbn frexp strnlen memchr memset memcpy snprintf vsnprintf vfprintf \
   __math_oflow __math_uflow __math_xflow \
   __rem_pio2 __rem_pio2_large __sin __cos __tan \

--- a/rts/float.c
+++ b/rts/float.c
@@ -45,4 +45,9 @@ export double float_arctan(double a) {
   return atan(a);
 }
 
+export double float_arctan2(double y, double x) {
+  extern double atan2(double, double);
+  return atan2(y, x);
+}
+
 #endif

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -791,6 +791,7 @@ module RTS = struct
     E.add_func_import env "rts" "float_arcsin" [F64Type] [F64Type];
     E.add_func_import env "rts" "float_arccos" [F64Type] [F64Type];
     E.add_func_import env "rts" "float_arctan" [F64Type] [F64Type];
+    E.add_func_import env "rts" "float_arctan2" [F64Type; F64Type] [F64Type];
     E.add_func_import env "rts" "float_fmt" [F64Type] [I32Type];
     ()
 
@@ -7139,6 +7140,12 @@ and compile_exp (env : E.t) ae exp =
       SR.UnboxedFloat64,
       compile_exp_as env ae SR.UnboxedFloat64 e ^^
       E.call_import env "rts" "float_arctan"
+
+    | OtherPrim "fatan2", [y; x] ->
+      SR.UnboxedFloat64,
+      compile_exp_as env ae SR.UnboxedFloat64 y ^^
+      compile_exp_as env ae SR.UnboxedFloat64 x ^^
+      E.call_import env "rts" "float_arctan2"
 
     | OtherPrim "rts_version", [] ->
       SR.Vanilla,

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -199,6 +199,7 @@ let num_conv_prim t1 t2 =
 
 let prim =
   let via_float f v = Float.(Float (of_float (f (to_float (as_float v))))) in
+  let via_float2 f v w = Float.(Float (of_float (f (to_float (as_float v)) (to_float (as_float w))))) in
   function
   | "abs" -> fun _ v k -> k (Int (Nat.abs (as_int v)))
   | "fabs" -> fun _ v k -> k (Float (Float.abs (as_float v)))
@@ -226,6 +227,10 @@ let prim =
   | "fasin" -> fun _ v k -> k (via_float Stdlib.asin v)
   | "facos" -> fun _ v k -> k (via_float Stdlib.acos v)
   | "fatan" -> fun _ v k -> k (via_float Stdlib.atan v)
+  | "fatan2" -> fun _ v k ->
+    (match Value.as_tup v with
+     | [y; x] -> k (via_float2 Stdlib.atan2 y x)
+     | _ -> assert false)
 
   | "popcnt8" | "popcnt16" | "popcnt32" | "popcnt64" ->
      fun _ v k ->

--- a/src/prelude/prelude.ml
+++ b/src/prelude/prelude.ml
@@ -460,6 +460,7 @@ func tan(f : Float) : Float = (prim "ftan" : Float -> Float) f;
 func arcsin(f : Float) : Float = (prim "fasin" : Float -> Float) f;
 func arccos(f : Float) : Float = (prim "facos" : Float -> Float) f;
 func arctan(f : Float) : Float = (prim "fatan" : Float -> Float) f;
+func arctan2(y : Float, x : Float) : Float = (prim "fatan2" : (Float, Float) -> Float) (y, x);
 
 // Array utilities
 

--- a/test/run/float-ops.mo
+++ b/test/run/float-ops.mo
@@ -55,13 +55,20 @@ assert Prim.arcsin(Prim.sin(someRandomAngle)) == someRandomAngle;
 assert Prim.floatAbs(Prim.arccos(Prim.cos(someRandomAngle)) - someRandomAngle) < 0.00000000000000006;
 assert Prim.arctan(Prim.tan(someRandomAngle)) == someRandomAngle;
 
-assert Prim.floatAbs(Prim.arcsin(Prim.floatSqrt(2) / 2) - fortyFiveDegrees) < 0.0000000000000002;
+let sqrt2over2 : Float = Prim.floatSqrt(2) / 2;
+assert Prim.floatAbs(Prim.arcsin(sqrt2over2) - fortyFiveDegrees) < 0.0000000000000002;
 assert Prim.arcsin(1.0) == ninetyDegrees;
 
-assert Prim.arccos(Prim.floatSqrt(2) / 2) == fortyFiveDegrees;
+assert Prim.arccos(sqrt2over2) == fortyFiveDegrees;
 assert Prim.arccos(1.0) == 0.0;
 
 assert Prim.arctan(1.0) == fortyFiveDegrees;
+
+assert Prim.arctan2(sqrt2over2, sqrt2over2) == fortyFiveDegrees;
+assert Prim.arctan2(-sqrt2over2, sqrt2over2) == -fortyFiveDegrees;
+assert Prim.arctan2(1, 0) == ninetyDegrees;
+assert Prim.arctan2(0, 0) == 0.0;
+assert Prim.arctan2(-1, 0) == -ninetyDegrees;
 
 // Conversions
 assert (Prim.floatToInt64(pi) == (3 : Int64));


### PR DESCRIPTION
Interpreter and compiler support. Argument order agrees with OCaml and C.

Necessitates another C file for `rts`, namely `atan2.c`.

Adds tests.