### PR TITLE
cleanup: remove redundant flag

### DIFF
--- a/rts/Makefile
+++ b/rts/Makefile
@@ -96,7 +96,6 @@ CLANG_FLAGS = \
 
 WASM_FLAGS = \
    --target=wasm32-emscripten \
-   -fvisibility=hidden \
    -fno-builtin -ffreestanding \
    --optimize=3 \
 


### PR DESCRIPTION
`-fvisibility=hidden` is already in `CLANG_FLAGS`