### PR TITLE
rts: --optimize=2 (was: 3)

### DIFF
--- a/rts/Makefile
+++ b/rts/Makefile
@@ -97,7 +97,7 @@ CLANG_FLAGS = \
 WASM_FLAGS = \
    --target=wasm32-emscripten \
    -fno-builtin -ffreestanding \
-   --optimize=2 \
+   --optimize=s \
 
 #
 # Build targets


### PR DESCRIPTION
Only perform optimisations that don't blow up code (e.g. loop unrolling) and optimise for size.