### PR TITLE
IDL-Motoko spec: Map Blob ↔ blob

### DIFF
--- a/design/IDL-Motoko.md
+++ b/design/IDL-Motoko.md
@@ -85,6 +85,7 @@ e(Word<n>) = nat<n> for n = 8, 16, 32, 64
 e(Float) = float64
 e(Char) = nat32
 e(Text) = text
+e(Blob) = blob
 e(Principal) = principal
 e({ <typ-field>;* }) = record { ef(<typ-field>);* }
 e(variant { <typ-field>;* }) = variant { ef(<typ-field>);* }
@@ -134,7 +135,7 @@ i(reserved) = Any
 i(empty) = None
 i(opt <datatype>) = ? i(<datatype>)
 i(vec <datatype>) = [ i(<datatype>) ]
-i(blob) = [ word8 ] // if Motoko had a bytes type, it would show up here
+i(blob) = Blob
 i(record { <datatype>;^N }) = ( i(<datatype>),^N ) if n > 1 // matches tuple short-hand
 i(record { <fieldtype>;* }) = { if(<fieldtype>);* }
 i(variant { <fieldtype>;* }) = variant { ivf(<fieldtype>);* }


### PR DESCRIPTION
This just updates the spec as per #1618, but not yet the implementation.