### PR TITLE
niv-updater: Update all dependendencies at least weekly

### DIFF
--- a/.github/workflows/niv-updater-rare.yml
+++ b/.github/workflows/niv-updater-rare.yml
@@ -1,0 +1,29 @@
+name: Automatically update niv-managed dependencies
+on:
+  # Manual override, one can start the workflow by running:
+  # curl -H "Accept: application/vnd.github.everest-preview+json" \
+  #  -H "Authorization: token <your-token-here>" \
+  #  --request POST \
+  #  --data '{"event_type": "niv-updater-nudge", "client_payload": {}}' \
+  #  https://api.github.com/repos/dfinity-lab/motoko/dispatches
+  # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
+  repository_dispatch:
+    types: niv-updater-nudge
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run every monday
+    - cron:  '0 0 * * 1'
+jobs:
+  niv-updater:
+    name: 'Check for updates'
+    runs-on: ubuntu-latest
+    steps:
+      - name: niv-updater-action
+        uses: knl/niv-updater-action@v5
+        with:
+          # might be too noisy
+          whitelist: 'nixpkgs,dfinity,ic-ref,musl-wasi'
+          labels: |
+            automerge-squash
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIV_UPDATER_TOKEN }}


### PR DESCRIPTION
we have a job that updates some dependencies daily. For stuff like
`dfinity` that was too frequent, but not updating at all means we
notices issues to late. So let's update them weekly.