### PR TITLE
Introduce monadic let syntax for diag.result monad

### DIFF
--- a/src/idllib/pipeline.ml
+++ b/src/idllib/pipeline.ml
@@ -18,11 +18,11 @@ let dump_prog flag prog =
     if flag then
       Wasm.Sexpr.print 80 (Arrange_idl.prog prog)
     else ()
-    
+
 (* Parsing *)
 
 type rel_path = string
-  
+
 type parse_result = (Syntax.prog * rel_path) Diag.result
 
 let parse_with lexer parser name =
@@ -62,7 +62,7 @@ let parse_file filename : parse_result =
   try parse_file filename
   with Sys_error s ->
     error Source.no_region "file" (sprintf "cannot open \"%s\"" filename)
-             
+
 (* Type checking *)
 
 let check_prog senv prog
@@ -103,26 +103,27 @@ let chase_imports senv imports =
       Diag.return ()
     else begin
         pending := S.add file !pending;
-        Diag.bind (parse_file file) (fun (prog, base) ->
-            Diag.bind (Resolve_import.resolve prog base) (fun imports ->
-                Diag.bind (go_set imports) (fun () ->
-                    Diag.bind (merge_env imports senv !lib_env) (fun base_env ->
-                        Diag.bind (check_prog base_env prog) (fun (scope, _) ->
-                            lib_env := LibEnv.add file scope !lib_env;
-                            pending := S.remove file !pending;
-                            Diag.return ()
-          )))))
+        let open Diag.Syntax in
+        let* prog, base = parse_file file in
+        let* imports = Resolve_import.resolve prog base in
+        let* () = go_set imports in
+        let* base_env = merge_env imports senv !lib_env in
+        let* scope, _ = check_prog base_env prog in
+        lib_env := LibEnv.add file scope !lib_env;
+        pending := S.remove file !pending;
+        Diag.return ()
       end
   and go_set todo = Diag.traverse_ go todo
   in Diag.map (fun () -> !lib_env) (go_set imports)
 
 let load_prog parse senv =
-  Diag.bind parse (fun (prog, base) ->
-      Diag.bind (Resolve_import.resolve prog base) (fun imports ->
-          Diag.bind (chase_imports senv imports) (fun lib_env ->
-              Diag.bind (merge_env imports senv lib_env) (fun base_env ->
-                  Diag.bind (check_prog base_env prog) (fun (scope, actor) ->
-                      Diag.return (prog, scope, actor))))))
+  let open Diag.Syntax in
+  let* prog, base = parse in
+  let* imports = Resolve_import.resolve prog base in
+  let* lib_env = chase_imports senv imports in
+  let* base_env = merge_env imports senv lib_env in
+  let* scope, actor = check_prog base_env prog in
+  Diag.return (prog, scope, actor)
 
 (* Only type checking *)
 
@@ -131,20 +132,22 @@ let initial_stat_env = Typing.empty_scope
 let check_string source : load_result = load_prog (parse_string source) initial_stat_env
 let check_file file : load_result = load_prog (parse_file file) initial_stat_env
 let check_prog prog : Typing.scope Diag.result =
-  Diag.bind (check_prog initial_stat_env prog) (fun (scope, _) -> Diag.return scope)
+  let open Diag.Syntax in
+  let* scope, _ = check_prog initial_stat_env prog in
+  Diag.return scope
 
 (* JS Compilation *)
 
 type compile_result = Buffer.t Diag.result
 
 let compile_js_file file : compile_result =
-  Diag.bind (check_file file)
-    (fun (prog, senv, _) ->
-      phase "JS Compiling" file;
-      Diag.return (Compile_js.compile senv prog))
+  let open Diag.Syntax in
+  let* prog, senv, _ = check_file file in
+  phase "JS Compiling" file;
+  Diag.return (Compile_js.compile senv prog)
 
 let compile_js_string source : compile_result =
-  Diag.bind (check_string source)
-    (fun (prog, senv, _) ->
-      phase "JS Compiling" "source3";
-      Diag.return (Compile_js.compile senv prog))
+  let open Diag.Syntax in
+  let* prog, senv, _ = check_string source in
+  phase "JS Compiling" "source3";
+  Diag.return (Compile_js.compile senv prog)

--- a/src/lang_utils/diag.ml
+++ b/src/lang_utils/diag.ml
@@ -25,6 +25,10 @@ let bind x f = match x with
     | Ok (z, msgs2) -> Ok (z, msgs1 @ msgs2)
     | Stdlib.Error msgs2 -> Error (msgs1 @ msgs2)
 
+module Syntax = struct
+  let (let*) = bind
+end
+
 let rec traverse : ('a -> 'b result) -> 'a list -> 'b list result = fun f -> function
   | [] -> return []
   | x :: xs -> bind (f x) (fun y -> map (fun ys -> y :: ys) (traverse f xs))

--- a/src/lang_utils/diag.mli
+++ b/src/lang_utils/diag.mli
@@ -35,6 +35,10 @@ val run : 'a result -> 'a (* Prints messages, and exits upon failure *)
 
 val warn : Source.region -> string -> string -> unit result
 
+module Syntax : sig
+  val (let*) : 'a result -> ('a -> 'b result) -> 'b result
+end
+
 (*
 An impure, but more more convenient interface.
 

--- a/src/pipeline/dune
+++ b/src/pipeline/dune
@@ -19,5 +19,5 @@
     codegen
   )
   (inline_tests)
-  (preprocess (pps ppx_inline_test))
+  (preprocess (per_module ((pps ppx_inline_test) resolve_import_test)))
 )

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -165,25 +165,27 @@ let infer_prog senv prog
     | Error _ -> ()
   end;
   phase "Definedness" prog.Source.note;
-  Diag.bind r (fun t_sscope ->
-    Diag.bind (Definedness.check_prog prog) (fun () -> Diag.return t_sscope)
-  )
+  let open Diag.Syntax in
+  let* t_sscope = r in
+  let* () = Definedness.check_prog prog in
+  Diag.return t_sscope
 
 let rec check_progs senv progs : Scope.scope Diag.result =
   match progs with
   | [] -> Diag.return senv
   | p::ps ->
-    Diag.bind (infer_prog senv p) (fun (_t, sscope) ->
-      let senv' = Scope.adjoin senv sscope in
-      check_progs senv' ps
-    )
+    let open Diag.Syntax in
+    let* _t, sscope = infer_prog senv p in
+    let senv' = Scope.adjoin senv sscope in
+    check_progs senv' ps
 
 let check_lib senv lib : Scope.scope Diag.result =
   phase "Checking" (Filename.basename lib.Source.note);
-  Diag.bind (Typing.check_lib senv lib) (fun sscope ->
-    phase "Definedness" (Filename.basename lib.Source.note);
-    Diag.bind (Definedness.check_lib lib) (fun () -> Diag.return sscope)
-  )
+  let open Diag.Syntax in
+  let* sscope = Typing.check_lib senv lib in
+  phase "Definedness" (Filename.basename lib.Source.note);
+  let* () = Definedness.check_lib lib in
+  Diag.return sscope
 
 (* Parsing libraries *)
 
@@ -321,54 +323,56 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
         }]
       else begin
         pending := add ri.Source.it !pending;
-        Diag.bind (parsefn ri.Source.at f) (fun (prog, base) ->
-        Diag.bind (Static.prog prog) (fun () ->
-        Diag.bind (ResolveImport.resolve (resolve_flags ()) prog base) (fun more_imports ->
-        Diag.bind (go_set more_imports) (fun () ->
+        let open Diag.Syntax in
+        let* prog, base = parsefn ri.Source.at f in
+        let* () = Static.prog prog in
+        let* more_imports =
+          ResolveImport.resolve (resolve_flags ()) prog base
+        in
+        let* () = go_set more_imports in
         let lib = lib_of_prog f prog in
-        Diag.bind (check_lib !senv lib) (fun sscope ->
+        let* sscope = check_lib !senv lib in
         libs := lib :: !libs; (* NB: Conceptually an append *)
         senv := Scope.adjoin !senv sscope;
         pending := remove ri.Source.it !pending;
         Diag.return ()
-        )))))
       end
     | Syntax.IDLPath (f, _) ->
-       Diag.bind (Idllib.Pipeline.check_file f) (fun (prog, idl_scope, actor_opt) ->
-       if actor_opt = None then
-         Error [Diag.{
-           sev = Error; at = ri.Source.at; cat = "import";
-           text = Printf.sprintf "file %s does not define a service" f
-         }]
-       else
-         let actor = Mo_idl.Idl_to_mo.check_prog idl_scope actor_opt in
-         let sscope = Scope.lib f actor in
-         senv := Scope.adjoin !senv sscope;
-         Diag.return ()
-       )
+      let open Diag.Syntax in
+      let* prog, idl_scope, actor_opt = Idllib.Pipeline.check_file f in
+      if actor_opt = None then
+        Error [Diag.{
+          sev = Error; at = ri.Source.at; cat = "import";
+          text = Printf.sprintf "file %s does not define a service" f
+        }]
+      else
+        let actor = Mo_idl.Idl_to_mo.check_prog idl_scope actor_opt in
+        let sscope = Scope.lib f actor in
+        senv := Scope.adjoin !senv sscope;
+        Diag.return ()
 
   and go_set todo = Diag.traverse_ go todo
   in
   Diag.map (fun () -> (List.rev !libs, !senv)) (go_set imports)
 
 let load_progs parsefn files senv : load_result =
-  Diag.bind (Diag.traverse (parsefn Source.no_region) files) (fun parsed ->
-  Diag.bind (resolve_progs parsed) (fun rs ->
+  let open Diag.Syntax in
+  let* parsed = Diag.traverse (parsefn Source.no_region) files in
+  let* rs = resolve_progs parsed in
   let progs' = List.map fst rs in
   let libs = Lib.List.concat_map snd rs in
-  Diag.bind (chase_imports parsefn senv libs) (fun (libs, senv') ->
-  Diag.bind (check_progs senv' progs') (fun senv'' ->
+  let* libs, senv' = chase_imports parsefn senv libs in
+  let* senv'' = check_progs senv' progs' in
   Diag.return (libs, progs', senv'')
-  ))))
 
 let load_decl parse_one senv : load_decl_result =
-  Diag.bind parse_one (fun parsed ->
-  Diag.bind (resolve_prog parsed) (fun (prog, libs) ->
-  Diag.bind (chase_imports parse_file senv libs) (fun (libs, senv') ->
-  Diag.bind (infer_prog senv' prog) (fun (t, sscope) ->
+  let open Diag.Syntax in
+  let* parsed = parse_one in
+  let* prog, libs = resolve_prog parsed in
+  let* libs, senv' = chase_imports parse_file senv libs in
+  let* t, sscope = infer_prog senv' prog in
   let senv'' = Scope.adjoin senv' sscope in
   Diag.return (libs, prog, senv'', t, sscope)
-  ))))
 
 
 (* Interpretation (Source) *)
@@ -440,9 +444,9 @@ let check_string s name : check_result =
 (* Generate IDL *)
 
 let generate_idl files : Idllib.Syntax.prog Diag.result =
-  Diag.bind (load_progs parse_file files initial_stat_env)
-    (fun (libs, progs, senv) ->
-      Diag.return (Mo_idl.Mo_to_idl.prog (progs, senv)))
+  let open Diag.Syntax in
+  let* libs, progs, senv = load_progs parse_file files initial_stat_env in
+  Diag.return (Mo_idl.Mo_to_idl.prog (progs, senv))
 
 (* Running *)
 
@@ -619,15 +623,17 @@ let compile_prog mode do_link libs progs : Wasm_exts.CustomModule.extended_modul
   Codegen.Compile.compile mode name rts prog_ir
 
 let compile_files mode do_link files : compile_result =
-  Diag.bind (load_progs parse_file files initial_stat_env)
-    (fun (libs, progs, senv) ->
-    Diag.bind (Typing.check_actors senv progs) (fun () ->
-    Diag.return (compile_prog mode do_link libs progs)))
+  let open Diag.Syntax in
+  let* libs, progs, senv = load_progs parse_file files initial_stat_env in
+  let* () = Typing.check_actors senv progs in
+  Diag.return (compile_prog mode do_link libs progs)
 
 let compile_string mode s name : compile_result =
-  Diag.bind (load_decl (parse_string name s) initial_stat_env)
-    (fun (libs, prog, senv, _t, _sscope) ->
-    Diag.return (compile_prog mode false libs [prog]))
+  let open Diag.Syntax in
+  let* libs, prog, senv, _t, _sscope =
+    load_decl (parse_string name s) initial_stat_env
+  in
+  Diag.return (compile_prog mode false libs [prog])
 
 (* Interpretation (IR) *)
 

--- a/src/pipeline/resolve_import.ml
+++ b/src/pipeline/resolve_import.ml
@@ -253,20 +253,21 @@ type resolved_flags = {
 
 let resolve_flags : flags -> resolved_flags Diag.result
   = fun { actor_idl_path; package_urls; actor_aliases } ->
-  Diag.bind (resolve_packages package_urls) (fun packages ->
-  Diag.bind (resolve_aliases actor_aliases) (fun aliases ->
-      Diag.return { packages; aliases; actor_idl_path }))
+  let open Diag.Syntax in
+  let* packages = resolve_packages package_urls in
+  let* aliases = resolve_aliases actor_aliases in
+  Diag.return { packages; aliases; actor_idl_path }
 
 let resolve
   : flags -> Syntax.prog -> filepath -> resolved_imports Diag.result
   = fun flags p base ->
-  Diag.bind (resolve_flags flags) (fun { packages; aliases; actor_idl_path } ->
-    Diag.with_message_store (fun msgs ->
-      let base = if Sys.is_directory base then base else Filename.dirname base in
-      let imported = ref RIM.empty in
-      List.iter (resolve_import_string msgs base actor_idl_path aliases packages imported) (prog_imports p);
-      Some (List.map (fun (rim,at) -> rim @@ at) (RIM.bindings !imported))
-    )
+  let open Diag.Syntax in
+  let* { packages; aliases; actor_idl_path } = resolve_flags flags in
+  Diag.with_message_store (fun msgs ->
+    let base = if Sys.is_directory base then base else Filename.dirname base in
+    let imported = ref RIM.empty in
+    List.iter (resolve_import_string msgs base actor_idl_path aliases packages imported) (prog_imports p);
+    Some (List.map (fun (rim,at) -> rim @@ at) (RIM.bindings !imported))
   )
 
 


### PR DESCRIPTION
Introduce monadic let syntax for diag.result monad

Using OCaml binding operators for monadic let bindings. Reference:
https://caml.inria.fr/pub/docs/manual-ocaml/bindingops.html#ss%3Aletops-rationale

Reduces nesting in monadic code.

Note that I had to limit ppx preprocessing in pipeline module to
pipeline.resolve_import_test as the ppx we're using is too old to
process the new syntax.
