### PR TITLE
Backend: Clarify terminology around boxed and tagged scalar

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -34,6 +34,10 @@ See documentation of module BitTagged for more detail.
 let ptr_skew = -1l
 let ptr_unskew = 1l
 
+(* Generating function names for functions parametrized by prim types *)
+let prim_fun_name p stem = Printf.sprintf "%s<%s>" stem (Type.string_of_prim p)
+
+
 (* Helper functions to produce annotated terms (Wasm.AST) *)
 let nr x = { Wasm.Source.it = x; Wasm.Source.at = Wasm.Source.no_region }
 
@@ -1106,12 +1110,12 @@ module BitTagged = struct
      The bytes are stored in the _most_ significant byte(s) of the `i32`,
      thus the second lowest bit is 0.
      All arithmetic is implemented directly on that representation, see
-     UnboxedSmallWord.
+     TaggedSmallWord.
   *)
   let scalar_shift = 2l
 
-  let if_unboxed env retty is1 is2 =
-    Func.share_code1 env "is_unboxed" ("x", I32Type) [I32Type] (fun env get_x ->
+  let if_tagged_scalar env retty is1 is2 =
+    Func.share_code1 env "is_tagged_scalar" ("x", I32Type) [I32Type] (fun env get_x ->
       (* Get bit *)
       get_x ^^
       compile_bitand_const 0x2l ^^
@@ -1124,11 +1128,11 @@ module BitTagged = struct
      whether both are scalars and invoke is1 (the fast path)
      if so, and otherwise is2 (the slow path).
   *)
-  let if_both_unboxed env retty is1 is2 =
+  let if_both_tagged_scalar env retty is1 is2 =
     G.i (Binary (Wasm.Values.I32 I32Op.Or)) ^^
-    if_unboxed env retty is1 is2
+    if_tagged_scalar env retty is1 is2
 
-  let can_unbox (n : int64) =
+  let can_untag_scalar (n : int64) =
     let lower_bound = 0L in (* TBR *)
     let upper_bound = Int64.shift_left 1L 30 in
     lower_bound <= n && n < upper_bound
@@ -1143,12 +1147,8 @@ module BitTagged = struct
     compile_shl_const scalar_shift
 
   (* The untag_i32 and tag_i32 functions expect 32 bit numbers *)
-  let untag_i32 env =
-    compile_shrU_const scalar_shift
-
-  let tag_i32 =
-    compile_unboxed_const scalar_shift ^^
-    G.i (Binary (Wasm.Values.I32 I32Op.Shl))
+  let untag_i32 env = compile_shrU_const scalar_shift
+  let tag_i32 = compile_shl_const scalar_shift
 
 end (* BitTagged *)
 
@@ -1416,7 +1416,7 @@ module BoxedWord64 = struct
   let payload_field = Tagged.header_size
 
   let vanilla_lit env i =
-    if BitTagged.can_unbox i
+    if BitTagged.can_untag_scalar i
     then Int32.(logor (shift_left (Int64.to_int32 i) 2) (shift_right_logical (Int64.to_int32 i) 31))
     else
       E.add_static env StaticBytes.[
@@ -1442,7 +1442,7 @@ module BoxedWord64 = struct
 
   let unbox env = Func.share_code1 env "unbox_i64" ("n", I32Type) [I64Type] (fun env get_n ->
       get_n ^^
-      BitTagged.if_unboxed env [I64Type]
+      BitTagged.if_tagged_scalar env [I64Type]
         ( get_n ^^ BitTagged.untag_scalar env)
         ( get_n ^^ Heap.load_field64 payload_field)
     )
@@ -1509,7 +1509,7 @@ module BoxedSmallWord = struct
   let payload_field = Tagged.header_size
 
   let vanilla_lit env i =
-    if BitTagged.can_unbox (Int64.of_int (Int32.to_int i))
+    if BitTagged.can_untag_scalar (Int64.of_int (Int32.to_int i))
     then Int32.(logor (shift_left i 2) (shift_right_logical i 31))
     else
       E.add_static env StaticBytes.[
@@ -1535,7 +1535,7 @@ module BoxedSmallWord = struct
 
   let unbox env = Func.share_code1 env "unbox_i32" ("n", I32Type) [I32Type] (fun env get_n ->
       get_n ^^
-      BitTagged.if_unboxed env [I32Type]
+      BitTagged.if_tagged_scalar env [I32Type]
         ( get_n ^^ BitTagged.untag_i32 env)
         ( get_n ^^ Heap.load_field payload_field)
     )
@@ -1544,7 +1544,7 @@ module BoxedSmallWord = struct
 
 end (* BoxedSmallWord *)
 
-module UnboxedSmallWord = struct
+module TaggedSmallWord = struct
   (* While smaller-than-32bit words are treated as i32 from the WebAssembly perspective,
      there are certain differences that are type based. This module provides helpers to abstract
      over those. *)
@@ -1566,10 +1566,6 @@ module UnboxedSmallWord = struct
   let padding_of_type ty = Int32.(sub (const_of_type ty 1l) one)
 
   let mask_of_type ty = Int32.lognot (padding_of_type ty)
-
-  let name_of_type ty seed = match Arrange_type.prim ty with
-    | Wasm.Sexpr.Atom s -> seed ^ "<" ^ s ^ ">"
-    | wtf -> todo "name_of_type" wtf seed
 
   (* Makes sure that we only shift/rotate the maximum number of bits available in the word. *)
   let clamp_shift_amount = function
@@ -1621,13 +1617,13 @@ module UnboxedSmallWord = struct
        G.i (Binary (Wasm.Values.I32 I32Op.Shl)) ^^
        G.i (Binary (Wasm.Values.I32 I32Op.And))
 
-  (* Code points occupy 21 bits, no alloc needed in vanilla SR. *)
-  let unbox_codepoint = compile_shrU_const 8l
-  let box_codepoint = compile_shl_const 8l
+  (* Code points occupy 21 bits, so can always be tagged scalars *)
+  let untag_codepoint = compile_shrU_const 8l
+  let tag_codepoint = compile_shl_const 8l
 
   (* Checks (n < 0xD800 || 0xE000 ≤ n ≤ 0x10FFFF),
      ensuring the codepoint range and the absence of surrogates. *)
-  let check_and_box_codepoint env get_n =
+  let check_and_tag_codepoint env get_n =
     get_n ^^ compile_unboxed_const 0xD800l ^^
     G.i (Compare (Wasm.Values.I32 I32Op.GeU)) ^^
     get_n ^^ compile_unboxed_const 0xE000l ^^
@@ -1637,7 +1633,7 @@ module UnboxedSmallWord = struct
     G.i (Compare (Wasm.Values.I32 I32Op.GtU)) ^^
     G.i (Binary (Wasm.Values.I32 I32Op.Or)) ^^
     E.then_trap_with env "codepoint out of range" ^^
-    get_n ^^ box_codepoint
+    get_n ^^ tag_codepoint
 
   let vanilla_lit ty v =
     Int32.(shift_left (of_int v) (to_int (shift_of_type ty)))
@@ -1649,7 +1645,7 @@ module UnboxedSmallWord = struct
     G.i (Binary (Wasm.Values.I32 I32Op.Mul))
 
   let compile_word_power env ty =
-    let rec pow () = Func.share_code2 env (name_of_type ty "pow")
+    let rec pow () = Func.share_code2 env (prim_fun_name ty "pow")
                        (("n", I32Type), ("exp", I32Type)) [I32Type]
                        Wasm.Values.(fun env get_n get_exp ->
         let one = compile_unboxed_const (const_of_type ty 1l) in
@@ -1669,7 +1665,7 @@ module UnboxedSmallWord = struct
                  mul)))
     in pow ()
 
-end (* UnboxedSmallWord *)
+end (* TaggedSmallWord *)
 
 
 module Float = struct
@@ -2025,7 +2021,7 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
   (* creates a boxed bignum from an unboxed 31-bit signed (and rotated) value *)
   let extend_and_box64 env = extend64 ^^ box64 env
 
-  (* check if both arguments are compact (i.e. unboxed),
+  (* check if both arguments are tagged scalars,
      if so, promote to signed i64 (with right bit (i.e. LSB) zero) and perform the fast path.
      Otherwise make sure that both arguments are in heap representation,
      and run the slow path on them.
@@ -2037,7 +2033,7 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
         let set_res, get_res = new_local env "res" in
         let set_res64, get_res64 = new_local64 env "res64" in
         get_a ^^ get_b ^^
-        BitTagged.if_both_unboxed env [I32Type]
+        BitTagged.if_both_tagged_scalar env [I32Type]
           begin
             get_a ^^ extend64 ^^
             get_b ^^ extend64 ^^
@@ -2048,10 +2044,10 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
               (get_res64 ^^ box64 env)
           end
           begin
-            get_a ^^ BitTagged.if_unboxed env [I32Type]
+            get_a ^^ BitTagged.if_tagged_scalar env [I32Type]
               (get_a ^^ extend_and_box64 env)
               get_a ^^
-            get_b ^^ BitTagged.if_unboxed env [I32Type]
+            get_b ^^ BitTagged.if_tagged_scalar env [I32Type]
               (get_b ^^ extend_and_box64 env)
               get_b ^^
             slow env ^^ set_res ^^ get_res ^^
@@ -2082,7 +2078,7 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
     let set_b64, get_b64 = new_local64 env "b64" in
     let set_res64, get_res64 = new_local64 env "res64" in
     get_a ^^ get_b ^^
-    BitTagged.if_both_unboxed env [I32Type]
+    BitTagged.if_both_tagged_scalar env [I32Type]
       begin
         (* estimate bitcount of result: `bits(a) * b <= 65` guarantees
            the absence of overflow in 64-bit arithmetic *)
@@ -2115,10 +2111,10 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
           end
       end
       begin
-        get_a ^^ BitTagged.if_unboxed env [I32Type]
+        get_a ^^ BitTagged.if_tagged_scalar env [I32Type]
           (get_a ^^ extend_and_box64 env)
           get_a ^^
-        get_b ^^ BitTagged.if_unboxed env [I32Type]
+        get_b ^^ BitTagged.if_tagged_scalar env [I32Type]
           (get_b ^^ extend_and_box64 env)
           get_b ^^
         Num.compile_unsigned_pow env ^^ set_res ^^ get_res ^^
@@ -2131,7 +2127,7 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
   let compile_is_negative env =
     let set_n, get_n = new_local env "n" in
     set_n ^^ get_n ^^
-    BitTagged.if_unboxed env [I32Type]
+    BitTagged.if_tagged_scalar env [I32Type]
       (get_n ^^ compile_bitand_const 1l)
       (get_n ^^ Num.compile_is_negative env)
 
@@ -2150,7 +2146,7 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
 
   let compile_neg env =
     Func.share_code1 env "B_neg" ("n", I32Type) [I32Type] (fun env get_n ->
-      get_n ^^ BitTagged.if_unboxed env [I32Type]
+      get_n ^^ BitTagged.if_tagged_scalar env [I32Type]
         begin
           get_n ^^ compile_unboxed_one ^^
           G.i (Compare (Wasm.Values.I32 I32Op.Eq)) ^^
@@ -2170,17 +2166,17 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
     Func.share_code2 env name (("a", I32Type), ("b", I32Type)) [I32Type]
       (fun env get_a get_b ->
         get_a ^^ get_b ^^
-        BitTagged.if_both_unboxed env [I32Type]
+        BitTagged.if_both_tagged_scalar env [I32Type]
           begin
             get_a ^^ extend64 ^^
             get_b ^^ extend64 ^^
             fast env
           end
           begin
-            get_a ^^ BitTagged.if_unboxed env [I32Type]
+            get_a ^^ BitTagged.if_tagged_scalar env [I32Type]
               (get_a ^^ extend_and_box64 env)
               get_a ^^
-            get_b ^^ BitTagged.if_unboxed env [I32Type]
+            get_b ^^ BitTagged.if_tagged_scalar env [I32Type]
               (get_b ^^ extend_and_box64 env)
               get_b ^^
             slow env
@@ -2196,7 +2192,7 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
   let try_unbox iN fast slow env =
     let set_a, get_a = new_local env "a" in
     set_a ^^ get_a ^^
-    BitTagged.if_unboxed env [iN]
+    BitTagged.if_tagged_scalar env [iN]
       (get_a ^^ fast env)
       (get_a ^^ slow env)
 
@@ -2354,7 +2350,7 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
   let truncate_to_word64 env =
     let set_a, get_a = new_local env "a" in
     set_a ^^ get_a ^^
-    BitTagged.if_unboxed env [I64Type]
+    BitTagged.if_tagged_scalar env [I64Type]
       begin
         get_a ^^ extend ^^ compile_unboxed_one ^^
         G.i (Binary (Wasm.Values.I32 I32Op.ShrS)) ^^
@@ -2364,20 +2360,20 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
   let truncate_to_word32 env =
     let set_a, get_a = new_local env "a" in
     set_a ^^ get_a ^^
-    BitTagged.if_unboxed env [I32Type]
+    BitTagged.if_tagged_scalar env [I32Type]
       (get_a ^^ extend ^^ compile_unboxed_one ^^ G.i (Binary (Wasm.Values.I32 I32Op.ShrS)))
       (get_a ^^ Num.truncate_to_word32 env)
 
   let to_word64 env =
     let set_a, get_a = new_local env "a" in
     set_a ^^ get_a ^^
-    BitTagged.if_unboxed env [I64Type]
+    BitTagged.if_tagged_scalar env [I64Type]
       (get_a ^^ extend64 ^^ compile_shrS64_const 1L)
       (get_a ^^ Num.to_word64 env)
   let to_word32 env =
     let set_a, get_a = new_local env "a" in
     set_a ^^ get_a ^^
-    BitTagged.if_unboxed env [I32Type]
+    BitTagged.if_tagged_scalar env [I32Type]
       (get_a ^^ extend ^^ compile_unboxed_one ^^ G.i (Binary (Wasm.Values.I32 I32Op.ShrS)))
       (get_a ^^ Num.to_word32 env)
   let to_word32_with env =
@@ -2385,7 +2381,7 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
     let set_err_msg, get_err_msg = new_local env "err_msg" in
     set_err_msg ^^ set_a ^^
     get_a ^^
-    BitTagged.if_unboxed env [I32Type]
+    BitTagged.if_tagged_scalar env [I32Type]
       (get_a ^^ extend ^^ compile_unboxed_one ^^ G.i (Binary (Wasm.Values.I32 I32Op.ShrS)))
       (get_a ^^ get_err_msg ^^ Num.to_word32_with env)
 end
@@ -2530,7 +2526,7 @@ module Prim = struct
   let prim_intToWord32 env = BigNum.truncate_to_word32 env
   let prim_shiftToWordN env b =
     prim_intToWord32 env ^^
-    UnboxedSmallWord.shift_leftWordNtoI32 b
+    TaggedSmallWord.shift_leftWordNtoI32 b
 end (* Prim *)
 
 module Object = struct
@@ -2868,7 +2864,7 @@ module Blob = struct
     E.call_import env "rts" "blob_iter_done"
   let iter_next env =
     E.call_import env "rts" "blob_iter_next" ^^
-    UnboxedSmallWord.msb_adjust Type.Word8
+    TaggedSmallWord.msb_adjust Type.Word8
 
   let dyn_alloc_scratch env = alloc env ^^ payload_ptr_unskewed
 
@@ -2902,7 +2898,7 @@ module Text = struct
   let len env =
     E.call_import env "rts" "text_len" ^^ BigNum.from_word32 env
   let prim_showChar env =
-    UnboxedSmallWord.unbox_codepoint ^^
+    TaggedSmallWord.untag_codepoint ^^
     E.call_import env "rts" "text_singleton"
   let to_blob env = E.call_import env "rts" "blob_of_text"
   let iter env =
@@ -2911,7 +2907,7 @@ module Text = struct
     E.call_import env "rts" "text_iter_done"
   let iter_next env =
     E.call_import env "rts" "text_iter_next" ^^
-    UnboxedSmallWord.box_codepoint
+    TaggedSmallWord.tag_codepoint
 
   let compare env op =
     let open Operator in
@@ -4175,17 +4171,17 @@ module Serialization = struct
         compile_unboxed_const 4l ^^ advance_data_buf
       | Prim Char ->
         get_data_buf ^^
-        get_x ^^ UnboxedSmallWord.unbox_codepoint ^^
+        get_x ^^ TaggedSmallWord.untag_codepoint ^^
         G.i (Store {ty = I32Type; align = 0; offset = 0l; sz = None}) ^^
         compile_unboxed_const 4l ^^ advance_data_buf
       | Prim (Int16|Nat16|Word16) ->
         get_data_buf ^^
-        get_x ^^ UnboxedSmallWord.lsb_adjust Word16 ^^
+        get_x ^^ TaggedSmallWord.lsb_adjust Word16 ^^
         G.i (Store {ty = I32Type; align = 0; offset = 0l; sz = Some Wasm.Types.Pack16}) ^^
         compile_unboxed_const 2l ^^ advance_data_buf
       | Prim (Int8|Nat8|Word8) ->
         get_data_buf ^^
-        get_x ^^ UnboxedSmallWord.lsb_adjust Word8 ^^
+        get_x ^^ TaggedSmallWord.lsb_adjust Word8 ^^
         G.i (Store {ty = I32Type; align = 0; offset = 0l; sz = Some Wasm.Types.Pack8}) ^^
         compile_unboxed_const 1l ^^ advance_data_buf
       | Prim Bool ->
@@ -4492,15 +4488,15 @@ module Serialization = struct
         let set_n, get_n = new_local env "len" in
         assert_prim_typ t ^^
         ReadBuf.read_word32 env get_data_buf ^^ set_n ^^
-        UnboxedSmallWord.check_and_box_codepoint env get_n
+        TaggedSmallWord.check_and_tag_codepoint env get_n
       | Prim (Int16|Nat16|Word16) ->
         assert_prim_typ t ^^
         ReadBuf.read_word16 env get_data_buf ^^
-        UnboxedSmallWord.msb_adjust Word16
+        TaggedSmallWord.msb_adjust Word16
       | Prim (Int8|Nat8|Word8) ->
         assert_prim_typ t ^^
         ReadBuf.read_byte env get_data_buf ^^
-        UnboxedSmallWord.msb_adjust Word8
+        TaggedSmallWord.msb_adjust Word8
       | Prim Bool ->
         assert_prim_typ t ^^
         ReadBuf.read_byte env get_data_buf
@@ -5036,7 +5032,7 @@ module GC = struct
 
     (* If this is an unboxed scalar, ignore it *)
     get_obj ^^
-    BitTagged.if_unboxed env [] (get_end_to_space ^^ G.i Return) G.nop ^^
+    BitTagged.if_tagged_scalar env [] (get_end_to_space ^^ G.i Return) G.nop ^^
 
     let update_ptr new_val_code =
       get_ptr_loc ^^ new_val_code ^^ store_ptr in
@@ -6057,10 +6053,10 @@ let const_lit_of_lit : Ir.lit -> Const.lit = function
   | Word16Lit n   -> Const.Vanilla (Value.Word16.to_bits n)
   | Word32Lit n   -> Const.Word32 n
   | Word64Lit n   -> Const.Word64 n
-  | Int8Lit n     -> Const.Vanilla (UnboxedSmallWord.vanilla_lit Type.Int8 (Value.Int_8.to_int n))
-  | Nat8Lit n     -> Const.Vanilla (UnboxedSmallWord.vanilla_lit Type.Nat8 (Value.Nat8.to_int n))
-  | Int16Lit n    -> Const.Vanilla (UnboxedSmallWord.vanilla_lit Type.Int16 (Value.Int_16.to_int n))
-  | Nat16Lit n    -> Const.Vanilla (UnboxedSmallWord.vanilla_lit Type.Nat16 (Value.Nat16.to_int n))
+  | Int8Lit n     -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Int8 (Value.Int_8.to_int n))
+  | Nat8Lit n     -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Nat8 (Value.Nat8.to_int n))
+  | Int16Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Int16 (Value.Int_16.to_int n))
+  | Nat16Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Nat16 (Value.Nat16.to_int n))
   | Int32Lit n    -> Const.Word32 (Int32.of_int (Value.Int_32.to_int n))
   | Nat32Lit n    -> Const.Word32 (Int32.of_int (Value.Nat32.to_int n))
   | Int64Lit n    -> Const.Word64 (Big_int.int64_of_big_int (Value.Int_64.to_big_int n))
@@ -6142,7 +6138,7 @@ let compile_unop env t op =
      G.i (Binary (Wasm.Values.I64 I64Op.Xor))
   | NotOp, Type.(Prim (Word8 | Word16 | Word32 as ty)) ->
      StackRep.of_type t, StackRep.of_type t,
-     compile_unboxed_const (UnboxedSmallWord.mask_of_type ty) ^^
+     compile_unboxed_const (TaggedSmallWord.mask_of_type ty) ^^
      G.i (Binary (Wasm.Values.I32 I32Op.Xor))
   | _ ->
     todo "compile_unop" (Arrange_ops.unop op)
@@ -6213,7 +6209,7 @@ let powInt64_shortcut fast env get_a get_b slow =
 
 (* kernel for Int64 arithmetic, invokes estimator for fast path *)
 let compile_Int64_kernel env name op shortcut =
-  Func.share_code2 env (UnboxedSmallWord.name_of_type Type.Int64 name)
+  Func.share_code2 env (prim_fun_name Type.Int64 name)
     (("a", I64Type), ("b", I64Type)) [I64Type]
     BigNum.(fun env get_a get_b ->
     shortcut
@@ -6273,7 +6269,7 @@ let powNat64_shortcut fast env get_a get_b slow =
 
 (* kernel for Nat64 arithmetic, invokes estimator for fast path *)
 let compile_Nat64_kernel env name op shortcut =
-  Func.share_code2 env (UnboxedSmallWord.name_of_type Type.Nat64 name)
+  Func.share_code2 env (prim_fun_name Type.Nat64 name)
     (("a", I64Type), ("b", I64Type)) [I64Type]
     BigNum.(fun env get_a get_b ->
     shortcut
@@ -6307,7 +6303,7 @@ let enforce_32_signed_bits env =
   enforce_32_unsigned_bits env
 
 let compile_Int32_kernel env name op =
-     Func.share_code2 env (UnboxedSmallWord.name_of_type Type.Int32 name)
+     Func.share_code2 env (prim_fun_name Type.Int32 name)
        (("a", I32Type), ("b", I32Type)) [I32Type]
        (fun env get_a get_b ->
          let (set_res, get_res) = new_local64 env "res" in
@@ -6319,7 +6315,7 @@ let compile_Int32_kernel env name op =
          get_res ^^ G.i (Convert (Wasm.Values.I32 I32Op.WrapI64)))
 
 let compile_Nat32_kernel env name op =
-     Func.share_code2 env (UnboxedSmallWord.name_of_type Type.Nat32 name)
+     Func.share_code2 env (prim_fun_name Type.Nat32 name)
        (("a", I32Type), ("b", I32Type)) [I32Type]
        (fun env get_a get_b ->
          let (set_res, get_res) = new_local64 env "res" in
@@ -6347,7 +6343,7 @@ let enforce_signed_bits env n =
 let enforce_16_signed_bits env = enforce_signed_bits env 16
 
 let compile_smallInt_kernel' env ty name op =
-  Func.share_code2 env (UnboxedSmallWord.name_of_type ty name)
+  Func.share_code2 env (prim_fun_name ty name)
     (("a", I32Type), ("b", I32Type)) [I32Type]
     (fun env get_a get_b ->
       let (set_res, get_res) = new_local env "res" in
@@ -6362,7 +6358,7 @@ let compile_smallInt_kernel env ty name op =
   compile_smallInt_kernel' env ty name (G.i (Binary (Wasm.Values.I32 op)))
 
 let compile_smallNat_kernel' env ty name op =
-  Func.share_code2 env (UnboxedSmallWord.name_of_type ty name)
+  Func.share_code2 env (prim_fun_name ty name)
     (("a", I32Type), ("b", I32Type)) [I32Type]
     (fun env get_a get_b ->
       let (set_res, get_res) = new_local env "res" in
@@ -6433,7 +6429,7 @@ let compile_binop env t op =
   | Type.(Prim Nat32),                        SubOp -> compile_Nat32_kernel env "sub" I64Op.Sub
   | Type.(Prim (Nat8|Nat16 as ty)),           SubOp -> compile_smallNat_kernel env ty "sub" I32Op.Sub
   | Type.(Prim Float),                        SubOp -> G.i (Binary (Wasm.Values.F64 F64Op.Sub))
-  | Type.(Prim (Word8|Word16|Word32 as ty)),  MulOp -> UnboxedSmallWord.compile_word_mul env ty
+  | Type.(Prim (Word8|Word16|Word32 as ty)),  MulOp -> TaggedSmallWord.compile_word_mul env ty
   | Type.(Prim Int32),                        MulOp -> compile_Int32_kernel env "mul" I64Op.Mul
   | Type.(Prim Int16),                        MulOp -> compile_smallInt_kernel env Type.Int16 "mul" I32Op.Mul
   | Type.(Prim Int8),                         MulOp -> compile_smallInt_kernel' env Type.Int8 "mul"
@@ -6445,20 +6441,20 @@ let compile_binop env t op =
   | Type.(Prim Float),                        MulOp -> G.i (Binary (Wasm.Values.F64 F64Op.Mul))
   | Type.(Prim (Nat8|Nat16|Nat32|Word8|Word16|Word32 as ty)), DivOp ->
     G.i (Binary (Wasm.Values.I32 I32Op.DivU)) ^^
-    UnboxedSmallWord.msb_adjust ty
+    TaggedSmallWord.msb_adjust ty
   | Type.(Prim (Nat8|Nat16|Nat32|Word8|Word16|Word32)), ModOp -> G.i (Binary (Wasm.Values.I32 I32Op.RemU))
   | Type.(Prim Int32),                        DivOp -> G.i (Binary (Wasm.Values.I32 I32Op.DivS))
   | Type.(Prim (Int8|Int16 as ty)),           DivOp ->
-    Func.share_code2 env (UnboxedSmallWord.name_of_type ty "div")
+    Func.share_code2 env (prim_fun_name ty "div")
       (("a", I32Type), ("b", I32Type)) [I32Type]
       (fun env get_a get_b ->
         let (set_res, get_res) = new_local env "res" in
         get_a ^^ get_b ^^ G.i (Binary (Wasm.Values.I32 I32Op.DivS)) ^^
-        UnboxedSmallWord.msb_adjust ty ^^ set_res ^^
+        TaggedSmallWord.msb_adjust ty ^^ set_res ^^
         get_a ^^ compile_eq_const 0x80000000l ^^
         G.if_ (StackRep.to_block_type env SR.UnboxedWord32)
           begin
-            get_b ^^ UnboxedSmallWord.lsb_adjust ty ^^ compile_eq_const (-1l) ^^
+            get_b ^^ TaggedSmallWord.lsb_adjust ty ^^ compile_eq_const (-1l) ^^
             G.if_ (StackRep.to_block_type env SR.UnboxedWord32)
               (G.i Unreachable)
               get_res
@@ -6467,13 +6463,13 @@ let compile_binop env t op =
   | Type.(Prim Float),                        DivOp -> G.i (Binary (Wasm.Values.F64 F64Op.Div))
   | Type.(Prim Float),                        ModOp -> E.call_import env "rts" "float_rem"
   | Type.(Prim (Int8|Int16|Int32)),           ModOp -> G.i (Binary (Wasm.Values.I32 I32Op.RemS))
-  | Type.(Prim (Word8|Word16|Word32 as ty)),  PowOp -> UnboxedSmallWord.compile_word_power env ty
+  | Type.(Prim (Word8|Word16|Word32 as ty)),  PowOp -> TaggedSmallWord.compile_word_power env ty
   | Type.(Prim ((Nat8|Nat16) as ty)),         PowOp ->
-    Func.share_code2 env (UnboxedSmallWord.name_of_type ty "pow")
+    Func.share_code2 env (prim_fun_name ty "pow")
       (("n", I32Type), ("exp", I32Type)) [I32Type]
       (fun env get_n get_exp ->
         let (set_res, get_res) = new_local env "res" in
-        let bits = UnboxedSmallWord.bits_of_type ty in
+        let bits = TaggedSmallWord.bits_of_type ty in
         get_exp ^^
         G.if_ [I32Type]
           begin
@@ -6481,21 +6477,21 @@ let compile_binop env t op =
             G.if_ [I32Type]
               begin
                 unsigned_dynamics get_n ^^ compile_sub_const (Int32.of_int bits) ^^
-                get_exp ^^ UnboxedSmallWord.lsb_adjust ty ^^ G.i (Binary (Wasm.Values.I32 I32Op.Mul)) ^^
+                get_exp ^^ TaggedSmallWord.lsb_adjust ty ^^ G.i (Binary (Wasm.Values.I32 I32Op.Mul)) ^^
                 compile_unboxed_const (-30l) ^^
                 G.i (Compare (Wasm.Values.I32 I32Op.LtS)) ^^ then_arithmetic_overflow env ^^
-                get_n ^^ UnboxedSmallWord.lsb_adjust ty ^^
-                get_exp ^^ UnboxedSmallWord.lsb_adjust ty ^^
-                UnboxedSmallWord.compile_word_power env Type.Word32 ^^ set_res ^^
+                get_n ^^ TaggedSmallWord.lsb_adjust ty ^^
+                get_exp ^^ TaggedSmallWord.lsb_adjust ty ^^
+                TaggedSmallWord.compile_word_power env Type.Word32 ^^ set_res ^^
                 get_res ^^ enforce_unsigned_bits env bits ^^
-                get_res ^^ UnboxedSmallWord.msb_adjust ty
+                get_res ^^ TaggedSmallWord.msb_adjust ty
               end
               get_n (* n@{0,1} ** (1+exp) == n *)
           end
           (compile_unboxed_const
-             Int32.(shift_left one (to_int (UnboxedSmallWord.shift_of_type ty))))) (* x ** 0 == 1 *)
+             Int32.(shift_left one (to_int (TaggedSmallWord.shift_of_type ty))))) (* x ** 0 == 1 *)
   | Type.(Prim Nat32),                        PowOp ->
-    Func.share_code2 env (UnboxedSmallWord.name_of_type Type.Nat32 "pow")
+    Func.share_code2 env (prim_fun_name Type.Nat32 "pow")
       (("n", I32Type), ("exp", I32Type)) [I32Type]
       (fun env get_n get_exp ->
         let (set_res, get_res) = new_local64 env "res" in
@@ -6508,7 +6504,7 @@ let compile_binop env t op =
                 get_exp ^^ compile_unboxed_const 32l ^^
                 G.i (Compare (Wasm.Values.I32 I32Op.GeU)) ^^ then_arithmetic_overflow env ^^
                 unsigned_dynamics get_n ^^ compile_sub_const 32l ^^
-                get_exp ^^ UnboxedSmallWord.lsb_adjust Type.Nat32 ^^ G.i (Binary (Wasm.Values.I32 I32Op.Mul)) ^^
+                get_exp ^^ TaggedSmallWord.lsb_adjust Type.Nat32 ^^ G.i (Binary (Wasm.Values.I32 I32Op.Mul)) ^^
                 compile_unboxed_const (-62l) ^^
                 G.i (Compare (Wasm.Values.I32 I32Op.LtS)) ^^ then_arithmetic_overflow env ^^
                 get_n ^^ G.i (Convert (Wasm.Values.I64 I64Op.ExtendUI32)) ^^
@@ -6521,11 +6517,11 @@ let compile_binop env t op =
           end
           compile_unboxed_one) (* x ** 0 == 1 *)
   | Type.(Prim ((Int8|Int16) as ty)),         PowOp ->
-    Func.share_code2 env (UnboxedSmallWord.name_of_type ty "pow")
+    Func.share_code2 env (prim_fun_name ty "pow")
       (("n", I32Type), ("exp", I32Type)) [I32Type]
       (fun env get_n get_exp ->
         let (set_res, get_res) = new_local env "res" in
-        let bits = UnboxedSmallWord.bits_of_type ty in
+        let bits = TaggedSmallWord.bits_of_type ty in
         get_exp ^^ compile_unboxed_zero ^^
         G.i (Compare (Wasm.Values.I32 I32Op.LtS)) ^^ E.then_trap_with env "negative power" ^^
         get_exp ^^
@@ -6535,21 +6531,21 @@ let compile_binop env t op =
             G.if_ [I32Type]
               begin
                 signed_dynamics get_n ^^ compile_sub_const (Int32.of_int (bits - 1)) ^^
-                get_exp ^^ UnboxedSmallWord.lsb_adjust ty ^^ G.i (Binary (Wasm.Values.I32 I32Op.Mul)) ^^
+                get_exp ^^ TaggedSmallWord.lsb_adjust ty ^^ G.i (Binary (Wasm.Values.I32 I32Op.Mul)) ^^
                 compile_unboxed_const (-30l) ^^
                 G.i (Compare (Wasm.Values.I32 I32Op.LtS)) ^^ then_arithmetic_overflow env ^^
-                get_n ^^ UnboxedSmallWord.lsb_adjust ty ^^
-                get_exp ^^ UnboxedSmallWord.lsb_adjust ty ^^
-                UnboxedSmallWord.compile_word_power env Type.Word32 ^^
+                get_n ^^ TaggedSmallWord.lsb_adjust ty ^^
+                get_exp ^^ TaggedSmallWord.lsb_adjust ty ^^
+                TaggedSmallWord.compile_word_power env Type.Word32 ^^
                 set_res ^^ get_res ^^ get_res ^^ enforce_signed_bits env bits ^^
-                get_res ^^ UnboxedSmallWord.msb_adjust ty
+                get_res ^^ TaggedSmallWord.msb_adjust ty
               end
               get_n (* n@{0,1} ** (1+exp) == n *)
           end
           (compile_unboxed_const
-             Int32.(shift_left one (to_int (UnboxedSmallWord.shift_of_type ty))))) (* x ** 0 == 1 *)
+             Int32.(shift_left one (to_int (TaggedSmallWord.shift_of_type ty))))) (* x ** 0 == 1 *)
   | Type.(Prim Int32),                        PowOp ->
-    Func.share_code2 env (UnboxedSmallWord.name_of_type Type.Int32 "pow")
+    Func.share_code2 env (prim_fun_name Type.Int32 "pow")
       (("n", I32Type), ("exp", I32Type)) [I32Type]
       (fun env get_n get_exp ->
         let (set_res, get_res) = new_local64 env "res" in
@@ -6578,7 +6574,7 @@ let compile_binop env t op =
                 get_exp ^^ compile_unboxed_const 32l ^^
                 G.i (Compare (Wasm.Values.I32 I32Op.GeU)) ^^ then_arithmetic_overflow env ^^
                 signed_dynamics get_n ^^ compile_sub_const 31l ^^
-                get_exp ^^ UnboxedSmallWord.lsb_adjust Type.Int32 ^^ G.i (Binary (Wasm.Values.I32 I32Op.Mul)) ^^
+                get_exp ^^ TaggedSmallWord.lsb_adjust Type.Int32 ^^ G.i (Binary (Wasm.Values.I32 I32Op.Mul)) ^^
                 compile_unboxed_const (-62l) ^^
                 G.i (Compare (Wasm.Values.I32 I32Op.LtS)) ^^ then_arithmetic_overflow env ^^
                 get_n ^^ G.i (Convert (Wasm.Values.I64 I64Op.ExtendSI32)) ^^
@@ -6621,23 +6617,23 @@ let compile_binop env t op =
   | Type.(Prim Word64),                       XorOp -> G.i (Binary (Wasm.Values.I64 I64Op.Xor))
   | Type.Prim Type.(Word8 | Word16 | Word32), XorOp -> G.i (Binary (Wasm.Values.I32 I32Op.Xor))
   | Type.(Prim Word64),                       ShLOp -> G.i (Binary (Wasm.Values.I64 I64Op.Shl))
-  | Type.(Prim (Word8|Word16|Word32 as ty)),  ShLOp -> UnboxedSmallWord.(
+  | Type.(Prim (Word8|Word16|Word32 as ty)),  ShLOp -> TaggedSmallWord.(
      lsb_adjust ty ^^ clamp_shift_amount ty ^^
      G.i (Binary (Wasm.Values.I32 I32Op.Shl)))
   | Type.(Prim Word64),                       UShROp -> G.i (Binary (Wasm.Values.I64 I64Op.ShrU))
-  | Type.(Prim (Word8|Word16|Word32 as ty)),  UShROp -> UnboxedSmallWord.(
+  | Type.(Prim (Word8|Word16|Word32 as ty)),  UShROp -> TaggedSmallWord.(
      lsb_adjust ty ^^ clamp_shift_amount ty ^^
      G.i (Binary (Wasm.Values.I32 I32Op.ShrU)) ^^
      sanitize_word_result ty)
   | Type.(Prim Word64),                       SShROp -> G.i (Binary (Wasm.Values.I64 I64Op.ShrS))
-  | Type.(Prim (Word8|Word16|Word32 as ty)),  SShROp -> UnboxedSmallWord.(
+  | Type.(Prim (Word8|Word16|Word32 as ty)),  SShROp -> TaggedSmallWord.(
      lsb_adjust ty ^^ clamp_shift_amount ty ^^
      G.i (Binary (Wasm.Values.I32 I32Op.ShrS)) ^^
      sanitize_word_result ty)
   | Type.(Prim Word64),                       RotLOp -> G.i (Binary (Wasm.Values.I64 I64Op.Rotl))
   | Type.Prim Type.                  Word32,  RotLOp -> G.i (Binary (Wasm.Values.I32 I32Op.Rotl))
-  | Type.Prim Type.(Word8 | Word16 as ty),    RotLOp -> UnboxedSmallWord.(
-     Func.share_code2 env (name_of_type ty "rotl") (("n", I32Type), ("by", I32Type)) [I32Type]
+  | Type.Prim Type.(Word8 | Word16 as ty),    RotLOp -> TaggedSmallWord.(
+     Func.share_code2 env (prim_fun_name ty "rotl") (("n", I32Type), ("by", I32Type)) [I32Type]
        Wasm.Values.(fun env get_n get_by ->
       let beside_adjust = compile_shrU_const (Int32.sub 32l (shift_of_type ty)) in
       get_n ^^ get_n ^^ beside_adjust ^^ G.i (Binary (I32 I32Op.Or)) ^^
@@ -6645,8 +6641,8 @@ let compile_binop env t op =
       sanitize_word_result ty))
   | Type.(Prim Word64),                       RotROp -> G.i (Binary (Wasm.Values.I64 I64Op.Rotr))
   | Type.Prim Type.                  Word32,  RotROp -> G.i (Binary (Wasm.Values.I32 I32Op.Rotr))
-  | Type.Prim Type.(Word8 | Word16 as ty),    RotROp -> UnboxedSmallWord.(
-     Func.share_code2 env (name_of_type ty "rotr") (("n", I32Type), ("by", I32Type)) [I32Type]
+  | Type.Prim Type.(Word8 | Word16 as ty),    RotROp -> TaggedSmallWord.(
+     Func.share_code2 env (prim_fun_name ty "rotr") (("n", I32Type), ("by", I32Type)) [I32Type]
        Wasm.Values.(fun env get_n get_by ->
       get_n ^^ get_n ^^ lsb_adjust ty ^^ G.i (Binary (I32 I32Op.Or)) ^^
       get_by ^^ lsb_adjust ty ^^ clamp_shift_amount ty ^^ G.i (Binary (I32 I32Op.Rotr)) ^^
@@ -6870,7 +6866,7 @@ and compile_exp (env : E.t) ae exp =
       | (Nat|Int), (Word8|Word16) ->
         SR.Vanilla,
         compile_exp_vanilla env ae e ^^
-        Prim.prim_shiftToWordN env (UnboxedSmallWord.shift_of_type t2)
+        Prim.prim_shiftToWordN env (TaggedSmallWord.shift_of_type t2)
 
       | (Nat|Int), Word32 ->
         SR.UnboxedWord32,
@@ -6917,13 +6913,13 @@ and compile_exp (env : E.t) ae exp =
         StackRep.of_type ty,
         let pty = prim_of_typ ty in
         compile_exp_vanilla env ae e ^^
-        Func.share_code1 env (UnboxedSmallWord.name_of_type pty "Int->") ("n", I32Type) [I32Type] (fun env get_n ->
+        Func.share_code1 env (prim_fun_name pty "Int->") ("n", I32Type) [I32Type] (fun env get_n ->
           get_n ^^
-          BigNum.fits_signed_bits env (UnboxedSmallWord.bits_of_type pty) ^^
+          BigNum.fits_signed_bits env (TaggedSmallWord.bits_of_type pty) ^^
           E.else_trap_with env "losing precision" ^^
           get_n ^^
           BigNum.truncate_to_word32 env ^^
-          UnboxedSmallWord.msb_adjust pty)
+          TaggedSmallWord.msb_adjust pty)
 
       | Nat, Nat64 ->
         SR.UnboxedWord64,
@@ -6940,28 +6936,28 @@ and compile_exp (env : E.t) ae exp =
         StackRep.of_type ty,
         let pty = prim_of_typ ty in
         compile_exp_vanilla env ae e ^^
-        Func.share_code1 env (UnboxedSmallWord.name_of_type pty "Nat->") ("n", I32Type) [I32Type] (fun env get_n ->
+        Func.share_code1 env (prim_fun_name pty "Nat->") ("n", I32Type) [I32Type] (fun env get_n ->
           get_n ^^
-          BigNum.fits_unsigned_bits env (UnboxedSmallWord.bits_of_type pty) ^^
+          BigNum.fits_unsigned_bits env (TaggedSmallWord.bits_of_type pty) ^^
           E.else_trap_with env "losing precision" ^^
           get_n ^^
           BigNum.truncate_to_word32 env ^^
-          UnboxedSmallWord.msb_adjust pty)
+          TaggedSmallWord.msb_adjust pty)
 
       | Char, Word32 ->
         SR.UnboxedWord32,
         compile_exp_vanilla env ae e ^^
-        UnboxedSmallWord.unbox_codepoint
+        TaggedSmallWord.untag_codepoint
 
       | (Nat8|Word8|Nat16|Word16), Nat ->
         SR.Vanilla,
         compile_exp_vanilla env ae e ^^
-        Prim.prim_shiftWordNtoUnsigned env (UnboxedSmallWord.shift_of_type t1)
+        Prim.prim_shiftWordNtoUnsigned env (TaggedSmallWord.shift_of_type t1)
 
       | (Int8|Word8|Int16|Word16), Int ->
         SR.Vanilla,
         compile_exp_vanilla env ae e ^^
-        Prim.prim_shiftWordNtoSigned env (UnboxedSmallWord.shift_of_type t1)
+        Prim.prim_shiftWordNtoSigned env (TaggedSmallWord.shift_of_type t1)
 
       | (Nat32|Word32), Nat ->
         SR.Vanilla,
@@ -6987,7 +6983,7 @@ and compile_exp (env : E.t) ae exp =
         SR.Vanilla,
         compile_exp_as env ae SR.UnboxedWord32 e ^^
         Func.share_code1 env "Word32->Char" ("n", I32Type) [I32Type]
-        UnboxedSmallWord.check_and_box_codepoint
+        TaggedSmallWord.check_and_tag_codepoint
 
       | Float, Int64 ->
         SR.UnboxedWord64,
@@ -7178,12 +7174,12 @@ and compile_exp (env : E.t) ae exp =
       SR.Vanilla,
       compile_exp_vanilla env ae e ^^
       G.i (Unary (Wasm.Values.I32 I32Op.Popcnt)) ^^
-      UnboxedSmallWord.msb_adjust Type.Word8
+      TaggedSmallWord.msb_adjust Type.Word8
     | OtherPrim "popcnt16", [e] ->
       SR.Vanilla,
       compile_exp_vanilla env ae e ^^
       G.i (Unary (Wasm.Values.I32 I32Op.Popcnt)) ^^
-      UnboxedSmallWord.msb_adjust Type.Word16
+      TaggedSmallWord.msb_adjust Type.Word16
     | OtherPrim "popcnt32", [e] ->
       SR.UnboxedWord32,
       compile_exp_as env ae SR.UnboxedWord32 e ^^
@@ -7192,12 +7188,12 @@ and compile_exp (env : E.t) ae exp =
       SR.UnboxedWord64,
       compile_exp_as env ae SR.UnboxedWord64 e ^^
       G.i (Unary (Wasm.Values.I64 I64Op.Popcnt))
-    | OtherPrim "clz8", [e] -> SR.Vanilla, compile_exp_vanilla env ae e ^^ UnboxedSmallWord.clz_kernel Type.Word8
-    | OtherPrim "clz16", [e] -> SR.Vanilla, compile_exp_vanilla env ae e ^^ UnboxedSmallWord.clz_kernel Type.Word16
+    | OtherPrim "clz8", [e] -> SR.Vanilla, compile_exp_vanilla env ae e ^^ TaggedSmallWord.clz_kernel Type.Word8
+    | OtherPrim "clz16", [e] -> SR.Vanilla, compile_exp_vanilla env ae e ^^ TaggedSmallWord.clz_kernel Type.Word16
     | OtherPrim "clz32", [e] -> SR.UnboxedWord32, compile_exp_as env ae SR.UnboxedWord32 e ^^ G.i (Unary (Wasm.Values.I32 I32Op.Clz))
     | OtherPrim "clz64", [e] -> SR.UnboxedWord64, compile_exp_as env ae SR.UnboxedWord64 e ^^ G.i (Unary (Wasm.Values.I64 I64Op.Clz))
-    | OtherPrim "ctz8", [e] -> SR.Vanilla, compile_exp_vanilla env ae e ^^ UnboxedSmallWord.ctz_kernel Type.Word8
-    | OtherPrim "ctz16", [e] -> SR.Vanilla, compile_exp_vanilla env ae e ^^ UnboxedSmallWord.ctz_kernel Type.Word16
+    | OtherPrim "ctz8", [e] -> SR.Vanilla, compile_exp_vanilla env ae e ^^ TaggedSmallWord.ctz_kernel Type.Word8
+    | OtherPrim "ctz16", [e] -> SR.Vanilla, compile_exp_vanilla env ae e ^^ TaggedSmallWord.ctz_kernel Type.Word16
     | OtherPrim "ctz32", [e] -> SR.UnboxedWord32, compile_exp_as env ae SR.UnboxedWord32 e ^^ G.i (Unary (Wasm.Values.I32 I32Op.Ctz))
     | OtherPrim "ctz64", [e] -> SR.UnboxedWord64, compile_exp_as env ae SR.UnboxedWord64 e ^^ G.i (Unary (Wasm.Values.I64 I64Op.Ctz))
 
@@ -7217,11 +7213,11 @@ and compile_exp (env : E.t) ae exp =
     | OtherPrim "Array.tabulate", [_;_] ->
       const_sr SR.Vanilla (Arr.tabulate env)
     | OtherPrim "btst8", [_;_] ->
-      const_sr SR.Vanilla (UnboxedSmallWord.btst_kernel env Type.Word8)
+      const_sr SR.Vanilla (TaggedSmallWord.btst_kernel env Type.Word8)
     | OtherPrim "btst16", [_;_] ->
-      const_sr SR.Vanilla (UnboxedSmallWord.btst_kernel env Type.Word16)
+      const_sr SR.Vanilla (TaggedSmallWord.btst_kernel env Type.Word16)
     | OtherPrim "btst32", [_;_] ->
-      const_sr SR.UnboxedWord32 (UnboxedSmallWord.btst_kernel env Type.Word32)
+      const_sr SR.UnboxedWord32 (TaggedSmallWord.btst_kernel env Type.Word32)
     | OtherPrim "btst64", [_;_] ->
       const_sr SR.UnboxedWord64 (
         let (set_b, get_b) = new_local64 env "b" in


### PR DESCRIPTION
for example, small words are never boxed (they are not heap allocated),
merely tagged.

Also `UnboxedSmallWord.name_of_type` was used for types other than small
words, so I moved it out of that module.