### PR TITLE
Update niv-updater-action to v6

### DIFF
--- a/.github/workflows/niv-updater-rare.yml
+++ b/.github/workflows/niv-updater-rare.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@v5
+        uses: knl/niv-updater-action@v6
         with:
           # might be too noisy
           whitelist: 'nixpkgs,dfinity,ic-ref,musl-wasi'

--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@v5
+        uses: knl/niv-updater-action@v6
         with:
           # might be too noisy
           blacklist: 'nixpkgs,dfinity,ic-ref,musl-wasi'


### PR DESCRIPTION
Various fixes in the output, to make it more correct, and avoid spamming
of GitHub histories. Should be faster, too.

This release brings the following:

Formatting:
* Fix: Add an empty line after the title. Now GitHub Commits list looks
  better.
* Fix: Remove preceeding space in the title
* Output branch name used by niv, so that it is clear what is being
  tracked
* Add a title prefix support via `title_prefix` option

Being nice:
* Reformat mentions in the changelog to reduce spamming of mentioned
  developers (now, @knl will not generate a GitHub notification when
  present in the changelog)
* Add option to avoid GitHub backreferencing the PR. That is, when we
  have #123 in the changelog, it will be a correct link to the correct
  repository, however, the referenced PR/issue will not contain a
  reference, thus reducing the spamming. See
  https://github.com/knl/niv-updater-action/issues/26 for more details.
* Make the location of `sources.json` customizable

Performance:
* Replace the use of jo with jq, thus avoiding to install jo
* Do not install hub CLI, as it is present in the default image. This
  should avoid installing hub, speeding up the start.