### PR TITLE
Remove redundant parens/braces from Prelude

### DIFF
--- a/src/prelude/prelude.ml
+++ b/src/prelude/prelude.ml
@@ -520,7 +520,7 @@ type ErrorCode = {
 };
 
 // creation and inspection of abstract error
-func error(message : Text) : Error = {
+func error(message : Text) : Error {
   let e = (#canister_reject, message);
   (prim "cast" : (ErrorCode, Text) -> Error) e
 };


### PR DESCRIPTION
Often the function only invokes a specific primitive. No need for enclosing blocks in these cases.
Also, when we already need a block, then the `=` is not needed.