### PR TITLE
Backend: Move allocate-on-use logic into lib

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -666,7 +666,7 @@ module Func = struct
     , E.get_local_names env1)
 
   let define_built_in env name params retty mk_body =
-    E.define_built_in env name (fun () -> of_body env params retty mk_body)
+    E.define_built_in env name (lazy (of_body env params retty mk_body))
 
   (* (Almost) transparently lift code into a function and call this function. *)
   (* Also add a hack to support multiple return values *)

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -101,7 +101,7 @@ sig
   type ('a, 'b) t
   val make : (unit -> ('a * ('b -> unit))) -> ('a, 'b) t
   val use : ('a, 'b) t -> 'a
-  val def : ('a, 'b) t -> (unit -> 'b) -> unit
+  val def : ('a, 'b) t -> ('b Lazy.t) -> unit
 end
 
 module Int :


### PR DESCRIPTION
this is a pure refactoring that moves the alloc-on-use logic that we
already use for built in (RTS-internal) functions into a dedicated
`Lib` module. After this refactoring, #1752 should look nicer and easier
to review.

This also introduces `named_imports`, to no longer track keep track of
imported functions together with built-in functions.