### PR TITLE
INF-1395: Update common

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -70,7 +70,8 @@ let commonBuildInputs = pkgs:
   ]; in
 
 let darwin_standalone =
-  let common = import nixpkgs.sources.common { inherit (nixpkgs) system; }; in
+  let common = import (nixpkgs.sources.common + "/pkgs")
+    { inherit (nixpkgs) system; repoRoot = ./.; }; in
   common.lib.standaloneRust; in
 
 let ocaml_exe = name: bin:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -2,7 +2,7 @@
     "common": {
         "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "4834d255f106f3f1d68907fc76be1b83d9b47d1c",
+        "rev": "0f0751e4dad2155109bc3961e8e232257bf87ece",
         "type": "git"
     },
     "dfinity": {


### PR DESCRIPTION
This updates `common` and the way it is imported (only the subpath
`pkgs/` should now be imported).