### PR TITLE
make -C src shouldonly build native targets, not .js

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,9 @@ DESER_TARGET = _build/default/exes/deser.exe
 
 DUNE_OPTS ?=
 
-ALL_TARGETS = $(MO_IDE_TARGET) $(MO_LD_TARGET) $(MO_DOC_TARGET) $(MOC_TARGET) $(MOC_JS_TARGET) $(DIDC_TARGET) $(DESER_TARGET) $(DIDC_JS_TARGET)
+NATIVE_TARGETS = $(MO_IDE_TARGET) $(MO_LD_TARGET) $(MO_DOC_TARGET) $(MOC_TARGET) $(DIDC_TARGET) $(DESER_TARGET)
+JS_TARGETS = $(MOC_JS_TARGET) $(DIDC_JS_TARGET)
+ALL_TARGETS = $(NATIVE_TARGETS) $(JS_TARGETS)
 
 .PHONY: all clean moc mo-doc mo-ide mo-ld moc.js didc deser unit-tests didc.js
 
@@ -23,15 +25,13 @@ SOURCE_ID = source_id/source_id.ml
 # This targets is spelled out so that `make`
 # only invokes `dune` once, much faster
 all: $(SOURCE_ID) grammar
-	dune build $(DUNE_OPTS) $(ALL_TARGETS)
+	dune build $(DUNE_OPTS) $(NATIVE_TARGETS)
 	@ln -fs $(MOC_TARGET) moc
 	@ln -fs $(MO_IDE_TARGET) mo-ide
 	@ln -fs $(MO_DOC_TARGET) mo-doc
 	@ln -fs $(MO_LD_TARGET) mo-ld
-	@ln -fs $(MOC_JS_TARGET) moc.js
 	@ln -fs $(DIDC_TARGET) didc
 	@ln -fs $(DESER_TARGET) deser
-	@ln -fs $(DIDC_JS_TARGET) didc.js
 
 moc: $(SOURCE_ID)
 	dune build $(DUNE_OPTS) $(MOC_TARGET)


### PR DESCRIPTION
as these are slow to build and usually not needed in local development.
CI still builds these targets.

Fixes #1798