### PR TITLE
test/compare*.sh: Use the nix cache as normal

### DIFF
--- a/test/compare-perf.sh
+++ b/test/compare-perf.sh
@@ -27,7 +27,6 @@ function build_ref_to {
   then
     echo "Building $2 moc from working copy.."
     chronic nix-build -E '((import ./..) {}).tests.perf' \
-      --option binary-caches '' \
       -o $2-perf
   else
     echo "Building $2 moc (rev $1).."
@@ -41,7 +40,6 @@ function build_ref_to {
       let checkout = (builtins.fetchGit {url = path; ref = ref; rev = rev;}).outPath; in
       builtins.trace checkout (
       ((import checkout) {}).tests.perf)' \
-      --option binary-caches '' \
       -o $2-perf
   fi
   test -e $2-perf || exit 1

--- a/test/compare-wat.sh
+++ b/test/compare-wat.sh
@@ -29,7 +29,6 @@ function build_ref_to {
   then
     echo "Building $2 moc from working copy.."
     chronic nix-build -E '((import ./..) {}).moc' \
-      --option binary-caches '' \
       -o $2-moc/
   else
     echo "Building $2 moc (rev $1).."
@@ -43,7 +42,6 @@ function build_ref_to {
       let checkout = (builtins.fetchGit {url = path; ref = ref; rev = rev;}).outPath; in
       builtins.trace checkout (
       ((import checkout) {}).moc)' \
-      --option binary-caches '' \
       -o $2-moc/
   fi
   test -x $2-moc/bin/moc || exit 1


### PR DESCRIPTION
seems to be the better default.