### PR TITLE
Make print_ptr an exported function

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3138,8 +3138,6 @@ module Dfinity = struct
 
   let register env =
 
-      let print_ptr_fn = E.built_in env "print_ptr" in
-
       Func.define_built_in env "print_ptr" [("ptr", I32Type); ("len", I32Type)] [] (fun env ->
         match E.mode env with
         | Flags.WasmMode -> G.i Nop
@@ -3194,7 +3192,7 @@ module Dfinity = struct
 
       E.add_export env (nr {
         name = Wasm.Utf8.decode "print_ptr";
-        edesc = nr (FuncExport (nr print_ptr_fn))
+        edesc = nr (FuncExport (nr (E.built_in env "print_ptr")))
       })
 
   let print_ptr_len env = G.i (Call (nr (E.built_in env "print_ptr")))


### PR DESCRIPTION
This makes it possible to call print_pts from the RTS. Without an
exported print_ptr we need different RTS builds for WASI and IC to be
able to implement printers. With print_ptr we can just us it in the RTS
and the compiler would pick the implementation that works for the target
platform (WASI or IC).