### PR TITLE
Add variable for the SDK name to the language sections

### DIFF
--- a/doc/modules/language-guide/pages/compiler-ref.adoc
+++ b/doc/modules/language-guide/pages/compiler-ref.adoc
@@ -1,5 +1,6 @@
 = Compiler reference
 :proglang: Motoko
+:sdk-short-name: DFINITY Canister SDK
 :company-id: DFINITY
 
 The Motoko compiler (`+moc+`) is the primary tool for compiling Motoko programs into executable WebAssembly (Wasm) modules. 

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -1,6 +1,7 @@
 = Language quick reference
 :proglang: Motoko
 :candid: Candid
+:sdk-short-name: DFINITY Canister SDK
 :company-id: DFINITY
 ////
 * targetting release 0.5.4


### PR DESCRIPTION
Add the missing variable to a couple of language guide section to eliminate a warning during doc builds.