### PR TITLE
Bump ic-ref to release-0.10

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -20,9 +20,9 @@
         "version": "3.2.25"
     },
     "ic-ref": {
-        "ref": "release-0.9",
+        "ref": "release-0.10",
         "repo": "ssh://git@github.com/dfinity-lab/ic-ref",
-        "rev": "61f6a8699dad9cc081abf5eb145cf4498b698644",
+        "rev": "ab1c15531b3e3e88018cea40f8a23000751e699f",
         "type": "git"
     },
     "libtommath": {

--- a/src/prelude/prelude.ml
+++ b/src/prelude/prelude.ml
@@ -361,6 +361,7 @@ let @ic00 = actor "aaaaa-aa" : actor {
     wasm_module : Blob;
     arg : Blob;
     compute_allocation : ?Nat;
+    memory_allocation : ?Nat;
   } -> async ()
 };
 
@@ -373,7 +374,8 @@ func @create_actor_helper(wasm_module_ : Blob, arg_ : Blob) : async Principal = 
     canister_id = canister_id_;
     wasm_module = wasm_module_;
     arg = arg_;
-    compute_allocation = null
+    compute_allocation = null;
+    memory_allocation = null;
   });
   return canister_id_;
 };


### PR DESCRIPTION
which means we have to pass `memory_allocation` to the management canister.