### PR TITLE
Bump ic-ref

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -22,7 +22,7 @@
     "ic-ref": {
         "ref": "release-0.11",
         "repo": "ssh://git@github.com/dfinity-lab/ic-ref",
-        "rev": "ebd6b2a31aa37aa159e50c6c3d944b2ca0a68a09",
+        "rev": "ad6ea9e56295342e3eb4cdd8c46e2b27796cb2a1",
         "type": "git"
     },
     "libtommath": {

--- a/test/run.sh
+++ b/test/run.sh
@@ -82,7 +82,10 @@ function normalize () {
     sed 's/source location: @[a-f0-9]*/source location: @___:/g' |
     sed 's/Ignore Diff:.*/Ignore Diff: (ignored)/ig' |
     sed 's/compiler (revision .*)/compiler (revision XXX)/ig' |
+    # Normalize canister id prefixes in debug prints, added by dfinity 67e9c11
     sed 's/\[Canister [0-9a-z\-]*\]/debug.print:/g' |
+    # Normalize instruction locations on traps, added by ic-ref ad6ea9e
+    sed 's/region:0x[0-9a-fA-F]\+-0x[0-9a-fA-F]\+/:0.1/g' |
     cat > $1.norm
     mv $1.norm $1
   fi


### PR DESCRIPTION
New version shows trapping instruction locations. A sed line added to
run.sh to remove locations from the compared outputs.

Adding error locations to error messages requires keeping location
information around in the interpreter (winter) so it makes things
slightly slower (probably because of increased residency causing
loger/more GCs in winter). Output from running the entire test suite:

    $ /usr/bin/time make
    300.21user 37.07system 3:58.65elapsed 141%CPU (0avgtext+0avgdata 2356160maxresident)k
    21744inputs+475528outputs (32major+28004283minor)pagefaults 0swaps

After:

    304.06user 38.25system 4:01.24elapsed 141%CPU (0avgtext+0avgdata 2355648maxresident)k
    0inputs+475528outputs (0major+28387118minor)pagefaults 0swaps

It's 3s longer (1.2%).