### PR TITLE
Correct moc reference in run.sh

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -409,7 +409,7 @@ do
         fi
 
         flags_var_name="FLAGS_${runner//-/_}"
-        run $mo_base.$runner.comp moc ${!flags_var_name} --hide-warnings -c $mo_file -o $out/$base/$mo_base.$runner.wasm
+        run $mo_base.$runner.comp $moc ${!flags_var_name} --hide-warnings -c $mo_file -o $out/$base/$mo_base.$runner.wasm
       done
 
       # mangle drun script


### PR DESCRIPTION
I believe it should be `$moc`, not `moc`, otherwise we'll test the one coming from `nix`, not the just built one.