### PR TITLE
Moc command line arguments: read command line arguments from file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 = Motoko compiler changelog
 
+* new `moc` command-line arguments `--args <file>` and `--args0 <file>` for reading newline/NUL terminated arguments from `<file>`.
+
 == 0.5.4 (2021-01-07)
 
 * _Option blocks_ `do ? <block>` and _option checks_ `<exp> !`.

--- a/doc/modules/language-guide/pages/compiler-ref.adoc
+++ b/doc/modules/language-guide/pages/compiler-ref.adoc
@@ -32,6 +32,10 @@ You can use the following options with the `+moc+` command.
 
 |`+--actor-alias+` |Specifies an actor import alias.
 
+|`+--args <file>+` |Read additional newline separated command line arguments from <file>
+
+|`+--args0 <file>+` |Read additional NUL separated command line arguments from <file>
+
 |`+-c+` |Compiles programs to WebAssembly.
 
 |`+--check+` |Performs type checking only.

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -95,8 +95,10 @@ let argspec = Arg.align [
   "--sanity-checks",
   Arg.Unit
     (fun () -> Flags.sanity := true),
-    " enable sanity checking in the RTS and generated code";
-]
+  " enable sanity checking in the RTS and generated code";
+    ]
+  @  Args.inclusion_args
+
 
 
 let set_out_file files ext =
@@ -176,7 +178,7 @@ let () =
   (useful for debugging infinite loops)
   *)
   Printexc.record_backtrace true;
-  Arg.parse argspec add_arg usage;
+  Arg.parse_expand argspec add_arg usage;
   if !mode = Default then mode := (if !args = [] then Interact else Compile);
   Flags.compiled := (!mode = Compile || !mode = Idl);
   process_profiler_flags ();

--- a/src/mo_config/args.ml
+++ b/src/mo_config/args.ml
@@ -26,3 +26,13 @@ let error_args = [
   "--error-detail", Arg.Set_int Flags.error_detail, " set error message detail for syntax errors"
   (* TODO move --hide-warnings here? *)
   ]
+
+let inclusion_args = [
+    (* generic arg inclusion from file *)
+  "--args", Arg.Expand Arg.read_arg,
+    "<file> Read additional newline separated command line arguments \n\
+    \      from <file>";
+  "--args0", Arg.Expand Arg.read_arg0,
+    "<file> Read additional NUL separated command line arguments from \n\
+    \      <file>"
+  ]

--- a/src/mo_config/args.mli
+++ b/src/mo_config/args.mli
@@ -1,2 +1,3 @@
 val error_args : (Arg.key * Arg.spec * Arg.doc) list
 val package_args : (Arg.key * Arg.spec * Arg.doc) list
+val inclusion_args : (Arg.key * Arg.spec * Arg.doc) list


### PR DESCRIPTION
Add two command lines arguments to moc (only):

```
  --args <file> Read additional newline separated command line arguments 
      from <file>
  --args0 <file> Read additional NUL separated command line arguments from 
      <file>
```
Adapted from similar ocaml arguments, `-args` and `-args0`

As requested by @luc-mercier 