### PR TITLE
Bug fix: fix unit representation to be scalar 0, not pointer 2

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3019,7 +3019,7 @@ module Tuple = struct
 
   (* We represent the boxed empty tuple as the unboxed scalar 0, i.e. simply as
      number (but really anything is fine, we never look at this) *)
-  let unit_vanilla_lit = 1l
+  let unit_vanilla_lit = 0l
   let compile_unit = compile_unboxed_const unit_vanilla_lit
 
   (* Expects on the stack the pointer to the array. *)


### PR DESCRIPTION
We claim to represent the unit value by scalar 0 in comments, but actually used pointer 2, due to a change in the tagging scheme.

Probably benign, but worth fixing.

(Found by decoding heap in browser-debug.js.)
