### PR TITLE
Bump rustc version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,8 +20,8 @@ let haskellPackages = nixpkgs.haskellPackages.override {
     }; in
 let
   rtsBuildInputs = with nixpkgs; [
-    clang_10 # for native/wasm building
-    lld_10 # for wasm building
+    clang_11 # for native/wasm building
+    lld_11 # for wasm building
     rustc-nightly
     cargo-nightly
     xargo
@@ -31,9 +31,9 @@ let
     # When compiling natively, we want to use `clang` (which is a nixpkgs
     # provided wrapper that sets various include paths etc).
     # But for some reason it does not handle building for Wasm well, so
-    # there we use plain clang-10. There is no stdlib there anyways.
-    export CLANG="${nixpkgs.clang_10}/bin/clang"
-    export WASM_CLANG="clang-10"
+    # there we use plain clang-11. There is no stdlib there anyways.
+    export CLANG="${nixpkgs.clang_11}/bin/clang"
+    export WASM_CLANG="clang-11"
     export WASM_LD=wasm-ld
   '';
 in

--- a/default.nix
+++ b/default.nix
@@ -131,7 +131,7 @@ rec {
         name = "motoko-rts-deps";
         src = subpath rts/motoko-rts;
         sourceRoot = null;
-        sha256 = "11la5fl0fgx6i5g52p56sf48yz7f0mqrgm38m320xh3wyqa2nim6";
+        sha256 = "0kpqc6i8mbk5fw0rc1f74z3rdh3ay7h04ljjadzpcz0s49b0sznb";
         copyLockfile = true;
       };
     in

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -41,7 +41,7 @@ let
         # Rust nightly
         (self: super: let
           moz_overlay = import self.sources.nixpkgs-mozilla self super;
-          rust-channel = moz_overlay.rustChannelOf { date = "2020-07-22"; channel = "nightly"; };
+          rust-channel = moz_overlay.rustChannelOf { date = "2021-01-11"; channel = "nightly"; };
         in rec {
           rustc-nightly = rust-channel.rust.override {
             targets = [ "wasm32-unknown-unknown" "wasm32-unknown-emscripten" ];

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -96,10 +96,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "66cd39409e8ae1e2981edfb33bb06c164893d70d",
-        "sha256": "1c44akgqbqsm2b6k5b850lb0q7wq5l5p4hm6bqbaif1h05sc2bkx",
+        "rev": "e6a184aca0d0d3252a516c317afbfa30fcc7e5d7",
+        "sha256": "066nkgr7snnlk7q85xz38mxrfbd36b9pasdrwpbc1n6ifbx1q9mz",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/66cd39409e8ae1e2981edfb33bb06c164893d70d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e6a184aca0d0d3252a516c317afbfa30fcc7e5d7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-mozilla": {

--- a/rts/motoko-rts/Cargo.lock
+++ b/rts/motoko-rts/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "compiler_builtins"
-version = "0.1.32"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc4ac2c824d2bfc612cba57708198547e9a26943af0632aff033e0693074d5c"
+checksum = "3748f82c7d366a0b4950257d19db685d4958d2fa27c6d164a3f069fec42b748b"
 
 [[package]]
 name = "libc"

--- a/rts/motoko-rts/Cargo.toml
+++ b/rts/motoko-rts/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.2.73"
 
 # Added here so that it ends up in Cargo.lock, so that nix will pre-fetch it
 [dependencies.compiler_builtins]
-version = "0.1.32"
+version = "0.1.39"
 # Without this feature we get dozens of duplicate symbol errors when generating
 # the final shared .wasm file:
 #

--- a/test/lsp-int/lsp-int.cabal
+++ b/test/lsp-int/lsp-int.cabal
@@ -14,8 +14,8 @@ executable lsp-int
   main-is:             Main.hs
   -- other-modules:
   other-extensions:    OverloadedStrings, DuplicateRecordFields
-  build-depends:       base ^>=4.13
-                     , text ^>=1.2
+  build-depends:       base
+                     , text
                      , hspec
                      , HUnit
                      , filepath

--- a/test/random/qc-motoko.cabal
+++ b/test/random/qc-motoko.cabal
@@ -15,8 +15,8 @@ executable qc-motoko
   other-modules:       Embedder, Turtle.Pipe
   other-extensions:    ConstraintKinds, StandaloneDeriving, DataKinds, KindSignatures, GADTs, MultiParamTypeClasses
   ghc-options:         -O -threaded -with-rtsopts=-N2
-  build-depends:       base ^>=4.13.0.0
-                     , text ^>=1.2.3.1
+  build-depends:       base
+                     , text
                      , process
                      , exceptions
                      , managed


### PR DESCRIPTION
This PR bumps rustc version which enables cargo's `build-std` feature
(#2251) and also allows us to remove some feature flags that became
stable in the meantime (ptr_offset_from, maybe others too).

(`build-std` feature exists in the current version too, but it's too
buggy or too different than the currently documented version, so I
couldn't use it)