### PR TITLE
Test case: an await may not yield

### DIFF
--- a/test/run-drun/await-without-yield.mo
+++ b/test/run-drun/await-without-yield.mo
@@ -1,0 +1,29 @@
+import Prim "mo:prim";
+actor a {
+
+  var s = 0;
+  public func ping(): async () {
+  };
+
+  // this observes how far the trap rolls back
+  public func bar(): async () {
+    s := 1;
+    let f = ping();
+    s := 2;
+    await f;
+    s := 3; // this will be rolled back!
+    await f;
+    ignore(0/0);
+  };
+
+  public func go() {
+    try {
+      await bar();
+      Prim.debugPrint("Huh, bar() replied?");
+    } catch _ {
+      Prim.debugPrint(debug_show s);
+    };
+  }
+};
+a.go(); //OR-CALL ingress go "DIDL\x00\x00"
+

--- a/test/run-drun/ok/await-without-yield.drun-run.ok
+++ b/test/run-drun/ok/await-without-yield.drun-run.ok
@@ -1,0 +1,3 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/await-without-yield.ic-ref-run.ok
+++ b/test/run-drun/ok/await-without-yield.ic-ref-run.ok
@@ -1,0 +1,7 @@
+→ update create_canister()
+← replied: (record {hymijyo = service "cvccv-qqaaq-aaaaa-aaaaa-c"})
+→ update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
+← replied: ()
+→ update go()
+debug.print: 2
+← replied: ()

--- a/test/run-drun/ok/await-without-yield.run-ir.ok
+++ b/test/run-drun/ok/await-without-yield.run-ir.ok
@@ -1,0 +1,1 @@
+await-without-yield.mo:16.12-16.15: execution error, arithmetic overflow

--- a/test/run-drun/ok/await-without-yield.run-low.ok
+++ b/test/run-drun/ok/await-without-yield.run-low.ok
@@ -1,0 +1,1 @@
+await-without-yield.mo:16.12-16.15: execution error, arithmetic overflow

--- a/test/run-drun/ok/await-without-yield.run.ok
+++ b/test/run-drun/ok/await-without-yield.run.ok
@@ -1,0 +1,1 @@
+await-without-yield.mo:16.12-16.15: execution error, arithmetic overflow


### PR DESCRIPTION
This test case demonstrates that `await a` on a fulfilled promise `a`
will not yield, and thus a trap afterwards might rollback a state change
from before.