### PR TITLE
Speed up check_ir

### DIFF
--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -88,12 +88,9 @@ let type_error at : string -> Diag.message = Diag.error_message at "M0000" "IR t
 let error env at fmt =
     Printf.ksprintf (fun s -> raise (CheckFailed (Diag.string_of_message (type_error at s)))) fmt
 
-let check env at p fmt =
-  if p
-  then Printf.ikfprintf (fun () -> ()) () fmt
-  else error env at fmt
-
-
+let check env at p s =
+  if not p then
+    error env at "%s" s
 
 let add_lab c x t = {c with labs = T.Env.add x t c.labs}
 
@@ -121,16 +118,17 @@ let disjoint_union env at fmt env1 env2 =
 (* Types *)
 
 let check_sub env at t1 t2 =
-  check env at (T.sub t1 t2) "subtype violation:\n  %s\n  %s\n"
-    (T.string_of_typ_expand t1) (T.string_of_typ_expand t2)
+  if not (T.sub t1 t2) then
+    error env at "subtype violation:\n  %s\n  %s\n"
+      (T.string_of_typ_expand t1) (T.string_of_typ_expand t2)
 
 let check_shared env at t =
-  check env at (T.shared t)
-    "message argument is not sharable:\n  %s" (T.string_of_typ_expand t)
+  if not (T.shared t) then
+    error env at "message argument is not sharable:\n  %s" (T.string_of_typ_expand t)
 
 let check_concrete env at t =
-  check env at (T.concrete t)
-    "message argument is not concrete:\n  %s" (T.string_of_typ_expand t)
+  if not (T.concrete t) then
+    error env at "message argument is not concrete:\n  %s" (T.string_of_typ_expand t)
 
 let has_prim_eq t =
   (* Which types have primitive equality implemented in the backend? *)
@@ -169,8 +167,8 @@ let rec check_typ env typ : unit =
         check_con env c;
         check_typ_bounds env tbs typs no_region
       | T.Abs (tbs, _) ->
-        check env no_region (T.ConSet.mem c env.cons) "free type constructor %s "
-          (T.string_of_typ typ);
+        if not (T.ConSet.mem c env.cons) then
+          error env no_region "free type constructor %s " (T.string_of_typ typ);
         check_typ_bounds env tbs typs no_region
     end
   | T.Any -> ()
@@ -194,28 +192,28 @@ let rec check_typ env typ : unit =
       | T.Returns ->
         check env no_region (sort = T.Shared T.Write)
           "one-shot query function pointless";
-        check env no_region (ts2 = [])
-          "one-shot function cannot have non-unit return types:\n  %s"
-          (T.string_of_typ_expand (T.seq ts2));
+        if not (ts2 = []) then
+          error env no_region "one-shot function cannot have non-unit return types:\n  %s"
+            (T.string_of_typ_expand (T.seq ts2));
       | T.Promises ->
         check env no_region (binds <> [])
           "promising function has no scope type argument";
         check env no_region env.flavor.Ir.has_async_typ
           "promising function in post-async flavor";
-        check env no_region (sort <> T.Local)
-          "promising function cannot be local:\n  %s" (T.string_of_typ typ);
-        check env no_region (List.for_all T.shared ts2)
-          "message result is not sharable:\n  %s" (T.string_of_typ typ)
+        if not (sort <> T.Local) then
+          error env no_region "promising function cannot be local:\n  %s" (T.string_of_typ typ);
+        if not (List.for_all T.shared ts2) then
+          error env no_region "message result is not sharable:\n  %s" (T.string_of_typ typ)
       | T.Replies ->
         check env no_region (not env.flavor.Ir.has_async_typ)
           "replying function in pre-async flavor";
-        check env no_region (sort <> T.Local)
-          "replying function cannot be local:\n  %s" (T.string_of_typ typ);
-        check env no_region (List.for_all T.shared ts2)
-          "message result is not sharable:\n  %s" (T.string_of_typ typ)
-    end else
-        check env no_region (control = T.Returns)
-          "promising function cannot be local:\n  %s" (T.string_of_typ_expand typ);
+        if not (sort <> T.Local) then
+          error env no_region"replying function cannot be local:\n  %s" (T.string_of_typ typ);
+        if not (List.for_all T.shared ts2) then
+          error env no_region "message result is not sharable:\n  %s" (T.string_of_typ typ)
+      end else
+     if not (control = T.Returns) then
+       error env no_region "promising function cannot be local:\n  %s" (T.string_of_typ_expand typ);
   | T.Opt typ ->
     check_typ env typ
   | T.Async (typ1, typ2) ->
@@ -740,7 +738,8 @@ let rec check_exp env (exp:Ir.exp) : unit =
   (* check const annotation *)
   (* see ir_passes/const.ml for an explanation *)
   let check_var ctxt v =
-    check (T.Env.find v env.vals).const "const %s with non-const variable %s" ctxt v in
+    if not (T.Env.find v env.vals).const then
+      error env exp.at "const %s with non-const variable %s" ctxt v in
   if exp.note.Note.const
   then begin
     match exp.it with
@@ -840,8 +839,8 @@ and check_args env args =
   let rec go ve = function
     | [] -> ve
     | a::as_ ->
-      check env a.at (not (T.Env.mem a.it ve))
-        "duplicate binding for %s in argument list" a.it;
+      if (T.Env.mem a.it ve) then
+        error env a.at "duplicate binding for %s in argument list" a.it;
       check_typ env a.note;
       let val_info = {typ = a.note; const = false; loc_known = env.lvl = TopLvl } in
       let env' = T.Env.add a.it val_info ve in
@@ -857,8 +856,8 @@ and gather_pat env const ve0 pat : val_env =
     | LitP _ ->
       ve
     | VarP id ->
-      check env pat.at (not (T.Env.mem id ve0))
-        "duplicate binding for %s in block" id;
+      if T.Env.mem id ve0 then
+        error env pat.at "duplicate binding for %s in block" id;
       let val_info = {typ = pat.note; const; loc_known = env.lvl = TopLvl} in
       T.Env.add id val_info ve (*TBR*)
     | TupP pats ->


### PR DESCRIPTION
Fixes #2256 

Speed up check_ir which was producing redundant error strings even for checks that passed. 


Before and After x3 on qr.mo
```
[nix-shell:~/motoko/test/perf]$ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.

[nix-shell:~/motoko/test/perf]$ time moc qr.mo 

real	0m3.602s
user	0m3.583s
sys	0m0.020s

[nix-shell:~/motoko/test/perf]$ time moc qr.mo 

real	0m3.959s
user	0m3.910s
sys	0m0.050s

[nix-shell:~/motoko/test/perf]$ time moc qr.mo 

real	0m3.736s
user	0m3.700s
sys	0m0.036s

[nix-shell:~/motoko/test/perf]$ git checkout claudio/check-
claudio/check-dont-compile-examples   claudio/check-ir-lazy-errors 

[nix-shell:~/motoko/test/perf]$ git checkout claudio/check-ir-lazy-errors 
Switched to branch 'claudio/check-ir-lazy-errors'
Your branch is up-to-date with 'origin/claudio/check-ir-lazy-errors'.

[nix-shell:~/motoko/test/perf]$ time moc qr.mo 

real	0m2.951s
user	0m2.920s
sys	0m0.032s

[nix-shell:~/motoko/test/perf]$ time moc qr.mo 

real	0m2.711s
user	0m2.657s
sys	0m0.055s

[nix-shell:~/motoko/test/perf]$ time moc qr.mo 

real	0m2.945s
user	0m2.891s
sys	0m0.056s

[nix-shell:~/motoko/test/perf]$ 
```