### PR TITLE
nix: Make sure that gitMinimal is built as part of CI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -408,12 +408,13 @@ rec {
     };
 
   inherit drun;
+  inherit (nixpkgs) wabt wasmtime wasm;
   filecheck = nixpkgs.linkFarm "FileCheck"
     [ { name = "bin/FileCheck"; path = "${nixpkgs.llvm}/bin/FileCheck";} ];
-  wabt = nixpkgs.wabt;
-  wasmtime = nixpkgs.wasmtime;
-  xargo = nixpkgs.xargo;
-  wasm = nixpkgs.wasm;
+  inherit (nixpkgs) xargo;
+
+  # gitMinimal is used by nix/gitSource.nix; building it here warms the nix cache
+  inherit (nixpkgs) gitMinimal;
 
   overview-slides = stdenv.mkDerivation {
     name = "overview-slides";


### PR DESCRIPTION
it is a dependency of `gitSource.nix`, but not exercised on CI. By
including it explicitly here we make sure that the nix cache has it.

This mirrors https://github.com/dfinity-lab/common/pull/358