### PR TITLE
Revert "Type components in object type syntax (#2359)"

### DIFF
--- a/doc/modules/language-guide/examples/grammar.txt
+++ b/doc/modules/language-guide/examples/grammar.txt
@@ -57,7 +57,6 @@
     '<' <list(<typ>, ',')> '>'
 
 <typ_field> ::= 
-    'type' <id> '=' <typ>
     'var'? <id> ':' <typ>
     <id> ('<' <list(<typ_bind>, ',')> '>')? <typ_nullary> ':' <typ>
 

--- a/src/docs/html.ml
+++ b/src/docs/html.ml
@@ -165,11 +165,9 @@ and html_of_typ_binders : env -> Syntax.typ_bind list -> t =
 and html_of_typ_field : env -> Syntax.typ_field -> t =
  fun env field ->
   (* TODO mut might be wrong here *)
-  match field.Source.it with
-  | Syntax.ValField (id, typ, mut) ->
-      html_of_mut mut ++ string (id.Source.it ^ " : ") ++ html_of_type env typ
-  | Syntax.TypField (id, typ) ->
-      string ("type " ^ id.Source.it ^ " = ") ++ html_of_type env typ
+  html_of_mut field.Source.it.Syntax.mut
+  ++ string (field.Source.it.Syntax.id.Source.it ^ " : ")
+  ++ html_of_type env field.Source.it.Syntax.typ
 
 and html_of_typ_item : env -> Syntax.typ_item -> t =
  fun env (oid, t) ->

--- a/src/docs/plain.ml
+++ b/src/docs/plain.ml
@@ -149,14 +149,9 @@ and plain_of_typ_binders :
 and plain_of_typ_field :
     Buffer.t -> (Syntax.path -> string) -> Syntax.typ_field -> unit =
  fun buf render_path field ->
-  match field.Source.it with
-  | Syntax.ValField (id, typ, mut) ->
-      plain_of_mut buf mut;
-      bprintf buf "%s : " id.it;
-      plain_of_typ buf render_path typ
-  | Syntax.TypField (id, typ) ->
-      bprintf buf "type %s = " id.it;
-      plain_of_typ buf render_path typ
+  plain_of_mut buf field.it.Syntax.mut;
+  bprintf buf "%s : " field.it.Syntax.id.it;
+  plain_of_typ buf render_path field.it.Syntax.typ
 
 and plain_of_typ_item :
     Buffer.t -> (Syntax.path -> string) -> Syntax.typ_item -> unit =

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -145,9 +145,8 @@ and stab s_opt = match s_opt with
     | Flexible -> Atom "Flexible"
     | Stable -> Atom "Stable")
 
-and typ_field (tf : typ_field) = match tf.it with
-  | ValField (id, t, m) -> id.it $$ [typ t; mut m]
-  | TypField (id, t) -> id.it $$ ["Typ" $$ [ typ t ]]
+and typ_field (tf : typ_field)
+  = tf.it.id.it $$ [typ tf.it.typ; mut tf.it.mut]
 
 and typ_item ((id, ty) : typ_item) =
   match id with

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -53,9 +53,7 @@ and typ' =
 
 and scope = typ
 and typ_field = typ_field' Source.phrase
-and typ_field' =
-  | ValField of id * typ * mut
-  | TypField of id * typ
+and typ_field' = {id : id; typ : typ; mut : mut}
 
 and typ_tag = typ_tag' Source.phrase
 and typ_tag' = {tag : id; typ : typ}

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -164,11 +164,8 @@ let share_typ t =
     { t with it = funcT ({s with it = Type.Shared Type.Write}, tbs, t1, t2)}
   | _ -> t
 
-let share_typfield' = function
-  | TypField (x, t) -> TypField (x, t)
-  | ValField (x, t, m) -> ValField (x, share_typ t, m)
-
-let share_typfield (tf : typ_field) = { tf with it = share_typfield' tf.it }
+let share_typfield (tf : typ_field) =
+  {tf with it = {tf.it with typ = share_typ tf.it.typ}}
 
 let share_exp e =
   match e.it with
@@ -453,14 +450,12 @@ inst :
   | LT ts=seplist(typ_bind, COMMA) GT { ts }
 
 typ_field :
-  | TYPE x=id EQ t=typ
-    { TypField (x, t) @@ at $sloc }
   | mut=var_opt x=id COLON t=typ
-    { ValField (x, t, mut) @@ at $sloc }
+    { {id = x; typ = t; mut} @@ at $sloc }
   | x=id tps=typ_params_opt t1=typ_nullary COLON t2=typ
     { let t = funcT(Type.Local @@ no_region, tps, t1, t2)
               @! span x.at t2.at in
-      ValField (x, t, Const @@ no_region) @@ at $sloc }
+      {id = x; typ = t; mut = Const @@ no_region} @@ at $sloc }
 
 typ_tag :
   | HASH x=id t=annot_opt

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -469,13 +469,7 @@ and check_typ' env typ : T.typ =
     T.Async (t0, t)
   | ObjT (sort, fields) ->
     check_ids env "object type" "field"
-      (List.filter_map (fun (field : typ_field) ->
-        match field.it with ValField (x, _, _) -> Some x | _ -> None
-      ) fields);
-    check_ids env "object type" "type field"
-      (List.filter_map (fun (field : typ_field) ->
-        match field.it with TypField (x, _) -> Some x | _ -> None
-      ) fields);
+      (List.map (fun (field : typ_field) -> field.it.id) fields);
     let fs = List.map (check_typ_field env sort.it) fields in
     T.Obj (sort.it, List.sort T.compare_field fs)
   | ParT typ ->
@@ -483,19 +477,15 @@ and check_typ' env typ : T.typ =
   | NamedT (_, typ) ->
     check_typ env typ
 
-and check_typ_field env s typ_field : T.field = match typ_field.it with
-  | ValField (id, typ, mut) ->
-    let t = infer_mut mut (check_typ env typ) in
-    if not env.pre && s = T.Actor then begin
-      if not (T.is_shared_func t) then
-        error env typ.at "M0042" "actor field %s must have shared function type, but has type\n  %s"
-          id.it (T.string_of_typ_expand t)
-    end;
-    T.{lab = id.it; typ = t}
-  | TypField (id,  typ) ->
-    let t = check_typ env typ in
-    let c = Con.fresh id.it (T.Def ([], t)) in
-    T.{lab = id.it; typ = Typ c}
+and check_typ_field env s typ_field : T.field =
+  let {id; mut; typ} = typ_field.it in
+  let t = infer_mut mut (check_typ env typ) in
+  if not env.pre && s = T.Actor then begin
+    if not (T.is_shared_func t) then
+      error env typ.at "M0042" "actor field %s must have shared function type, but has type\n  %s"
+        id.it (T.string_of_typ_expand t)
+  end;
+  T.{lab = id.it; typ = t}
 
 and check_typ_tag env typ_tag =
   let {tag; typ} = typ_tag.it in

--- a/test/fail/bad-type-comp.mo
+++ b/test/fail/bad-type-comp.mo
@@ -1,3 +1,0 @@
-ignore ((module {}) : module { type T = Null });
-ignore ((module { public type T = Int}) : module { type T = Null });
-ignore ((module { public type T = Null}) : module { type T = Null; type T = Null });

--- a/test/fail/ok/bad-type-comp.tc.ok
+++ b/test/fail/ok/bad-type-comp.tc.ok
@@ -1,9 +1,0 @@
-bad-type-comp.mo:1.10-1.19: type error [M0096], expression of type
-  module {}
-cannot produce expected type
-  module {type T = Null}
-bad-type-comp.mo:2.10-2.39: type error [M0096], expression of type
-  module {type T = Int}
-cannot produce expected type
-  module {type T = Null}
-bad-type-comp.mo:3.73-3.74: type error [M0018], duplicate type field name T in object type

--- a/test/fail/ok/bad-type-comp.tc.ret.ok
+++ b/test/fail/ok/bad-type-comp.tc.ret.ok
@@ -1,1 +1,0 @@
-Return code 1

--- a/test/run/type-comp-in-type.mo
+++ b/test/run/type-comp-in-type.mo
@@ -1,9 +1,0 @@
-module M {
-  public let value = null;
-  public type T = Null;
-};
-
-type MT = module { value : Null; type T = Null };
-
-ignore (M : module { value : Null; type T = Null });
-ignore (M : MT);


### PR DESCRIPTION
This reverts commit 745b676d8553ff8443dc82a6c71454338895dfc0, it is doing too
much things wrong (see #760)