### PR TITLE
Parser: Do not allow <vis> or <stab> before a plain expression

### DIFF
--- a/doc/modules/language-guide/examples/grammar.txt
+++ b/doc/modules/language-guide/examples/grammar.txt
@@ -225,16 +225,17 @@
     'var'? <id> '=' <exp>
 
 <dec_field> ::= 
-    <vis> <stab> <dec>
+    <vis> <stab> <dec_nonexp>
+    <stab> <dec_nonexp>
+    <vis> <dec_nonexp>
+    <dec>
 
 <vis> ::= 
-    <empty>
     'private'
     'public'
     'system'
 
 <stab> ::= 
-    <empty>
     'flexible'
     'stable'
 
@@ -278,9 +279,12 @@
     <shared_pat_opt> 'func' <id>? ('<' <list(<typ_bind>, ',')> '>')? <pat_plain> (':' <typ>)? <func_body>
     <shared_pat_opt> <obj_sort>? 'class' <id>? ('<' <list(<typ_bind>, ',')> '>')? <pat_plain> (':' <typ>)? <class_body>
 
-<dec> ::= 
+<dec_nonexp> ::= 
     <dec_var>
     <dec_nonvar>
+
+<dec> ::= 
+    <dec_nonexp>
     <exp_nondec>
 
 <func_body> ::= 

--- a/src/mo_frontend/printers.ml
+++ b/src/mo_frontend/printers.ml
@@ -138,6 +138,7 @@ let string_of_symbol symbol : string =
   | X (N N_catch) -> "<catch>"
   | X (N N_class_body) -> "<class_body>"
   | X (N N_dec) -> "<dec>"
+  | X (N N_dec_nonexp) -> "<dec_nonexp>"
   | X (N N_dec_field) -> "<dec_field>"
   | X (N N_deprecated_dec_list_unamb) -> "<deprecated_dec_list_unamb>"
   | X (N N_dec_nonvar) -> "<dec_nonvar>"

--- a/test/fail/ok/stability-parse-error1.tc.ok
+++ b/test/fail/ok/stability-parse-error1.tc.ok
@@ -1,0 +1,2 @@
+stability-parse-error1.mo:3.12-3.18: syntax error [M0001], unexpected token 'ignore', expected one of token or <phrase> sequence:
+  <dec_nonexp>

--- a/test/fail/ok/stability-parse-error1.tc.ret.ok
+++ b/test/fail/ok/stability-parse-error1.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/stability-parse-error2.tc.ok
+++ b/test/fail/ok/stability-parse-error2.tc.ok
@@ -1,0 +1,2 @@
+stability-parse-error2.mo:3.12-3.13: syntax error [M0001], unexpected token '(', expected one of token or <phrase> sequence:
+  <dec_nonexp>

--- a/test/fail/ok/stability-parse-error2.tc.ret.ok
+++ b/test/fail/ok/stability-parse-error2.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/stability.tc.ok
+++ b/test/fail/ok/stability.tc.ok
@@ -1,18 +1,16 @@
 stability.mo:3.7-3.15: type error [M0132], misplaced stability declaration on field of non-actor
 stability.mo:5.4-5.10: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
 stability.mo:6.4-6.12: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
-stability.mo:7.4-7.12: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
-stability.mo:8.4-8.12: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
-stability.mo:15.4-15.10: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
-stability.mo:16.4-16.10: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
-stability.mo:17.15-17.16: type error [M0131], variable f is declared stable but has non-stable type
+stability.mo:13.4-13.10: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
+stability.mo:14.4-14.10: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
+stability.mo:15.15-15.16: type error [M0131], variable f is declared stable but has non-stable type
   () -> ()
-stability.mo:39.11-39.41: type error [M0131], variable o6 is declared stable but has non-stable type
+stability.mo:37.11-37.41: type error [M0131], variable o6 is declared stable but has non-stable type
   {f : () -> ()}
-stability.mo:43.11-43.23: type error [M0131], variable m3 is declared stable but has non-stable type
+stability.mo:41.11-41.23: type error [M0131], variable m3 is declared stable but has non-stable type
   module {}
-stability.mo:46.4-46.12: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
-stability.mo:47.4-47.10: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
-stability.mo:50.15-50.20: type error [M0131], variable wrong is declared stable but has non-stable type
+stability.mo:44.4-44.12: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
+stability.mo:45.4-45.10: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
+stability.mo:48.15-48.20: type error [M0131], variable wrong is declared stable but has non-stable type
   module {}
-stability.mo:26.15-26.25: type error [M0019], stable variable names foo and nxnnbkddcv in actor type have colliding hashes
+stability.mo:24.15-24.25: type error [M0019], stable variable names foo and nxnnbkddcv in actor type have colliding hashes

--- a/test/fail/stability-parse-error1.mo
+++ b/test/fail/stability-parse-error1.mo
@@ -1,0 +1,5 @@
+// those of stability.mo that are now parse errors
+actor {
+  flexible ignore 666; // reject
+}
+

--- a/test/fail/stability-parse-error2.mo
+++ b/test/fail/stability-parse-error2.mo
@@ -1,0 +1,5 @@
+// those of stability.mo that are now parse errors
+actor {
+  flexible (); // reject
+}
+

--- a/test/fail/stability.mo
+++ b/test/fail/stability.mo
@@ -4,8 +4,6 @@ actor {
    };
    stable type T = Int;  // reject
    flexible type U = Int; // reject
-   flexible ignore 666; // reject
-   flexible (); // reject
 
    stable var x : Int = 0; // accept
    stable var y : [var Int] = [var]; // accept


### PR DESCRIPTION
extraced from #2358, and useful even if that PR ends up not changing the
grammar.