### PR TITLE
[fix] Language manual: section on switch

### DIFF
--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -2072,17 +2072,17 @@ Otherwise, `r1` is `false` and the result is `()` (if `<exp3>` is absent) or the
 === Switch
 
 The switch expression
-  `switch <exp0> { (case <pat> <block-or-exp>;)+ }`
+  `switch <exp> { (case <pat> <block-or-exp>;)+ }`
 has type `T` provided:
 
-* `exp0` has type `U`; and
-* for each case `case <pat> <exp>` in the sequence `(case <pat> <block-or-exp>;)+` :
+* `exp` has type `U`; and
+* for each case `case <pat> <block-or-exp>` in the sequence `(case <pat> <block-or-exp>;)+` :
   * pattern `<pat>` has type `U`; and,
-  * expression `<exp>` has type `T`
+  * expression `<block-or-exp>` has type `T`
 
-The expression evaluates `<exp0>` to a result `r1`.
-If `r1` is `trap`, the result is `trap`.
-Otherwise, `r1` is some value `v`.
+The expression evaluates `<exp>` to a result `r`.
+If `r` is `trap`, the result is `trap`.
+Otherwise, `r` is some value `v`.
 Let `case <pat> <block-or-exp>;` be the first case in `(case <pat> <block-or-exp>;)+` such that `<pat>` matches `v` for some binding of identifiers to values.
 Then result of the `switch` is the result of evaluating `<block-or-exp>` under that binding.
 If no case has a pattern that matches `v`, the result of the switch is `trap`.


### PR DESCRIPTION
Fix inconsistent notation and remove unnecessary indexing.