### PR TITLE
nix/sources.json: fetch wasm-profiler via SSH instead of HTTP

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -136,7 +136,7 @@
         "version": "v0.2.0"
     },
     "wasm-profiler": {
-        "branch": "master",
+        "branch": "main",
         "repo": "ssh://git@github.com/dfinity/wasm-profiler",
         "rev": "7cfb023e6f1d9a522fc56d24c35ace6d7f981f49",
         "type": "git"


### PR DESCRIPTION
The https://github.com/dfinity/wasm-profiler repository has been made private
which prevents fetching it publicly via HTTP. So this changes its
source to fetch it via SSH.