### PR TITLE
Update links to developer guide content

### DIFF
--- a/doc/modules/language-guide/pages/about-this-guide.adoc
+++ b/doc/modules/language-guide/pages/about-this-guide.adoc
@@ -59,7 +59,7 @@ For transparency into the principles that guide the engineering effort, the engi
 
 The following guiding principles represent the core values of the engineering organization in prioritized order:
 
-. Seamless integration with the link:../developers-guide/introduction-key-concepts{outfilesuffix}#ic-overview[{IC} platform] to ensure that {proglang} provides full language support for the actor-based model, asynchronous messaging, data persistence, interface description language interoperability, and other features.
+. Seamless integration with the link:../developers-guide/concepts/what-is-ic{outfilesuffix}#ic-overview[{IC} platform] to ensure that {proglang} provides full language support for the actor-based model, asynchronous messaging, data persistence, interface description language interoperability, and other features.
 . Ergonomics to ensure that {proglang} embraces familiarity, simplicity, clarity, explicitness, and other human factors.
 . Formal correctness to ensure that {proglang} maintains state isolation, a sound type system and type safety, precision, pattern matching, appropriate defaults, and coding best-practices.
 

--- a/doc/modules/language-guide/pages/motoko-introduction.adoc
+++ b/doc/modules/language-guide/pages/motoko-introduction.adoc
@@ -4,7 +4,7 @@
 :sdk-short-name: DFINITY Canister SDK
 :sdk-long-name: DFINITY Canister Software Development Kit (SDK)
 
-{proglang} is a modern programming language you can use specifically for link:../developers-guide/introduction-key-concepts{outfilesuffix}#ic-overview[{IC} platform] programs or as a general-purpose language for programs running on other platforms.
+{proglang} is a modern programming language you can use specifically for link:../developers-guide/concepts/what-is-ic{outfilesuffix}#ic-overview[{IC} platform] programs or as a general-purpose language for programs running on other platforms.
 
 == Approachability
 
@@ -20,12 +20,12 @@ Specifically, {proglang} programs are _type sound_ since {proglang} includes a p
 The {proglang} type system statically checks that each {proglang} program will execute safely, without internal type errors, on all possible inputs. 
 Consequently, entire classes of common programming pitfalls that are common in other languages are ruled out, including null pointer errors, mis-matched argument and result types and many others.
 
-To execute, {proglang} statically compiles to link:about-this-guide{outfilesuffix}#wasm[WebAssembly], a portable binary format that abstracts cleanly over modern computer hardware, and thus permits its execution broadly on the Internet, and the link:../developers-guide/introduction-key-concepts{outfilesuffix}#ic-overview[{IC}].
+To execute, {proglang} statically compiles to link:about-this-guide{outfilesuffix}#wasm[WebAssembly], a portable binary format that abstracts cleanly over modern computer hardware, and thus permits its execution broadly on the Internet, and the link:../developers-guide/concepts/what-is-ic{outfilesuffix}#ic-overview[{IC}].
 
 [[pitch-actors]]
 == Each microservice as an _actor_
 
-{proglang} provides an *actor-based* programming model to developers to express _server behavior_, including that of _micro services_ on the Internet and the link:../developers-guide/introduction-key-concepts{outfilesuffix}#ic-overview[{IC}].
+{proglang} provides an *actor-based* programming model to developers to express _server behavior_, including that of _micro services_ on the Internet and the link:../developers-guide/concepts/what-is-ic{outfilesuffix}#ic-overview[{IC}].
 
 An actor is similar to an object, but is special in that its isolated state exists _remotely_, and its interactions with the world are _asynchronous_.
 


### PR DESCRIPTION
Links got broken when I move some topics around. Updated to point to the correct path with this PR.