### PR TITLE
Niv auto-updater: Do not update wasm-profiler

### DIFF
--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -22,7 +22,7 @@ jobs:
         uses: knl/niv-updater-action@v9
         with:
           # might be too noisy
-          blacklist: 'nixpkgs,dfinity,ic-ref,musl-wasi,common,niv'
+          blacklist: 'nixpkgs,dfinity,ic-ref,musl-wasi,common,niv,wasm-profiler'
           labels: |
             automerge-squash
           keep_updating: true


### PR DESCRIPTION
niv updater stumbles over it, reported upstream at
https://github.com/knl/niv-updater-action/issues/44