### PR TITLE
Style guide: Fix adoc syntax; do not mention Word

### DIFF
--- a/doc/modules/language-guide/pages/style.adoc
+++ b/doc/modules/language-guide/pages/style.adoc
@@ -149,7 +149,7 @@ let sum =
   f + g + h + i + k + l +
   m + n + o + p;
 ....
-
++
 Rationale: Among other reasons, this style of formatting:
 +
 --


### PR DESCRIPTION
Asciidoc needs to be told that these code fragments are part of the
previous bullet by means of paragraph-joining `+` symbols.