### PR TITLE
flamegraph: Pass --hash

### DIFF
--- a/test/profile-report.sh
+++ b/test/profile-report.sh
@@ -59,8 +59,8 @@ for file in perf/*.mo; do
     wasm-profiler-postproc flamegraph "_profile_build/$base.instrumented.wasm" \
     > "_profile_build/$base.flamegraph"
 
-  flamegraph --title "$base.mo" \
+  flamegraph --hash --title "$base.mo" \
     < "_profile_build/$base.flamegraph" > "_profile/$base.svg"
-  flamegraph --title "$base.mo (reverse)" --reverse \
+  flamegraph --hash --title "$base.mo (reverse)" --reverse \
     < "_profile_build/$base.flamegraph" > "_profile/$base-reverse.svg"
 done


### PR DESCRIPTION
otherwise `flamegraph` picks random colors, which makes the output
nondeterministic.