### PR TITLE
Fix moc build errors with OCaml 4.12.0

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -2630,11 +2630,10 @@ module Object = struct
 
   (* This is for static objects *)
   let vanilla_lit env (fs : (string * int32) list) : int32 =
-    let open List in
     let (hashes, ptrs) = fs
-      |> map (fun (n, ptr) -> (Mo_types.Hash.hash n,ptr))
-      |> sort compare
-      |> split
+      |> List.map (fun (n, ptr) -> (Mo_types.Hash.hash n,ptr))
+      |> List.sort compare
+      |> List.split
     in
 
     let hash_ptr = E.add_static env StaticBytes.[ i32s hashes ] in


### PR DESCRIPTION
OCaml 4.12 adds `List.compare`, which breaks this code in compile.ml.

With this PR it builds with both 4.10 and 4.12.

OCaml 4.12 support needed to run https://github.com/ocaml/ocaml-lsp. There is
probably a way to run the latest version of ocaml-lsp with OCaml 4.10, but I
couldn't figure it out, and fixing moc for OCaml 4.12 was easy.