### PR TITLE
niv-updater-action: Make sure it finishes in time

### DIFF
--- a/.github/workflows/niv-updater-rare.yml
+++ b/.github/workflows/niv-updater-rare.yml
@@ -16,10 +16,12 @@ on:
 jobs:
   niv-updater:
     name: 'Check for updates'
+    timeout-minutes: 2 # if this takes more than 2 minutes then something's wrong
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@dbe84dffd27c7b5079dd748ce61a3e9797a68cf8
+        # Use our fork until https://github.com/knl/niv-updater-action/pull/46 is merged
+        uses: dfinity-lab/niv-updater-action@46d903454cded66eb06b1d17aeb2ddae403fc553
         with:
           # might be too noisy
           whitelist: 'dfinity,ic-ref,musl-wasi,common,niv'

--- a/.github/workflows/niv-updater-trial.yml
+++ b/.github/workflows/niv-updater-trial.yml
@@ -22,10 +22,12 @@ on:
 jobs:
   niv-updater:
     name: 'Check for updates'
+    timeout-minutes: 2 # if this takes more than 2 minutes then something's wrong
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@dbe84dffd27c7b5079dd748ce61a3e9797a68cf8
+        # Use our fork until https://github.com/knl/niv-updater-action/pull/46 is merged
+        uses: dfinity-lab/niv-updater-action@46d903454cded66eb06b1d17aeb2ddae403fc553
         with:
           whitelist: 'nixpkgs,musl-wasi'
           labels: |

--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -16,10 +16,12 @@ on:
 jobs:
   niv-updater:
     name: 'Check for updates'
+    timeout-minutes: 2 # if this takes more than 2 minutes then something's wrong
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@dbe84dffd27c7b5079dd748ce61a3e9797a68cf8
+        # Use our fork until https://github.com/knl/niv-updater-action/pull/46 is merged
+        uses: dfinity-lab/niv-updater-action@46d903454cded66eb06b1d17aeb2ddae403fc553
         with:
           # might be too noisy
           blacklist: 'nixpkgs,dfinity,ic-ref,musl-wasi,common,niv,wasm-profiler'


### PR DESCRIPTION
The action didn't pull niv from the cache and wasted many GitHub Actions
minutes building niv. We use our fork where the issue is fixed until
knl/niv-updater-action#46 is merged.

This also sets a timeout of 2mn.

Thanks to @nmattia for noticing and fixing.