### PR TITLE
Update instructions for reporting compiler bugs

### DIFF
--- a/src/mo_config/internal_error.ml
+++ b/src/mo_config/internal_error.ml
@@ -10,6 +10,6 @@ let setup_handler () =
   Printexc.record_backtrace true;
   Printexc.set_uncaught_exception_handler (fun exn rb ->
     Printf.eprintf "OOPS! You've triggered a compiler bug.\n";
-    Printf.eprintf "Please report this Motoko issue at forum.dfinity.org with the following details:\n\nMotoko (revision %s)\n\n" Source_id.id;
+    Printf.eprintf "Please report this Motoko issue at https://github.com/dfinity/motoko/issues with the following details:\n\nMotoko (revision %s)\n\n" Source_id.id;
     default_uncaught_exception_handler exn rb
   );


### PR DESCRIPTION
Link to GitHub issues now that Motoko is open source.

Spotted here: https://forum.dfinity.org/t/motoko-compiler-bug/5095