### PR TITLE
Release build: embed actual version number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
 
     - run: nix-build --max-jobs 1 release-files.nix --argstr releaseVersion '${{ needs.changelog.outputs.version }}'
 
-    - name: Upload Release Asset
+    - name: Upload Release Assets
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,4 +83,4 @@ jobs:
         tag: ${{ github.ref }}
         file: result/*
         file_glob: true
-        body: ${{ needs.changelog.outputs.version }}
+        body: ${{ needs.changelog.outputs.release_body }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     - name: "nix-build"
       # these are the dependencies listed in release-files. Sorry for the duplication
       run: |
-        nix-build --max-jobs 1 --argstr motoko_release ${{needs.changelog.outputs.version}} \
+        nix-build --max-jobs 1 --argstr releaseVersion ${{needs.changelog.outputs.version}} \
           -A moc -A mo-ide -A mo-doc -A js.moc -A js.moc_interpreter
 
   # Finally do the upload. Hopefully the previous job has uploaded the
@@ -73,6 +73,8 @@ jobs:
       with:
         name: ic-hs-test
         # NB: No auth token, we don’t expect to push new stuff here
+
+    - run: nix-build --max-jobs 1 release-files.nix --argstr releaseVersion '${{ needs.changelog.outputs.version }}'
 
     - name: Upload Release Asset
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,28 +8,20 @@ on:
     - '*'
 
 jobs:
-  # this assumes that the nix cache is warm
-  # In particular, we assume we can fetch the darwin build products
-  # May require restarting the job otherwise
-  release:
+  # first check that the changelog is in good order and extract the changelog
+  # This will fail for non-release tags.
+  changelog:
     runs-on: 'ubuntu-latest'
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v12
-    - uses: cachix/cachix-action@v10
-      with:
-        name: ic-hs-test
-        # NB: No auth token, we don’t expect to push new stuff here
 
     # from https://github.community/t/how-to-get-just-the-tag-name/16241/7
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-    - run: nix-build --max-jobs 1 release-files.nix --argstr releaseVersion '${{ steps.get_version.outputs.VERSION }}'
+      run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
 
     - name: Extract changelog
-      id: read_release
+      id: read_changelog
       run: |
         export VERSION='${{ steps.get_version.outputs.VERSION }}'
         perl -0777 -ne '/^# Motoko compiler changelog\n\n== (??{quotemeta($ENV{VERSION})}) \(\d\d\d\d-\d\d-\d\d\)\n\n(.*?)^==/sm or die "Changelog does not look right for this version\n" ; print $1' Changelog.md > changelog-extract.md
@@ -39,7 +31,48 @@ jobs:
         r="${r//'%'/'%25'}"
         r="${r//$'\n'/'%0A'}"
         r="${r//$'\r'/'%0D'}"
-        echo "::set-output name=RELEASE_BODY::$r"
+        echo "::set-output name=release_body::$r"
+
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      release_body: ${{ steps.read_changelog.outputs.release_body }}
+
+  # Now build the release on both linux and darwin, with the version number set
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    needs: changelog
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v12
+    - uses: cachix/cachix-action@v10
+      with:
+        name: ic-hs-test
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: cachix watch-store ic-hs-test &
+    - name: "nix-build"
+      # these are the dependencies listed in release-files. Sorry for the duplication
+      run: |
+        nix-build --max-jobs 1 --argstr motoko_release ${{needs.changelog.outputs.version}} \
+          -A moc -A mo-ide -A mo-doc -A js.moc -A js.moc_interpreter
+
+  # Finally do the upload. Hopefully the previous job has uploaded the
+  # build product to the nix cache, as we cannot build the darwin products on
+  # linux
+  release:
+    runs-on: 'ubuntu-latest'
+    needs:
+    - changelog
+    - build
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v12
+    - uses: cachix/cachix-action@v10
+      with:
+        name: ic-hs-test
+        # NB: No auth token, we don’t expect to push new stuff here
 
     - name: Upload Release Asset
       uses: svenstaro/upload-release-action@v2
@@ -48,4 +81,4 @@ jobs:
         tag: ${{ github.ref }}
         file: result/*
         file_glob: true
-        body: ${{ steps.read_release.outputs.RELEASE_BODY }}
+        body: ${{ needs.changelog.outputs.version }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,5 @@
 # Motoko compiler changelog
 
-== 0.6.9999 (2021-06-10)
-
-Testrelease!
-
-With more than one line
-
 == 0.6.3 (2021-06-10)
 
 * Motoko is now open source!

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Motoko compiler changelog
 
+== 0.6.999 (2021-06-10)
+
+Testrelease!
+
 == 0.6.3 (2021-06-10)
 
 * Motoko is now open source!

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,10 @@
 # Motoko compiler changelog
 
-== 0.6.999 (2021-06-10)
+== 0.6.9999 (2021-06-10)
 
 Testrelease!
+
+With more than one line
 
 == 0.6.3 (2021-06-10)
 

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,9 @@
   # If you have access to it, create an empty file enable-internals
   # in this directory, and it will be used.
   internal ? builtins.pathExists ./enable-internals,
+
+  # version to embed in the release. Used by `.github/workflows/release.yml`
+  motoko_release ? null,
 }:
 
 let nixpkgs = import ./nix { inherit system; }; in
@@ -109,6 +112,8 @@ let ocaml_exe = name: bin: rts:
       src = subpath ./src;
 
       buildInputs = commonBuildInputs staticpkgs;
+
+      MOTOKO_RELEASE = motoko_release;
 
       # we only need to include the wasm statically when building moc, not
       # other binaries

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
   internal ? builtins.pathExists ./enable-internals,
 
   # version to embed in the release. Used by `.github/workflows/release.yml`
-  motoko_release ? null,
+  releaseVersion ? null,
 }:
 
 let nixpkgs = import ./nix { inherit system; }; in
@@ -113,7 +113,7 @@ let ocaml_exe = name: bin: rts:
 
       buildInputs = commonBuildInputs staticpkgs;
 
-      MOTOKO_RELEASE = motoko_release;
+      MOTOKO_RELEASE = releaseVersion;
 
       # we only need to include the wasm statically when building moc, not
       # other binaries

--- a/release-files.nix
+++ b/release-files.nix
@@ -31,7 +31,7 @@ let
     nixpkgs.runCommandNoCC "motoko-release-${releaseVersion}" {} ''
       mkdir $out
       cp ${as_tarball "x86_64-linux" (with linux; [ mo-ide mo-doc moc ])} $out/motoko-linux64-${releaseVersion}.tar.gz
-      cp ${as_tarball "x86_64-darwin" (with linux; [ mo-ide mo-doc moc ])} $out/motoko-macos-${releaseVersion}.tar.gz
+      cp ${as_tarball "x86_64-darwin" (with darwin; [ mo-ide mo-doc moc ])} $out/motoko-macos-${releaseVersion}.tar.gz
       cp ${as_js "moc" linux.js.moc} $out/moc-${releaseVersion}.js
       cp ${as_js "moc-interpreter" linux.js.moc_interpreter} $out/moc-interpreter-${releaseVersion}.js
     '';

--- a/release-files.nix
+++ b/release-files.nix
@@ -7,8 +7,8 @@
 { releaseVersion ? "latest" }:
 let
   nixpkgs = import ./nix { };
-  linux = import ./default.nix { system = "x86_64-linux"; internal = true; };
-  darwin = import ./default.nix { system = "x86_64-darwin"; internal = true; };
+  linux = import ./default.nix { system = "x86_64-linux"; internal = true; inherit releaseVersion; };
+  darwin = import ./default.nix { system = "x86_64-darwin"; internal = true; inherit releaseVersion; };
 
   as_tarball = dir: derivations:
     nixpkgs.runCommandNoCC "motoko-${releaseVersion}.tar.gz" {

--- a/src/codegen/die.ml
+++ b/src/codegen/die.ml
@@ -437,7 +437,7 @@ let tag_open : dw_TAG -> die list =
       prim_type Int in
     [unreferencable_tag dw_TAG_compile_unit
        (dw_attrs
-          [ Producer (Printf.sprintf "DFINITY Motoko compiler, revision %s" Source_id.id);
+          [ Producer (Printf.sprintf "DFINITY Motoko compiler %s" Source_id.banner);
             Language dw_LANG_Motoko; Name file; Stmt_list 0;
             Comp_dir dir; Use_UTF8 true; Low_pc; Addr_base 8; Ranges ] @
         base_types @ builtin_types)]

--- a/src/exes/deser.ml
+++ b/src/exes/deser.ml
@@ -491,7 +491,7 @@ end
 (* CLI *)
 
 let name = "deser"
-let banner = "Candid toolkit (revision " ^ Source_id.id ^ ")"
+let banner = "Candid toolkit " ^ Source_id.banner
 let usage = "Usage: " ^ name ^ " [option] [file ...]"
 
 let mode = ref Nary

--- a/src/exes/didc.ml
+++ b/src/exes/didc.ml
@@ -2,7 +2,7 @@ open Idllib
 open Printf
 
 let name = "didc"
-let banner = "Candid compiler (revision " ^ Source_id.id ^ ")"
+let banner = "Candid compiler " ^ Source_id.banner
 let usage = "Usage: " ^ name ^ " [option] [file ...]"
 
 

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -4,7 +4,7 @@ open Mo_config
 open Printf
 
 let name = "moc"
-let banner = "Motoko compiler (revision " ^ Source_id.id ^ ")"
+let banner = "Motoko compiler " ^ Source_id.banner
 let usage = "Usage: " ^ name ^ " [option] [file ...]"
 
 

--- a/src/mo_config/internal_error.ml
+++ b/src/mo_config/internal_error.ml
@@ -10,6 +10,6 @@ let setup_handler () =
   Printexc.record_backtrace true;
   Printexc.set_uncaught_exception_handler (fun exn rb ->
     Printf.eprintf "OOPS! You've triggered a compiler bug.\n";
-    Printf.eprintf "Please report this Motoko issue at forum.dfinity.org with the following details:\n\nMotoko (revision %s)\n\n" Source_id.id;
+    Printf.eprintf "Please report this Motoko issue at forum.dfinity.org with the following details:\n\nMotoko %s\n\n" Source_id.banner;
     default_uncaught_exception_handler exn rb
   );

--- a/src/source_id/.gitignore
+++ b/src/source_id/.gitignore
@@ -1,1 +1,1 @@
-source_id.ml
+generated.ml

--- a/src/source_id/gen.sh
+++ b/src/source_id/gen.sh
@@ -2,13 +2,18 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-file="source_id.ml"
+file="generated.ml"
+
+if [ -n "$MOTOKO_RELEASE" ]
+then echo "let release = Some \"$MOTOKO_RELEASE\"" > $file.tmp
+else echo "let release = None" > $file.tmp
+fi
 
 if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = true ]
-then echo "let id = \"$(git describe --always --dirty)\"" > $file.tmp
+then echo "let id = \"$(git describe --always --dirty)\"" >> $file.tmp
 elif [ -n "$out" ]
-then echo "let id = \"$(echo $out|cut -d/ -f4|cut -d- -f1|fold -w8 | paste -sd'-' -)\"" > $file.tmp
-else echo "let id = \"unidentified version\"" > $file.tmp
+then echo "let id = \"$(echo "$out"|cut -d/ -f4|cut -d- -f1|fold -w8 | paste -sd'-' -)\"" >> $file.tmp
+else echo "let id = \"unidentified version\"" >> $file.tmp
 fi
 if [ ! -e $file ] || ! cmp -s $file.tmp $file
 then mv $file.tmp $file

--- a/src/source_id/generated.mli
+++ b/src/source_id/generated.mli
@@ -1,0 +1,2 @@
+val release : string option
+val id : string

--- a/src/source_id/source_id.ml
+++ b/src/source_id/source_id.ml
@@ -1,0 +1,5 @@
+let release = Generated.release
+let id = Generated.id
+let banner = match Generated.release with
+  | None -> "(source " ^ Generated.id ^ ")"
+  | Some r -> r ^ " (source " ^ Generated.id ^ ")"

--- a/src/source_id/source_id.mli
+++ b/src/source_id/source_id.mli
@@ -1,0 +1,3 @@
+val release : string option
+val id : string
+val banner : string

--- a/test/repl/ok/double-import.stdout.ok
+++ b/test/repl/ok/double-import.stdout.ok
@@ -1,4 +1,4 @@
-Motoko compiler (revision XXX)
+Motoko compiler (source XXX)
 -- Parsing stdin:
 > -- Parsing lib/empty.mo:
 -- Checking empty.mo:

--- a/test/repl/ok/file-and-repl.stdout.ok
+++ b/test/repl/ok/file-and-repl.stdout.ok
@@ -1,4 +1,4 @@
-Motoko compiler (revision XXX)
+Motoko compiler (source XXX)
 -- Parsing /dev/fd/63:
 -- Checking /dev/fd/63:
 -- Definedness /dev/fd/63:

--- a/test/repl/ok/outrange-int-nat.stdout.ok
+++ b/test/repl/ok/outrange-int-nat.stdout.ok
@@ -1,4 +1,4 @@
-Motoko compiler (revision XXX)
+Motoko compiler (source XXX)
 > let Prim : module {...}
 > +127 : Int8
 > > -128 : Int8

--- a/test/repl/ok/pretty-val.stdout.ok
+++ b/test/repl/ok/pretty-val.stdout.ok
@@ -1,4 +1,4 @@
-Motoko compiler (revision XXX)
+Motoko compiler (source XXX)
 > let Prim : module {...}
 >   let a_small : [var Text] = ["hello", "hello", "hello", "hello", "hello"]
 > let a_large :

--- a/test/repl/ok/stateful.stdout.ok
+++ b/test/repl/ok/stateful.stdout.ok
@@ -1,3 +1,3 @@
-Motoko compiler (revision XXX)
+Motoko compiler (source XXX)
 > let x : Nat = 42
 > > > > 

--- a/test/repl/ok/triangle-import.stdout.ok
+++ b/test/repl/ok/triangle-import.stdout.ok
@@ -1,4 +1,4 @@
-Motoko compiler (revision XXX)
+Motoko compiler (source XXX)
 -- Parsing stdin:
 > -- Parsing lib/b.mo:
 -- Parsing lib/c.mo:

--- a/test/repl/ok/type-lub-repl.stdout.ok
+++ b/test/repl/ok/type-lub-repl.stdout.ok
@@ -1,4 +1,4 @@
-Motoko compiler (revision XXX)
+Motoko compiler (source XXX)
 > [null, ?42, ?(-25)] : [(?Int)]
 > [null, null] : [Null]
 > [{a = 42}, {b = 42}] : [{}]

--- a/test/repl/ok/variant-shorthand.stdout.ok
+++ b/test/repl/ok/variant-shorthand.stdout.ok
@@ -1,4 +1,4 @@
-Motoko compiler (revision XXX)
+Motoko compiler (source XXX)
 > #bar : {#bar}
 > #foo(#bar) : {#foo : {#bar}}
 > [#Monday, #Tuesday, #Wednesday, #Thursday, #Friday, #Saturday, #Sunday] :

--- a/test/run.sh
+++ b/test/run.sh
@@ -78,7 +78,7 @@ function normalize () {
     sed 's/trap at 0x[a-f0-9]*/trap at 0x___:/g' |
     sed 's/^\(         [0-9]\+:\).*!/\1 /g' | # wasmtime backtrace locations
     sed 's/Ignore Diff:.*/Ignore Diff: (ignored)/ig' |
-    sed 's/compiler (revision .*)/compiler (revision XXX)/ig' |
+    sed 's/compiler (source .*)/compiler (source XXX)/ig' |
     # Normalize canister id prefixes in debug prints
     sed 's/\[Canister [0-9a-z\-]*\]/debug.print:/g' |
     # Normalize instruction locations on traps, added by ic-ref ad6ea9e


### PR DESCRIPTION
this way we’ll get something like
```
$ moc --version
Motoko compiler 0.1 (source cq98vl2b-xnb74m6b-2k3959b5-7jjskw5s)
```

I still want to include the source id, as a safe guard against two
builds for the same version floating around.

This means that the create-release-on-tag job will have to rebuild. I am
_not_ running the tests there, hoping that they won’t break if one
changes the banner…

Only release builds will have a version numbers. Builds of arbitrary
revisions will print what the do now, and executables built in the nix
shell will continue to report the `git describe` output, as of now.

This also fixes an embarrassing but that was actually deploying linux binaries in `motoko-macos-0.1.tar.gz`, which means the previous release was kinda broken. We should do another release once this is merged.