### PR TITLE
RTS makefile: Track .rs files in subdirectories

### DIFF
--- a/rts/Makefile
+++ b/rts/Makefile
@@ -157,9 +157,9 @@ $(MUSL_WASM_A): $(MUSL_WASM_O)
 RTS_RUST_WASM_A=_build/wasm/libmotoko_rts.a
 RTS_RUST_DEBUG_WASM_A=_build/wasm/libmotoko_rts_debug.a
 
+RTS_RUST_FILES=$(shell ls **/*.rs)
+
 TOMMATH_BINDINGS_RS=_build/tommath_bindings.rs
-
-
 
 $(TOMMATH_BINDINGS_RS): | _build
 	bindgen $(TOMMATHSRC)/tommath.h \
@@ -200,11 +200,11 @@ $(TOMMATH_BINDINGS_RS): | _build
 	# macros like `mp_get_u32` and `mp_isneg` need to be manually implemented.
 
 
-$(RTS_RUST_WASM_A): $(TOMMATH_BINDINGS_RS) $(wildcard motoko-rts/src/*.rs) | _build/wasm
+$(RTS_RUST_WASM_A): $(TOMMATH_BINDINGS_RS) $(RTS_RUST_FILES) | _build/wasm
 	cd motoko-rts && xargo build --release --target=wasm32-unknown-emscripten
 	cp motoko-rts/target/wasm32-unknown-emscripten/release/libmotoko_rts.a $@
 
-$(RTS_RUST_DEBUG_WASM_A): $(TOMMATH_BINDINGS_RS) $(wildcard motoko-rts/src/*.rs) | _build/wasm
+$(RTS_RUST_DEBUG_WASM_A): $(TOMMATH_BINDINGS_RS) $(RTS_RUST_FILES) | _build/wasm
 	cd motoko-rts && xargo build --target=wasm32-unknown-emscripten
 	cp motoko-rts/target/wasm32-unknown-emscripten/debug/libmotoko_rts.a $@
 

--- a/rts/Makefile
+++ b/rts/Makefile
@@ -157,6 +157,7 @@ $(MUSL_WASM_A): $(MUSL_WASM_O)
 RTS_RUST_WASM_A=_build/wasm/libmotoko_rts.a
 RTS_RUST_DEBUG_WASM_A=_build/wasm/libmotoko_rts_debug.a
 
+# this relies on bash and globstar, see https://stackoverflow.com/questions/2483182/recursive-wildcards-in-gnu-make
 RTS_RUST_FILES=$(shell ls **/*.rs)
 
 TOMMATH_BINDINGS_RS=_build/tommath_bindings.rs


### PR DESCRIPTION
This fixes tracking of .rs files in subdirectories by the RTS Makefile.
Previously a file in e.g. `motoko-rts/src/my_dir` would not be tracked, only
the ones at the top-level `motoko-rts/src` would be tracked. With this patch it
now recursively tracks all .rs files.
