### PR TITLE
Increase parallel jobs on GitHub CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
     - run: cachix watch-store ic-hs-test &
 
     - name: "nix-build"
-      run: nix-build --max-jobs 1 -A all-systems-go
+      run: nix-build --max-jobs 10 -A all-systems-go


### PR DESCRIPTION
Currently Hydra jobs take minutes, GitHub CI jobs take hours. I'm wondering if
we could make GitHub CI runs faster by increasing parallel jobs.

Submitting a PR to see if there are any problems with this (perhaps resource
limits).
