### PR TITLE
Compacting GC: get object size before threading fields

### DIFF
--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -114,10 +114,13 @@ unsafe fn update_fwd_refs(heap_base: u32) {
         // object header
         unthread(p, free);
 
+        // Get the size before threading the fields, to handle self references.
+        let size = object_size(p as usize).to_bytes().0;
+
         // Thread fields
         thread_obj_fields(p, heap_base);
 
-        free += object_size(p as usize).to_bytes().0;
+        free += size;
 
         bit = bitmap_iter.next();
     }


### PR DESCRIPTION
This fixes a bug when an object refers to itself. If we thread the
fields first, by the time we get the object's size the header will be
gone. So we need to get the size first, then thread the fields.

Bug caught by #2573 and a test will be added with that PR.