### PR TITLE
GH CI: update nix, increase max-jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v13
+      with:
+        # We need a nix version with NixOS/nix#3564 to be able to use
+        # `--max-jobs`, so using NixOS/nix@323e545. See 8365e73 for the problem
+        # with `--max-jobs`. Install URL is obtained from CI logs for the nix
+        # commit: https://github.com/NixOS/nix/runs/2895674848 expand "Run
+        # cachenix/install-nix-action@v13" job, then the "Run
+        # cachenix/install-nix-action@v13" step, and you'll see a line starting
+        # with `install_url`.
+        install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
+        install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
 
     # We are using the ic-hs-test cachix cache that is also used by
     # dfinity/ic-hs. This is partly laziness (on need to set up a separate
@@ -22,4 +32,4 @@ jobs:
     - run: cachix watch-store ic-hs-test &
 
     - name: "nix-build"
-      run: nix-build --max-jobs 1 -A all-systems-go
+      run: nix-build --max-jobs 10 -A all-systems-go


### PR DESCRIPTION
This version should include https://github.com/NixOS/nix/pull/3564 and
allow us to increase max-jobs. See #2621 for the previous attempt,
reverted in 8365e739f.

The install URL is obtained from https://github.com/NixOS/nix/runs/2895674848 (https://github.com/NixOS/nix/commit/323e5450a1a6e4eb97ba1c9aeba195187cfaff37)