### PR TITLE
Remove note about open sourcing Motoko

### DIFF
--- a/doc/modules/language-guide/pages/motoko.adoc
+++ b/doc/modules/language-guide/pages/motoko.adoc
@@ -19,6 +19,8 @@ The {proglang} programming language is a new, modern, type-sound language design
 Motoko is specifically designed to support the unique features of the Internet Computer and to provide a familiar yet robust programming environment.
 As a new language {proglang} is constantly evolving with support for new features and improvements.
 
+The Motoko compiler, documentation and other tooling is https://github.com/dfinity/motoko[open source] and released under the Apache 2.0 license. Contributions are welcome.
+
 [.cards.cards-4.personas.conceal-title]
 {empty}
 
@@ -122,4 +124,3 @@ Our goal is to enable any language (with a compiler that targets WebAssembly) to
 with other, perhaps foreign, canisters through language neutral Candid interfaces.
 
 Its tailored design means {proglang} should be the easiest and safest language for coding on the {IC}, at least for the forseeable future.
-

--- a/doc/modules/language-guide/pages/motoko.adoc
+++ b/doc/modules/language-guide/pages/motoko.adoc
@@ -18,7 +18,6 @@ Check back regularly to try new features and see what's changed.
 The {proglang} programming language is a new, modern, type-sound language designed for developers who want to build the next generation of apps and services to run directly on the internet.
 Motoko is specifically designed to support the unique features of the Internet Computer and to provide a familiar yet robust programming environment.
 As a new language {proglang} is constantly evolving with support for new features and improvements.
-Keep checking back for updates and for the announcement of the {proglang} becoming available as an open source project.
 
 [.cards.cards-4.personas.conceal-title]
 {empty}


### PR DESCRIPTION
Since Motoko has already been open sourced, we can remove this line.

Requested by Elizabeth Yang