### PR TITLE
RTS: fix pages calculation in grow_memory

### DIFF
--- a/rts/motoko-rts/src/alloc/gc.rs
+++ b/rts/motoko-rts/src/alloc/gc.rs
@@ -24,7 +24,7 @@ pub unsafe extern "C" fn alloc_words(n: Words<u32>) -> SkewedPtr {
     skew(old_hp as usize)
 }
 
-/// Page allocation. Ensures that the memory up to the given pointer is allocated.
+/// Page allocation. Ensures that the memory up to, but excluding, the given pointer is allocated.
 pub(crate) unsafe fn grow_memory(ptr: usize) {
     let page_size = u64::from(WASM_PAGE_SIZE.0);
     let total_pages_needed = (((ptr as u64) + page_size - 1) / page_size) as usize;

--- a/rts/motoko-rts/src/alloc/gc.rs
+++ b/rts/motoko-rts/src/alloc/gc.rs
@@ -26,7 +26,8 @@ pub unsafe extern "C" fn alloc_words(n: Words<u32>) -> SkewedPtr {
 
 /// Page allocation. Ensures that the memory up to the given pointer is allocated.
 pub(crate) unsafe fn grow_memory(ptr: usize) {
-    let total_pages_needed = ((ptr / WASM_PAGE_SIZE.as_usize()) + 1) as i32;
+    let page_size = u64::from(WASM_PAGE_SIZE.0);
+    let total_pages_needed = (((ptr as u64) + page_size - 1) / page_size) as i32;
     let current_pages = wasm32::memory_size(0) as i32;
     let new_pages_needed = total_pages_needed - current_pages;
     if new_pages_needed > 0 {

--- a/rts/motoko-rts/src/alloc/gc.rs
+++ b/rts/motoko-rts/src/alloc/gc.rs
@@ -27,11 +27,10 @@ pub unsafe extern "C" fn alloc_words(n: Words<u32>) -> SkewedPtr {
 /// Page allocation. Ensures that the memory up to the given pointer is allocated.
 pub(crate) unsafe fn grow_memory(ptr: usize) {
     let page_size = u64::from(WASM_PAGE_SIZE.0);
-    let total_pages_needed = (((ptr as u64) + page_size - 1) / page_size) as i32;
-    let current_pages = wasm32::memory_size(0) as i32;
-    let new_pages_needed = total_pages_needed - current_pages;
-    if new_pages_needed > 0 {
-        if wasm32::memory_grow(0, new_pages_needed as usize) == core::usize::MAX {
+    let total_pages_needed = (((ptr as u64) + page_size - 1) / page_size) as usize;
+    let current_pages = wasm32::memory_size(0);
+    if total_pages_needed > current_pages {
+        if wasm32::memory_grow(0, total_pages_needed - current_pages) == core::usize::MAX {
             rts_trap_with("Cannot grow memory");
         }
     }


### PR DESCRIPTION
Originally discussed here: https://github.com/dfinity/motoko/pull/2573#discussion_r660366802

Previously grow_memory would allocate one more page than necessary when
the argument is a multiple of Wasm page size. New calculation fixes
that. The code is basically

    (ptr + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE

I.e. divide argument by WASM_PAGE_SIZE, round up. However we do this in
u64 to avoid overflows in `ptr` is larger than `u32::MAX -
WASM_PAGE_SIZE + 1`

Also moves `total_pages - current_pages` to the slow path to improve
performance slightly.

CanCan backend benchmark reports 0.002% increase in cycles.
