### PR TITLE
Update and improve doc

### DIFF
--- a/doc/modules/language-guide/pages/compiler-ref.adoc
+++ b/doc/modules/language-guide/pages/compiler-ref.adoc
@@ -40,6 +40,8 @@ You can use the following options with the `+moc+` command.
 
 |`+--check+` |Performs type checking only.
 
+|`+--compacting-gc+` |Link with compacting GC instead of copying GC.
+
 |`+--debug+` |Respects debug expressions in the source (the default).
 
 |`+-dp+` |Dumps parse.
@@ -48,7 +50,7 @@ You can use the following options with the `+moc+` command.
 
 |`+-dl+` |Dumps intermediate representation
 
-|`+--error-detail+` |Displays detailed error message for syntax errors.
+|`+--error-detail <n>+` |Set level of error message detail for syntax errors, n in [0..3] (default 2).
 
 |`+-help+`,`+--help+` |Displays usage information.
 
@@ -93,6 +95,9 @@ You can use the following options with the `+moc+` command.
 |`+-r+` |Interprets programs.
 
 |`+--release+` |Ignores debug expressions in the source.
+
+|`+--sanity-checks+` |Enable sanity checking in the runtime system and generated code (for compiler development only).
+
 
 |`+-stub-system-api+` |Uses the the stub version of the system API.
 

--- a/doc/modules/language-guide/pages/compiler-ref.adoc
+++ b/doc/modules/language-guide/pages/compiler-ref.adoc
@@ -25,18 +25,18 @@ moc [option] [file ...]
 
 You can use the following options with the `+moc+` command.
 
-[width="100%",cols="<31%,<69%",options="header",]
+[width="100%",cols="<45%,<55%",options="header",]
 |===
 |Option |Description
-|`+--actor-idl+` |Specifies a path to actor IDL files.
+|`+--actor-idl <idl-path>+` |Specifies a path to actor IDL (Candid) files.
 
-|`+--actor-alias+` |Specifies an actor import alias.
+|`+--actor-alias <alias> <principal>+` |Specifies an actor import alias.
 
 |`+--args <file>+` |Read additional newline separated command line arguments from <file>
 
 |`+--args0 <file>+` |Read additional NUL separated command line arguments from <file>
 
-|`+-c+` |Compiles programs to WebAssembly.
+|`+-c+` |Compile to WebAssembly.
 
 |`+--check+` |Performs type checking only.
 
@@ -44,11 +44,11 @@ You can use the following options with the `+moc+` command.
 
 |`+--debug+` |Respects debug expressions in the source (the default).
 
-|`+-dp+` |Dumps parse.
+//|`+-dp+` |Dumps parse.
 
-|`+-dt+` |Dumps type-checked AST.
+//|`+-dt+` |Dumps type-checked AST.
 
-|`+-dl+` |Dumps intermediate representation
+//|`+-dl+` |Dumps intermediate representation
 
 |`+--error-detail <n>+` |Set level of error message detail for syntax errors, n in [0..3] (default 2).
 
@@ -62,46 +62,43 @@ You can use the following options with the `+moc+` command.
 
 |`+-i+` |Runs the compiler in an interactive read–eval–print loop (REPL) shell so you can evaluate program execution (implies -r).
 
-|`+-iR+` |Interprets the lowered code.
+//|`+-iR+` |Interprets the lowered code.
 
-|`+--map+` |Outputs a source map.
+|`+--map+` |Outputs a Javascript source map.
 
-|`+-no-await+` |Disables await-lowering (with -iR).
+//|`+-no-await+` |Disables await-lowering (with -iR).
 
-|`+-no-async+` |Disables async-lowering (with -iR).
+//|`+-no-async+` |Disables async-lowering (with -iR).
 
-|`+-no-check-ir+` |Skips intermediate code checking.
+//|`+-no-check-ir+` |Skips intermediate code checking.
 
-|`+-no-link+` |Disables statically-linked runtime.
+//|`+-no-link+` |Disables statically-linked runtime.
 
-|`+-no-system-api+` |Disables system API imports. 
+|`+-no-system-api+` |Disables system API imports.
 
-|`+-o+` |Creates an output file.
+|`+-o <file>+` |Specifies the output file.
 
-|`+-p+` |Sets the print depth.
+|`+-p <n>+` |Sets the print depth.
 
-|`+--package <pkg-name> <pkg-URL>+` |Specifies a package-name package-URL pair, separated by a space.
+|`+--package <package-name> <package-path>+` |Specifies a package-name package-path pair, separated by a space.
 
 |`+--print-deps+` |Prints the dependencies for a given source file.
 
-|`+--profile+` |Activates profiling counters in interpreters.
+//|`+--profile+` |Activates profiling counters in interpreters.
 
-|`+--profile-field <field>+` |Includes the given field from the program result in the profile file. 
+//|`+--profile-field <field>+` |Includes the given field from the program result in the profile file.
 
-|`+--profile-file+` |Sets profiling output file. 
+//|`+--profile-file+` |Sets profiling output file.
 
-|`+--profile-line-prefix <prefix>+` |Adds the specified prefix string to each profile line.
+//|`+--profile-line-prefix <prefix>+` |Adds the specified prefix string to each profile line.
 
 |`+-r+` |Interprets programs.
 
 |`+--release+` |Ignores debug expressions in the source.
 
-|`+--sanity-checks+` |Enable sanity checking in the runtime system and generated code (for compiler development only).
+//|`+--sanity-checks+` |Enable sanity checking in the runtime system and generated code (for compiler development only).
 
-
-|`+-stub-system-api+` |Uses the the stub version of the system API.
-
-|`+-t+` |Activates tracing in interpreters.
+|`+-t+` |Activates tracing in interpreter.
 
 |`+-v+` |Generates verbose output.
 
@@ -109,4 +106,4 @@ You can use the following options with the `+moc+` command.
 
 |`+-wasi-system-api+` |Uses the WASI system API (wasmtime).
 |===
-   
+

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -629,23 +629,23 @@ The category of a type determines the operators (unary, binary, relational and i
 |===
 | Identifier | Category | Description
 
-| `Bool` | L | Boolean values `true` and `false` and logical operators
-| `Char` | O | Unicode characters
-| `Text` | T, O | Unicode strings of characters with concatenation `_ # _` and iteration
-| `Float` | A, O | 64-bit floating point values
-| `Int`  | A, O | signed integer values with arithmetic (unbounded)
-| `Int8`  | A, O | signed 8-bit integer values with checked arithmetic
-| `Int16`  | A, O | signed 16-bit integer values with checked arithmetic
-| `Int32`  | A, O | signed 32-bit integer values with checked arithmetic
-| `Int64`  | A, O | signed 64-bit integer values with checked arithmetic
-| `Nat`  | A, O | non-negative integer values with arithmetic (unbounded)
-| `Nat8`  | A, O | non-negative 8-bit integer values with checked arithmetic
-| `Nat16`  | A, O | non-negative 16-bit integer values with checked arithmetic
-| `Nat32`  | A, O | non-negative 32-bit integer values with checked arithmetic
-| `Nat64`  | A, O | non-negative 64-bit integer values with checked arithmetic
-| `Blob` | O | binary blobs with iterators
-| `Principal` | O | principals
-| `Error` | | (opaque) error values
+| link:base-libraries/bool{outfilesuffix}[`Bool`] | L | Boolean values `true` and `false` and logical operators
+| link:base-libraries/char{outfilesuffix}[`Char`] | O | Unicode characters
+| link:base-libraries/text{outfilesuffix}[`Text`] | T, O | Unicode strings of characters with concatenation `_ # _` and iteration
+| link:base-libraries/float{outfilesuffix}[`Float`] | A, O | 64-bit floating point values
+| link:base-libraries/int{outfilesuffix}[`Int`]  | A, O | signed integer values with arithmetic (unbounded)
+| link:base-libraries/int8{outfilesuffix}[`Int8`]  | A, O | signed 8-bit integer values with checked arithmetic
+| link:base-libraries/int16{outfilesuffix}[`Int16`]  | A, O | signed 16-bit integer values with checked arithmetic
+| link:base-libraries/int32{outfilesuffix}[`Int32`]  | A, O | signed 32-bit integer values with checked arithmetic
+| link:base-libraries/int64{outfilesuffix}[`Int64`] | A, O | signed 64-bit integer values with checked arithmetic
+| link:base-libraries/nat{outfilesuffix}[`Nat`]  | A, O | non-negative integer values with arithmetic (unbounded)
+| link:base-libraries/nat8{outfilesuffix}[`Nat8`]  | A, O | non-negative 8-bit integer values with checked arithmetic
+| link:base-libraries/nat16{outfilesuffix}[`Nat16`]  | A, O | non-negative 16-bit integer values with checked arithmetic
+| link:base-libraries/nat32{outfilesuffix}[`Nat32`]  | A, O | non-negative 32-bit integer values with checked arithmetic
+| link:base-libraries/nat64{outfilesuffix}[`Nat64`] | A, O | non-negative 64-bit integer values with checked arithmetic
+| link:base-libraries/blob{outfilesuffix}[`Blob`] | O | binary blobs with iterators
+| link:base-libraries/principal{outfilesuffix}[`Principal`] | O | principals
+| link:base-libraries/error{outfilesuffix}[`Error`] | | (opaque) error values
 |===
 
 

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -1812,7 +1812,7 @@ Otherwise `r1`  and `r2` are (respectively) a location `v1` (a mutable identifie
 The unary compound assignment `+<unop>= <exp>+` has type `()` provided:
 
 * `<exp>` has type `var T`, and
-* ``<unop>``s category is a category of `T`.
+* ``<unop>`'s category is a category of `T`.
 
 The unary compound assignment
 `+<unop>= <exp>+`  evaluates `<exp>` to a result `r`. If `r` is `trap` the evaluation traps, otherwise `r` is a location storing value `v` and `r` is updated to
@@ -1861,7 +1861,7 @@ If `var` is absent from `var? T` then the value `v` is the constant value `vi`.
 Otherwise,
 
 * if the indexing occurs as the target of an assignment expression
-  then `v` is the `i`th mutable location in the array;
+  then `v` is the ``i``-th mutable location in the array;
 * otherwise,
   `v` is `vi`, the value currently stored in the ``i``-th location of the array.
 

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -1338,7 +1338,7 @@ The `<sort>` of the matched object type must be determined by an enclosing type 
 === Variant pattern
 
 The variant pattern `# <id> <pat>?` matches a variant value (of the form `# <id'> v`) against a variant pattern. An absent `<pat>?` is shorthand for the unit pattern (`()`).
-Pattern matching fails if the tag `<id'>` of the value is distinct from the tag `<id>` of the pattern (i.e. `<id>` != `<id'>`); or the tags are equal but the value `v` does not match the pattern `<pat>?`.
+Pattern matching fails if the tag `<id'>` of the value is distinct from the tag `<id>` of the pattern (i.e. `<id>` <> `<id'>`); or the tags are equal but the value `v` does not match the pattern `<pat>?`.
 Pattern matching succeeds if the tag of the value is `<id>` (i.e. `<id'>` = `<id>`) and the value `v` matches the pattern `<pat>?`.
 The binding returned by a successful match is just the binding returned by the match of `v` against `<pat>?`.
 

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -371,7 +371,7 @@ The syntax of a _program_ `<prog>` is as follows:
 
 ```bnf
 <prog> ::=             programs
-    <imp>;* <dec>;*
+  <imp>;* <dec>;*
 ```
 
 A program is a sequence of imports `<imp>;*` followed by a sequence of declarations `<dec>;*` that ends with an optional actor or actor class declaration.
@@ -395,13 +395,13 @@ The syntax of an _import_ `<imp>`  is as follows:
 
 ```bnf
 <imp> ::= imports
-    import <id>? =? <url>
+  import <id>? =? <url>
 
 <url> ::=
-    "<filepath>"                      import module from relative <filepath>.mo
-    "mo:<package-name>/<filepath>"    import module from package
-    "canister:<canisterid>"           import external actor by <canisterid>
-    "canister:<name>"                 import external actor by <name>
+  "<filepath>"                      import module from relative <filepath>.mo
+  "mo:<package-name>/<filepath>"    import module from package
+  "canister:<canisterid>"           import external actor by <canisterid>
+  "canister:<name>"                 import external actor by <name>
 ```
 
 An import introduces a resource named '<id>?' referring to a local source module, module from a package of modules, or canister (imported as an actor).
@@ -412,9 +412,10 @@ An import introduces a resource named '<id>?' referring to a local source module
 The syntax of a _library_ (that can be referenced in an import) is as follows:
 
 ```bnf
-<lib> ::=                                                                                       library
-    <imp>;* module <id>? <obj-body>                                                               module
-    <imp>;* <shared-pat>? actor class <id> <typ-params>? <pat> (: <typ>)? <class-body>            actor class
+<lib> ::=                                               library
+  <imp>;* module <id>? <obj-body>                         module
+  <imp>;* <shared-pat>? actor class                       actor class
+    <id> <typ-params>? <pat> (: <typ>)? <class-body>
 ```
 
 A library `<lib>` is a sequence of imports `<imp>;*` followed by:
@@ -441,21 +442,22 @@ Because actor construction is asynchronous, an instance of an imported actor cla
 The syntax of a _declaration_ is as follows:
 
 ```bnf
-<dec> ::=                                                                              declaration
-  <exp>                                                                                  expression
-  let <pat> = <exp>                                                                      immutable
-  var <id> (: <typ>)? = <exp>                                                            mutable
-  <sort> <id>? =? <obj-body>                                                             object
-  <shared-pat>? func <id>? <typ-params>? <pat> (: <typ>)? =? <exp>                       function
-  type <id> <typ-params>? = <typ>                                                        type
-  <shared-pat>? <sort>? class <id>? <typ-params>? <pat> (: <typ>)? <class-body>          class
+<dec> ::=                                                               declaration
+  <exp>                                                                  expression
+  let <pat> = <exp>                                                      immutable
+  var <id> (: <typ>)? = <exp>                                            mutable
+  <sort> <id>? =? <obj-body>                                             object
+  <shared-pat>? func <id>? <typ-params>? <pat> (: <typ>)? =? <exp>       function
+  type <id> <typ-params>? = <typ>                                        type
+  <shared-pat>? <sort>? class                                            class
+    <id>? <typ-params>? <pat> (: <typ>)? <class-body>
 
 <obj-body> ::=           object body
-   { <dec-field>;* }       field declarations
+  { <dec-field>;* }       field declarations
 
 <class-body> ::=         class body
-    = <id>? <obj-body>     object body, optionally binding <id> to _this_ instance
-    <obj-body>             object body
+  = <id>? <obj-body>     object body, optionally binding <id> to 'this' instance
+  <obj-body>             object body
 ```
 
 The syntax of a shared function qualifier with call-context pattern is as follows:
@@ -646,6 +648,12 @@ The category of a type determines the operators (unary, binary, relational and i
 | `Error` | | (opaque) error values
 |===
 
+
+Although many of these types have linguistic support for literals and operators, each primitive type also has an eponymous
+base library providing related functions and values (see link:base-libraries/stdlib-intro{outfilesuffix}[Motoko Base Library]).
+For example, the link:base-libraries/text{outfilesuffix}[`Text`] library provides common functions on `Text` values.
+
+
 [[type-bool]]
 === Type `Bool`
 
@@ -657,10 +665,10 @@ The type `Bool` of category L (Logical) has values `true` and `false` and is sup
 === Type `Char`
 
 A `Char` of category O (Ordered) represents characters as a code point in the Unicode character
-set. Characters can be converted to `Nat32`, and `Nat32`s in the
+set. Characters can be converted to `Nat32`, and ``Nat32``s in the
 range _0 .. 0x1FFFFF_ can be converted to `Char` (the conversion traps
-if outside of this range). With `charToText` a character can be
-converted into a text of length 1.
+if outside of this range). Base library function `Char.toText` converts a character
+into the corresponding, single character `Text` value.
 
 [[type-text]]
 === Type `Text`
@@ -677,7 +685,6 @@ Operations on text values include concatenation (`_ # _`) and sequential iterati
 The type `Float` represents 64-bit floating point values of categories A (Arithmetic) and O (Ordered).
 
 The semantics of `Float` and its operations is in accordance with standard https://ieeexplore.ieee.org/document/8766229[IEEE 754-2019]  (See <<IEEE754>>).
-
 
 Common functions and values are defined in base library "base/Float".
 
@@ -759,9 +766,10 @@ shared functions and used for simple authentication. Although opaque, principals
 
 Assuming base library import,
 
-```
+[source.no-repl,motoko]
+....
 import E "mo:base/Error";
-```
+....
 
 Errors are opaque values constructed and examined with operations:
 
@@ -771,7 +779,8 @@ Errors are opaque values constructed and examined with operations:
 
 Type `E.ErrorCode` is equivalent to variant type:
 
-----
+[source.no-repl,motoko]
+....
 type ErrorCode = {
   // Fatal error.
   #system_fatal;
@@ -786,7 +795,7 @@ type ErrorCode = {
   // Future error code (with unrecognized numeric code)
   #future : Nat32;
 };
-----
+....
 
 A constructed error `e = E.reject(t)` has `E.code(e) = #canister_reject` and `E.message(e) = t`.
 
@@ -1139,10 +1148,10 @@ A module library evaluates by (transitively) evaluating its imports, binding the
 The actor class library `<imp>;* <dec>` where `<dec>` is of the form  `<shared-pat>? actor class <id> <typ-params>? <pat> (: <typ>)? <class-body>` has type:
 
 ```bnf
-  module {
-    type <id> = T;
-    <id> : (U1,...,Un) -> async T
-  }
+module {
+  type <id> = T;
+  <id> : (U1,...,Un) -> async T
+}
 ```
 
 provided that:
@@ -1154,9 +1163,9 @@ Notice that the imported type of the function `<id>` must be asynchronous.
 An actor class library evaluates by (transitively) evaluating its imports, binding their values to the identifiers in `<imp>;*`, and evaluating the (derived) module:
 
 ```bnf
-  module {
-    <dec>
-  }
+module {
+  <dec>
+}
 ```
 
 On the Internet Computer, if this library is imported as identifier `Lib`,
@@ -1436,7 +1445,8 @@ Motoko requires all type declarations to be productive.
 
 For example, the type definitions:
 
-```
+[source.no-repl,motoko]
+....
   type Person = { first : Text; last : Text };
 
   type List<T> = ?(T, List<T>);
@@ -1444,13 +1454,14 @@ For example, the type definitions:
   type Fst<T, U> = T;
 
   type Ok<T> = Fst<Any, Ok<T>>;
-```
+....
 
 are all productive and legal.
 
 But the type definitions,
 
-```
+[source.no-repl,motoko]
+....
   type C = C;
 
   type D<T, U> = D<U, T>;
@@ -1459,7 +1470,7 @@ But the type definitions,
   type F<T> = E<T>;
 
   type G<T> = Fst<G<T>, Any>;
-```
+....
 
 are all non-productive, since each definition will enter a loop after one or more
 expansions of its body.
@@ -1487,15 +1498,17 @@ The graph is expansive if, and only if, it contains a cycle with at least one ex
 
 For example, the type definition:
 
-```
+[source.no-repl,motoko]
+....
   type List<T> = ?(T, List<T>),
-```
+....
 
 that recursively instantiates `List` at the same parameter `T`, is non-expansive and accepted, but the similar looking definition:
 
-```
+[source.no-repl,motoko]
+....
   type Seq<T> = ?(T, Seq<[T]>),
-```
+....
 
 that recursively instantiates `Seq` with a larger type, `[T]`, containing `T`, is _expansive_ and rejected.
 
@@ -1585,16 +1598,23 @@ Static phrases are designed to be side-effect free, allowing the coalescing of d
 === Function declaration
 
 The function declaration  `<shared-pat>? func <id>? <typ-params>? <pat> (: <typ>)? =? <exp>` is syntactic sugar for
-a named `let` or anonymous declaration of a function expression. That is:
+a named `let` or anonymous declaration of a function expression.
+
+That is, when `<id>?` is present and the function is named:
 
 ```bnf
-<shared-pat>? func <id>? <typ-params>? <pat> (: <typ>)? =? <block-or-exp> :=
-  let <id> = <shared-pat>? func <typ-params>? <pat> (: <typ>)? =? <block-or-exp>    (when <id>? present)
-
-  <shared-pat>? func <typ-params>? <pat> (: <typ>)? =? <block-or-exp>               (when <id>? absent)
+<shared-pat>? func <id> <typ-params>? <pat> (: <typ>)? =? <block-or-exp> :=
+  let <id> = <shared-pat>? func <typ-params>? <pat> (: <typ>)? =? <block-or-exp>
 ```
 
-Named function definitions are recursive.
+But when `<id>?` is absent and the function is anonymous:
+
+```bnf
+<shared-pat>? func <typ-params>? <pat> (: <typ>)? =? <block-or-exp> :=
+  <shared-pat>? func <typ-params>? <pat> (: <typ>)? =? <block-or-exp>
+```
+
+Named function definitions support recursion (a named function can call itself).
 
 NOTE: In compiled code, `shared` functions can only appear as public actor fields.
 
@@ -1737,7 +1757,7 @@ Objects can be written in literal form `{ <exp-field>;* }`, consisting of a list
 ```bnf
 <exp-field> ::=                                object expression fields
   var? <id> (: <typ>) = <exp>                    field
-  var? <id> (: <typ>)                             punned field
+  var? <id> (: <typ>)                            punned field
 ```
 Such an object literal, sometimes called a _record_, is equivalent to the object declaration `object { <dec-field>;* }` where the declaration fields are obtained from the expression fields by prefixing each of them with `public let`, or just `public` in case of `var` fields.
 However, unlike declarations, the field list does not bind each `<id>` as a local name within the literal, i.e., the field names are _not_ in scope in the field expressions.

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -322,7 +322,7 @@ Equality and inequality are structural and based on the observable content of th
 | `+%=+`   | A | in place modulo
 | `+**=+`  | A | in place exponentiation
 | `+&=+`   | B | in place logical and
-| `+|=+`   | B | in place logical or
+| `+\|=+`   | B | in place logical or
 | `+^=+`   | B | in place exclusive or
 | `+<<=+`  | B | in place shift left
 | `+>>=+`  | B | in place shift right
@@ -348,7 +348,7 @@ Tokens on the same line have equal precedence with the indicated associativity.
 
 | LOWEST  | none | `if _ _` (no `else`), `loop _` (no `while`)
 |(higher)| none | `else`, `while`
-|(higher)| right | `:=`, `+=`, `-=`, `*=`, `+/=+`, `+%=+`, `+**=+`, `+#=+`, `+&=+`, `+|=+`, `+^=+`, `+<<=+`, `+>>=+`, `+<<>=+`, `+<>>=+`, `+%=`, `-%=`, `*%=`, `**%=`
+|(higher)| right | `:=`, `+=`, `-=`, `*=`, `+/=+`, `+%=+`, `+**=+`, `+#=+`, `+&=+`, `+\|=+`, `+^=+`, `+<<=+`, `+>>=+`, `+<<>=+`, `+<>>=+`, `+%=`, `-%=`, `*%=`, `**%=`
 |(higher)| left | `:`
 |(higher)| left | `or`
 |(higher)| left | `and`

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -664,10 +664,12 @@ The type `Bool` of category L (Logical) has values `true` and `false` and is sup
 [[type-char]]
 === Type `Char`
 
-A `Char` of category O (Ordered) represents characters as a code point in the Unicode character
-set. Characters can be converted to `Nat32`, and ``Nat32``s in the
-range _0 .. 0x1FFFFF_ can be converted to `Char` (the conversion traps
-if outside of this range). Base library function `Char.toText` converts a character
+A `Char` of category O (Ordered) represents a character as a code point in the Unicode character set.
+
+Base library function `Char.toNat32(c)` converts a `Char` value, `c` to its `Nat32` code point.
+Function `Char.fromNat32(n)` converts
+a `Nat32` value, `n`, in the range _x0..xD800_ or _0xE000..0x10FFFF_ of valid code points to its `Char` value; this conversion traps on invalid arguments.
+Function `Char.toText(c)` converts the `Char` `c`
 into the corresponding, single character `Text` value.
 
 [[type-text]]

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -119,7 +119,7 @@ Digit  ::= 0..9
 [[syntax-integers]]
 === Integers
 
-Integers are written as decimal or hexadecimal, `Ox`-prefixed natural numbers.
+Integers are written as decimal or hexadecimal, ``Ox``-prefixed natural numbers.
 Subsequent digits may be prefixed a single, semantically irrelevant, underscore.
 
 ```bnf
@@ -135,7 +135,7 @@ Negative integers may be constructed by applying a prefix negation `-` operation
 [[syntax-floats]]
 === Floats
 
-Floating point literals are written in decimal or `Ox`-prefixed hexadecimal scientific notation.
+Floating point literals are written in decimal or ``Ox``-prefixed hexadecimal scientific notation.
 
 ```bnf
 let frac = num
@@ -159,8 +159,8 @@ NOTE: the use of decimal notation, even for the base 2 exponent, is in keeping w
 A character is a single quote (`'`) delimited:
 
 * Unicode character in UTF-8,
-* `\`-escaped  newline, carriage return, tab, single or double quotation mark
-* `\`-prefixed ASCII character (TBR),
+* ``\``-escaped  newline, carriage return, tab, single or double quotation mark
+* ``\``-prefixed ASCII character (TBR),
 * or  `\u{` hexnum `}` enclosed valid, escaped Unicode character in hexadecimal (TBR).
 
 ```bnf
@@ -193,7 +193,7 @@ char := '\'' character '\''
 [[syntax-text]]
 === Text
 
-A text literal is `"`-delimited sequence of characters:
+A text literal is ``"``-delimited sequence of characters:
 
 ```bnf
 text ::= '"' character* '"'
@@ -374,7 +374,7 @@ The syntax of a _program_ `<prog>` is as follows:
     <imp>;* <dec>;*
 ```
 
-A program is sequence of imports `<imp>;*` followed by a sequence of declarations `<dec>;*` that ends with an optional actor or actor class declaration.
+A program is a sequence of imports `<imp>;*` followed by a sequence of declarations `<dec>;*` that ends with an optional actor or actor class declaration.
 The actor or actor class declaration determines the main actor, if any, of the program.
 
 For now, compiled programs must obey the following additional restrictions (not imposed on interpreted programs):
@@ -497,7 +497,7 @@ The _stability_ qualifier `<stab>` determines the _upgrade_ behaviour of actor f
 * The pattern in a `stable let <pat> = <exp>` declaration must be _simple_ where,  a pattern `pat` is  simple if it (recursively) consists of
 ** a variable pattern `<id>`, or
 ** an annotated simple pattern `<pat> : <typ>`, or
-** a parenthesised simple pattern `( <pat> )`.
+** a parenthesized simple pattern `( <pat> )`.
 
 [[syntax-expressions]]
 === Expression syntax
@@ -602,7 +602,7 @@ Type expressions are used to specify the types of arguments, constraints (a.k.a 
   Any                                           top
   None                                          bottom
   Error                                         errors/exceptions
-  ( type )                                      parenthesized type
+  ( <typ> )                                      parenthesized type
 
 <sort> ::= (actor | module | object)
 
@@ -890,7 +890,7 @@ No value has type `None`.
 As an empty type, `None` can be used to specify the impossible return value of an infinite loop or unconditional trap.
 
 [[paren-type]]
-=== Parenthesised type
+=== Parenthesized type
 
 A function that takes an immediate, syntactic tuple of length _n >= 0_ as its domain or range is a function that takes (respectively returns) _n_ values.
 

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -2214,7 +2214,7 @@ If the future is complete with (thrown) error value `e`, then `await <exp>` susp
 
 Note: suspending computation on `await`, regardless of the dynamic status of the future, ensures that all tentative state changes and message sends prior to the `await` are committed and irrevocable.
 
-WARNING: between suspension and resumption of a computation, the state of the enclosing actor may change due to concurrent processing of other incoming actor messages. It is the programmer's responsibility to guard against non-synchronized state changes.
+WARNING: Between suspension and resumption of a computation, the state of the enclosing actor may change due to concurrent processing of other incoming actor messages. It is the programmer's responsibility to guard against non-synchronized state changes.
 
 [[exp-throw]]
 === Throw
@@ -2316,7 +2316,7 @@ An invalid canister identifier or type may manifest itself, if at all, as a late
 when calling a function on the actor's proclaimed interface,
 which will either fail or be rejected.
 
-NOTE: The argument to `actor` should _not_ include the `ic:` resource locator used to specify an `import`. For example, use `actor "lg264-qjkae"`, not `actor "ic:lg264-qjkae"`.
+NOTE: The argument to `actor` should _not_ include the `ic:` resource locator used to specify an `import`. For example, use `+actor "lg264-qjkae"+`, not `+actor "ic:lg264-qjkae"+`.
 
 WARNING: Although they do not compromise type safety, actor references can easily introduce latent, dynamic errors.
 Accordingly, actor references should be used sparingly and only when needed.

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -249,16 +249,16 @@ For example, type `Int` is both arithmetic (A) and ordered (O) and supports both
 
 |===
 | `<relop>` | Category |
-|  `==` |  | equals
-|  `!=` |  | not equals
+|  `+==+` |  | equals
+|  `+!=+` |  | not equals
 | `␣<␣` | O | less than *(must be enclosed in whitespace)*
 | `␣>␣` | O | greater than *(must be enclosed in whitespace)*
-|  `\<=` | O | less than or equal
-|  `>=` | O | greater than or equal
+|  `+<=+` | O | less than or equal
+|  `+>=+` | O | greater than or equal
 |===
 
 
-Note that equality (`==`) and inequality (`!=`) do not have categories.
+Note that equality (`+==+`) and inequality (`+!=+`) do not have categories.
 Instead, equality and inequality are applicable to arguments of all
 _shared_ types, including non-primitive, compound types such as
 immutable arrays, records, and variants.
@@ -312,30 +312,30 @@ Equality and inequality are structural and based on the observable content of th
 === Assignment operators
 
 |===
-|`:=`, `<unop>=`, `<binop>=`| Category|
+|`:=`, `+<unop>=+`, `+<binop>=+`| Category|
 
 | `:=`   | * | assignment (in place update)
 | `+=`   | A | in place add
 | `-=`   | A | in place subtract
 | `*=`   | A | in place multiply
 | `/=`   | A | in place divide
-| `%=`   | A | in place modulo
-| `**=`  | A | in place exponentiation
-| `&=`   | B | in place logical and
-| `\|=`   | B | in place logical or
-| `^=`   | B | in place exclusive or
-| `<\<=`  | B | in place shift left
-| `>>=`  | B | in place shift right
-| `<<>=` | B | in place rotate left
-| `<>>=` | B | in place rotate right
-| `+%=`   | B | in place add (wrap-on-overflow)
-| `-%=`   | B | in place subtract (wrap-on-overflow)
+| `+%=+`   | A | in place modulo
+| `+**=+`  | A | in place exponentiation
+| `+&=+`   | B | in place logical and
+| `+|=+`   | B | in place logical or
+| `+^=+`   | B | in place exclusive or
+| `+<<=+`  | B | in place shift left
+| `+>>=+`  | B | in place shift right
+| `+<<>=+` | B | in place rotate left
+| `+<>>=+` | B | in place rotate right
+| `++%=+`   | B | in place add (wrap-on-overflow)
+| `+-%=+`   | B | in place subtract (wrap-on-overflow)
 | `*%=`   | B | in place multiply (wrap-on-overflow)
 | `**%=`  | B | in place exponentiation (wrap-on-overflow)
-| `#=`   | T | in place concatenation
+| `+#=+`   | T | in place concatenation
 |===
 
-The category of a compound assignment `<unop>=`/`<binop>=` is given by the category of the operator `<unop>`/`<binop>`.
+The category of a compound assignment `+<unop>=+`/`+<binop>=+` is given by the category of the operator `<unop>`/`<binop>`.
 
 [[syntax-precedence]]
 === Operator and keyword precedence
@@ -348,13 +348,13 @@ Tokens on the same line have equal precedence with the indicated associativity.
 
 | LOWEST  | none | `if _ _` (no `else`), `loop _` (no `while`)
 |(higher)| none | `else`, `while`
-|(higher)| right | `:=`, `+=`, `-=`, `*=`, `/=`, `%=`, `**=`, `#=`, `&=`, `\|=`, `^=`, `<\<=`, `>>=`, `<<>=`, `<>>=`, `+%=`, `-%=`, `*%=`, `**%=`,`
+|(higher)| right | `:=`, `+=`, `-=`, `*=`, `+/=+`, `+%=+`, `+**=+`, `+#=+`, `+&=+`, `+|=+`, `+^=+`, `+<<=+`, `+>>=+`, `+<<>=+`, `+<>>=+`, `+%=`, `-%=`, `*%=`, `**%=`
 |(higher)| left | `:`
 |(higher)| left | `or`
 |(higher)| left | `and`
-|(higher)| none | `==`, `!=`, `<`, `>`, `\<=`, `>`, `>=`
+|(higher)| none | `+==+`, `+!=+`, `<`, `>`, `+<=+`, `>`, `+>=+`
 |(higher)| left | `+`, `-`, `#`, `+%`, `-%`
-|(higher)| left | `*`, `/`, `%`, `*%`
+|(higher)| left | `+*+`, `/`, `%`, `+*%+`
 |(higher)| left | `\|`
 |(higher)| left | `+&+`
 |(higher)| left | `+^+`
@@ -701,13 +701,13 @@ All have categories A (Arithmetic), B (Bitwise) and O (Ordered).
 
 Operations that may under- or overflow the representation are checked and trap on error.
 
-The operations `+%`, `-%`, `*%` and `**%` provide access to wrap-around, modular arithmetic.
+The operations `+%`, `-%`, `+*%+` and `**%` provide access to wrap-around, modular arithmetic.
 
-As bitwise types, these types support bitwise operations *and* `(&)`,
-*or* `(|)` and *exclusive-or* `(^)`. Further, they can be rotated
-left `(<<>)`, right `(<>>)`, and shifted left `(<<)`, right `(>>)`.
+As bitwise types, these types support bitwise operations *and* (`&`),
+*r* (`|`) and *exclusive-or* (`^`). Further, they can be rotated
+left (`<<>`), right (`<>>`), and shifted left (`<<`), right (`>>`).
 The right-shift preserves the two's-complement sign.
-All shift and rotate amounts are considered modulo the numbers's bit width *n*.
+All shift and rotate amounts are considered modulo the numbers's bit width _n_.
 
 Bounded integer types are not in subtype relationship with each other or with
 other arithmetic types, and their literals need type annotation if
@@ -727,13 +727,13 @@ All have categories A (Arithmetic), B (Bitwise) and O (Ordered).
 
 Operations that may under- or overflow the representation are checked and trap on error.
 
-The operations `+%`, `-%`, `*%` and `**%` provide access to the modular, wrap-on-overflow operations.
+The operations `+%`, `-%`, `+*%+` and `**%` provide access to the modular, wrap-on-overflow operations.
 
-As bitwise types, these types support bitwise operations *and* `(&)`,
-*or* `(|)` and *exclusive-or* `(^)`. Further, they can be rotated
-left `(<<>)`, right `(<>>)`, and shifted left `(<<)`, right `(>>)`.
+As bitwise types, these types support bitwise operations _and_ (`&`),
+_or_ (`|`) and _exclusive-or_ (`^`). Further, they can be rotated
+left (`<<>`), right (`<>>`), and shifted left (`<<`), right (`>>`).
 The right-shift is logical.
-All shift and rotate amounts are considered modulo the number's bit width *n*.
+All shift and rotate amounts are considered modulo the number's bit width _n_.
 
 The corresponding module in the base library provides conversion functions:
 Conversion to `Int`, checked and wrapping conversions from `Int` and wrapping
@@ -765,13 +765,13 @@ import E "mo:base/Error";
 
 Errors are opaque values constructed and examined with operations:
 
-* `E.reject : Text -> Error`
-* `E.code : Error -> E.ErrorCode`
-* `E.message : Error -> Text`
+* `+E.reject : Text -> Error+`
+* `+E.code : Error -> E.ErrorCode+`
+* `+E.message : Error -> Text+`
 
 Type `E.ErrorCode` is equivalent to variant type:
 
-```
+----
 type ErrorCode = {
   // Fatal error.
   #system_fatal;
@@ -786,7 +786,7 @@ type ErrorCode = {
   // Future error code (with unrecognized numeric code)
   #future : Nat32;
 };
-```
+----
 
 A constructed error `e = E.reject(t)` has `E.code(e) = #canister_reject` and `E.message(e) = t`.
 
@@ -850,7 +850,7 @@ The `Null` type has a single value, the literal `null`. `Null` is a subtype of t
 [[function-types]]
 === Function types
 
-Type `<shared>? <typ-params>? <typ1> -> <typ2>` specifies the type of functions that consume (optional) type parameters `<typ-params>`, consume a value parameter of type `<typ1>` and produce a result of type `<typ2>`.
+Type `+<shared>? <typ-params>? <typ1> -> <typ2>+` specifies the type of functions that consume (optional) type parameters `<typ-params>`, consume a value parameter of type `<typ1>` and produce a result of type `<typ2>`.
 
 Both `<typ1>` and `<typ2>` may reference type parameters declared in `<typ-params>`.
 
@@ -985,8 +985,8 @@ type parameter.
 A type `T` is well-formed only if (recursively) its constituent types are well-formed, and:
 
 * if `T` is `async U` then `U` is shared, and
-* if `T` is `shared query? U -> V`, `U` is shared and
-  `V == ()` or `V == async W'` with `W` shared, and
+* if `T` is `+shared query? U -> V+`, `U` is shared and
+  `V == ()` or `V == async W` with `W` shared, and
 * if `T` is `C<T0, ..., Tn>` where:
 ** a declaration `type C<X0 <: U0, Xn <: Un>  = ...` is in scope, and
 ** `Ti <: Ui[ T0/X0, ..., Tn/Xn ]`, for each `0 \<= i \<= n`.
@@ -1037,8 +1037,8 @@ Two types `T`, `U` are related by subtyping, written `T <: U`, whenever, one of 
 +
 (That is, variant type `T` is a subtype of variant type `U` if every field of `T` subtypes the same field of `U`. In particular, `T` may specify fewer variants than `U`.)
 +
-* `T` is a function type `<shared>? <X0 <: V0, ..., Xn <: Vn> T1 -> T2`,
-  `U` is a function type `<shared>? <X0 <: W0, ..., Xn <: Wn> U1 -> U2` and
+* `T` is a function type `+<shared>? <X0 <: V0, ..., Xn <: Vn> T1 -> T2+`,
+  `U` is a function type `+<shared>? <X0 <: W0, ..., Xn <: Wn> U1 -> U2+` and
 ** `T` and `U` are either both equivalently `<shared>?`, and
 ** assuming constraints `X0 <: W0, ..., Xn <: Wn` then
 *** for all `i`, `Wi == Vi`, and
@@ -1238,8 +1238,8 @@ The declaration `<dec>` of a `system` field must be a manifest `func` declaratio
 |===
 |  name | type | description
 
-| `preupgrade`  | `() -> ()` | pre upgrade action
-| `postupgrade` | `() -> ()` | post upgrade action
+| `preupgrade`  | `+() -> ()+` | pre upgrade action
+| `postupgrade` | `+() -> ()+` | post upgrade action
 |===
 
 * `preupgrade`, when declared, is called during an upgrade, immediately _before_ the (current) values of the (retired) actor's stable variables are transferred to the replacement actor.
@@ -1325,7 +1325,7 @@ The set of identifiers bound by each field of the object pattern must be distinc
 The names of the pattern fields in the object pattern must be distinct.
 
 Object patterns support _punning_ for concision.
-A punned field `<id>` is shorthand for `<id> = <id>`; Similarly, a typed, punned field `<id> : <typ> ` is short-hand for `<id> = <id> : <typ>`. Both
+A punned field `<id>` is shorthand for `<id> = <id>`; Similarly, a typed, punned field `<id> : <typ>` is short-hand for `<id> = <id> : <typ>`. Both
 bind the matched value of the field named `<id>` to the identifier `<id>`.
 
 Pattern matching fails if one of the pattern fields fails to match the corresponding field value of the object value.
@@ -1338,7 +1338,7 @@ The `<sort>` of the matched object type must be determined by an enclosing type 
 === Variant pattern
 
 The variant pattern `# <id> <pat>?` matches a variant value (of the form `# <id'> v`) against a variant pattern. An absent `<pat>?` is shorthand for the unit pattern (`()`).
-Pattern matching fails if the tag `<id'>` of the value is distinct from the `<id>` of the pattern (i.e. `<id>` <> `<id'>`); or the tags are equal but the value `v` does not match the pattern `<pat>?`.
+Pattern matching fails if the tag `<id'>` of the value is distinct from the tag `<id>` of the pattern (i.e. `<id>` != `<id'>`); or the tags are equal but the value `v` does not match the pattern `<pat>?`.
 Pattern matching succeeds if the tag of the value is `<id>` (i.e. `<id'>` = `<id>`) and the value `v` matches the pattern `<pat>?`.
 The binding returned by a successful match is just the binding returned by the match of `v` against `<pat>?`.
 
@@ -1347,7 +1347,7 @@ The binding returned by a successful match is just the binding returned by the m
 
 The annotated pattern `<pat> : <typ>` matches value of `v` type `<typ>` against the pattern `<pat>`.
 
-`<pat> : <typ>` is *not* a dynamic type test, but is used to constrain the types of identifiers bound in `<pat>`, e.g. in the argument pattern to a function.
+`<pat> : <typ>` is _not_ a dynamic type test, but is used to constrain the types of identifiers bound in `<pat>`, e.g. in the argument pattern to a function.
 
 [[pat-option]]
 === Option pattern
@@ -1400,7 +1400,7 @@ The variable declaration `var <id> (: <typ>)? = <exp>` declares a *mutable* vari
 The declaration `var <id>` has type `()` provided:
 
 * `<exp>` has type `T`; and
-* If the annotation `(:<typ>)?` is present, then `T == <typ>`.
+* If the annotation `(:<typ>)?` is present, then `T` == `<typ>`.
 
 Within the scope of the declaration, `<id>` has type `var T` (see <<exp-assn>>).
 
@@ -1468,6 +1468,7 @@ expansions of its body.
 ==== Expansiveness
 
 A set of mutually recursive type or class declarations will be rejected if the set is _expansive_.
+
 Expansiveness is a syntactic criterion. To determine whether a set of singly or mutually recursive type definitions, say
 
 ```
@@ -1478,9 +1479,9 @@ Expansiveness is a syntactic criterion. To determine whether a set of singly or 
 
 is expansive, construct a directed graph whose vertices are the formal type parameters (identified by position), `C#i`, with the following `{0,1}`-labeled edges:
 
-* For each occurrence of parameter `C#i` as immediate, `j`-th argument to type `D<...,C#i,...>`, add a *non-expansive*, `0`-labeled edge `C#i -0-> D#j`.
+* For each occurrence of parameter `C#i` as immediate, `j`-th argument to type `D<...,C#i,...>`, add a _non-expansive_, `0`-labeled edge,`+C#i -0-> D#j+`.
 
-* For each occurrence of parameter `C#i` as a proper sub-expression of the `j`-th argument to type `D<...,T[C#i],..>` add an *expansive* `1`-labeled edge `C#i -1-> D#j`.
+* For each occurrence of parameter `C#i` as a proper sub-expression of the `j`-th argument to type `D<...,T[C#i],..>` add an _expansive_ `1`-labeled edge, `+C#i -1-> D#j+`.
 
 The graph is expansive if, and only if, it contains a cycle with at least one expansive edge.
 
@@ -1498,9 +1499,9 @@ that recursively instantiates `List` at the same parameter `T`, is non-expansive
 
 that recursively instantiates `Seq` with a larger type, `[T]`, containing `T`, is *expansive* and rejected.
 
-* Type `List<T>` is non-expansive because its graph, `{ List#0 -0-> List#0 }`, though cyclic, has no expansive edge.
+* Type `List<T>` is non-expansive because its graph, `+{ List#0 -0-> List#0 }+`, though cyclic, has no expansive edge.
 
-* Type `Seq<T>`, on the other hand, is expansive, because its graph, `{ Seq#0 -1-> Seq#0 }`, has a cycle that includes an expansive edge.
+* Type `Seq<T>`, on the other hand, is expansive, because its graph, `+{ Seq#0 -1-> Seq#0 }+`, has a cycle that includes an expansive edge.
 
 
 [[decl-obj]]
@@ -1681,7 +1682,7 @@ The relational expression `<exp1> <relop> <exp2>` has type `Bool` provided:
 
 * `<exp1>` has type `T`, and
 * `<exp2>` has type `T`, and
-* `<relop>` is equality `==` or inequality `!=`, `T` is _shared_, and `T` is the least type such that `<exp1>` and `<exp2>` have type `T`;
+* `<relop>` is equality `+==+` or inequality `+!=+`, `T` is _shared_, and `T` is the least type such that `<exp1>` and `<exp2>` have type `T`;
 * the category O (Ordered) is a category of `T` and <relop>; or
 
 The binary operator expression `<exp1> <relop> <exp2>` evaluates `exp1` to a result `r1`. If `r1` is `trap`, the expression results in `trap`.
@@ -1742,7 +1743,7 @@ Such an object literal, sometimes called a *record*, is equivalent to the object
 However, unlike declarations, the field list does not bind each `<id>` as a local name within the literal, i.e., the field names are _not_ in scope in the field expressions.
 
 Object expressions support _punning_ for concision.
-A punned field `<id>` is shorthand for `<id> = <id>`; Similarly, a typed, punned field `<id> : <typ> ` is short-hand for `<id> = <id> : <typ>`. Both
+A punned field `<id>` is shorthand for `<id> = <id>`; Similarly, a typed, punned field `<id> : <typ>` is short-hand for `<id> = <id> : <typ>`. Both
 associate the field named `<id>` with the value of the identifier `<id>`.
 
 [[exp-proj]]
@@ -1770,16 +1771,16 @@ The iterator access `<exp> . <id>` has type `T` provided `<exp>` has type `U`, a
 |===
 | U | <id> | T  | Description
 | `Text` | `size` | `Nat` | size (or length) in characters
-| `Text` | `chars` | `{ next: () -> Char? }` | character iterator, first to last
+| `Text` | `chars` | `+{ next: () -> Char? }+` | character iterator, first to last
 | | | |
 | `Blob` | `size` | `Nat` | size in bytes
-| `Blob` | `vals` | `{ next: () -> Nat8? }` | byte iterator, first to last
+| `Blob` | `vals` | `+{ next: () -> Nat8? }+` | byte iterator, first to last
 | | | |
 | `[var? T]` | `size` | `Nat` | number of elements
-| `[var? T]` | `get` | `Nat -> T` | indexed read function
-| `[var? T]` | `keys` | `{ next: () -> Nat? }` | index iterator, by ascending index
-| `[var? T]` | `vals` | `{ next: () -> T? }` | value iterator, by ascending index
-| `[var T]` | `put` | `(Nat, T) -> ()` | indexed write function (mutable arrays only)
+| `[var? T]` | `get` | `+Nat -> T+` | indexed read function
+| `[var? T]` | `keys` | `+{ next: () -> Nat? }+` | index iterator, by ascending index
+| `[var? T]` | `vals` | `+{ next: () -> T? }+` | value iterator, by ascending index
+| `[var T]` | `put` | `+(Nat, T) -> ()+` | indexed write function (mutable arrays only)
 |===
 
 The projection `<exp> . <id>` evaluates `<exp>` to a result `r`.
@@ -1808,13 +1809,13 @@ Otherwise `r1`  and `r2` are (respectively) a location `v1` (a mutable identifie
 [[exp-uassn]]
 === Unary compound assignment
 
-The unary compound assignment `<unop>= <exp>` has type `()` provided:
+The unary compound assignment `+<unop>= <exp>+` has type `()` provided:
 
 * `<exp>` has type `var T`, and
-* `<unop>`'s category is a category of `T`.
+* ``<unop>``s category is a category of `T`.
 
 The unary compound assignment
-`<unop>= <exp>`  evaluates `<exp>` to a result `r`. If `r` is `trap` the evaluation traps, otherwise `r` is a location storing value `v` and `r` is updated to
+`+<unop>= <exp>+`  evaluates `<exp>` to a result `r`. If `r` is `trap` the evaluation traps, otherwise `r` is a location storing value `v` and `r` is updated to
 contain the value `<unop> v`.
 
 [[exp-bassn]]
@@ -1824,10 +1825,10 @@ The binary compound assignment `<exp1> <binop>= <exp2>` has type `()` provided:
 
 * `<exp1>` has type `var T`, and
 * `<exp2>` has type `T`, and
-* `<binop>`'s category is a category of `T`.
+* ``<binop>``'s category is a category of `T`.
 
-For binary operator `<binop>`, `<exp1> <binop>= <exp1>`,
-the compound assignment expression `<exp1> <binop>= <exp2>` evaluates `<exp1>` to a result `r1`. If `r1` is `trap`, the expression results in `trap`.
+For binary operator `<binop>`,
+the compound assignment expression `+<exp1> <binop>= <exp2>+` evaluates `<exp1>` to a result `r1`. If `r1` is `trap`, the expression results in `trap`.
 Otherwise, `exp2` is evaluated to a result `r2`. If `r2` is `trap`, the expression results in `trap`.
 
 Otherwise `r1`  and `r2` are (respectively) a location `v1` (a mutable identifier, an item of a mutable array or a mutable field of object) and a value `v2`. The expression updates the current value, `w` stored in `v1` with the new value `w <binop> v2` and returns the empty tuple `()`.
@@ -1862,14 +1863,14 @@ Otherwise,
 * if the indexing occurs as the target of an assignment expression
   then `v` is the `i`th mutable location in the array;
 * otherwise,
-  `v` is `vi`, the value currently stored in the `i`th location of the array.
+  `v` is `vi`, the value currently stored in the ``i``-th location of the array.
 
 [[exp-call]]
 === Function calls
 
 The function call expression `<exp1> <T0,...,Tn>? <exp2>` has type `T` provided:
 
-* the function `<exp1>` has function type `<shared>? < X0 <: V0, ..., Xn <: Vn > U1-> U2`; and
+* the function `<exp1>` has function type `+<shared>? < X0 <: V0, ..., Xn <: Vn > U1-> U2+`; and
 * if `<T0,...,Tn>?` is absent but n > 0 then there exists minimal `T0, ..., Tn` (inferred by the compiler) such that:
 * each type argument satisfies the corresponding type parameter's bounds:
   for each `1 \<= i \<= n`, `Ti <: [T0/X0, ..., Tn/Xn]Vi`; and
@@ -1892,12 +1893,12 @@ NOTE: The exhaustiveness side condition on `shared` function expressions ensures
 [[exp-func]]
 === Functions
 
-The function expression `<shared-pat>? func < X0 <: T0, ..., Xn <: Tn > <pat1> (: U2)? =? <block-or-exp>` has type `<shared>? < X0 <: T0, ..., Xn <: Tn > U1-> U2` if, under the
+The function expression `<shared-pat>? func < X0 <: T0, ..., Xn <: Tn > <pat1> (: U2)? =? <block-or-exp>` has type `+<shared>? < X0 <: T0, ..., Xn <: Tn > U1-> U2+` if, under the
 assumption that `X0 <: T0, ..., Xn <: Tn`:
 
 * `<shared-pat>?` is of the form `shared query? <pat>` if and only if `<shared>?` is `shared query?` (the `query` modifiers must agree);
 * all the types in `T0, ..., Tn` and `U2` are well-formed and well-constrained;
-* pattern `<pat>` has *context type* `{ caller : Principal }`;
+* pattern `<pat>` has _context type_ `{ caller : Principal }`;
 * pattern `<pat1>` has type `U1`;
 * if the function is `shared` then `<pat>` and `<pat1>` must be exhaustive;
 * expression `<block-or-exp>` has type return type `U2` under the assumption that `<pat1>` has type `U1`.
@@ -1922,7 +1923,7 @@ The block expression `{ <dec>;* }` has type `T` provided the last declaration in
 All identifiers declared in block must be distinct type identifiers or distinct value identifiers and are in scope in the definition of all other declarations in the block.
 
 The bindings of identifiers declared in `{ dec;* }` are local to the block.
-The type `T` must be well-formed in the enclosing environment of the block. In particular, any local, recursive types that cannot be expanded to types well-formed the enclosing environment must not appear in `T`.
+
 
 The type system ensures that a value identifier cannot be evaluated before its declaration has been evaluated, precluding run-time errors at the cost of rejection some well-behaved programs.
 
@@ -2237,7 +2238,7 @@ Expression `assert <exp>` evaluates `<exp>` to a result `r`. If `r` is `trap` ev
 The type annotation expression `<exp> : <typ>` has type `T` provided:
 
 * `<typ>` is `T`, and
-* `<exp>` has type `U` where `U` <: `T`.
+* `<exp>` has type `U` where `U <: T`.
 
 Type annotation may be used to aid the type-checker when it cannot otherwise determine the type of `<exp>` or when one wants to constrain the inferred type, `U` of `<exp>` to a less-informative super-type `T` provided `U <: T`.
 

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -2334,7 +2334,7 @@ The result of evaluating `( <exp> )` is the result of evaluating `<exp>`.
 
 Whenever `<exp>` has type `T` and `T <: U` (`T` subtypes `U`) then by virtue of _implicit subsumption_, `<exp>` also has type `U` (without extra syntax).
 
-In general, this means that an expression of a more specific type may appear wherever an expression of a more general type is expected, provided the specific and general types are related by subtyping.
+In general, this means that an expression of a more specific type may appear wherever an expression of a more general type is expected, provided the specific and general types are related by subtyping. This static change of type has no runtime cost.
 
 == References
 

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -251,8 +251,8 @@ For example, type `Int` is both arithmetic (A) and ordered (O) and supports both
 | `<relop>` | Category |
 |  `+==+` |  | equals
 |  `+!=+` |  | not equals
-| `␣<␣` | O | less than *(must be enclosed in whitespace)*
-| `␣>␣` | O | greater than *(must be enclosed in whitespace)*
+| `␣<␣` | O | less than _(must be enclosed in whitespace)_
+| `␣>␣` | O | greater than _(must be enclosed in whitespace)_
 |  `+<=+` | O | less than or equal
 |  `+>=+` | O | greater than or equal
 |===
@@ -289,7 +289,7 @@ Equality and inequality are structural and based on the observable content of th
 | `\|`   | B | bitwise or
 | `^`   | B | exclusive or
 | `<<`  | B | shift left
-| `␣>>` | B | shift right *(must be preceded by whitespace)*
+| `␣>>` | B | shift right _(must be preceded by whitespace)_
 | `<<>` | B | rotate left
 | `<>>` | B | rotate right
 
@@ -381,7 +381,7 @@ For now, compiled programs must obey the following additional restrictions (not 
 
 * a `shared` function can only appear as a public field of an actor or actor class;
 * a program may contain at most one actor or actor class declaration, i.e. the final main actor or actor class; and
-* any main actor class declaration should be *anonymous*; if named, the class name should not be used as a value within the class and will be reported as an unavailable identifier.
+* any main actor class declaration should be _anonymous_; if named, the class name should not be used as a value within the class and will be reported as an unavailable identifier.
 
 The last two restrictions are designed to forbid programmatic actor class recursion, pending compiler support.
 
@@ -658,7 +658,7 @@ The type `Bool` of category L (Logical) has values `true` and `false` and is sup
 
 A `Char` of category O (Ordered) represents characters as a code point in the Unicode character
 set. Characters can be converted to `Nat32`, and `Nat32`s in the
-range *0 .. 0x1FFFFF* can be converted to `Char` (the conversion traps
+range _0 .. 0x1FFFFF_ can be converted to `Char` (the conversion traps
 if outside of this range). With `charToText` a character can be
 converted into a text of length 1.
 
@@ -689,7 +689,7 @@ The types `Int` and `Nat` are signed integral and natural numbers of categories 
 Both `Int` and `Nat` are arbitrary precision,
 with only subtraction `-` on `Nat` trapping on underflow.
 
-The subtype relation `Nat <: Int` holds, so every expression of type `Nat` is also an expression of type `Int` (but *not* vice versa).
+The subtype relation `Nat <: Int` holds, so every expression of type `Nat` is also an expression of type `Int` (but _not_ vice versa).
 In particular, every value of type `Nat` is also a value of type `Int`, without change of representation.
 
 [[bounded-integers]]
@@ -703,8 +703,8 @@ Operations that may under- or overflow the representation are checked and trap o
 
 The operations `+%`, `-%`, `+*%+` and `**%` provide access to wrap-around, modular arithmetic.
 
-As bitwise types, these types support bitwise operations *and* (`&`),
-*r* (`|`) and *exclusive-or* (`^`). Further, they can be rotated
+As bitwise types, these types support bitwise operations _and_ (`&`),
+_or_ (`|`) and _exclusive-or_ (`^`). Further, they can be rotated
 left (`<<>`), right (`<>>`), and shifted left (`<<`), right (`>>`).
 The right-shift preserves the two's-complement sign.
 All shift and rotate amounts are considered modulo the numbers's bit width _n_.
@@ -811,7 +811,7 @@ of a value (for example, `Acme.Collections.List`).
 [[object-types]]
 === Object types
 
-`<sort>? { <typ-field>;* }` specifies an object type by listing its zero or more named *type fields*.
+`<sort>? { <typ-field>;* }` specifies an object type by listing its zero or more named _type fields_.
 
 Within an object type, the names of fields must be distinct (both by name and hash value).
 
@@ -874,17 +874,17 @@ Future types typically appear as the result type of a `shared` function that pro
 
 The optional identifier `<id>`, naming its components, is for documentation purposes only and cannot be used for component access. In particular, tuple types that differ only in the names of components are equivalent.
 
-The empty tuple type `()` is called the *unit type*.
+The empty tuple type `()` is called the _unit type_.
 
 [[any-type]]
 === Any type
 
-Type `Any` is the *top* type, i.e. the super-type of all types. All values have type `Any`.
+Type `Any` is the _top_ type, i.e. the super-type of all types. All values have type `Any`.
 
 [[none-type]]
 === None type
 
-Type `None` is the *bottom* type, a subtype of all other types.
+Type `None` is the _bottom_ type, a subtype of all other types.
 No value has type `None`.
 
 As an empty type, `None` can be used to specify the impossible return value of an infinite loop or unconditional trap.
@@ -892,7 +892,7 @@ As an empty type, `None` can be used to specify the impossible return value of a
 [[paren-type]]
 === Parenthesised type
 
-A function that takes an immediate, syntactic tuple of length *n >= 0* as its domain or range is a function that takes (respectively returns) *n* values.
+A function that takes an immediate, syntactic tuple of length _n >= 0_ as its domain or range is a function that takes (respectively returns) _n_ values.
 
 When enclosing the argument or result type of a function, which is itself a tuple type,  `( <tuple-typ> )` declares that the function takes or returns a single (boxed) value of type `<tuple-type>`.
 
@@ -911,9 +911,9 @@ In all other positions, `( <typ> )` has the same meaning as `<typ>`.
 A type field specifies the name and type of a field of an object.
 The field names within a single object type must be distinct and have non-colliding hashes.
 
-`<id> : <typ>` specifies an *immutable* field, named `<id>` of type `<typ>`.
+`<id> : <typ>` specifies an _immutable_ field, named `<id>` of type `<typ>`.
 
-`var <id> : <typ>` specifies a *mutable* field, named `<id>` of type `<typ>`.
+`var <id> : <typ>` specifies a _mutable_ field, named `<id>` of type `<typ>`.
 
 [[type-tags]]
 === Variant type fields
@@ -1161,7 +1161,7 @@ An actor class library evaluates by (transitively) evaluating its imports, bindi
 
 On the Internet Computer, if this library is imported as identifier `Lib`,
 then calling `await Lib.<id>(<exp1>, ..., <expn>)`, installs a fresh instance of the actor class as an isolated IC canister, passing the values of `<exp1>`, ..., `<expn>`
-as installation arguments, and returns a reference to a (remote) actor of *type* `Lib.<id>`, that is, `T`.
+as installation arguments, and returns a reference to a (remote) actor of _type_ `Lib.<id>`, that is, `T`.
 Installation is (necessarily) asynchronous.
 
 [[imports]]
@@ -1176,7 +1176,7 @@ In detail, if `<url>` is of the form:
 
 * `"<filepath>"` then `<id>` is bound to the library module defined in file `<filepath>.mo`.
   `<filepath>` is interpreted relative to the absolute location of the enclosing file.
-  Note the `.mo` extension is implicit and should *not* be included in `<url>`.
+  Note the `.mo` extension is implicit and should _not_ be included in `<url>`.
   For example, `import U "lib/Util"` defines `U` to reference the module in local file
   `./lib/Util`.
 
@@ -1272,7 +1272,7 @@ Otherwise, the result of the declaration is the value of the last declaration in
 the union of the bindings introduced by each declaration in `<dec>;*`.
 
 It is a compile-time error if any declaration in `<dec>;*` might require the value of an identifier declared in `<dec>;*`
-before that identifier's declaration has been evaluated. Such *use-before-define* errors are detected by a simple,
+before that identifier's declaration has been evaluated. Such _use-before-define_ errors are detected by a simple,
 conservative static analysis not described here.
 
 [[patterns]]
@@ -1285,7 +1285,7 @@ successful binding, mapping identifiers of the pattern to values, or failure.
 
 The consequences of pattern match failure depends on the context of the pattern.
 
-* In a function application or `let`-binding, failure to match the formal argument pattern or `let`-pattern causes a *trap*.
+* In a function application or `let`-binding, failure to match the formal argument pattern or `let`-pattern causes a _trap_.
 * In a `case` branch of a `switch` expression, failure to match that case's pattern continues with an attempt to match the next case of the switch, trapping only when no such case remains.
 
 [[pat-wildcard]]
@@ -1311,7 +1311,7 @@ For integer literals only, the optional `<unop>` determines the sign of the valu
 The tuple pattern `( <pat>,* )` matches a n-tuple value against an n-tuple of patterns (both the tuple and pattern must have the same number of items).
 The set of identifiers bound by each component of the tuple pattern must be distinct.
 
-The empty tuple pattern `()` is called the *unit pattern*.
+The empty tuple pattern `()` is called the _unit pattern_.
 
 Pattern matching fails if one of the patterns fails to match the corresponding item of the tuple value.
 Pattern matching succeeds if every pattern matches the corresponding component of the tuple value.
@@ -1354,7 +1354,7 @@ The annotated pattern `<pat> : <typ>` matches value of `v` type `<typ>` against 
 
 The option `? <pat>` matches a value of option type `? <typ>`.
 
-The match *fails* if the value is `null`. If the value is `? v`, for some value `v`, then the result of matching `? <pat>` is the result of matching `v` against `<pat>`.
+The match _fails_ if the value is `null`. If the value is `? v`, for some value `v`, then the result of matching `? <pat>` is the result of matching `v` against `<pat>`.
 
 Conversely, the `null` literal pattern may be used to test whether a value of option type is the value `null` and not `? v` for some `v`.
 
@@ -1390,12 +1390,12 @@ The let declaration `let <pat> = <exp>` has type `T` and declares the bindings i
 The declaration `let <pat> = <exp>` evaluates `<exp>` to a result `r`. If `r` is `trap`, the declaration evaluates to `trap`. If `r` is a value `v` then evaluation proceeds by
 matching the value `v` against `<pat>`. If matching fails, then the result is `trap`. Otherwise, the result is `v` and the binding of all identifiers in `<pat>` to their matching values in `v`.
 
-All bindings declared by a `let` (if any) are *immutable*.
+All bindings declared by a `let` (if any) are _immutable_.
 
 [[decl-var]]
 === Var declaration
 
-The variable declaration `var <id> (: <typ>)? = <exp>` declares a *mutable* variable `<id>` with initial value `<exp>`. The variable's value can be updated by assignment.
+The variable declaration `var <id> (: <typ>)? = <exp>` declares a _mutable_ variable `<id>` with initial value `<exp>`. The variable's value can be updated by assignment.
 
 The declaration `var <id>` has type `()` provided:
 
@@ -1497,7 +1497,7 @@ that recursively instantiates `List` at the same parameter `T`, is non-expansive
   type Seq<T> = ?(T, Seq<[T]>),
 ```
 
-that recursively instantiates `Seq` with a larger type, `[T]`, containing `T`, is *expansive* and rejected.
+that recursively instantiates `Seq` with a larger type, `[T]`, containing `T`, is _expansive_ and rejected.
 
 * Type `List<T>` is non-expansive because its graph, `+{ List#0 -0-> List#0 }+`, though cyclic, has no expansive edge.
 
@@ -1510,7 +1510,7 @@ that recursively instantiates `Seq` with a larger type, `[T]`, containing `T`, i
 Declaration `<sort> <id>? <obj-body>`, where `<obj_body>` is of the form `=? { <dec-field>;* }`, declares an object with optional identifier `<id>` and zero or more fields `<dec-field>;*`.
 Fields can be declared with `public` or `private` visibility; if the visibility is omitted, it defaults to `private`.
 
-The qualifier `<sort>` (one of `actor`, `module` or `object`) specifies the *sort* of the object's type. The sort imposes restrictions on the types of the public object fields.
+The qualifier `<sort>` (one of `actor`, `module` or `object`) specifies the _sort_ of the object's type. The sort imposes restrictions on the types of the public object fields.
 
 Let `T = <sort> { [var0] id0 : T0, ... , [varn] idn : T0 }` denote the type of the object.
 Let `<dec>;*` be the sequence of declarations embedded in `<dec-field>;*`.
@@ -1707,7 +1707,7 @@ The tuple projection `<exp> . <nat>` has type `Ti` provided `<exp>` has tuple ty
 
 The projection `<exp> . <nat>` evaluates `<exp>` to a result `r`. If `r` is `trap`, then  the result is `trap`. Otherwise, `r` must be a tuple  `(v1,...,vi,...,vn)` and the result of the projection is the value `vi`.
 
-The empty tuple expression `()` is called the *unit value*.
+The empty tuple expression `()` is called the _unit value_.
 
 [[exp-option]]
 === Option expressions
@@ -1739,7 +1739,7 @@ Objects can be written in literal form `{ <exp-field>;* }`, consisting of a list
   var? <id> (: <typ>) = <exp>                    field
   var? <id> (: <typ>)                             punned field
 ```
-Such an object literal, sometimes called a *record*, is equivalent to the object declaration `object { <dec-field>;* }` where the declaration fields are obtained from the expression fields by prefixing each of them with `public let`, or just `public` in case of `var` fields.
+Such an object literal, sometimes called a _record_, is equivalent to the object declaration `object { <dec-field>;* }` where the declaration fields are obtained from the expression fields by prefixing each of them with `public let`, or just `public` in case of `var` fields.
 However, unlike declarations, the field list does not bind each `<id>` as a local name within the literal, i.e., the field names are _not_ in scope in the field expressions.
 
 Object expressions support _punning_ for concision.
@@ -1912,7 +1912,7 @@ Note that a `<shared-pat>` function may itself be `shared <pat>` or `shared quer
 * A `shared <pat>` function may be invoked from a remote caller. Unless causing a trap, the effects on the callee persist beyond completion of the call.
 * A `shared query <pat>` function may be also be invoked from a remote caller, but the effects on the callee are transient and discarded once the call has completed with a result (whether a value or error).
 
-In either case, `<pat>` provides access to a context value identifying the *caller* of the shared (query) function.
+In either case, `<pat>` provides access to a context value identifying the _caller_ of the shared (query) function.
 
 NOTE: The context type is a record to allow extension with further fields in future releases.
 
@@ -2296,7 +2296,7 @@ An invalid canister identifier or type may manifest itself, if at all, as a late
 when calling a function on the actor's proclaimed interface,
 which will either fail or be rejected.
 
-NOTE: The argument to `actor` should *not* include the `ic:` resource locator used to specify an `import`. For example, use `actor "lg264-qjkae"`, not `actor "ic:lg264-qjkae"`.
+NOTE: The argument to `actor` should _not_ include the `ic:` resource locator used to specify an `import`. For example, use `actor "lg264-qjkae"`, not `actor "ic:lg264-qjkae"`.
 
 WARNING: Although they do not compromise type safety, actor references can easily introduce latent, dynamic errors.
 Accordingly, actor references should be used sparingly and only when needed.

--- a/src/exes/didc.ml
+++ b/src/exes/didc.ml
@@ -22,14 +22,14 @@ let set_mode m () =
 
 let out_file = ref ""
 
-let argspec = Arg.align
+let argspec =
 [
   "--js", Arg.Unit (set_mode Js), " output Javascript binding";
   "--check", Arg.Unit (set_mode Check), " type-check only";
   "--pp", Arg.Unit (set_mode PrettyPrint), " Pretty print did file";
   "-v", Arg.Set Flags.verbose, " verbose output";
   "-dp", Arg.Set Flags.dump_parse, " dump parse";
-  "-o", Arg.Set_string out_file, " output file";
+  "-o", Arg.Set_string out_file, "<file>  output file";
   "--version",
     Arg.Unit (fun () -> printf "%s\n" banner; exit 0), " show version";
 ]
@@ -57,15 +57,15 @@ let process_file file : unit =
      Buffer.add_string buf "\n";
      Buffer.output_buffer oc buf;
      close_out oc
-     
+
 let print_exn exn =
   Printf.printf "%!";
   Printf.eprintf "Internal error, %s\n" (Printexc.to_string exn);
   Printexc.print_backtrace stderr;
   Printf.eprintf "%!"
-       
+
 let () =
-  (* 
+  (*
   Sys.catch_break true; - enable to get stacktrace on interrupt
   (useful for debugging infinite loops)
   *)

--- a/src/exes/mo_doc.ml
+++ b/src/exes/mo_doc.ml
@@ -11,17 +11,16 @@ let set_format f = match f with
   | s -> Printf.eprintf "Unknown output format: %s" s
 let usage = "Documentation generator for Motoko"
 
-let argspec =
-  Arg.align
-    [ "--source",
+let argspec = [
+      "--source",
       Arg.String set_source,
-      " specifies what directory to search for source files. Defaults to `src`"
+      "<path>  specifies what directory to search for source files. Defaults to `src`"
     ; "--output",
       Arg.String set_output,
-      " specifies where the documentation will be generated. Defaults to `docs`"
+      "<path>  specifies where the documentation will be generated. Defaults to `docs`"
     ; "--format",
       Arg.String set_format,
-      " specifies the generated format. One of `html`, `adoc`, or `plain` Defaults to `html`"
+      "<format>  specifies the generated format. One of `html`, `adoc`, or `plain` Defaults to `html`"
     ]
 
 let () =

--- a/src/exes/mo_ide.ml
+++ b/src/exes/mo_ide.ml
@@ -10,15 +10,14 @@ let set_entry_point ep = entry_point := Some ep
 let usage = "LSP server for motoko"
 
 let argspec =
-  Arg.align
     [ "--debug",
       Arg.Unit set_debug,
       " outputs logging information to a lsp.log file"
     ; "--canister-main",
       Arg.String set_entry_point,
-      " specifies the entry point for the current project"
+      "<file>  specifies the entry point for the current project"
     ; "--port", Arg.Int set_port,
-      " when specified communicates over TCP on the given port"
+      "<port>  when specified communicates over TCP on the given port"
     ]
     @ Args.error_args
     @ Args.package_args

--- a/src/exes/mo_ld.ml
+++ b/src/exes/mo_ld.ml
@@ -23,12 +23,12 @@ let usage_err s =
   eprintf "%s\n" usage;
   exit 1
 
-let argspec = Arg.align
+let argspec =
 [
-  "-b", Arg.Set_string base_file, " base file (e.g. output of moc --no-link)";
-  "-l", Arg.Set_string lib_file, " library file";
-  "-o", Arg.Set_string out_file, " output file";
-  "-n", Arg.Set_string lib_name, " library name (defaults to \"rts\")";
+  "-b", Arg.Set_string base_file, "<file> base file (e.g. output of moc --no-link)";
+  "-l", Arg.Set_string lib_file, "<file> library file";
+  "-o", Arg.Set_string out_file, "<file> output file";
+  "-n", Arg.Set_string lib_name, "<name> library name (defaults to \"rts\")";
   "--version", Arg.Unit print_banner, " show version";
 ]
 

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -28,7 +28,7 @@ let interpret_ir = ref false
 let gen_source_map = ref false
 let explain_code = ref ""
 
-let argspec = Arg.align [
+let argspec = [
   "-c", Arg.Unit (set_mode Compile), " compile programs to WebAssembly";
   "-g", Arg.Set Flags.debug_info, " generate source-level debug information";
   "-r", Arg.Unit (set_mode Run), " interpret programs";
@@ -37,10 +37,10 @@ let argspec = Arg.align [
   "--idl", Arg.Unit (set_mode Idl), " generate IDL spec";
   "--print-deps", Arg.Unit (set_mode PrintDeps), " prints the dependencies for a given source file";
   "--explain", Arg.String (fun c -> explain_code := c; set_mode Explain ()), " provides a detailed explanation of an error message";
-  "-o", Arg.Set_string out_file, " output file";
+  "-o", Arg.Set_string out_file, "<file>  output file";
 
   "-v", Arg.Set Flags.verbose, " verbose output";
-  "-p", Arg.Set_int Flags.print_depth, " set print depth";
+  "-p", Arg.Set_int Flags.print_depth, "<n>  set print depth";
   "--hide-warnings", Arg.Clear Flags.print_warnings, " hide warnings";
   "-Werror", Arg.Set Flags.warnings_are_errors, " treat warnings as werrors";
   ]
@@ -59,11 +59,11 @@ let argspec = Arg.align [
 
   @ [
   "--profile", Arg.Set Flags.profile, " activate profiling counters in interpreters ";
-  "--profile-file", Arg.Set_string Flags.profile_file, " set profiling output file ";
-  "--profile-line-prefix", Arg.Set_string Flags.profile_line_prefix, " prefix each profile line with the given string ";
+  "--profile-file", Arg.Set_string Flags.profile_file, "<file>  set profiling output file ";
+  "--profile-line-prefix", Arg.Set_string Flags.profile_line_prefix, "<string>  prefix each profile line with the given string ";
   "--profile-field",
   Arg.String (fun n -> Flags.(profile_field_names := n :: !profile_field_names)),
-  " profile file includes the given field from the program result ";
+  "<field>  profile file includes the given field from the program result ";
   "-iR", Arg.Set interpret_ir, " interpret the lowered code";
   "-no-await", Arg.Clear Flags.await_lowering, " no await-lowering (with -iR)";
   "-no-async", Arg.Clear Flags.async_lowering, " no async-lowering (with -iR)";

--- a/src/mo_config/args.ml
+++ b/src/mo_config/args.ml
@@ -17,22 +17,22 @@ let string_map flag r desc =
 
 (* Everything related to imports, packages, aliases *)
 let package_args = [
-  string_map "--package" Flags.package_urls "<args> specify a package-name-package-URL pair, separated by a space";
-  "--actor-idl", Arg.String (fun fp -> Flags.actor_idl_path := Some fp), " path to actor IDL files";
-  string_map "--actor-alias" Flags.actor_aliases " actor import alias"
+  string_map "--package" Flags.package_urls "<package-name> <package-path> specify a <package-name> <package-path> pair, separated by a space";
+  "--actor-idl", Arg.String (fun fp -> Flags.actor_idl_path := Some fp), "<idl-path>   path to actor IDL (Candid) files";
+  string_map "--actor-alias" Flags.actor_aliases "<alias> <principal>  actor import alias"
   ]
 
 let error_args = [
-  "--error-detail", Arg.Set_int Flags.error_detail, "<n> set error message detail for syntax errors, n in [0..3] (default 2)"
+  "--error-detail", Arg.Set_int Flags.error_detail, "<n>  set error message detail for syntax errors, n in [0..3] (default 2)"
   (* TODO move --hide-warnings here? *)
   ]
 
 let inclusion_args = [
     (* generic arg inclusion from file *)
   "--args", Arg.Expand Arg.read_arg,
-    "<file> read additional newline separated command line arguments \n\
+    "<file>  read additional newline separated command line arguments \n\
     \      from <file>";
   "--args0", Arg.Expand Arg.read_arg0,
-    "<file> read additional NUL separated command line arguments from \n\
+    "<file>  read additional NUL separated command line arguments from \n\
     \      <file>"
   ]

--- a/src/mo_config/args.ml
+++ b/src/mo_config/args.ml
@@ -17,22 +17,22 @@ let string_map flag r desc =
 
 (* Everything related to imports, packages, aliases *)
 let package_args = [
-  string_map "--package" Flags.package_urls "<args> Specify a package-name-package-URL pair, separated by a space";
+  string_map "--package" Flags.package_urls "<args> specify a package-name-package-URL pair, separated by a space";
   "--actor-idl", Arg.String (fun fp -> Flags.actor_idl_path := Some fp), " path to actor IDL files";
   string_map "--actor-alias" Flags.actor_aliases " actor import alias"
   ]
 
 let error_args = [
-  "--error-detail", Arg.Set_int Flags.error_detail, " set error message detail for syntax errors"
+  "--error-detail", Arg.Set_int Flags.error_detail, "<n> set error message detail for syntax errors, n in [0..3] (default 2)"
   (* TODO move --hide-warnings here? *)
   ]
 
 let inclusion_args = [
     (* generic arg inclusion from file *)
   "--args", Arg.Expand Arg.read_arg,
-    "<file> Read additional newline separated command line arguments \n\
+    "<file> read additional newline separated command line arguments \n\
     \      from <file>";
   "--args0", Arg.Expand Arg.read_arg0,
-    "<file> Read additional NUL separated command line arguments from \n\
+    "<file> read additional NUL separated command line arguments from \n\
     \      <file>"
   ]


### PR DESCRIPTION
 * fix formatting of lots of broken operators (asciidoc gaslighting)
 * remove defunct avoidance clause on block typing; 
 * fix formatting of function arrows.
 * mardown italics -> asciidoc italics
 * add links to base for each prim type
 * minor changes here and there
 * indent some bnf to avoid scrollbars
* document new compiler options/regularlize description (we should really hide most of them)

I think the rich ASCII doc diff is too large for GH to handle, so many read 

https://hydra.dfinity.systems/build/5455225/download/1/docs/language-guide/language-manual.html

side by side with this.

Or just approve it.