### PR TITLE
Fix a typo and accidental renaming

### DIFF
--- a/rts/motoko-rts/src/closure_table.rs
+++ b/rts/motoko-rts/src/closure_table.rs
@@ -37,7 +37,7 @@ static mut N_CLOSURES: u32 = 0;
 // Next free slot
 static mut FREE_SLOT: u32 = 0;
 
-unsafe fn crate_closure_table<M: Memory>(mem: &mut M) {
+unsafe fn create_closure_table<M: Memory>(mem: &mut M) {
     TABLE = alloc_array(mem, INITIAL_SIZE);
     FREE_SLOT = 0;
     N_CLOSURES = 0;
@@ -71,7 +71,7 @@ unsafe fn double_closure_table<M: Memory>(mem: &mut M) {
 #[ic_mem_fn]
 pub unsafe fn remember_closure<M: Memory>(mem: &mut M, ptr: SkewedPtr) -> u32 {
     if TABLE.0 == 0 {
-        crate_closure_table(mem);
+        create_closure_table(mem);
     }
 
     if FREE_SLOT == TABLE.as_array().len() {

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -72,11 +72,11 @@ unsafe fn mark_compact<M: Memory, SetHp: Fn(u32)>(
     mem: &mut M,
     set_hp: SetHp,
     heap_base: u32,
-    mem_end: u32,
+    heap_end: u32,
     static_roots: SkewedPtr,
     closure_table_loc: *mut SkewedPtr,
 ) {
-    let mem_size = Bytes(mem_end - heap_base);
+    let mem_size = Bytes(heap_end - heap_base);
 
     alloc_bitmap(mem, mem_size);
     alloc_mark_stack(mem);


### PR DESCRIPTION
Accidental renaming was done in #2573 while renaming the "Heap" trait to
"Memory" and "heap" identifiers to "mem".