### PR TITLE
 Compacting GC: thread backwards pointers in marking

### DIFF
--- a/rts/motoko-rts-tests/src/gc.rs
+++ b/rts/motoko-rts-tests/src/gc.rs
@@ -29,15 +29,43 @@ pub fn test() {
 }
 
 fn test_heaps() -> Vec<TestHeap> {
-    vec![TestHeap {
-        heap: hashmap! {
-            0 => vec![0, 2],
-            2 => vec![0],
-            3 => vec![3],
+    vec![
+        // Just a random test that covers a bunch of cases:
+        // - Self references
+        // - Forward pointers
+        // - Backwards pointers
+        // - More than one fields in an object
+        TestHeap {
+            heap: hashmap! {
+                0 => vec![0, 2],
+                2 => vec![0],
+                3 => vec![3],
+            },
+            roots: vec![0, 2, 3],
+            closure_table: vec![0],
         },
-        roots: vec![0, 2, 3],
-        closure_table: vec![0],
-    }]
+        // Tests pointing to the same object in multiple fields of an object. Also has unreachable
+        // objects.
+        TestHeap {
+            heap: hashmap! {
+                0 => vec![],
+                1 => vec![],
+                2 => vec![],
+            },
+            roots: vec![1],
+            closure_table: vec![0, 0],
+        },
+        // Root points backwards in heap. Caught a bug in mark-compact collector.
+        TestHeap {
+            heap: hashmap! {
+                0 => vec![],
+                1 => vec![2],
+                2 => vec![1],
+            },
+            roots: vec![2],
+            closure_table: vec![],
+        },
+    ]
 }
 
 #[derive(Debug)]
@@ -66,17 +94,6 @@ fn test_gc(
     closure_table: &[ObjectIdx],
 ) {
     let heap = MotokoHeap::new(refs, roots, closure_table, gc);
-
-    // Check `check_dynamic_heap` sanity
-    check_dynamic_heap(
-        refs,
-        roots,
-        closure_table,
-        &**heap.heap(),
-        heap.heap_base_offset(),
-        heap.heap_ptr_offset(),
-        heap.closure_table_ptr_offset(),
-    );
 
     for _ in 0..3 {
         gc.run(heap.clone());

--- a/rts/motoko-rts-tests/src/mark_stack.rs
+++ b/rts/motoko-rts-tests/src/mark_stack.rs
@@ -32,12 +32,12 @@ fn test_<M: Memory>(mem: &mut M, n_objs: u32) -> TestCaseResult {
         alloc_mark_stack(mem);
 
         for obj in &objs {
-            push_mark_stack(mem, *obj as usize);
+            push_mark_stack(mem, *obj as usize, obj.wrapping_sub(1));
         }
 
-        for obj in objs.iter().rev() {
+        for obj in objs.iter().copied().rev() {
             let popped = pop_mark_stack();
-            if popped != Some(*obj as usize) {
+            if popped != Some((obj as usize, obj.wrapping_sub(1))) {
                 free_mark_stack();
                 return Err(TestCaseError::Fail(
                     format!(

--- a/rts/motoko-rts-tests/src/mark_stack.rs
+++ b/rts/motoko-rts-tests/src/mark_stack.rs
@@ -32,6 +32,7 @@ fn test_<M: Memory>(mem: &mut M, n_objs: u32) -> TestCaseResult {
         alloc_mark_stack(mem);
 
         for obj in &objs {
+            // Pushing a dummy argument derived from `obj` for tag
             push_mark_stack(mem, *obj as usize, obj.wrapping_sub(1));
         }
 

--- a/rts/motoko-rts/src/gc/copying.rs
+++ b/rts/motoko-rts/src/gc/copying.rs
@@ -146,7 +146,7 @@ unsafe fn evac<M: Memory>(
 unsafe fn scav<M: Memory>(mem: &mut M, begin_from_space: usize, begin_to_space: usize, obj: usize) {
     let obj = obj as *mut Obj;
 
-    crate::visitor::visit_pointer_fields(obj, begin_from_space, |field_addr| {
+    crate::visitor::visit_pointer_fields(obj, obj.tag(), begin_from_space, |field_addr| {
         evac(mem, begin_from_space, begin_to_space, field_addr as usize);
     });
 }

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -141,7 +141,7 @@ unsafe fn mark_fields<M: Memory>(mem: &mut M, obj: *mut Obj, obj_tag: Tag, heap_
         mark_object(mem, field_value, heap_base);
 
         // Thread if backwards pointer
-        if field_value.unskew() < field_addr as usize {
+        if field_value.unskew() < obj as usize {
             thread(field_addr);
         }
     });

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -152,7 +152,7 @@ unsafe fn mark_root_mutbox_fields<M: Memory>(mem: &mut M, mutbox: *mut MutBox, h
     if pointer_to_dynamic_heap(field_addr, heap_base as usize) {
         // TODO: We should be able to omit the "already marked" check here as no two root MutBox
         // can point to the same object (I think)
-        mark_stack::push_mark_stack(mem, (*field_addr).unskew(), heap_base);
+        push_mark_stack(mem, *field_addr, heap_base);
         // It's OK to thread forward pointers here as the static objects won't be moved, so we will
         // be able to unthread objects pointed by these fields later.
         thread(field_addr);

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -150,7 +150,9 @@ unsafe fn mark_root_mutbox_fields<M: Memory>(mem: &mut M, mutbox: *mut MutBox, h
     let field_addr = &mut (*mutbox).field;
     // TODO: Not sure if this check is necessary?
     if pointer_to_dynamic_heap(field_addr, heap_base as usize) {
-        mark_stack::push_mark_stack(mem, (*field_addr).unskew(), (*field_addr).tag());
+        // TODO: We should be able to omit the "already marked" check here as no two root MutBox
+        // can point to the same object (I think)
+        mark_stack::push_mark_stack(mem, (*field_addr).unskew(), heap_base);
         // It's OK to thread forward pointers here as the static objects won't be moved, so we will
         // be able to unthread objects pointed by these fields later.
         thread(field_addr);

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -1,4 +1,6 @@
-//! Implements "threaded compaction" as described in The Garbage Collection Handbook section 3.3.
+//! Implements threaded compaction as described in "High-Performance Garbage Collection for
+//! Memory-Constrained Environments" section 5.1.2, which is an improved version of the original
+//! threaded compaction algorithm described in The Garbage Collection Handbook section 3.3.
 
 pub mod bitmap;
 pub mod mark_stack;

--- a/rts/motoko-rts/src/visitor.rs
+++ b/rts/motoko-rts/src/visitor.rs
@@ -103,6 +103,6 @@ pub unsafe fn visit_pointer_fields<F>(
     }
 }
 
-unsafe fn pointer_to_dynamic_heap(field_addr: *mut SkewedPtr, heap_base: usize) -> bool {
+pub unsafe fn pointer_to_dynamic_heap(field_addr: *mut SkewedPtr, heap_base: usize) -> bool {
     (!(*field_addr).is_tagged_scalar()) && ((*field_addr).unskew() >= heap_base)
 }

--- a/rts/motoko-rts/src/visitor.rs
+++ b/rts/motoko-rts/src/visitor.rs
@@ -3,11 +3,15 @@ use crate::types::*;
 
 /// A visitor that passes field addresses of fields with pointers to dynamic heap to the given
 /// callback
-pub unsafe fn visit_pointer_fields<F>(obj: *mut Obj, heap_base: usize, mut visit_ptr_field: F)
-where
+pub unsafe fn visit_pointer_fields<F>(
+    obj: *mut Obj,
+    tag: Tag,
+    heap_base: usize,
+    mut visit_ptr_field: F,
+) where
     F: FnMut(*mut SkewedPtr),
 {
-    match obj.tag() {
+    match tag {
         TAG_OBJECT => {
             let obj = obj as *mut Object;
             let obj_payload = obj.payload_addr();


### PR DESCRIPTION
This PR implements the mark-compact GC algorithm briefly described by
"High-Performance Garbage Collection for Memory-Constrained Environments"
section 5.1.2 (I think the original paper is "An Efficient Garbage Compaction
Algorithm" but that paper is a bit difficult to follow).

The idea is as follows: when marking an object we thread backwards pointers of
that object. After we linearly scan the heap as before. For a live object, we
unthread it and update backwards pointers to it to the objects new location,
move the object, and then thread its forwards pointers. After the pass all
objects are moved and all references are updated.

This reduces number of passes in the original mark-compact collector to 2.

CanCan backend benchmark reports -19.8% in instructions. Compared to copying
GC, mark-compact GC is now 36% slower, instead of 70% as before.

This PR also optimizes `mark_static_roots` by inlining `mark_fields` in the
body and specializing it for `MutBox`: static root array only points to static
`MutBox`es so no need to call more general `mark_fields`. This optimization
gives us approximately -2% in instructions.

See also #2641 for another, slower variant of the algorithm.
