### PR TITLE
Smarter GC scheduling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,20 @@
 * Trap on attempt to upgrade when canister not stopped and there are outstanding callbacks.
   (This failure mode can be avoided by stopping the canister before upgrade.)
 
+* New garbage collection scheduling: previously Motoko runtime would do gc
+  after every upgrade message. We now schedule a gc when
+
+  1. Heap grows more than 50% and 10 MiB since the last GC, or
+  2. Heap size is more than 3 GiB
+
+  (1) is to make sure we don't do gc on tiny heaps, and for larger heaps we
+  allow small allocations and do gc on large allocations. (2) is to make sure
+  on large heaps we will have enough allocation space in the next message.
+
+  New scheduling reduces cycles significantly at the cost of more Wasm pages.
+
+  New flag `--force-gc` restores the old behavior.
+
 == 0.6.5 (2021-07-08)
 
 * Add alternative, _compacting_ gc, enabled with new moc flag `--compacting-gc`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,17 +3,16 @@
 * Trap on attempt to upgrade when canister not stopped and there are outstanding callbacks.
   (This failure mode can be avoided by stopping the canister before upgrade.)
 
-* New garbage collection scheduling: previously Motoko runtime would do gc
-  after every upgrade message. We now schedule a gc when
+* Vastly improved garbage collection scheduling: previously Motoko runtime would do GC
+  after every upgrade message. We now schedule a GC when
 
   1. Heap grows more than 50% and 10 MiB since the last GC, or
   2. Heap size is more than 3 GiB
 
-  (1) is to make sure we don't do gc on tiny heaps, and for larger heaps we
-  allow small allocations and do gc on large allocations. (2) is to make sure
-  on large heaps we will have enough allocation space in the next message.
+  (1) is to make sure we don't do GC on tiny heaps or after only small amounts of allocation. (2) is to make sure that
+  on large heaps we will have enough allocation space during the next message.
 
-  New scheduling reduces cycles significantly at the cost of more Wasm pages.
+  This scheduling reduces cycles substantially, but may moderately increase memory usage.
 
   New flag `--force-gc` restores the old behavior.
 

--- a/rts/motoko-rts/src/gc.rs
+++ b/rts/motoko-rts/src/gc.rs
@@ -18,7 +18,7 @@ unsafe fn should_do_gc() -> bool {
 
     // Regardless of other parameters (`HEAP_GROWTH_FACTOR`, `SMALL_HEAP_DELTA`) we want to do GC
     // if `HP` is more than this amount.
-    const MAX_HP_FOR_GC: u64 = 3 * 1024 * 1024 * 1024; // 3 GiB
+    const MAX_HP_FOR_GC: u64 = 1 * 1024 * 1024 * 1024; // 3 GiB
 
     let heap_limit = min(
         max(

--- a/rts/motoko-rts/src/gc.rs
+++ b/rts/motoko-rts/src/gc.rs
@@ -23,7 +23,7 @@ unsafe fn should_do_gc() -> bool {
     let heap_limit = min(
         max(
             (f64::from(LAST_HP) * HEAP_GROWTH_FACTOR) as u64,
-            SMALL_HEAP_DELTA.0,
+            u64::from(LAST_HP) + SMALL_HEAP_DELTA.0,
         ),
         MAX_HP_FOR_GC,
     );

--- a/rts/motoko-rts/src/gc.rs
+++ b/rts/motoko-rts/src/gc.rs
@@ -4,6 +4,7 @@ pub mod mark_compact;
 #[cfg(feature = "ic")]
 unsafe fn should_do_gc() -> bool {
     use crate::memory::ic::{HP, LAST_HP};
+    use crate::types::Bytes;
 
     use core::cmp::{max, min};
 
@@ -13,7 +14,7 @@ unsafe fn should_do_gc() -> bool {
     // On small heaps `last_hp * HEAP_GROWTH_FACTOR` will be quite small. To avoid doing redundant
     // collections in such cases we only check `last_hp * HEAP_GROWTH_FACTOR` if at least this
     // much is allocated.
-    const SMALL_HEAP_DELTA: u64 = 10 * 1024 * 1024; // 10 MiB
+    const SMALL_HEAP_DELTA: Bytes<u64> = Bytes(10 * 1024 * 1024); // 10 MiB
 
     // Regardless of other parameters (`HEAP_GROWTH_FACTOR`, `SMALL_HEAP_DELTA`) we want to do GC
     // if `HP` is more than this amount.
@@ -22,7 +23,7 @@ unsafe fn should_do_gc() -> bool {
     let heap_limit = min(
         max(
             (f64::from(LAST_HP) * HEAP_GROWTH_FACTOR) as u64,
-            SMALL_HEAP_DELTA,
+            SMALL_HEAP_DELTA.0,
         ),
         MAX_HP_FOR_GC,
     );

--- a/rts/motoko-rts/src/gc.rs
+++ b/rts/motoko-rts/src/gc.rs
@@ -8,20 +8,20 @@ unsafe fn should_do_gc() -> bool {
     use core::cmp::{max, min};
 
     // A factor of last heap size. We allow at most this much allocation before doing GC.
-    const HEAP_GROWING_FACTOR: f32 = 1.5;
+    const HEAP_GROWTH_FACTOR: f32 = 1.5;
 
-    // On small heaps `last_hp * HEAP_GROWING_FACTOR` will be quite small. To avoid doing redundant
-    // collections in such cases we only check `last_hp * HEAP_GROWING_FACTOR` if at least this
+    // On small heaps `last_hp * HEAP_GROWTH_FACTOR` will be quite small. To avoid doing redundant
+    // collections in such cases we only check `last_hp * HEAP_GROWTH_FACTOR` if at least this
     // much is allocated.
     const SMALL_HEAP_DELTA: u32 = 10 * 1024 * 1024; // 10 MiB
 
-    // Regardless of other parameters (`HEAP_GROWING_FACTOR`, `SMALL_HEAP_DELTA`) we want to do GC
+    // Regardless of other parameters (`HEAP_GROWTH_FACTOR`, `SMALL_HEAP_DELTA`) we want to do GC
     // if `HP` is more than this amount.
     const MAX_HP_FOR_GC: u32 = 3 * 1024 * 1024 * 1024; // 3 GiB
 
     let heap_limit = min(
         max(
-            (LAST_HP as f32 * HEAP_GROWING_FACTOR) as u32,
+            (LAST_HP as f32 * HEAP_GROWTH_FACTOR) as u32,
             SMALL_HEAP_DELTA,
         ),
         MAX_HP_FOR_GC,

--- a/rts/motoko-rts/src/gc.rs
+++ b/rts/motoko-rts/src/gc.rs
@@ -1,2 +1,31 @@
 pub mod copying;
 pub mod mark_compact;
+
+#[cfg(feature = "ic")]
+unsafe fn should_do_gc() -> bool {
+    use crate::memory::ic::{HP, LAST_HP};
+
+    use core::cmp::{max, min};
+
+    // A factor of last heap size. We allow at most this much allocation before doing GC.
+    const HEAP_GROWING_FACTOR: f32 = 1.5;
+
+    // On small heaps `last_hp * HEAP_GROWING_FACTOR` will be quite small. To avoid doing redundant
+    // collections in such cases we only check `last_hp * HEAP_GROWING_FACTOR` if at least this
+    // much is allocated.
+    const SMALL_HEAP_DELTA: u32 = 10 * 1024 * 1024; // 10 MiB
+
+    // Regardless of other parameters (`HEAP_GROWING_FACTOR`, `SMALL_HEAP_DELTA`) we want to do GC
+    // if `HP` is more than this amount.
+    const MAX_HP_FOR_GC: u32 = 3 * 1024 * 1024 * 1024; // 3 GiB
+
+    let heap_limit = min(
+        max(
+            (LAST_HP as f32 * HEAP_GROWING_FACTOR) as u32,
+            SMALL_HEAP_DELTA,
+        ),
+        MAX_HP_FOR_GC,
+    );
+
+    HP >= heap_limit
+}

--- a/rts/motoko-rts/src/gc.rs
+++ b/rts/motoko-rts/src/gc.rs
@@ -8,24 +8,24 @@ unsafe fn should_do_gc() -> bool {
     use core::cmp::{max, min};
 
     // A factor of last heap size. We allow at most this much allocation before doing GC.
-    const HEAP_GROWTH_FACTOR: f32 = 1.5;
+    const HEAP_GROWTH_FACTOR: f64 = 1.5;
 
     // On small heaps `last_hp * HEAP_GROWTH_FACTOR` will be quite small. To avoid doing redundant
     // collections in such cases we only check `last_hp * HEAP_GROWTH_FACTOR` if at least this
     // much is allocated.
-    const SMALL_HEAP_DELTA: u32 = 10 * 1024 * 1024; // 10 MiB
+    const SMALL_HEAP_DELTA: u64 = 10 * 1024 * 1024; // 10 MiB
 
     // Regardless of other parameters (`HEAP_GROWTH_FACTOR`, `SMALL_HEAP_DELTA`) we want to do GC
     // if `HP` is more than this amount.
-    const MAX_HP_FOR_GC: u32 = 3 * 1024 * 1024 * 1024; // 3 GiB
+    const MAX_HP_FOR_GC: u64 = 3 * 1024 * 1024 * 1024; // 3 GiB
 
     let heap_limit = min(
         max(
-            (LAST_HP as f32 * HEAP_GROWTH_FACTOR) as u32,
+            (f64::from(LAST_HP) * HEAP_GROWTH_FACTOR) as u64,
             SMALL_HEAP_DELTA,
         ),
         MAX_HP_FOR_GC,
     );
 
-    HP >= heap_limit
+    u64::from(HP) >= heap_limit
 }

--- a/rts/motoko-rts/src/gc/copying.rs
+++ b/rts/motoko-rts/src/gc/copying.rs
@@ -5,12 +5,15 @@ use crate::types::*;
 use motoko_rts_macros::ic_mem_fn;
 
 #[ic_mem_fn(ic_only)]
+unsafe fn schedule_copying_gc<M: Memory>(mem: &mut M) {
+    if super::should_do_gc() {
+        copying_gc(mem);
+    }
+}
+
+#[ic_mem_fn(ic_only)]
 unsafe fn copying_gc<M: Memory>(mem: &mut M) {
     use crate::memory::ic;
-
-    if !super::should_do_gc() {
-        return;
-    }
 
     copying_gc_internal(
         mem,

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -17,12 +17,15 @@ use crate::visitor::{pointer_to_dynamic_heap, visit_pointer_fields};
 use motoko_rts_macros::ic_mem_fn;
 
 #[ic_mem_fn(ic_only)]
+unsafe fn schedule_compacting_gc<M: Memory>(mem: &mut M) {
+    if super::should_do_gc() {
+        compacting_gc(mem);
+    }
+}
+
+#[ic_mem_fn(ic_only)]
 unsafe fn compacting_gc<M: Memory>(mem: &mut M) {
     use crate::memory::ic;
-
-    if !super::should_do_gc() {
-        return;
-    }
 
     compacting_gc_internal(
         mem,

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -16,22 +16,28 @@ use motoko_rts_macros::ic_mem_fn;
 
 #[ic_mem_fn(ic_only)]
 unsafe fn compacting_gc<M: Memory>(mem: &mut M) {
+    use crate::memory::ic;
+
+    if !super::should_do_gc() {
+        return;
+    }
+
     compacting_gc_internal(
         mem,
-        crate::memory::ic::get_heap_base(),
+        ic::get_heap_base(),
         // get_hp
-        || crate::memory::ic::HP as usize,
+        || ic::HP as usize,
         // set_hp
-        |hp| crate::memory::ic::HP = hp,
-        crate::memory::ic::get_static_roots(),
+        |hp| ic::HP = hp,
+        ic::get_static_roots(),
         crate::closure_table::closure_table_loc(),
         // note_live_size
-        |live_size| {
-            crate::memory::ic::MAX_LIVE = ::core::cmp::max(crate::memory::ic::MAX_LIVE, live_size)
-        },
+        |live_size| ic::MAX_LIVE = ::core::cmp::max(ic::MAX_LIVE, live_size),
         // note_reclaimed
-        |reclaimed| crate::memory::ic::RECLAIMED += Bytes(reclaimed.0 as u64),
+        |reclaimed| ic::RECLAIMED += Bytes(reclaimed.0 as u64),
     );
+
+    ic::LAST_HP = ic::HP;
 }
 
 pub unsafe fn compacting_gc_internal<

--- a/rts/motoko-rts/src/memory/ic.rs
+++ b/rts/motoko-rts/src/memory/ic.rs
@@ -19,6 +19,9 @@ pub(crate) static mut ALLOCATED: Bytes<u64> = Bytes(0);
 /// Heap pointer
 pub(crate) static mut HP: u32 = 0;
 
+/// Heap pointer after last GC
+pub(crate) static mut LAST_HP: u32 = 0;
+
 // Provided by generated code
 extern "C" {
     pub(crate) fn get_heap_base() -> u32;
@@ -28,6 +31,7 @@ extern "C" {
 #[no_mangle]
 unsafe extern "C" fn init() {
     HP = get_heap_base() as u32;
+    LAST_HP = HP;
 }
 
 #[no_mangle]

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -501,6 +501,7 @@ module E = struct
 
   let collect_garbage env =
     let gc_fn = if !Flags.compacting_gc then "compacting_gc" else "copying_gc" in
+    let gc_fn = if !Flags.force_gc then gc_fn else "schedule_" ^ gc_fn in
     call_import env "rts" gc_fn
 end
 
@@ -830,6 +831,8 @@ module RTS = struct
     E.add_func_import env "rts" "get_reclaimed" [] [I64Type];
     E.add_func_import env "rts" "copying_gc" [] [];
     E.add_func_import env "rts" "compacting_gc" [] [];
+    E.add_func_import env "rts" "schedule_copying_gc" [] [];
+    E.add_func_import env "rts" "schedule_compacting_gc" [] [];
     E.add_func_import env "rts" "alloc_words" [I32Type] [I32Type];
     E.add_func_import env "rts" "get_total_allocations" [] [I64Type];
     E.add_func_import env "rts" "get_heap_size" [] [I32Type];

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -104,6 +104,10 @@ let argspec = [
   "--compacting-gc",
   Arg.Unit (fun () -> Flags.compacting_gc := true),
   " link with compacting GC instead of copying GC";
+
+  "--force-gc",
+  Arg.Unit (fun () -> Flags.force_gc := true),
+  " disable GC scheduling, always do GC after an update message (for testing)";
     ]
 
   @  Args.inclusion_args

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -31,3 +31,4 @@ let compiled = ref false
 let error_detail = ref 2
 let sanity = ref false
 let compacting_gc = ref false
+let force_gc = ref false

--- a/test/run.sh
+++ b/test/run.sh
@@ -31,6 +31,9 @@ SKIP_RUNNING=${SKIP_RUNNING:-no}
 ONLY_TYPECHECK=no
 ECHO=echo
 
+# Always do GC in tests, unless it's disabled in `EXTRA_MOC_ARGS`
+EXTRA_MOC_ARGS="--force-gc $EXTRA_MOC_ARGS"
+
 while getopts "adpstir" o; do
     case "${o}" in
         a)


### PR DESCRIPTION
We now avoid doing GC after every message and only do when

- Heap grows more than HEAP_GROWTH_FACTOR since last GC (1) and more than
  SMALL_HEAP_DELTA is allocated since last GC (2)

or

- Current heap size is more than MAX_HEAP_FOR_GC (3)

(1) is to make sure we don't do GC when heap size does not change much. On
small heaps `heap_size * HEAP_GROWING_FACTOR` will be a small amount, so (2) is
to avoid doing redundant GCs in such cases. (3) is to make sure we'll have
allocation space for the next message when heap is larger than MAX_HEAP_FOR_GC.

(Thanks to @ulan for the algorithm)

New moc flag `--force-gc` added to do GC after every update message in tests.
New scheduling is enabled by default.

## Benchmarks

Using CanCan backend benchmark

![instructions](https://user-images.githubusercontent.com/448274/126979064-5af044ba-ea56-432e-a2af-7faf3d563735.png)

![total_instructions](https://user-images.githubusercontent.com/448274/126979056-fb2f16e3-d5ff-41a1-99ed-ab31f7a4fbcd.png)

![dirtied_host_pages](https://user-images.githubusercontent.com/448274/126979059-a44ea697-9167-487e-a6d7-89dc4cfa3ae6.png)

![total_dirtied_host_pages](https://user-images.githubusercontent.com/448274/126979048-ae4dc9d8-54e7-4dd3-9cf5-6df4415b72bb.png)

![accessed_host_pages](https://user-images.githubusercontent.com/448274/126979062-3b4f3b0e-f0a9-46af-8f4c-7ac0b14ff48b.png)

![total_accessed_host_pages](https://user-images.githubusercontent.com/448274/126979051-dde59292-aec8-4b74-bc79-47899c686543.png)

![total_Wasm_pages_in_use](https://user-images.githubusercontent.com/448274/126979058-27ee803b-1737-4630-a5d1-0a0e0f391eed.png)

With the current parameters (HEAP_GROWING_FACTOR, SMALL_HEAP_DELTA,
MAX_HP_FOR_GC) we only do GC once, somewhere between calls 600 and 800. As a
result, instructions and dirtied pages are dramatically lower, but we allocate
more Wasm pages. After the GC we no longer need to grow the heap so total Wasm
pages is constant.

## Testing

Currently tests allocate very little and with the new scheduler we end up not
doing any GC in tests. To avoid reducing test coverage tests are currently run
with `--force-gc`. After #2684 I will run drun tests with both schedulers.
Currently the new scheduler is tested manually using the test suite and CanCan
backend.
