### PR TITLE
Use upstream `niv-updater-action` again

### DIFF
--- a/.github/workflows/niv-updater-rare.yml
+++ b/.github/workflows/niv-updater-rare.yml
@@ -20,8 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        # Use our fork until https://github.com/knl/niv-updater-action/pull/46 is merged
-        uses: dfinity-lab/niv-updater-action@46d903454cded66eb06b1d17aeb2ddae403fc553
+        uses: knl/niv-updater-action@60f23607814cf4f2e80a1e32ee74f8323897d09e
         with:
           # might be too noisy
           whitelist: 'dfinity,ic-ref,musl-wasi,common,niv'

--- a/.github/workflows/niv-updater-trial.yml
+++ b/.github/workflows/niv-updater-trial.yml
@@ -26,8 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        # Use our fork until https://github.com/knl/niv-updater-action/pull/46 is merged
-        uses: dfinity-lab/niv-updater-action@46d903454cded66eb06b1d17aeb2ddae403fc553
+        uses: knl/niv-updater-action@60f23607814cf4f2e80a1e32ee74f8323897d09e
         with:
           whitelist: 'nixpkgs,musl-wasi'
           labels: |

--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -20,8 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        # Use our fork until https://github.com/knl/niv-updater-action/pull/46 is merged
-        uses: dfinity-lab/niv-updater-action@46d903454cded66eb06b1d17aeb2ddae403fc553
+        uses: knl/niv-updater-action@60f23607814cf4f2e80a1e32ee74f8323897d09e
         with:
           # might be too noisy
           blacklist: 'nixpkgs,dfinity,ic-ref,musl-wasi,common,niv,wasm-profiler'


### PR DESCRIPTION
Now that knl/niv-updater-action#46 is merged, use the official upstream repo.

The same change works in dfinity/sdk#1747.