### PR TITLE
Updated error message for empty input

### DIFF
--- a/rts/motoko-rts/src/idl.rs
+++ b/rts/motoko-rts/src/idl.rs
@@ -100,7 +100,7 @@ unsafe fn parse_idl_header<M: Memory>(
     main_types_out: *mut *mut u8,
 ) {
     if (*buf).ptr == (*buf).end {
-        idl_trap_with("empty input");
+        idl_trap_with("empty input. Expected Candid-encoded argument, but received a zero-length argument");
     }
 
     // Magic bytes (DIDL)


### PR DESCRIPTION
Updated error message of empty input to be more explanatory per discussion below:

https://forum.dfinity.org/t/canister-xxx-trapped-explicitly-idl-error-empty-input/6002