### PR TITLE
Mark-compact GC: update STACK_TOP when growing mark stack

### DIFF
--- a/rts/motoko-rts/src/gc/mark_compact/mark_stack.rs
+++ b/rts/motoko-rts/src/gc/mark_compact/mark_stack.rs
@@ -13,13 +13,13 @@ pub const INIT_STACK_SIZE: Words<u32> = Words(64);
 static mut STACK_BLOB_PTR: *mut Blob = null_mut();
 
 /// Bottom of the mark stack
-static mut STACK_BASE: *mut usize = null_mut();
+pub static mut STACK_BASE: *mut usize = null_mut();
 
 /// Top of the mark stack
-static mut STACK_TOP: *mut usize = null_mut();
+pub static mut STACK_TOP: *mut usize = null_mut();
 
 /// Next free slot in the mark stack
-static mut STACK_PTR: *mut usize = null_mut();
+pub static mut STACK_PTR: *mut usize = null_mut();
 
 pub unsafe fn alloc_mark_stack<M: Memory>(mem: &mut M) {
     debug_assert!(STACK_BLOB_PTR.is_null());
@@ -39,7 +39,7 @@ pub unsafe fn free_mark_stack() {
 }
 
 /// Doubles the stack size
-unsafe fn grow_stack<M: Memory>(mem: &mut M) {
+pub unsafe fn grow_stack<M: Memory>(mem: &mut M) {
     let stack_cap: Words<u32> = STACK_BLOB_PTR.len().to_words();
     let p = mem.alloc_words(stack_cap).unskew() as *mut usize;
 

--- a/rts/motoko-rts/src/gc/mark_compact/mark_stack.rs
+++ b/rts/motoko-rts/src/gc/mark_compact/mark_stack.rs
@@ -48,6 +48,7 @@ unsafe fn grow_stack<M: Memory>(mem: &mut M) {
 
     let new_cap: Words<u32> = Words(stack_cap.0 * 2);
     (*STACK_BLOB_PTR).len = new_cap.to_bytes();
+    STACK_TOP = STACK_BASE.add(new_cap.as_usize());
 }
 
 pub unsafe fn push_mark_stack<M: Memory>(mem: &mut M, obj: usize, obj_tag: Tag) {

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -17,6 +17,10 @@ impl Words<u32> {
     pub fn to_bytes(self) -> Bytes<u32> {
         Bytes(self.0 * WORD_SIZE)
     }
+
+    pub fn as_usize(self) -> usize {
+        self.0 as usize
+    }
 }
 
 impl<A: Add<Output = A>> Add for Words<A> {


### PR DESCRIPTION
When growing mark stack we should update `STACK_TOP` otherwise subsequent
pushes will think that the stack is full and call `grow_stack` again.

Discovered while debugging strange allocation pattern in #2650 with the
compacting GC. It turns out once the mark stack is full ever subsequent push
(until stack is smaller than the initial size again) doubles the stack size,
causing redundant allocations.

Regression test added.
