### PR TITLE
Use `int32_of_big_int` when computing bignum limbs

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -2497,7 +2497,7 @@ module BigNumLibtommath : BigNumType = struct
         then []
         else
           let (a, b) = Big_int.quomod_big_int n twoto28 in
-          [ Int32.of_int (Big_int.int_of_big_int b) ] @ go a
+          [ Big_int.int32_of_big_int b ] @ go a
       in go n
     in
     (* how many 32 bit digits *)


### PR DESCRIPTION
I suspect this will also resolve potential problems with trapping on 32-bit compilation platforms. I don't think it is related to #2671, but who knows?