### PR TITLE
RTS: Introduce heap objects for unused space

### DIFF
--- a/rts/motoko-rts/src/debug.rs
+++ b/rts/motoko-rts/src/debug.rs
@@ -226,6 +226,13 @@ pub(crate) unsafe fn print_boxed_object(buf: &mut WriteBuf, p: usize) {
                 (*concat).text2.0
             );
         }
+        TAG_ONE_WORD_FILLER => {
+            let _ = write!(buf, "<One word filler>",);
+        }
+        TAG_FREE_SPACE => {
+            let free_space = obj as *const FreeSpace;
+            let _ = write!(buf, "<Free space {} words>", (*free_space).words.0);
+        }
         other => {
             let _ = write!(buf, "<??? {} ???>", other);
         }

--- a/rts/motoko-rts/src/principal_id.rs
+++ b/rts/motoko-rts/src/principal_id.rs
@@ -124,13 +124,8 @@ pub unsafe fn base32_of_checksummed_blob<M: Memory>(mem: &mut M, b: SkewedPtr) -
         stash_enc_base32(pump.pending_data as u8, pump.dest);
         pump.dest = pump.dest.add(1);
         // Discount padding
-        let old_len = blob.len();
         let new_len = Bytes(pump.dest.offset_from(dest) as u32);
-        // Zero the slop, for debug functions
-        for i in new_len.0..old_len.0 {
-            blob.set(i, 0);
-        }
-        (*blob).len = new_len;
+        blob.shrink(new_len);
     }
 
     r
@@ -207,13 +202,8 @@ pub unsafe fn base32_to_blob<M: Memory>(mem: &mut M, b: SkewedPtr) -> SkewedPtr 
     }
 
     // Adjust resulting blob len
-    let old_len = blob.len();
     let new_len = Bytes(pump.dest.offset_from(dest) as u32);
-    // Zero the slop, for debug functions
-    for i in new_len.0..old_len.0 {
-        blob.set(i, 0);
-    }
-    (*blob).len = new_len;
+    blob.shrink(new_len);
     r
 }
 
@@ -260,13 +250,8 @@ unsafe fn base32_to_principal<M: Memory>(mem: &mut M, b: SkewedPtr) -> SkewedPtr
     }
 
     // Adjust result length
-    let old_len = blob.len();
     let new_len = Bytes(dest as u32 - blob.payload_addr() as u32);
-    // Zero the slop, for debug functions
-    for i in new_len.0..old_len.0 {
-        blob.set(i, 0);
-    }
-    (*blob).len = new_len;
+    blob.shrink(new_len);
     r
 }
 

--- a/rts/motoko-rts/src/visitor.rs
+++ b/rts/motoko-rts/src/visitor.rs
@@ -89,7 +89,7 @@ pub unsafe fn visit_pointer_fields<F>(
             }
         }
 
-        TAG_BITS64 | TAG_BITS32 | TAG_BLOB | TAG_BIGINT => {
+        TAG_BITS64 | TAG_BITS32 | TAG_BLOB | TAG_BIGINT | TAG_ONE_WORD_FILLER | TAG_FREE_SPACE => {
             // These don't have pointers, skip
         }
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1159,6 +1159,8 @@ module Tagged = struct
     | Null (* For opt. Static singleton! *)
     | StableSeen (* Marker that we have seen this thing before *)
     | CoercionFailure (* Used in the Candid decoder. Static singleton! *)
+    | OneWordFiller (* Only used by the RTS *)
+    | FreeSpace (* Only used by the RTS *)
 
   (* Let's leave out tag 0 to trap earlier on invalid memory *)
   let int_of_tag = function
@@ -1176,6 +1178,8 @@ module Tagged = struct
     | BigInt -> 13l
     | Concat -> 14l
     | Null -> 15l
+    | OneWordFiller -> 16l
+    | FreeSpace -> 17l
     | CoercionFailure -> 0xfffffffel
     | StableSeen -> 0xffffffffl
 


### PR DESCRIPTION
Two new objects OneWordFiller and FreeSpace introduced to mark unused
spaces in heap.

These are mainly needed in #2706 and for new gc experiments, but they
are also useful to mark the slop when shrinking blobs in principal id
functions.

Previously when shrinking a blob we were filling the unused space with
zeros, and the gc was skipping the zeros when scanning the heap for e.g.
debug prints or sanity checks.

With OneWordFiller and FreeSpace, for 1 and 2 words unused space we do
the same amount of writes (header or header + length), for anything
larger we do 2 writes, instead of one write per word.