### PR TITLE
src/Makefile: Create/delete source_id/generated.ml

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,7 @@ ALL_TARGETS = $(NATIVE_TARGETS) $(JS_TARGETS)
 .PHONY: all clean moc mo-doc mo-ide mo-ld moc.js didc deser candid-tests unit-tests didc.js
 
 # let make update check this file every time
-SOURCE_ID = source_id/source_id.ml
+SOURCE_ID = source_id/generated.ml
 
 # This targets is spelled out so that `make`
 # only invokes `dune` once, much faster


### PR DESCRIPTION
since #2587, the generated file is `source_id/generated.ml`, and no
longer `source_id/source_id.ml`. The latter is a normal file that `make
clean` should not delete. So let’s tell `make` about this.

(It seems that either nobody runs `make clean`, or everybody expects
weird behaviour and isn’t surprised that `make clean` deletes committed
files.)