### PR TITLE
nix-shell: Do not include nix-built candid-tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -647,7 +647,7 @@ rec {
     # both, while not actually building `moc`
     #
     propagatedBuildInputs =
-      let dont_build = [ moc mo-ld didc deser ]; in
+      let dont_build = [ moc mo-ld didc deser candid-tests ]; in
       nixpkgs.lib.lists.unique (builtins.filter (i: !(builtins.elem i dont_build)) (
         commonBuildInputs nixpkgs ++
         rts.buildInputs ++


### PR DESCRIPTION
so that ./bin/candid-tests is used and incremental development is
possible, just as for the other binaries built “by us” (`moc` etc.)