### PR TITLE
Make Promise.lazy_value more forgiving

### DIFF
--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -458,7 +458,14 @@ struct
   let value_opt p = !p
   let value p = match !p with Some x -> x | None -> raise Promise
   let lazy_value p f =
-    (if not (is_fulfilled p) then fulfill p (f ()));
+    begin
+      if not (is_fulfilled p) then
+      let x = f () in
+      (* Evaluating f might have actually fulfilled this. We assume f to be pure
+         (or at least be idempotent), and do not try to update it again.
+      *)
+      if not (is_fulfilled p) then fulfill p x
+    end;
     value p
 end
 

--- a/test/run/issue2714.mo
+++ b/test/run/issue2714.mo
@@ -1,0 +1,4 @@
+type A = { #y : A };
+// func bar(x: A): Text { debug_show(x); };
+func foo(blob: ?A) : () { ignore (debug_show(blob)); };
+foo(null);


### PR DESCRIPTION
it was possible that the thunk passed to `lazy_value` would itself
fulfil the promise, which led to an exception in some cases.

Assuming the function to `lazy_value` always produces the same value, we
can avoid that by simply not raising an exception here.

This fixes #2714.