### PR TITLE
Use deterministic hashers in RTS test suite

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -167,7 +167,7 @@ rec {
         name = "motoko-rts-deps";
         src = subpath ./rts;
         sourceRoot = "rts/motoko-rts-tests";
-        sha256 = "1vr9mvjrddjv7xga6hhzq39x8qzdqsnhwic76apv7ksfkh0psfx2";
+        sha256 = "0sy7jglz9pxw2lz0qjyplchcfn78d7789sd93xwybisamjynlniy";
         copyLockfile = true;
       };
     in

--- a/rts/motoko-rts-tests/Cargo.lock
+++ b/rts/motoko-rts-tests/Cargo.lock
@@ -31,6 +31,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3748f82c7d366a0b4950257d19db685d4958d2fa27c6d164a3f069fec42b748b"
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,12 +61,6 @@ name = "libc"
 version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "motoko-rts"
@@ -82,8 +85,8 @@ name = "motoko-rts-tests"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "fxhash",
  "libc",
- "maplit",
  "motoko-rts",
  "proptest",
 ]

--- a/rts/motoko-rts-tests/Cargo.toml
+++ b/rts/motoko-rts-tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.4.3"
+fxhash = "0.2.1"
 libc = { version = "0.2.81", default_features = false }
-maplit = "1.0.2"
 motoko-rts = { path = "../motoko-rts/native" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/rts/motoko-rts-tests/src/main.rs
+++ b/rts/motoko-rts-tests/src/main.rs
@@ -14,9 +14,6 @@ mod utf8;
 
 use motoko_rts::types::Bytes;
 
-#[macro_use]
-extern crate maplit;
-
 fn main() {
     if std::mem::size_of::<usize>() != 4 {
         println!("Motoko RTS only works on 32-bit architectures");


### PR DESCRIPTION
By default Rust's HashMap and HashSet hashers are non-deterministic,
which is a problem when debugging as the tests can fail differently in
consecutive runs. I even observed that a buggy test passes when I run
the test suite repeatedly a few times.

This PR switches to `fxhash`s HashMap and HashSet, which is just std map
and set with a deterministic hasher. In the future we should be careful
to not use std maps and sets and always use fxhash.

`maplit` is removed as the `hashmap` and `hashset` macros only allow
generating std maps and sets with non-det hashers.