### PR TITLE
Fix handling of self references in mark-compact GC, imrpove tests

### DIFF
--- a/rts/motoko-rts-tests/src/gc.rs
+++ b/rts/motoko-rts-tests/src/gc.rs
@@ -37,35 +37,32 @@ fn test_heaps() -> Vec<TestHeap> {
         // - Backwards pointers
         // - More than one fields in an object
         TestHeap {
-            heap: vec![(0, vec![0, 2]), (2, vec![0]), (3, vec![3])]
-                .into_iter()
-                .collect(),
+            heap: vec![(0, vec![0, 2]), (2, vec![0]), (3, vec![3])],
             roots: vec![0, 2, 3],
             continuation_table: vec![0],
         },
         // Tests pointing to the same object in multiple fields of an object. Also has unreachable
         // objects.
         TestHeap {
-            heap: vec![(0, vec![]), (1, vec![]), (2, vec![])]
-                .into_iter()
-                .collect(),
+            heap: vec![(0, vec![]), (1, vec![]), (2, vec![])],
             roots: vec![1],
             continuation_table: vec![0, 0],
         },
         // Root points backwards in heap. Caught a bug in mark-compact collector.
         TestHeap {
-            heap: vec![(0, vec![]), (1, vec![2]), (2, vec![1])]
-                .into_iter()
-                .collect(),
+            heap: vec![(0, vec![]), (1, vec![2]), (2, vec![1])],
             roots: vec![2],
             continuation_table: vec![],
         },
     ]
 }
 
+// All fields are vectors to preserve ordering. Objects are allocated/ added to root arrays etc. in
+// the same order they appear in these vectors. Each object in `heap` should have a unique index,
+// which is checked when creating the heap.
 #[derive(Debug)]
 struct TestHeap {
-    heap: FxHashMap<ObjectIdx, Vec<ObjectIdx>>,
+    heap: Vec<(ObjectIdx, Vec<ObjectIdx>)>,
     roots: Vec<ObjectIdx>,
     continuation_table: Vec<ObjectIdx>,
 }
@@ -84,7 +81,7 @@ fn test_gcs(heap_descr: &TestHeap) {
 
 fn test_gc(
     gc: GC,
-    refs: &FxHashMap<ObjectIdx, Vec<ObjectIdx>>,
+    refs: &[(ObjectIdx, Vec<ObjectIdx>)],
     roots: &[ObjectIdx],
     continuation_table: &[ObjectIdx],
 ) {
@@ -132,7 +129,7 @@ fn test_gc(
 ///
 fn check_dynamic_heap(
     post_gc: bool,
-    objects: &FxHashMap<ObjectIdx, Vec<ObjectIdx>>,
+    objects: &[(ObjectIdx, Vec<ObjectIdx>)],
     roots: &[ObjectIdx],
     continuation_table: &[ObjectIdx],
     heap: &[u8],
@@ -140,6 +137,11 @@ fn check_dynamic_heap(
     heap_ptr_offset: usize,
     continuation_table_ptr_offset: usize,
 ) {
+    let objects_map: FxHashMap<ObjectIdx, &[ObjectIdx]> = objects
+        .iter()
+        .map(|(obj, refs)| (*obj, refs.as_slice()))
+        .collect();
+
     // Current offset in the heap
     let mut offset = heap_base_offset;
 
@@ -184,7 +186,7 @@ fn check_dynamic_heap(
             );
         }
 
-        let object_expected_pointees = objects.get(&object_idx).unwrap_or_else(|| {
+        let object_expected_pointees = objects_map.get(&object_idx).unwrap_or_else(|| {
             panic!("Object with index {} is not in the objects map", object_idx)
         });
 
@@ -212,7 +214,7 @@ fn check_dynamic_heap(
     // At this point we've checked that all seen objects point to the expected objects (as
     // specified by `objects`). Check that we've seen the reachable objects and only the reachable
     // objects.
-    let reachable_objects = compute_reachable_objects(roots, continuation_table, objects);
+    let reachable_objects = compute_reachable_objects(roots, continuation_table, &objects_map);
 
     // Objects we've seen in the heap
     let seen_objects: FxHashSet<ObjectIdx> = seen.keys().copied().collect();
@@ -264,7 +266,7 @@ fn check_dynamic_heap(
 fn compute_reachable_objects(
     roots: &[ObjectIdx],
     continuation_table: &[ObjectIdx],
-    heap: &FxHashMap<ObjectIdx, Vec<ObjectIdx>>,
+    heap: &FxHashMap<ObjectIdx, &[ObjectIdx]>,
 ) -> FxHashSet<ObjectIdx> {
     let root_iter = roots.iter().chain(continuation_table.iter()).copied();
 
@@ -272,7 +274,7 @@ fn compute_reachable_objects(
     let mut work_list: Vec<ObjectIdx> = root_iter.collect();
 
     while let Some(next) = work_list.pop() {
-        let pointees = heap
+        let pointees = *heap
             .get(&next)
             .unwrap_or_else(|| panic!("Object {} is in the work list, but not in heap", next));
 

--- a/rts/motoko-rts-tests/src/gc.rs
+++ b/rts/motoko-rts-tests/src/gc.rs
@@ -33,11 +33,17 @@ fn test_heaps() -> Vec<TestHeap> {
     vec![
         // Just a random test that covers a bunch of cases:
         // - Self references
+        // - Unreachable objects
         // - Forward pointers
         // - Backwards pointers
         // - More than one fields in an object
         TestHeap {
-            heap: vec![(0, vec![0, 2]), (2, vec![0]), (3, vec![3])],
+            heap: vec![
+                (0, vec![0, 2]),
+                (1, vec![0, 1, 2, 3]),
+                (2, vec![0]),
+                (3, vec![3]),
+            ],
             roots: vec![0, 2, 3],
             continuation_table: vec![0],
         },

--- a/rts/motoko-rts-tests/src/gc/heap.rs
+++ b/rts/motoko-rts-tests/src/gc/heap.rs
@@ -33,7 +33,7 @@ impl MotokoHeap {
     /// `super::MAX_MARK_STACK_SIZE`. In the worst case the size would be the same as the heap
     /// size, but that's not a realistic scenario.
     pub fn new(
-        map: &FxHashMap<ObjectIdx, Vec<ObjectIdx>>,
+        map: &[(ObjectIdx, Vec<ObjectIdx>)],
         roots: &[ObjectIdx],
         continuation_table: &[ObjectIdx],
         gc: GC,
@@ -151,7 +151,7 @@ impl MotokoHeapInner {
     }
 
     fn new(
-        map: &FxHashMap<ObjectIdx, Vec<ObjectIdx>>,
+        map: &[(ObjectIdx, Vec<ObjectIdx>)],
         roots: &[ObjectIdx],
         continuation_table: &[ObjectIdx],
         gc: GC,
@@ -163,7 +163,7 @@ impl MotokoHeapInner {
 
         let dynamic_heap_size_without_continuation_table_bytes = {
             let object_headers_words = map.len() * 3;
-            let references_words = map.values().map(Vec::len).sum::<usize>();
+            let references_words = map.iter().map(|(_, refs)| refs.len()).sum::<usize>();
             (object_headers_words + references_words) * WORD_SIZE
         };
 
@@ -274,7 +274,7 @@ fn heap_size_for_gc(
 /// Returns a mapping from object indices (`ObjectIdx`) to their addresses (see module
 /// documentation for "offset" and "address" definitions).
 fn create_dynamic_heap(
-    refs: &FxHashMap<ObjectIdx, Vec<ObjectIdx>>,
+    refs: &[(ObjectIdx, Vec<ObjectIdx>)],
     continuation_table: &[ObjectIdx],
     dynamic_heap: &mut [u8],
 ) -> FxHashMap<ObjectIdx, usize> {
@@ -328,7 +328,7 @@ fn create_dynamic_heap(
     // Add the continuation table
     let n_objects = refs.len();
     // fields+1 for the scalar field (idx)
-    let n_fields: usize = refs.values().map(|fields| fields.len() + 1).sum();
+    let n_fields: usize = refs.iter().map(|(_, fields)| fields.len() + 1).sum();
     let continuation_table_offset =
         (size_of::<Array>() * n_objects as u32).to_bytes().0 as usize + n_fields * WORD_SIZE;
 

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -211,7 +211,7 @@ unsafe fn update_refs<SetHp: Fn(u32)>(set_hp: SetHp, heap_base: u32) {
 /// Thread forwards pointers in object
 unsafe fn thread_fwd_pointers(obj: *mut Obj, heap_base: u32) {
     visit_pointer_fields(obj, obj.tag(), heap_base as usize, |field_addr| {
-        if (*field_addr).unskew() > field_addr as usize {
+        if (*field_addr).unskew() > obj as usize {
             thread(field_addr)
         }
     });

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -149,8 +149,8 @@ unsafe fn mark_fields<M: Memory>(mem: &mut M, obj: *mut Obj, obj_tag: Tag, heap_
         let field_value = *field_addr;
         mark_object(mem, field_value, heap_base);
 
-        // Thread if backwards pointer
-        if field_value.unskew() < obj as usize {
+        // Thread if backwards or self pointer
+        if field_value.unskew() <= obj as usize {
             thread(field_addr);
         }
     });


### PR DESCRIPTION
One line fix to thread self references during marking in mark-compact GC.

We had a test with self references but it accidentally passed. The problem was
none of the objects below the object with self reference were dead, so the
object was not moved, and as a result the field with the self reference had the
correct value even though we didn't update it.

The test is updated to add a dead object before the object with self ref. It
fails without the fix.

Test code is also updated to use a vector for the heap description, instead of
a map. This allows specifying object order in heap. With the previous HashMap
based implementation there is no way to reason about the object orders, so for
example the test with a backward pointer might or might not have a backward
pointer, depending on the HashMap (and hasher) implementation. With the vector
representation allocation is done in the same order as the test description,
allowing testing backward and forward pointers.

Thanks to @ulan for the catching the bug.