### PR TITLE
Improve on #2708 by applying strength reduction and abolishing termination checks

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -2711,12 +2711,26 @@ module Object = struct
   let idx_hash_raw env low_bound =
     let name = Printf.sprintf "obj_idx<%d>" low_bound  in
     Func.share_code2 env name (("x", I32Type), ("hash", I32Type)) [I32Type] (fun env get_x get_hash ->
+      let set_x = G.i (LocalSet (nr 0l)) in
       let (set_h_ptr, get_h_ptr) = new_local env "h_ptr" in
 
       get_x ^^ Heap.load_field hash_ptr_field ^^ set_h_ptr ^^
 
-      get_x ^^ Heap.load_field size_field ^^
+        (*get_x ^^ Heap.load_field size_field ^^*)
       (* Linearly scan through the fields (binary search can come later) *)
+        (* unskew h_ptr and advance both to low bound *)
+        get_h_ptr ^^ compile_add_const Int32.(of_int (1 + low_bound * to_int Heap.word_size)) ^^ set_h_ptr ^^
+          get_x ^^ compile_add_const Int32.(of_int ((3 + low_bound) * to_int Heap.word_size)) ^^ set_x ^^
+    G.loop_ [] (
+        get_h_ptr ^^ load_unskewed_ptr ^^
+        get_hash ^^ G.i (Compare (Wasm.Values.I32 I32Op.Eq)) ^^
+        G.if_ [] (get_x ^^ G.i Return)
+          (get_h_ptr ^^ compile_add_const Heap.word_size ^^ set_h_ptr ^^
+             get_x ^^ compile_add_const Heap.word_size ^^ set_x
+          ^^ G.i (Br (nr 1l)))
+    ) ^^ G.i Unreachable
+
+(*
       from_m_to_n env (Int32.of_int low_bound) (fun get_i ->
         get_i ^^
         compile_mul_const Heap.word_size ^^
@@ -2735,6 +2749,8 @@ module Object = struct
           ) G.nop
       ) ^^
       E.trap_with env "internal error: object field not found"
+ *)
+
     )
 
   (* Returns a pointer to the object field (possibly following the indirection) *)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1516,8 +1516,8 @@ module Word64 = struct
     let name = prim_fun_name Type.Nat64 "wpow_nat" in
     Func.share_code2 env name (("n", I64Type), ("exp", I64Type)) [I64Type]
       (fun env get_n get_exp ->
-        let set_n = G.i (LocalSet (nr 0l)) in
-        let set_exp = G.i (LocalSet (nr 1l)) in
+        let set_n = G.setter_for get_n in
+        let set_exp = G.setter_for get_exp in
         let (set_acc, get_acc) = new_local64 env "acc" in
 
         (* start with result = 1 *)
@@ -1730,8 +1730,8 @@ module TaggedSmallWord = struct
     let name = prim_fun_name ty "wpow_nat" in
     Func.share_code2 env name (("n", I32Type), ("exp", I32Type)) [I32Type]
       (fun env get_n get_exp ->
-        let set_n = G.i (LocalSet (nr 0l)) in
-        let set_exp = G.i (LocalSet (nr 1l)) in
+        let set_n = G.setter_for get_n in
+        let set_exp = G.setter_for get_exp in
         let (set_acc, get_acc) = new_local env "acc" in
 
         (* unshift arguments *)
@@ -2711,7 +2711,7 @@ module Object = struct
   let idx_hash_raw env low_bound =
     let name = Printf.sprintf "obj_idx<%d>" low_bound  in
     Func.share_code2 env name (("x", I32Type), ("hash", I32Type)) [I32Type] (fun env get_x get_hash ->
-      let set_x = G.i (LocalSet (nr 0l)) in
+      let set_x = G.setter_for get_x in
       let (set_h_ptr, get_h_ptr) = new_local env "h_ptr" in
 
       get_x ^^ Heap.load_field hash_ptr_field ^^
@@ -4093,8 +4093,8 @@ module Serialization = struct
     let name = "@serialize_go<" ^ typ_hash t ^ ">" in
     Func.share_code3 env name (("x", I32Type), ("data_buffer", I32Type), ("ref_buffer", I32Type)) [I32Type; I32Type]
     (fun env get_x get_data_buf get_ref_buf ->
-      let set_data_buf = G.i (LocalSet (nr 1l)) in
-      let set_ref_buf = G.i (LocalSet (nr 2l)) in
+      let set_data_buf = G.setter_for get_data_buf in
+      let set_ref_buf = G.setter_for get_ref_buf in
 
       (* Some combinators for writing values *)
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -604,26 +604,6 @@ let compile_while cond body =
       cond ^^ G.if_ [] (body ^^ G.i (Br (nr 1l))) G.nop
     )
 
-(* Expects a number n on the stack. Iterates from start expr to below that number. *)
-let from_start_to_n env get_start mk_body =
-    let (set_n, get_n) = new_local env "n" in
-    let (set_i, get_i) = new_local env "i" in
-    set_n ^^
-    get_start ^^
-    set_i ^^
-
-    compile_while
-      ( get_i ^^
-        get_n ^^
-        G.i (Compare (Wasm.Values.I32 I32Op.LtU))
-      ) (
-        mk_body get_i ^^
-
-        get_i ^^
-        compile_add_const 1l ^^
-        set_i
-      )
-
 (* Expects a number n on the stack. Iterates from m to below that number. *)
 let from_m_to_n env m mk_body =
     let (set_n, get_n) = new_local env "n" in
@@ -2729,16 +2709,15 @@ module Object = struct
 
   (* Returns a pointer to the object field (without following the indirection) *)
   let idx_hash_raw env low_bound =
-    compile_unboxed_const (Int32.of_int low_bound) ^^
-    let name = Printf.sprintf "obj_idx"  in
-    Func.share_code3 env name (("x", I32Type), ("hash", I32Type), ("low_bound", I32Type)) [I32Type] (fun env get_x get_hash get_bound ->
+    let name = Printf.sprintf "obj_idx<%d>" low_bound  in
+    Func.share_code2 env name (("x", I32Type), ("hash", I32Type)) [I32Type] (fun env get_x get_hash ->
       let (set_h_ptr, get_h_ptr) = new_local env "h_ptr" in
 
       get_x ^^ Heap.load_field hash_ptr_field ^^ set_h_ptr ^^
 
       get_x ^^ Heap.load_field size_field ^^
       (* Linearly scan through the fields (binary search can come later) *)
-      from_start_to_n env get_bound (fun get_i ->
+      from_m_to_n env (Int32.of_int low_bound) (fun get_i ->
         get_i ^^
         compile_mul_const Heap.word_size ^^
         get_h_ptr ^^

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -189,6 +189,14 @@ let branch_to_ (p : depth) : t =
 let labeled_block_ (ty : stack_type) depth (body : t) : t =
   block_ ty (remember_depth depth body)
 
+(* Obtain the setter from a known variable's getter *)
+
+let setter_for (getter : t) =
+  match List.map (fun {it; _} -> it) (getter 0l Wasm.Source.no_region []) with
+  | [LocalGet v] -> i (LocalSet v)
+  | [GlobalGet v] -> i (GlobalSet v)
+  | _ -> failwith "input must be a getter"
+
 (* Intended to be used within assert *)
 
 let is_nop (is : t) =


### PR DESCRIPTION
Pick up an idea to reduce the computational complexity of the loop searching for the field hash:
- don't use multiplication, use addition instead
- trust the type system that the hash is present, and scrap the termination check

This gives us a nice 0.5% reduction in benchmarks for cycles usage as well as shaving off the 0.1% size increase that we suffered with #2708.

------------------
### Measurements

this gives us a comparison in binary size for 65 calls:
```
[nix-shell:~/motoko]$ wasm2wat qr-sharemoc.wasm | grep obj_idx | grep 'call ' | wc -l
65
```
there is a single `func $obj_idx`
```
[nix-shell:~/motoko]$ ls -l *moc.wasm
-rw-r--r-- 1 ggreif staff 257898 Aug 13 12:19 qr-oldmoc.wasm <<< previous `master`
-rw-r--r-- 1 ggreif staff 258162 Aug 13 12:19 qr-newmoc.wasm <<< current `master`
-rw-r--r-- 1 ggreif staff 258039 Aug 13 14:36 qr-sharemoc.wasm  <<< this commit (2569509)
-rw-r--r-- 1 ggreif staff 258027 Aug 17 09:37 qr-shavemoc.wasm <<< rearchitected loop
```
Looks like calling a nullary wrapper that calls the bottleneck with pushed bound will improve things (worth exploring, but not done in this PR).
