### PR TITLE
Add tests to check for compilation of bottom (as object)

### DIFF
--- a/test/run/idx.mo
+++ b/test/run/idx.mo
@@ -34,6 +34,11 @@ func absurdities(inp : Int) {
     if (inp == 2) go2(loop {});
     if (inp == 3) go3(loop {});
     if (inp == 4) go4(loop {});
+
+    if (inp == 1) (loop {}).field;
+    if (inp == 2) (loop {}).a;
+    if (inp == 3) (loop {}).other;
+    if (inp == 4) (loop {}).foo;
 };
 
 go();

--- a/test/run/idx.mo
+++ b/test/run/idx.mo
@@ -25,7 +25,15 @@ func go() {
     go4({ a = 25; foo = 8; field = 42; other = 83 });
     let co4 = CO4();
     let a = co4.a;
-    go4(co4)
+    go4(co4);
+    if (co4.a == 0) { absurdities(co4.foo) }
+};
+
+func absurdities(inp : Int) {
+    if (inp == 1) go1(loop {});
+    if (inp == 2) go2(loop {});
+    if (inp == 3) go3(loop {});
+    if (inp == 4) go4(loop {});
 };
 
 go();

--- a/test/run/idx.mo
+++ b/test/run/idx.mo
@@ -26,7 +26,7 @@ func go() {
     let co4 = CO4();
     let a = co4.a;
     go4(co4);
-    if (co4.a == 0) { absurdities(co4.foo) }
+    absurdities(co4.foo)
 };
 
 func absurdities(inp : Int) {


### PR DESCRIPTION
This is a follow-on to #2708, addressing a [review comment](https://github.com/dfinity/motoko/pull/2708#discussion_r686132804).

The resulting Wasm is as expected:
``` wasm
  (func $absurdities (type 8) (param $clos i32) (param $inp i32)
    local.get $inp
    i32.const 2
    call $B_eq
    if  ;; label = @1
      loop  ;; label = @2
        br 0 (;@2;)
      end
      unreachable
    end
...
```
the rest is analogous.