### PR TITLE
Update linker in prep for updating LLVM

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -8205,13 +8205,10 @@ and conclude_module env start_fi_o =
     let open Wasm_exts.CustomModule in
     { module_;
       dylink = None;
-      name = {
-        module_ = None;
-        function_names =
-            List.mapi (fun i (f,n,_) -> Int32.(add ni' (of_int i), n)) funcs;
-        locals_names =
-            List.mapi (fun i (f,_,ln) -> Int32.(add ni' (of_int i), ln)) funcs;
-        };
+      name = { empty_name_section with function_names =
+                 List.mapi (fun i (f,n,_) -> Int32.(add ni' (of_int i), n)) funcs;
+               locals_names =
+                 List.mapi (fun i (f,_,ln) -> Int32.(add ni' (of_int i), ln)) funcs; };
       motoko = {
         labels = E.get_labs env;
       };

--- a/src/wasm-exts/customModule.ml
+++ b/src/wasm-exts/customModule.ml
@@ -8,12 +8,26 @@ type name_section = {
   module_ : string option;
   function_names : (int32 * string) list;
   locals_names : (int32 * (int32 * string) list) list;
+  label_names : (int32 * (int32 * string) list) list;
+  type_names : (int32 * string) list;
+  table_names : (int32 * string) list;
+  memory_names : (int32 * string) list;
+  global_names : (int32 * string) list;
+  elem_segment_names : (int32 * string) list;
+  data_segment_names : (int32 * string) list;
 }
 
 let empty_name_section : name_section = {
   module_ = None;
   function_names = [];
   locals_names = [];
+  label_names = [];
+  type_names = [];
+  table_names = [];
+  memory_names = [];
+  global_names = [];
+  elem_segment_names = [];
+  data_segment_names = [];
 }
 
 type dylink_section = {


### PR DESCRIPTION
- Implement extended name section
  (https://github.com/WebAssembly/extended-name-section/blob/master/proposals/extended-name-section/Overview.md)

- Handle `start` functions in the RTS module in linker

These changes are needed to update to LLVM 12: #2542