### PR TITLE
Remove unnecessary attribute passing in release expression

### DIFF
--- a/release-files.nix
+++ b/release-files.nix
@@ -7,8 +7,8 @@
 { releaseVersion ? "latest" }:
 let
   nixpkgs = import ./nix { };
-  linux = import ./default.nix { system = "x86_64-linux"; internal = true; inherit releaseVersion; };
-  darwin = import ./default.nix { system = "x86_64-darwin"; internal = true; inherit releaseVersion; };
+  linux = import ./default.nix { system = "x86_64-linux"; inherit releaseVersion; };
+  darwin = import ./default.nix { system = "x86_64-darwin"; inherit releaseVersion; };
 
   as_tarball = dir: derivations:
     nixpkgs.runCommandNoCC "motoko-${releaseVersion}.tar.gz" {


### PR DESCRIPTION
This might resolve the glitch that threw the last release from the rails: https://github.com/dfinity/motoko/pull/2765#issuecomment-913717691

There was no receive-side match for the argument `internal`, thus the nix call failed.