### PR TITLE
Prim.trap: Expose ic0.trap

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3480,7 +3480,7 @@ module IC = struct
   let trap_with env s =
     Blob.lit_ptr_len env s ^^ trap_ptr_len env
 
-  let _trap_text env  =
+  let trap_text env  =
     Text.to_blob env ^^ Blob.as_ptr_len env ^^ trap_ptr_len env
 
   let default_exports env =
@@ -7837,6 +7837,11 @@ and compile_exp (env : E.t) ae exp =
       SR.unit,
       compile_exp_vanilla env ae e ^^
       IC.print_text env
+
+    | OtherPrim "trap", [e] ->
+      SR.unit,
+      compile_exp_vanilla env ae e ^^
+      IC.trap_text env
 
     | OtherPrim ("blobToArray"|"blobToArrayMut"), e ->
       const_sr SR.Vanilla (Arr.ofBlob env)

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -184,6 +184,7 @@ let prim =
                                           | code -> Wasm.Utf8.encode [code]
                                in k (Text str)
   | "print" -> fun _ v k -> Printf.printf "%s\n%!" (as_text v); k unit
+  | "trap" -> fun _ v k -> Printf.printf "%s\n%!" (as_text v); raise (Invalid_argument "explicit trap")
   | "rts_version" -> fun _ v k -> as_unit v; k (Text "0.1")
   | "rts_heap_size" -> fun _ v k -> as_unit v; k (Int (Int.of_int 0))
   | "rts_total_allocation" -> fun _ v k -> as_unit v; k (Int (Int.of_int 0))

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -50,6 +50,10 @@ func debugPrintNat(x : Nat) { debugPrint (@text_of_Nat x) };
 func debugPrintInt(x : Int) { debugPrint (@text_of_Int x) };
 func debugPrintChar(x : Char) { debugPrint (charToText x) };
 
+// Trapping
+
+func trap(x : Text) { (prim "trap" : Text -> None) x };
+
 // RTS stats
 
 func rts_version() : Text { (prim "rts_version" : () -> Text) () };

--- a/test/run-drun/explicit-trap.mo
+++ b/test/run-drun/explicit-trap.mo
@@ -1,0 +1,7 @@
+import Prim "mo:⛔";
+actor a {
+  public func go() {
+    Prim.trap("This is an explicit trap");
+  }
+};
+a.go(); //OR-CALL ingress go "DIDL\x00\x00"

--- a/test/run-drun/ok/explicit-trap.drun-run.ok
+++ b/test/run-drun/ok/explicit-trap.drun-run.ok
@@ -1,0 +1,3 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: This is an explicit trap

--- a/test/run-drun/ok/explicit-trap.ic-ref-run.ok
+++ b/test/run-drun/ok/explicit-trap.ic-ref-run.ok
@@ -1,0 +1,6 @@
+→ update create_canister(record {dnczaeh = null})
+← replied: (record {hymijyo = principal "cvccv-qqaaq-aaaaa-aaaaa-c"})
+→ update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
+← replied: ()
+→ update go()
+← rejected (RC_CANISTER_ERROR): canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: This is an explicit trap"

--- a/test/run-drun/ok/explicit-trap.run-ir.ok
+++ b/test/run-drun/ok/explicit-trap.run-ir.ok
@@ -1,0 +1,2 @@
+This is an explicit trap
+prim:___: execution error, explicit trap

--- a/test/run-drun/ok/explicit-trap.run-low.ok
+++ b/test/run-drun/ok/explicit-trap.run-low.ok
@@ -1,0 +1,2 @@
+This is an explicit trap
+prim:___: execution error, explicit trap

--- a/test/run-drun/ok/explicit-trap.run.ok
+++ b/test/run-drun/ok/explicit-trap.run.ok
@@ -1,0 +1,2 @@
+This is an explicit trap
+prim:___: execution error, explicit trap


### PR DESCRIPTION
the System API provides canisters with a way to explicitly trap with an
error message. This is very useful for developing, e.g. to get useful
messages in code you think is unreachable, or when checking invariants.

This exposes this as `Prim.trap`. Later this can be exposed in
`motoko-base` via `Debug.trap` maybe, and also the odd `Prelude.nyi`,
`Prelude.xxx` and `Prelude.unreachable` can be implemented that way in a
more helpful way.

Semantically this is like the existing `assert false`, just with better
control over the error message and a more helpful type (return type
`None`).