### PR TITLE
Refactor ascriptions (`as`) in RTS, avoid accessing Bytes/Words fields

### DIFF
--- a/rts/motoko-rts-tests/src/gc.rs
+++ b/rts/motoko-rts-tests/src/gc.rs
@@ -167,7 +167,7 @@ fn check_dynamic_heap(
             check_continuation_table(object_offset, continuation_table, heap);
             offset += (size_of::<Array>() + Words(continuation_table.len() as u32))
                 .to_bytes()
-                .0 as usize;
+                .as_usize();
             continue;
         }
 
@@ -306,7 +306,7 @@ fn check_continuation_table(mut offset: usize, continuation_table: &[ObjectIdx],
         offset += WORD_SIZE;
 
         // Skip object header for idx
-        let idx_address = ptr as usize + size_of::<Array>().to_bytes().0 as usize;
+        let idx_address = ptr as usize + size_of::<Array>().to_bytes().as_usize();
         let idx = get_scalar_value(read_word(heap, idx_address - heap.as_ptr() as usize));
 
         assert_eq!(idx, *obj);

--- a/rts/motoko-rts-tests/src/gc/heap.rs
+++ b/rts/motoko-rts-tests/src/gc/heap.rs
@@ -193,7 +193,7 @@ impl MotokoHeapInner {
         let dynamic_heap_size_bytes = dynamic_heap_size_without_continuation_table_bytes
             + (size_of::<Array>() + Words(continuation_table.len() as u32))
                 .to_bytes()
-                .0 as usize;
+                .as_usize();
 
         let total_heap_size_bytes = static_heap_size_bytes + dynamic_heap_size_bytes;
 
@@ -234,7 +234,7 @@ impl MotokoHeapInner {
 
         // Update heap pointer
         let old_hp = self.heap_ptr_address();
-        let new_hp = old_hp + bytes.0 as usize;
+        let new_hp = old_hp + bytes.as_usize();
         self.heap_ptr_offset = new_hp - self.heap.as_ptr() as usize;
 
         // Grow memory if needed
@@ -279,12 +279,12 @@ fn heap_size_for_gc(
                 // The bitmap implementation rounds up to 64-bits to be able to read as many
                 // bits as possible in one instruction and potentially skip 64 words in the
                 // heap with single 64-bit comparison
-                (((mark_bit_bytes.0 + 7) / 8) * 8) + size_of::<Blob>().to_bytes().0
+                (((mark_bit_bytes.as_u32() + 7) / 8) * 8) + size_of::<Blob>().to_bytes().as_u32()
             };
             // In the worst case the entire heap will be pushed to the mark stack, but in tests
             // we limit the size
-            let mark_stack_words = n_objects.clamp(INIT_STACK_SIZE.0 as usize, MAX_MARK_STACK_SIZE)
-                + size_of::<Blob>().0 as usize;
+            let mark_stack_words = n_objects.clamp(INIT_STACK_SIZE.as_usize(), MAX_MARK_STACK_SIZE)
+                + size_of::<Blob>().as_usize();
 
             total_heap_size_bytes + bitmap_size_bytes as usize + (mark_stack_words * WORD_SIZE)
         }
@@ -343,7 +343,7 @@ fn create_dynamic_heap(
             let field_offset = obj_offset
                 + (size_of::<Array>() + Words(1 + ref_idx as u32))
                     .to_bytes()
-                    .0 as usize;
+                    .as_usize();
             write_word(dynamic_heap, field_offset, u32::try_from(ref_addr).unwrap());
         }
     }
@@ -352,8 +352,10 @@ fn create_dynamic_heap(
     let n_objects = refs.len();
     // fields+1 for the scalar field (idx)
     let n_fields: usize = refs.iter().map(|(_, fields)| fields.len() + 1).sum();
-    let continuation_table_offset =
-        (size_of::<Array>() * n_objects as u32).to_bytes().0 as usize + n_fields * WORD_SIZE;
+    let continuation_table_offset = (size_of::<Array>() * n_objects as u32)
+        .to_bytes()
+        .as_usize()
+        + n_fields * WORD_SIZE;
 
     {
         let mut heap_offset = continuation_table_offset;
@@ -395,10 +397,10 @@ fn create_static_heap(
     write_word(heap, WORD_SIZE, u32::try_from(roots.len()).unwrap());
 
     // Current offset in the heap for the next static roots array element
-    let mut root_addr_offset = size_of::<Array>().to_bytes().0 as usize;
+    let mut root_addr_offset = size_of::<Array>().to_bytes().as_usize();
 
     // Current offset in the heap for the MutBox of the next root
-    let mut mutbox_offset = (size_of::<Array>().0 as usize + roots.len()) * WORD_SIZE;
+    let mut mutbox_offset = (size_of::<Array>().as_usize() + roots.len()) * WORD_SIZE;
 
     for root_address in root_addresses {
         // Add a MutBox for the object
@@ -417,7 +419,7 @@ fn create_static_heap(
         );
 
         root_addr_offset += WORD_SIZE;
-        mutbox_offset += size_of::<MutBox>().to_bytes().0 as usize;
+        mutbox_offset += size_of::<MutBox>().to_bytes().as_usize();
     }
 
     // Write continuation table pointer as the last word in static heap

--- a/rts/motoko-rts-tests/src/main.rs
+++ b/rts/motoko-rts-tests/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
 // Called by the RTS to panic
 #[no_mangle]
 extern "C" fn rts_trap(ptr: *const u8, len: Bytes<u32>) -> ! {
-    let msg = unsafe { std::slice::from_raw_parts(ptr, len.0 as usize) };
+    let msg = unsafe { std::slice::from_raw_parts(ptr, len.as_usize()) };
     match core::str::from_utf8(msg) {
         Err(err) => panic!(
             "rts_trap_with called with non-UTF8 string (error={:?}, string={:?})",

--- a/rts/motoko-rts-tests/src/memory.rs
+++ b/rts/motoko-rts-tests/src/memory.rs
@@ -8,8 +8,8 @@ pub struct TestMemory {
 
 impl TestMemory {
     pub fn new(size: Words<u32>) -> TestMemory {
-        let bytes = size.to_bytes().0;
-        let heap = vec![0u8; bytes as usize].into_boxed_slice();
+        let bytes = size.to_bytes().as_usize();
+        let heap = vec![0u8; bytes].into_boxed_slice();
         let hp = heap.as_ptr() as usize;
         TestMemory { heap, hp }
     }
@@ -32,7 +32,7 @@ impl Memory for TestMemory {
 
         // Update heap pointer
         let old_hp = self.hp;
-        let new_hp = old_hp + bytes.0 as usize;
+        let new_hp = old_hp + bytes.as_usize();
         self.hp = new_hp;
 
         // Grow memory if needed

--- a/rts/motoko-rts/src/bigint.rs
+++ b/rts/motoko-rts/src/bigint.rs
@@ -44,10 +44,10 @@ unsafe fn mp_alloc<M: Memory>(mem: &mut M, size: Bytes<u32>) -> *mut u8 {
     // NB. Cannot use as_bigint() here as header is not written yet
     let blob = ptr.get_ptr() as *mut BigInt;
     (*blob).header.tag = TAG_BIGINT;
-    // libtommath stores the size of the object in alloc
-    // as count of mp_digits (u64)
-    debug_assert_eq!((size.0 as usize % core::mem::size_of::<mp_digit>()), 0);
-    (*blob).mp_int.alloc = (size.0 as usize / core::mem::size_of::<mp_digit>()) as i32;
+    // libtommath stores the size of the object in alloc as count of mp_digits (u64)
+    let size = size.as_usize();
+    debug_assert_eq!((size % core::mem::size_of::<mp_digit>()), 0);
+    (*blob).mp_int.alloc = (size / core::mem::size_of::<mp_digit>()) as i32;
     blob.payload_addr() as *mut u8
 }
 
@@ -66,7 +66,7 @@ pub unsafe fn mp_calloc<M: Memory>(
     let payload = mp_alloc(mem, size) as *mut u32;
 
     // NB. alloc_bytes rounds up to words so we do the same here to set the whole buffer
-    for i in 0..size.to_words().0 {
+    for i in 0..size.to_words().as_usize() {
         *payload.add(i as usize) = 0;
     }
 

--- a/rts/motoko-rts/src/debug.rs
+++ b/rts/motoko-rts/src/debug.rs
@@ -110,7 +110,7 @@ unsafe fn print_heap(heap_start: u32, heap_end: u32) {
         write_buf.reset();
 
         let obj_size = object_size(p as usize);
-        p += obj_size.to_bytes().0;
+        p += obj_size.to_bytes().as_u32();
         i += obj_size;
     }
 }
@@ -200,7 +200,7 @@ pub(crate) unsafe fn print_boxed_object(buf: &mut WriteBuf, p: usize) {
         }
         TAG_BLOB => {
             let blob = obj as *const Blob;
-            let _ = write!(buf, "<Blob len={:#x}>", (*blob).len.0);
+            let _ = write!(buf, "<Blob len={:#x}>", (*blob).len.as_u32());
         }
         TAG_FWD_PTR => {
             let ind = obj as *const FwdPtr;
@@ -219,7 +219,7 @@ pub(crate) unsafe fn print_boxed_object(buf: &mut WriteBuf, p: usize) {
             let _ = write!(
                 buf,
                 "<Concat n_bytes={:#x} obj1={:#x} obj2={:#x}>",
-                (*concat).n_bytes.0,
+                (*concat).n_bytes.as_u32(),
                 (*concat).text1.get_raw(),
                 (*concat).text2.get_raw()
             );
@@ -229,7 +229,7 @@ pub(crate) unsafe fn print_boxed_object(buf: &mut WriteBuf, p: usize) {
         }
         TAG_FREE_SPACE => {
             let free_space = obj as *const FreeSpace;
-            let _ = write!(buf, "<Free space {} words>", (*free_space).words.0);
+            let _ = write!(buf, "<Free space {} words>", (*free_space).words.as_u32());
         }
         other => {
             let _ = write!(buf, "<??? {} ???>", other);

--- a/rts/motoko-rts/src/gc/copying.rs
+++ b/rts/motoko-rts/src/gc/copying.rs
@@ -28,7 +28,7 @@ unsafe fn copying_gc<M: Memory>(mem: &mut M) {
         // note_live_size
         |live_size| ic::MAX_LIVE = ::core::cmp::max(ic::MAX_LIVE, live_size),
         // note_reclaimed
-        |reclaimed| ic::RECLAIMED += Bytes(reclaimed.0 as u64),
+        |reclaimed| ic::RECLAIMED += Bytes(u64::from(reclaimed.as_u32())),
     );
 
     ic::LAST_HP = ic::HP;
@@ -73,7 +73,7 @@ pub unsafe fn copying_gc_internal<
     while p < get_hp() {
         let size = object_size(p);
         scav(mem, begin_from_space, begin_to_space, p);
-        p += size.to_bytes().0 as usize;
+        p += size.to_bytes().as_usize();
     }
 
     let end_to_space = get_hp();

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -39,7 +39,7 @@ unsafe fn compacting_gc<M: Memory>(mem: &mut M) {
         // note_live_size
         |live_size| ic::MAX_LIVE = ::core::cmp::max(ic::MAX_LIVE, live_size),
         // note_reclaimed
-        |reclaimed| ic::RECLAIMED += Bytes(reclaimed.0 as u64),
+        |reclaimed| ic::RECLAIMED += Bytes(u64::from(reclaimed.as_u32())),
     );
 
     ic::LAST_HP = ic::HP;
@@ -200,7 +200,7 @@ unsafe fn update_refs<SetHp: Fn(u32)>(set_hp: SetHp, heap_base: u32) {
             memcpy_words(p_new as usize, p as usize, p_size_words);
         }
 
-        free += p_size_words.to_bytes().0;
+        free += p_size_words.to_bytes().as_u32();
 
         // Thread forward pointers of the object
         thread_fwd_pointers(p_new as *mut Obj, heap_base);

--- a/rts/motoko-rts/src/gc/mark_compact/bitmap.rs
+++ b/rts/motoko-rts/src/gc/mark_compact/bitmap.rs
@@ -7,7 +7,7 @@ static mut BITMAP_PTR: *mut u8 = core::ptr::null_mut();
 
 pub unsafe fn alloc_bitmap<M: Memory>(mem: &mut M, heap_size: Bytes<u32>) {
     // We will have at most this many objects in the heap, each requiring a bit
-    let n_bits = heap_size.to_words().0;
+    let n_bits = heap_size.to_words().as_u32();
     // Each byte will hold 8 bits.
     let bitmap_bytes = (n_bits + 7) / 8;
     // Also round allocation up to 8-bytes to make iteration efficient. We want to be able to read
@@ -54,10 +54,10 @@ pub struct BitmapIter {
 }
 
 pub unsafe fn iter_bits() -> BitmapIter {
-    let blob_len_bytes = (BITMAP_PTR.sub(size_of::<Blob>().to_bytes().0 as usize) as *mut Obj)
+    let blob_len_bytes = (BITMAP_PTR.sub(size_of::<Blob>().to_bytes().as_usize()) as *mut Obj)
         .as_blob()
         .len()
-        .0;
+        .as_u32();
 
     debug_assert_eq!(blob_len_bytes % 8, 0);
 

--- a/rts/motoko-rts/src/gc/mark_compact/mark_stack.rs
+++ b/rts/motoko-rts/src/gc/mark_compact/mark_stack.rs
@@ -28,7 +28,7 @@ pub unsafe fn alloc_mark_stack<M: Memory>(mem: &mut M) {
     STACK_BLOB_PTR = alloc_blob(mem, INIT_STACK_SIZE.to_bytes()).get_ptr() as *mut Blob;
     STACK_BASE = STACK_BLOB_PTR.payload_addr() as *mut usize;
     STACK_PTR = STACK_BASE;
-    STACK_TOP = STACK_BASE.add(INIT_STACK_SIZE.0 as usize);
+    STACK_TOP = STACK_BASE.add(INIT_STACK_SIZE.as_usize());
 }
 
 pub unsafe fn free_mark_stack() {
@@ -46,7 +46,7 @@ pub unsafe fn grow_stack<M: Memory>(mem: &mut M) {
     // Make sure nothing was allocated after the stack
     debug_assert_eq!(STACK_TOP, p);
 
-    let new_cap: Words<u32> = Words(stack_cap.0 * 2);
+    let new_cap: Words<u32> = stack_cap * 2;
     (*STACK_BLOB_PTR).len = new_cap.to_bytes();
     STACK_TOP = STACK_BASE.add(new_cap.as_usize());
 }

--- a/rts/motoko-rts/src/mem_utils.rs
+++ b/rts/motoko-rts/src/mem_utils.rs
@@ -1,13 +1,13 @@
 use crate::types::{Bytes, Words};
 
 pub(crate) unsafe fn memcpy_words(to: usize, from: usize, n: Words<u32>) {
-    libc::memcpy(to as *mut _, from as *const _, n.to_bytes().0 as usize);
+    libc::memcpy(to as *mut _, from as *const _, n.to_bytes().as_usize());
 }
 
 pub(crate) unsafe fn memcpy_bytes(to: usize, from: usize, n: Bytes<u32>) {
-    libc::memcpy(to as *mut _, from as *const _, n.0 as usize);
+    libc::memcpy(to as *mut _, from as *const _, n.as_usize());
 }
 
 pub(crate) unsafe fn memzero(to: usize, n: Words<u32>) {
-    libc::memset(to as *mut _, 0, n.to_bytes().0 as usize);
+    libc::memset(to as *mut _, 0, n.to_bytes().as_usize());
 }

--- a/rts/motoko-rts/src/memory/ic.rs
+++ b/rts/motoko-rts/src/memory/ic.rs
@@ -63,11 +63,11 @@ impl Memory for IcMemory {
     unsafe fn alloc_words(&mut self, n: Words<u32>) -> Value {
         let bytes = n.to_bytes();
         // Update ALLOCATED
-        ALLOCATED += Bytes(bytes.0 as u64);
+        ALLOCATED += Bytes(u64::from(bytes.as_u32()));
 
         // Update heap pointer
         let old_hp = HP;
-        let new_hp = old_hp + bytes.0;
+        let new_hp = old_hp + bytes.as_u32();
         HP = new_hp;
 
         // Grow memory if needed
@@ -80,7 +80,7 @@ impl Memory for IcMemory {
 /// Page allocation. Ensures that the memory up to, but excluding, the given pointer is allocated.
 #[inline(never)]
 unsafe fn grow_memory(ptr: usize) {
-    let page_size = u64::from(WASM_PAGE_SIZE.0);
+    let page_size = u64::from(WASM_PAGE_SIZE.as_u32());
     let total_pages_needed = (((ptr as u64) + page_size - 1) / page_size) as usize;
     let current_pages = wasm32::memory_size(0);
     if total_pages_needed > current_pages {

--- a/rts/motoko-rts/src/principal_id.rs
+++ b/rts/motoko-rts/src/principal_id.rs
@@ -21,7 +21,7 @@ pub unsafe extern "C" fn compute_crc32(blob: Value) -> u32 {
 
     let mut crc: u32 = !0;
 
-    for i in 0..len.0 {
+    for i in 0..len.as_u32() {
         let octet = blob.get(i);
         crc = (crc >> 8) ^ CRC_TABLE[usize::from((crc & 0xFF) as u8 ^ octet)];
     }
@@ -97,7 +97,7 @@ pub unsafe fn base32_of_checksummed_blob<M: Memory>(mem: &mut M, b: Value) -> Va
     let n = b.as_blob().len();
     let mut data = b.as_blob().payload_addr();
 
-    let r = alloc_blob(mem, Bytes((n.0 + 4 + 4) / 5 * 8)); // contains padding
+    let r = alloc_blob(mem, Bytes((n.as_u32() + 4 + 4) / 5 * 8)); // contains padding
     let blob = r.as_blob();
     let dest = blob.payload_addr();
 
@@ -113,7 +113,7 @@ pub unsafe fn base32_of_checksummed_blob<M: Memory>(mem: &mut M, b: Value) -> Va
     enc_stash(&mut pump, (checksum >> 8) as u8);
     enc_stash(&mut pump, checksum as u8);
 
-    for _ in 0..n.0 {
+    for _ in 0..n.as_u32() {
         enc_stash(&mut pump, *data);
         data = data.add(1);
     }
@@ -184,7 +184,7 @@ pub unsafe fn base32_to_blob<M: Memory>(mem: &mut M, b: Value) -> Value {
     let mut data = b.as_blob().payload_addr();
 
     // Every group of 8 characters will yield 5 bytes
-    let r = alloc_blob(mem, Bytes(((n.0 + 7) / 8) * 5)); // we deal with padding later
+    let r = alloc_blob(mem, Bytes(((n.as_u32() + 7) / 8) * 5)); // we deal with padding later
     let blob = r.as_blob();
     let dest = blob.payload_addr();
 
@@ -196,7 +196,7 @@ pub unsafe fn base32_to_blob<M: Memory>(mem: &mut M, b: Value) -> Value {
         pending_data: 0,
     };
 
-    for _ in 0..n.0 {
+    for _ in 0..n.as_u32() {
         dec_stash(&mut pump, *data);
         data = data.add(1);
     }
@@ -223,12 +223,12 @@ unsafe fn base32_to_principal<M: Memory>(mem: &mut M, b: Value) -> Value {
     let mut data = blob.payload_addr();
 
     // Every group of 5 characters will yield 6 bytes (due to the hypen)
-    let r = alloc_blob(mem, Bytes(((n.0 + 4) / 5) * 6));
+    let r = alloc_blob(mem, Bytes(((n.as_u32() + 4) / 5) * 6));
     let blob = r.as_blob();
     let mut dest = blob.payload_addr();
 
     let mut n_written = 0;
-    for i in 0..n.0 {
+    for i in 0..n.as_u32() {
         let mut byte = *data;
         data = data.add(1);
 
@@ -242,7 +242,7 @@ unsafe fn base32_to_principal<M: Memory>(mem: &mut M, b: Value) -> Value {
         n_written += 1;
 
         // If quintet done, add hyphen
-        if n_written % 5 == 0 && i + 1 < n.0 {
+        if n_written % 5 == 0 && i + 1 < n.as_u32() {
             n_written = 0;
             *dest = b'-';
             dest = dest.add(1);

--- a/rts/motoko-rts/src/text.rs
+++ b/rts/motoko-rts/src/text.rs
@@ -86,7 +86,7 @@ pub unsafe fn text_concat<M: Memory>(mem: &mut M, s1: Value, s2: Value) -> Value
         let r_payload: *const u8 = r.as_blob().payload_addr();
         memcpy_bytes(r_payload as usize, blob1.payload_addr() as usize, blob1_len);
         memcpy_bytes(
-            r_payload.add(blob1_len.0 as usize) as usize,
+            r_payload.add(blob1_len.as_usize()) as usize,
             blob2.payload_addr() as usize,
             blob2_len,
         );
@@ -147,11 +147,11 @@ unsafe extern "C" fn text_to_buf(mut s: Value, mut buf: *mut u8) {
 
             if s2_len < Bytes(core::mem::size_of::<Crumb>() as u32) {
                 // If second string is smaller than size of a crumb just do it directly
-                text_to_buf(s2, buf.add(s1_len.0 as usize));
+                text_to_buf(s2, buf.add(s1_len.as_usize()));
                 s = s1;
             } else {
                 // Otherwise leave a breadcrumb to the location of the second string
-                let new_crumb: *mut Crumb = buf.add(s1_len.0 as usize) as *mut Crumb;
+                let new_crumb: *mut Crumb = buf.add(s1_len.as_usize()) as *mut Crumb;
                 (*new_crumb).t = s2;
                 (*new_crumb).next = next_crumb;
                 next_crumb = new_crumb;
@@ -237,9 +237,9 @@ unsafe fn text_compare_range(
         let s2_blob = s2_obj.as_blob();
 
         let cmp = libc::memcmp(
-            s1_blob.payload_addr().add(offset1.0 as usize) as *const _,
-            s2_blob.payload_addr().add(offset2.0 as usize) as *const _,
-            n.0 as usize,
+            s1_blob.payload_addr().add(offset1.as_usize()) as *const _,
+            s2_blob.payload_addr().add(offset2.as_usize()) as *const _,
+            n.as_usize(),
         );
 
         if cmp < 0 {
@@ -318,7 +318,7 @@ pub(crate) unsafe fn blob_compare(s1: Value, s2: Value) -> i32 {
 
     let payload1 = s1.as_blob().payload_addr();
     let payload2 = s2.as_blob().payload_addr();
-    let cmp = libc::memcmp(payload1 as *const _, payload2 as *const _, n.0 as usize);
+    let cmp = libc::memcmp(payload1 as *const _, payload2 as *const _, n.as_usize());
 
     if cmp == 0 {
         if n1 < n2 {
@@ -343,7 +343,7 @@ pub unsafe extern "C" fn text_len(text: Value) -> u32 {
 
         str::from_utf8_unchecked(slice::from_raw_parts(
             payload_addr as *const u8,
-            len.0 as usize,
+            len.as_usize(),
         ))
         .chars()
         .count() as u32

--- a/rts/motoko-rts/src/text_iter.rs
+++ b/rts/motoko-rts/src/text_iter.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn text_iter_done(iter: Value) -> u32 {
     let blob = array.get(ITER_BLOB_IDX).as_blob();
     let todo = array.get(ITER_TODO_IDX);
 
-    if pos >= blob.len().0 && todo.get_raw() == 0 {
+    if pos >= blob.len().as_u32() && todo.get_raw() == 0 {
         1
     } else {
         0
@@ -88,7 +88,7 @@ pub unsafe fn text_iter_next<M: Memory>(mem: &mut M, iter: Value) -> u32 {
     let pos = iter_array.get(ITER_POS_IDX).get_scalar();
 
     // If we are at the end of the current blob, find the next blob
-    if pos >= blob.len().0 {
+    if pos >= blob.len().as_u32() {
         let todo = iter_array.get(ITER_TODO_IDX);
 
         if todo.get_raw() == 0 {

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -39,6 +39,10 @@ impl Words<u32> {
         Bytes(self.0 * WORD_SIZE)
     }
 
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+
     pub fn as_usize(self) -> usize {
         self.0 as usize
     }
@@ -104,6 +108,10 @@ impl Bytes<u32> {
     pub fn to_words(self) -> Words<u32> {
         // Rust issue for adding ceiling_div: https://github.com/rust-lang/rfcs/issues/2844
         Words((self.0 + WORD_SIZE - 1) / WORD_SIZE)
+    }
+
+    pub fn as_u32(self) -> u32 {
+        self.0
     }
 
     pub fn as_usize(self) -> usize {
@@ -508,7 +516,7 @@ impl BigInt {
     }
 
     pub unsafe fn from_payload(ptr: *mut mp_digit) -> *mut Self {
-        (ptr as *mut u32).sub(size_of::<BigInt>().0 as usize) as *mut BigInt
+        (ptr as *mut u32).sub(size_of::<BigInt>().as_usize()) as *mut BigInt
     }
 
     /// Returns pointer to the `mp_int` struct


### PR DESCRIPTION
Ascriptions can be lossy, so every usage of `as` can potentially cause
problems as we refactor the code.

So in this PR we reduce the usage of `as`:

- For `Bytes` and `Words` values, instead of `x.0 as usize` we now use
  `x.as_usize()`. `usize` has the same size as `u32` on Wasm (which is
  the only target we support), so `as_usize()` method uses `as` without
  any checks in debug mode.

- For casting `u32` to `u64`, use `u64::from(x)`. `from` methods cannot
  fail, and for numeric types they are only implemented for casting a
  smaller type to a larger type.

- To aid readbility this PR also introduces `Words::as_u32` and
  `Bytes::u32` and uses these methods instead of accessing the unnamed
  field of `Words` and `Bytes`.

- Also remove a redundant unwrapping/wrapping of `Bytes` value when
  dividing it by a scalar. (`Bytes(bytes.0 / x)` -> `bytes / x`)