### PR TITLE
Reproducibility: Make assertion error messages reproducible

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3655,6 +3655,12 @@ module IC = struct
     Tuple.from_stack env 2
 
   let fail_assert env at =
+    let open Source in
+    let at = {
+        left = {at.left with file = Filename.basename at.left.file};
+        right = {at.right with file = Filename.basename at.right.file}
+      }
+    in
     E.trap_with env (Printf.sprintf "assertion failed at %s" (string_of_region at))
 
   let async_method_name = "__motoko_async_helper"

--- a/test/run-drun/assert.mo
+++ b/test/run-drun/assert.mo
@@ -1,0 +1,9 @@
+import Lib "assert/Lib";
+actor a {
+
+  public func go() : async () {
+    Lib.fail();
+  };
+
+};
+a.go(); //OR-CALL ingress go "DIDL\x00\x00"

--- a/test/run-drun/assert/Lib.mo
+++ b/test/run-drun/assert/Lib.mo
@@ -1,0 +1,8 @@
+module {
+
+  public func fail() : () {
+    assert false;
+  };
+
+};
+

--- a/test/run-drun/ok/assert.diff-ir.ok
+++ b/test/run-drun/ok/assert.diff-ir.ok
@@ -1,0 +1,5 @@
+--- assert.run
++++ assert.run-ir
+@@ -1 +1 @@
+-assert/Lib.mo:4.5-4.17: execution error, assertion failure
++assert/Lib.mo:3.27-5.4: execution error, assertion failure

--- a/test/run-drun/ok/assert.diff-low.ok
+++ b/test/run-drun/ok/assert.diff-low.ok
@@ -1,0 +1,5 @@
+--- assert.run
++++ assert.run-low
+@@ -1 +1 @@
+-assert/Lib.mo:4.5-4.17: execution error, assertion failure
++assert/Lib.mo:3.27-5.4: execution error, assertion failure

--- a/test/run-drun/ok/assert.drun-run.ok
+++ b/test/run-drun/ok/assert.drun-run.ok
@@ -1,0 +1,3 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: assertion failed at assert/Lib.mo:3.27-5.4

--- a/test/run-drun/ok/assert.drun-run.ok
+++ b/test/run-drun/ok/assert.drun-run.ok
@@ -1,3 +1,3 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: assertion failed at assert/Lib.mo:3.27-5.4
+ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: assertion failed at Lib.mo:3.27-5.4

--- a/test/run-drun/ok/assert.ic-ref-run.ok
+++ b/test/run-drun/ok/assert.ic-ref-run.ok
@@ -3,4 +3,4 @@
 → update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
 ← replied: ()
 → update go()
-← rejected (RC_CANISTER_ERROR): canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: assertion failed at assert/Lib.mo:3.27-5.4"
+← rejected (RC_CANISTER_ERROR): canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: assertion failed at Lib.mo:3.27-5.4"

--- a/test/run-drun/ok/assert.ic-ref-run.ok
+++ b/test/run-drun/ok/assert.ic-ref-run.ok
@@ -1,0 +1,6 @@
+→ update create_canister(record {settings = null})
+← replied: (record {hymijyo = principal "cvccv-qqaaq-aaaaa-aaaaa-c"})
+→ update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
+← replied: ()
+→ update go()
+← rejected (RC_CANISTER_ERROR): canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: assertion failed at assert/Lib.mo:3.27-5.4"

--- a/test/run-drun/ok/assert.run-ir.ok
+++ b/test/run-drun/ok/assert.run-ir.ok
@@ -1,0 +1,1 @@
+assert/Lib.mo:3.27-5.4: execution error, assertion failure

--- a/test/run-drun/ok/assert.run-low.ok
+++ b/test/run-drun/ok/assert.run-low.ok
@@ -1,0 +1,1 @@
+assert/Lib.mo:3.27-5.4: execution error, assertion failure

--- a/test/run-drun/ok/assert.run.ok
+++ b/test/run-drun/ok/assert.run.ok
@@ -1,0 +1,1 @@
+assert/Lib.mo:4.5-4.17: execution error, assertion failure

--- a/test/run-drun/ok/live-upgrade.ic-ref-run.ok
+++ b/test/run-drun/ok/live-upgrade.ic-ref-run.ok
@@ -27,4 +27,4 @@ debug.print: {version = 2}
 → update wait()
 ← replied: ()
 → query check(2)
-← rejected (RC_CANISTER_ERROR): canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: assertion failed at live-upgrade/live-upgrade.mo:11.49-13.4"
+← rejected (RC_CANISTER_ERROR): canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: assertion failed at live-upgrade.mo:11.49-13.4"


### PR DESCRIPTION
Our builds are not reproducible because the filepaths reported in assert messages are build environment dependent.

A simple fix is to only report the basename of the file in the assertion message, though this loses some information and may be ambiguous if a  project imports two distinct files with the same basename (this is possible, but not that likely, given the current scale of motoko projects.)

A better approach my be to relativize the source file to the current main file or package, but this probably requires pervasive changes to our Source.ml region representation, or other measures, like storing the root dir in the compilation unit.


TODO:

- [ ] normalize to base name in interpretation of AssertE (both source and IR interpreters), if we care about that level of fidelity.