### PR TITLE
RTS build: don't vendor Rust deps

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,6 +37,7 @@ let
     rust-bindgen
     rustfmt
     cacert
+    git
   ];
 
   llvmEnv = ''

--- a/default.nix
+++ b/default.nix
@@ -176,6 +176,7 @@ rec {
       preBuild = ''
         export XARGO_HOME=$PWD/xargo-home
         export CARGO_HOME=$PWD/cargo-home
+        export CARGO_HTTP_MULTIPLEXING=false
 
         ${llvmEnv}
         export TOMMATHSRC=${nixpkgs.sources.libtommath}

--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,7 @@ let
     wasmtime
     rust-bindgen
     rustfmt
+    cacert
   ];
 
   llvmEnv = ''
@@ -176,23 +177,10 @@ rec {
         export XARGO_HOME=$PWD/xargo-home
         export CARGO_HOME=$PWD/cargo-home
 
-        # this replicates logic from nixpkgs’ pkgs/build-support/rust/default.nix
-        mkdir -p $CARGO_HOME
-        echo "Using vendored sources from ${rustDeps}"
-        unpackFile ${rustDeps}
-        cat > $CARGO_HOME/config <<__END__
-          [source."crates-io"]
-          "replace-with" = "vendored-sources"
-
-          [source."vendored-sources"]
-          "directory" = "$(stripHash ${rustDeps})"
-        __END__
-
         ${llvmEnv}
         export TOMMATHSRC=${nixpkgs.sources.libtommath}
         export MUSLSRC=${nixpkgs.sources.musl-wasi}/libc-top-half/musl
         export MUSL_WASI_SYSROOT=${musl-wasi-sysroot}
-
       '';
 
       doCheck = true;


### PR DESCRIPTION
Vendoring dependencies is causing a lot of problems in #2761 and other
PRs, because `cargo vendor` currently has a bug and cannot vendor
standard dependencies (deps of alloc and std, see
https://github.com/rust-lang/wg-cargo-std-aware/issues/23).

For a long time I thought vendoring is a necessity and tried to work
around this issue by vendoring dependencies manually, or using
https://github.com/nix-community/naersk.

However, it turns out vendoring is not necessary, and we can download
dependencies in build step just fine. I also don't see any advantages of
vendoring the dependencies. So in this PR we remove vendoring.

Unblocks #2761.