### PR TITLE
Mergify: Update configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,9 @@
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=tests (ubuntu-latest)
+      - status-success=tests (macos-latest)
+
 pull_request_rules:
   - name: Automatic merge (squash)
     conditions:
@@ -8,9 +14,9 @@ pull_request_rules:
       - base=master
       - label=automerge-squash
     actions:
-      merge:
+      queue:
+        name: default
         method: squash
-        strict: smart
         commit_message: title+body
       delete_head_branch: {}
   - name: Automatic closing succesfull trials


### PR DESCRIPTION
mergify has deprecated the `strict: smart` method, and wants explicit
queues set up, as per https://blog.mergify.io/strict-mode-deprecation/