### PR TITLE
Add the motoko-base library to releases

### DIFF
--- a/release-files.nix
+++ b/release-files.nix
@@ -34,6 +34,7 @@ let
       cp ${as_tarball "x86_64-darwin" (with darwin; [ mo-ide mo-doc moc ])} $out/motoko-macos-${releaseVersion}.tar.gz
       cp ${as_js "moc" linux.js.moc} $out/moc-${releaseVersion}.js
       cp ${as_js "moc-interpreter" linux.js.moc_interpreter} $out/moc-interpreter-${releaseVersion}.js
+      tar --exclude=.github -C ${nixpkgs.sources.motoko-base} -czvf $out/motoko-base-library.tar.gz .
     '';
 in
 release


### PR DESCRIPTION
There doesn't seem to be any way to associate a specific motoko release with a version of base that's guaranteed to work with it, so this at least guarantees that we publish the same version that the testsuite passes with.