### PR TITLE
Disable "crate performance comment" job on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,10 @@ jobs:
         body-includes: '<!-- perf comment -->'
 
     - name: Create or update performance comment
-      if: runner.os == 'Linux' && github.event_name == 'pull_request'
+      # Forks can't add comments so this job does not run on forks, see
+      # motoko#2864.
+      if: runner.os == 'Linux' && github.event_name == 'pull_request' && \
+            github.event.pull_request.head.repo.full_name == github.repository
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,9 @@ jobs:
         comment-author: 'github-actions[bot]'
         body-includes: '<!-- perf comment -->'
 
+    # Forks can't add comments so this job does not run on forks, see
+    # motoko#2864.
     - name: Create or update performance comment
-      # Forks can't add comments so this job does not run on forks, see
-      # motoko#2864.
       if: runner.os == 'Linux' && github.event_name == 'pull_request' && \
             github.event.pull_request.head.repo.full_name == github.repository
       uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,8 +65,7 @@ jobs:
     # Forks can't add comments so this job does not run on forks, see
     # motoko#2864.
     - name: Create or update performance comment
-      if: runner.os == 'Linux' && github.event_name == 'pull_request' && \
-            github.event.pull_request.head.repo.full_name == github.repository
+      if: runner.os == 'Linux' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
This job cannot be run on forks without sharing secrets with forks, see
the note in [1] and #2864. To unblock PRs from forks this commit
disables "creates performance comment" job on forks. For now, for PRs
that can effect performance, we can run the job and post the results
manually.

[1]: https://github.com/peter-evans/create-or-update-comment#action-inputs