### PR TITLE
Revert "Bump up MAX_HP_FOR_GC from 1GB to 3GB (#2848)"

### DIFF
--- a/rts/motoko-rts/src/gc.rs
+++ b/rts/motoko-rts/src/gc.rs
@@ -18,7 +18,7 @@ unsafe fn should_do_gc() -> bool {
 
     // Regardless of other parameters (`HEAP_GROWTH_FACTOR`, `SMALL_HEAP_DELTA`) we want to do GC
     // if `HP` is more than this amount.
-    const MAX_HP_FOR_GC: u64 = 3 * 1024 * 1024 * 1024; // 3 GiB
+    const MAX_HP_FOR_GC: u64 = 1 * 1024 * 1024 * 1024; // 3 GiB
 
     let heap_limit = min(
         max(


### PR DESCRIPTION
This reverts commit c9d4d0863dd5593a3b2c8ebff1e6a00e6854b59c.

See https://github.com/dfinity/motoko/pull/2848#issuecomment-956238678