### PR TITLE
Backport random heap tests from osa1/page_alloc

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -191,7 +191,7 @@ rec {
         name = "motoko-rts-deps";
         src = subpath ./rts;
         sourceRoot = "rts/motoko-rts-tests";
-        sha256 = "129gfmn96vm7di903pxirg7zybl83q6nkwiqr3rsy7l1q8667kxx";
+        sha256 = "07i8mjky9w0c9gadxzpfvv9im40hj71v69a796q7vgg2j6agr03q";
         copyLockfile = true;
       };
 

--- a/rts/motoko-rts-tests/Cargo.lock
+++ b/rts/motoko-rts-tests/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "fxhash",
  "libc",
  "motoko-rts",
+ "oorandom",
  "proptest",
 ]
 
@@ -95,6 +96,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "ppv-lite86"

--- a/rts/motoko-rts-tests/Cargo.toml
+++ b/rts/motoko-rts-tests/Cargo.toml
@@ -9,4 +9,5 @@ byteorder = "1.4.3"
 fxhash = "0.2.1"
 libc = { version = "0.2.81", default_features = false }
 motoko-rts = { path = "../motoko-rts/native" }
+oorandom = "11.1.3"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/rts/motoko-rts-tests/src/gc.rs
+++ b/rts/motoko-rts-tests/src/gc.rs
@@ -6,6 +6,7 @@
 // To convert an offset into an address, add heap array's address to the offset.
 
 mod heap;
+mod random;
 mod utils;
 
 use heap::MotokoHeap;
@@ -22,11 +23,19 @@ use fxhash::{FxHashMap, FxHashSet};
 pub fn test() {
     println!("Testing garbage collection ...");
 
-    // TODO: Add more tests
-
+    println!("  Testing pre-defined heaps...");
     for test_heap in test_heaps() {
         test_gcs(&test_heap);
     }
+
+    println!("  Testing random heaps...");
+    let max_seed = 100;
+    for seed in 0..max_seed {
+        print!("\r{}/{}", seed + 1, max_seed);
+        std::io::Write::flush(&mut std::io::stdout()).unwrap();
+        test_random_heap(seed, 180);
+    }
+    print!("\r");
 }
 
 fn test_heaps() -> Vec<TestHeap> {
@@ -61,6 +70,11 @@ fn test_heaps() -> Vec<TestHeap> {
             continuation_table: vec![],
         },
     ]
+}
+
+fn test_random_heap(seed: u64, max_objects: u32) {
+    let random_heap = random::generate(seed, max_objects);
+    test_gcs(&random_heap);
 }
 
 // All fields are vectors to preserve ordering. Objects are allocated/ added to root arrays etc. in

--- a/rts/motoko-rts-tests/src/gc/random.rs
+++ b/rts/motoko-rts-tests/src/gc/random.rs
@@ -1,0 +1,60 @@
+use super::utils::ObjectIdx;
+use super::TestHeap;
+
+use oorandom::Rand32;
+
+fn rand_bool(rng: &mut Rand32) -> bool {
+    rng.rand_range(0..2) == 1
+}
+
+pub(super) fn generate(seed: u64, max_objects: u32) -> TestHeap {
+    let mut rng = Rand32::new(seed);
+
+    let n_objects = rng.rand_range(0..max_objects + 1);
+
+    let roots: Vec<ObjectIdx> = (0..n_objects)
+        .filter_map(|obj_idx| {
+            if rand_bool(&mut rng) {
+                Some(obj_idx)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let heap: Vec<(ObjectIdx, Vec<ObjectIdx>)> = (0..n_objects)
+        .map(|obj_idx| {
+            let n_fields = rng.rand_range(0..n_objects);
+
+            let field_values = (0..n_fields)
+                .filter_map(|_field_idx| {
+                    let field_value = rng.rand_range(0..n_objects);
+                    if field_value == obj_idx {
+                        None
+                    } else {
+                        Some(field_value)
+                    }
+                })
+                .collect::<Vec<ObjectIdx>>();
+
+            (obj_idx, field_values)
+        })
+        .collect();
+
+    // Same as roots
+    let continuation_table: Vec<ObjectIdx> = (0..n_objects)
+        .filter_map(|obj_idx| {
+            if rand_bool(&mut rng) {
+                Some(obj_idx)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    TestHeap {
+        heap,
+        roots,
+        continuation_table,
+    }
+}


### PR DESCRIPTION
This implements a very simple random heap generation that caught a lot of bugs
in #2706. The idea is similar to QuickCheck/proptest style property testing: we
generate random heaps using a pseudo-random number generator and a fixed seed,
and then run the GC tests as usual (run both collectors, check GC properties).

Difference from QuickCheck/proptest-style testing is we don't implement
shrinking. Implementing shrinking manually is not a lot of work, but I believe
it won't work in practice, because checking subsets of the nodes/edges of the
graph will take exponential time (N nodes will have 2^N subsets of nodes), and
we really need to check all subsets as these graphs won't have any properties
that allows us to shrink more efficiently.