### PR TITLE
Make mark-compact the default collector, improve scheduling

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -338,9 +338,9 @@ rec {
           EXTRA_MOC_ARGS = "--sanity-checks";
       });
 
-    compacting_gc_subdir = dir: deps:
+    copying_gc_subdir = dir: deps:
       (test_subdir dir deps).overrideAttrs (args: {
-          EXTRA_MOC_ARGS = "--sanity-checks --compacting-gc";
+          EXTRA_MOC_ARGS = "--sanity-checks --copying-gc";
       });
 
     perf_subdir = dir: deps:
@@ -428,10 +428,10 @@ rec {
       run        = test_subdir "run"        [ moc ] ;
       run-dbg    = snty_subdir "run"        [ moc ] ;
       ic-ref-run = test_subdir "run-drun"   [ moc ic-ref-run ];
-      ic-ref-run-compacting-gc = compacting_gc_subdir "run-drun" [ moc ic-ref-run ] ;
+      ic-ref-run-copying-gc = copying_gc_subdir "run-drun" [ moc ic-ref-run ] ;
       drun       = test_subdir "run-drun"   [ moc nixpkgs.drun ];
       drun-dbg   = snty_subdir "run-drun"   [ moc nixpkgs.drun ];
-      drun-compacting-gc = compacting_gc_subdir "run-drun" [ moc nixpkgs.drun ] ;
+      drun-copying-gc = copying_gc_subdir "run-drun" [ moc nixpkgs.drun ] ;
       fail       = test_subdir "fail"       [ moc ];
       repl       = test_subdir "repl"       [ moc ];
       ld         = test_subdir "ld"         [ mo-ld ];

--- a/rts/motoko-rts/src/constants.rs
+++ b/rts/motoko-rts/src/constants.rs
@@ -3,9 +3,9 @@ use crate::types::{Bytes, Words};
 /// Wasm word size. RTS only works correctly on platforms with this word size.
 pub const WORD_SIZE: u32 = 4;
 
-/// Wasm page size (64KiB) in bytes
+/// Wasm page size (64 KiB) in bytes
 pub const WASM_PAGE_SIZE: Bytes<u32> = Bytes(64 * 1024);
 
-/// Wasm heap size (4GiB) in words. Note that `to_bytes` on this value will overflow as 4GiB in
+/// Wasm heap size (4 GiB) in words. Note that `to_bytes` on this value will overflow as 4 GiB in
 /// bytes is `u32::MAX + 1`.
 pub const WASM_HEAP_SIZE: Words<u32> = Words(1024 * 1024 * 1024);

--- a/rts/motoko-rts/src/gc.rs
+++ b/rts/motoko-rts/src/gc.rs
@@ -2,30 +2,18 @@ pub mod copying;
 pub mod mark_compact;
 
 #[cfg(feature = "ic")]
-unsafe fn should_do_gc() -> bool {
-    use crate::memory::ic::{HP, LAST_HP};
-    use crate::types::Bytes;
+use crate::types::Bytes;
 
-    use core::cmp::{max, min};
+#[cfg(feature = "ic")]
+unsafe fn should_do_gc(max_live: Bytes<u64>) -> bool {
+    use crate::memory::ic::{HP, LAST_HP};
 
     // A factor of last heap size. We allow at most this much allocation before doing GC.
     const HEAP_GROWTH_FACTOR: f64 = 1.5;
 
-    // On small heaps `last_hp * HEAP_GROWTH_FACTOR` will be quite small. To avoid doing redundant
-    // collections in such cases we only check `last_hp * HEAP_GROWTH_FACTOR` if at least this
-    // much is allocated.
-    const SMALL_HEAP_DELTA: Bytes<u64> = Bytes(10 * 1024 * 1024); // 10 MiB
-
-    // Regardless of other parameters (`HEAP_GROWTH_FACTOR`, `SMALL_HEAP_DELTA`) we want to do GC
-    // if `HP` is more than this amount.
-    const MAX_HP_FOR_GC: u64 = 1 * 1024 * 1024 * 1024; // 3 GiB
-
-    let heap_limit = min(
-        max(
-            (f64::from(LAST_HP) * HEAP_GROWTH_FACTOR) as u64,
-            u64::from(LAST_HP) + SMALL_HEAP_DELTA.0,
-        ),
-        MAX_HP_FOR_GC,
+    let heap_limit = core::cmp::min(
+        (f64::from(LAST_HP) * HEAP_GROWTH_FACTOR) as u64,
+        (u64::from(LAST_HP) + max_live.0) / 2,
     );
 
     u64::from(HP) >= heap_limit

--- a/rts/motoko-rts/src/gc/copying.rs
+++ b/rts/motoko-rts/src/gc/copying.rs
@@ -1,4 +1,4 @@
-use crate::constants::WORD_SIZE;
+use crate::constants::{WASM_HEAP_SIZE, WORD_SIZE};
 use crate::mem_utils::{memcpy_bytes, memcpy_words};
 use crate::memory::Memory;
 use crate::types::*;
@@ -7,9 +7,12 @@ use motoko_rts_macros::ic_mem_fn;
 
 #[ic_mem_fn(ic_only)]
 unsafe fn schedule_copying_gc<M: Memory>(mem: &mut M) {
-    const MAX_LIVE: Bytes<u64> = Bytes(2 * 1024 * 1024 * 1024); // 2 GiB
+    // Half of the heap.
+    // NB. This expression is evaluated in compile time to a constant.
+    let max_live: Bytes<u64> =
+        Bytes(u64::from((WASM_HEAP_SIZE / 2).as_u32()) * u64::from(WORD_SIZE));
 
-    if super::should_do_gc(MAX_LIVE) {
+    if super::should_do_gc(max_live) {
         copying_gc(mem);
     }
 }

--- a/rts/motoko-rts/src/gc/copying.rs
+++ b/rts/motoko-rts/src/gc/copying.rs
@@ -7,7 +7,9 @@ use motoko_rts_macros::ic_mem_fn;
 
 #[ic_mem_fn(ic_only)]
 unsafe fn schedule_copying_gc<M: Memory>(mem: &mut M) {
-    if super::should_do_gc() {
+    const MAX_LIVE: Bytes<u64> = Bytes(2 * 1024 * 1024 * 1024); // 2 GiB
+
+    if super::should_do_gc(MAX_LIVE) {
         copying_gc(mem);
     }
 }

--- a/rts/motoko-rts/src/gc/copying.rs
+++ b/rts/motoko-rts/src/gc/copying.rs
@@ -1,4 +1,4 @@
-use crate::constants::{WASM_HEAP_SIZE, WORD_SIZE};
+use crate::constants::WORD_SIZE;
 use crate::mem_utils::{memcpy_bytes, memcpy_words};
 use crate::memory::Memory;
 use crate::types::*;
@@ -10,7 +10,7 @@ unsafe fn schedule_copying_gc<M: Memory>(mem: &mut M) {
     // Half of the heap.
     // NB. This expression is evaluated in compile time to a constant.
     let max_live: Bytes<u64> =
-        Bytes(u64::from((WASM_HEAP_SIZE / 2).as_u32()) * u64::from(WORD_SIZE));
+        Bytes(u64::from((crate::constants::WASM_HEAP_SIZE / 2).as_u32()) * u64::from(WORD_SIZE));
 
     if super::should_do_gc(max_live) {
         copying_gc(mem);

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -20,12 +20,10 @@ use motoko_rts_macros::ic_mem_fn;
 unsafe fn schedule_compacting_gc<M: Memory>(mem: &mut M) {
     // 512 MiB slack for mark stack + allocation area for the next message
     let slack: u64 = 512 * 1024 * 1024;
-    // x + slack + x/32 = heap_size
-    // (Reminder: one word in bitmap covers 32 words in heap)
-    // NB. `max_live` below is evaluated in compile time to a constant
     let heap_size_bytes: u64 = u64::from(WASM_HEAP_SIZE.as_u32()) * u64::from(WORD_SIZE);
-    let x: u64 = ((heap_size_bytes * 32) - (slack * 32)) / 33;
-    let max_bitmap_size_bytes = x / 32;
+    // Larger than necessary to keep things simple
+    let max_bitmap_size_bytes = heap_size_bytes / 32;
+    // NB. `max_live` is evaluated in compile time to a constant
     let max_live: Bytes<u64> = Bytes(heap_size_bytes - slack - max_bitmap_size_bytes);
 
     if super::should_do_gc(max_live) {

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -8,7 +8,7 @@ pub mod mark_stack;
 use bitmap::{alloc_bitmap, free_bitmap, get_bit, iter_bits, set_bit, BITMAP_ITER_END};
 use mark_stack::{alloc_mark_stack, free_mark_stack, pop_mark_stack, push_mark_stack};
 
-use crate::constants::{WASM_HEAP_SIZE, WORD_SIZE};
+use crate::constants::WORD_SIZE;
 use crate::mem_utils::memcpy_words;
 use crate::memory::Memory;
 use crate::types::*;
@@ -20,7 +20,8 @@ use motoko_rts_macros::ic_mem_fn;
 unsafe fn schedule_compacting_gc<M: Memory>(mem: &mut M) {
     // 512 MiB slack for mark stack + allocation area for the next message
     let slack: u64 = 512 * 1024 * 1024;
-    let heap_size_bytes: u64 = u64::from(WASM_HEAP_SIZE.as_u32()) * u64::from(WORD_SIZE);
+    let heap_size_bytes: u64 =
+        u64::from(crate::constants::WASM_HEAP_SIZE.as_u32()) * u64::from(WORD_SIZE);
     // Larger than necessary to keep things simple
     let max_bitmap_size_bytes = heap_size_bytes / 32;
     // NB. `max_live` is evaluated in compile time to a constant

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -18,7 +18,11 @@ use motoko_rts_macros::ic_mem_fn;
 
 #[ic_mem_fn(ic_only)]
 unsafe fn schedule_compacting_gc<M: Memory>(mem: &mut M) {
-    if super::should_do_gc() {
+    // Mark stack ignored. Max. bitmap can be 130,150,524 bytes.
+    // (x + x / 32 = 4 GiB, x = 4,164,816,771, x/32 = 130,150,524)
+    const MAX_LIVE: Bytes<u64> = Bytes(4_164_816_771);
+
+    if super::should_do_gc(MAX_LIVE) {
         compacting_gc(mem);
     }
 }

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -18,15 +18,15 @@ use motoko_rts_macros::ic_mem_fn;
 
 #[ic_mem_fn(ic_only)]
 unsafe fn schedule_compacting_gc<M: Memory>(mem: &mut M) {
-    // Mark stack assumed to be at most 512 MiB.
-    let max_mark_stack_size_bytes: u64 = 512 * 1024 * 1024;
-    // x + max_mark_stack_size + x/32 = 4 GiB, x = 3,644,214,675, x/32 = 113,881,708
+    // 512 MiB slack for mark stack + allocation area for the next message
+    let slack: u64 = 512 * 1024 * 1024;
+    // x + slack + x/32 = 4 GiB, x = 3,644,214,675, x/32 = 113,881,708
     // (Reminder: one word in bitmap covers 32 words in heap)
     // NB. `max_live` below is evaluated in compile time to a constant
     let heap_size_bytes: u64 = u64::from(WASM_HEAP_SIZE.as_u32()) * u64::from(WORD_SIZE);
     let max_bitmap_size_bytes: u64 = 113_881_708;
     let max_live: Bytes<u64> =
-        Bytes(heap_size_bytes - max_mark_stack_size_bytes - max_bitmap_size_bytes);
+        Bytes(heap_size_bytes - slack - max_bitmap_size_bytes);
 
     if super::should_do_gc(max_live) {
         compacting_gc(mem);

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -509,9 +509,13 @@ module E = struct
     Int32.(add (div (get_end_of_static_memory env) page_size) 1l)
 
   let collect_garbage env =
-    let gc_fn = if !Flags.compacting_gc then "compacting_gc" else "copying_gc" in
+    (* GC function name = "schedule_"? ("compacting" | "copying") "_gc" *)
+    let gc_fn = match !Flags.gc_strategy with
+    | Mo_config.Flags.MarkCompact -> "compacting"
+    | Mo_config.Flags.Copying -> "copying"
+    in
     let gc_fn = if !Flags.force_gc then gc_fn else "schedule_" ^ gc_fn in
-    call_import env "rts" gc_fn
+    call_import env "rts" (gc_fn ^ "_gc")
 end
 
 

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -102,8 +102,12 @@ let argspec = [
   " enable sanity checking in the RTS and generated code";
 
   "--compacting-gc",
-  Arg.Unit (fun () -> Flags.compacting_gc := true),
-  " link with compacting GC instead of copying GC";
+  Arg.Unit (fun () -> Flags.gc_strategy := Mo_config.Flags.MarkCompact),
+  " use compacting GC (default)";
+
+  "--copying-gc",
+  Arg.Unit (fun () -> Flags.gc_strategy := Mo_config.Flags.Copying),
+  " use copying GC";
 
   "--force-gc",
   Arg.Unit (fun () -> Flags.force_gc := true),

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -4,6 +4,8 @@ module M = Map.Make(String)
 
 type compile_mode = WasmMode | ICMode | RefMode | WASIMode
 
+type gc_strategy = MarkCompact | Copying
+
 let trace = ref false
 let verbose = ref false
 let print_warnings = ref true
@@ -30,5 +32,5 @@ let profile_field_names : string list ref = ref []
 let compiled = ref false
 let error_detail = ref 2
 let sanity = ref false
-let compacting_gc = ref false
+let gc_strategy = ref MarkCompact
 let force_gc = ref false


### PR DESCRIPTION
This PR makes mark-compact the default GC strategy and improves GC scheduling.

New flag `--copying-gc` added to enable copying GC. `--compacting-gc` is now
enabled by default.

# Motivation

Mark-compact GC uses more cycles than copying GC (see below), but in return it
almost halves dirtied pages, and allows us to use a more efficient GC scheduler
as it works with less scratch space. When both of these are taken into account,
it becomes clear that mark-compact GC is much more efficient than copying GC,
and should be the default.

Furthermore, when used with the mark-compact collector, a new GC scheduler
makes it possible for the tested canister to run same number of calls without
getting stuck, while doing less GC.

## Benchmarking

**Comparing GC cycles and dirtied pages**: We run an old [CanCan backend][1]
canister, compiled using `--force-gc`. drun script contains 1,000 calls to
`createProfile`, with different arguments:

    ingress rwlgt-iiaaa-aaaaa-aaaaa-cai createProfile "DIDL\x02n\x01m{\x02q\x00\x05test0\x00"

For drun we use dfinity `d3b184f303`, which has a modified replica that
generates a `canister_perf.csv` file after each run with cycles, read pages,
dirtied pages, and total Wasm pages.

Plots are then generated using the `canister_perf.csv` files generated by the
previous step using [generate_plots][2].

Results of the last call, comparing copying GC and compacting GC:

- Instructions: +34.7% (+12,052,682 cycles)
- Accessed pages: -47.5% (-296 pages)
- Dirtied pages: -47.8% (-296 pages)
- Total Wasm pages: -43.9% (-18 pages)

Execution team estimates that a single dirtied page costs between 10,000 and
100,000 cycles to the replica. If we assume 10,000, cycle costs of compacting
GC in the last call becomes 22% more (+9,092,682 cycles). If we assume 100,000,
then compacting GC uses 18% *less* cycles (-17,547,318 cycles). For this
canister, in the last call, compacting GC becomes more efficient in terms of
cycles when a dirtied page costs 40,719 or more cycles.

Below are plots comparing instructions, dirtied pages, read pages, and Wasm
pages for copying and compacting collectors.

<details>

<summary>Instructions, dirtied host pages, accessed host pages, total Wasm pages</summary>

![instructions](https://user-images.githubusercontent.com/448274/140894478-cdba0e25-7511-4bba-a7e1-b870b8e2c102.png)

![total_instructions](https://user-images.githubusercontent.com/448274/140894466-7df72356-63d3-421d-98ac-4fbf7a432959.png)

![dirtied_host_pages](https://user-images.githubusercontent.com/448274/140894473-1ef39607-2ed2-42c9-a36b-03174c42eff6.png)

![total_dirtied_host_pages](https://user-images.githubusercontent.com/448274/140894459-e99d79cb-a77e-4143-804d-67bdabaf81ed.png)

![accessed_host_pages](https://user-images.githubusercontent.com/448274/140894475-08f91d84-95b3-4038-ba7e-80114b219002.png)

![total_accessed_host_pages](https://user-images.githubusercontent.com/448274/140894465-a440a02a-015e-496c-a4d4-627402c2571b.png)

![total_Wasm_pages_in_use](https://user-images.githubusercontent.com/448274/140894467-417b443f-bbf9-4d1b-a896-4e881bc1ef40.png)

</details>

## Testing and benchmarking new scheduler

For benchmarking the new scheduler we use a [simulation][3].

We compare 3 schedulers:

1. The current one

2. The current one, except `MAX_HP_FOR_GC` is set 2 GiB.

   Reminder: `MAX_HP_FOR_GC` is the point where we start doing GC after every
   update call. Current value for it is 1 GiB.

3. `limit = min(live * 1.5, (live + max_live) / 2)` where `live` is the live
   amount after the last GC, and `max_live` is the max. live data allowed by the collector.

   For the copying GC, `max_live` is 2 GiB. For the mark-compact GC, `max_live`
   is 4,164,816,771 bytes. To calculate this number, we ignore the mark stack
   size. Mark stack size depends on the heap contents rather than size. In
   CanCan backend benchmark, it's 1024 words large for 1 GiB heap. To keep
   things simple we assume that the size is constant and negligible.

   Bitmap size can be at most 130,150,524 and the rest will be the heap. This
   is calculated with

       x + x/32 = 4 GiB, x = 4,164,816,771, x/32 = 130,150,524

   Reminder: one word in bitmap addresses 32 words in heap.

(Reminder: in the benchmarking section above, we use `--force-gc`, so the
scheduler is disabled and we do GC after every call)

The canister used allocates 100,000 bytes in each call, 50% of which survive
the GC. Unless specified, all GC parameters (`GROWTH_FACTOR`) are unchanged.

Metrics:

- Calls: number of calls the canister is able to make before getting stuck
  (Reminder: canister keeps allocating, and 50% of allocations are live)

- GCs: number of GCs scheduled

**Results of scheduler (1):**

|               | Calls           | GCs              |
| ------------- | --------------- | ---------------- |
| Copying       | 42,950          | 21,508           |
| Compacting    | 83,296          | 61,854           |
| Diff          | +40,346, +93.9% | +40,346, +187.5% |

Summary: the canister lives much longer with the compacting GC. Cycle usage
when this scheduler is used is as shown in the previous section.

<details>

<summary>Plots</summary>

![copying_old_1gb](https://user-images.githubusercontent.com/448274/140894786-a1b472b4-4cb0-4904-8b43-e81238f00716.png)

![compacting_old_1gb](https://user-images.githubusercontent.com/448274/140894784-d53fec03-6157-44f2-80be-f1dd43090ef6.png)

</details>

**Results of scheduler (2):**

|               | Calls           | GCs               |
| ------------- | --------------- | ----------------- |
| Copying       | 42,949          | 36                |
| Compacting    | 83,296          | 40,383            |
| Diff          | +40,347, +93.9% | +40,347, +112075% |

Summary: Setting `MAX_HEAP_FOR_GC` 2 GiB, does not make any difference in how
long the canister can run before getting stuck. However, we do less GC.
Especially with copying GC, this scheduler performs extremely well.

<details>

<summary>Plots</summary>

![copying_old_2gb](https://user-images.githubusercontent.com/448274/140894884-e5650ad0-f027-42d7-884b-eed3fa8e4160.png)

![compacting_old_2gb](https://user-images.githubusercontent.com/448274/140894880-672c823e-2d00-4c99-b868-887460c8b068.png)

</details>

**Results of scheduler (3):**

|               | Calls           | GCs               |
| ------------- | --------------- | ----------------- |
| Copying       | 42,950          | 74                |
| Compacting    | 83,296          | 78                |
| Diff          | +40,346, +93.9% | +4, +5.4%         |

Summary: this scheduler yields the best results when used on both collectors.
For copying GC, it's the same as (2). For mark-compact GC, the canister can run
for the same amount of calls, but number of GCs is significantly lower.

<details>

<summary>Plots</summary>

![copying_new](https://user-images.githubusercontent.com/448274/140894927-db64afc8-11ba-463c-9f10-61972f5fafcb.png)

![compacting_new](https://user-images.githubusercontent.com/448274/140894926-f986c4ad-53c4-4329-95fa-ec9e41cedd73.png)

</details>

[1]: https://github.com/dfinity/cancan-archived/
[2]: https://github.com/osa1/generate_plots
[3]: https://github.com/osa1/mmsim_2