### PR TITLE
Make bignum equality a bit more performant

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1584,7 +1584,7 @@ module Word64 = struct
         get_n ^^ get_exp ^^ compile_unsigned_pow env
       )
 
-  let compile_eq env = G.i (Compare (Wasm.Values.I64 I64Op.Eq))
+  let _compile_eq env = G.i (Compare (Wasm.Values.I64 I64Op.Eq))
   let compile_relop env i64op = G.i (Compare (Wasm.Values.I64 i64op))
 
 end (* BoxedWord64 *)
@@ -2291,7 +2291,26 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
             slow env
           end)
 
-  let compile_eq = try_comp_unbox2 "B_eq" Word64.compile_eq Num.compile_eq
+  let compile_eq env =
+    Func.share_code2 env "B_eq" (("a", I32Type), ("b", I32Type)) [I32Type]
+      (fun env get_a get_b ->
+        get_a ^^ get_b ^^
+        G.i (Compare (Wasm.Values.I32 I32Op.Eq)) ^^
+        G.if1 I32Type
+          (compile_unboxed_const (Bool.vanilla_lit true))
+          (get_a ^^ get_b ^^
+           BitTagged.if_both_tagged_scalar env [I32Type]
+             (compile_unboxed_const (Bool.vanilla_lit false))
+             begin
+               get_a ^^ BitTagged.if_tagged_scalar env [I32Type]
+                 (get_a ^^ extend_and_box64 env)
+                 get_a ^^
+               get_b ^^ BitTagged.if_tagged_scalar env [I32Type]
+                 (get_b ^^ extend_and_box64 env)
+                 get_b ^^
+               Num.compile_eq env
+             end))
+
   let compile_relop env bigintop =
     try_comp_unbox2 (name_from_relop bigintop)
       (fun env' -> Word64.compile_relop env' (i64op_from_relop bigintop))

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -2297,10 +2297,10 @@ module MakeCompact (Num : BigNumType) : BigNumType = struct
         get_a ^^ get_b ^^
         G.i (Compare (Wasm.Values.I32 I32Op.Eq)) ^^
         G.if1 I32Type
-          (compile_unboxed_const (Bool.vanilla_lit true))
+          (Bool.lit true)
           (get_a ^^ get_b ^^
            BitTagged.if_both_tagged_scalar env [I32Type]
-             (compile_unboxed_const (Bool.vanilla_lit false))
+             (Bool.lit false)
              begin
                get_a ^^ BitTagged.if_tagged_scalar env [I32Type]
                  (get_a ^^ extend_and_box64 env)


### PR DESCRIPTION
... by doing a pointer comparison first, and when not equal
proceed as usual (except when both are compact, the result
is `false`, as we already checked for identity).

Well, I conjecture that this helps, and the actual cycle counts w.r.t. our benchmarks indicate an improvement of 0.3%, so I guess this could go in.

The discussion happened in JIRA [IC-622], but the gist is captured in the PR.