### PR TITLE
Bump `install-nix-action` and disable GC for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     - name: "nix-build"
       # these are the dependencies listed in release-files. Sorry for the duplication
       run: |
-        nix-build --max-jobs 1 --argstr releaseVersion ${{needs.changelog.outputs.version}} \
+        env GC_DONT_GC=1 nix-build --max-jobs 1 --argstr releaseVersion ${{needs.changelog.outputs.version}} \
           -A moc -A mo-ide -A mo-doc -A js.moc -A js.moc_interpreter
 
   # Finally do the upload. Hopefully the previous job has uploaded the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     - build
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v14.1
     - uses: cachix/cachix-action@v10
       with:
         name: ic-hs-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v14.1
+    - uses: cachix/install-nix-action@v15
       with:
         extra_nix_config: |
           experimental-features = nix-command
@@ -71,7 +71,7 @@ jobs:
     - build
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v14.1
+    - uses: cachix/install-nix-action@v15
     - uses: cachix/cachix-action@v10
       with:
         name: ic-hs-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
         # fetch PR commit, not predicted merge commit
         ref: ${{ github.event.pull_request.head.sha }}
-    - uses: cachix/install-nix-action@v14.1
+    - uses: cachix/install-nix-action@v15
       with:
         extra_nix_config: |
           experimental-features = nix-command


### PR DESCRIPTION
Domen gave me the hint that the crashes tend to happen in `nix` GC,
see e.g. https://github.com/NixOS/nix/issues/4246

## Background

The GitHub release action for new tags keeps failing on MacOS X