### PR TITLE
Rename upgrade record to system

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -8783,7 +8783,7 @@ and main_actor as_opt mod_env ds fs up =
 
     (* Compile the declarations *)
     let ae2, decls_codeW = compile_decs_public env ae1 ds v2en
-      (Freevars.captured_vars (Freevars.system up))
+      Freevars.(captured_vars (system up))
     in
 
     (* Export the public functions *)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -8783,7 +8783,7 @@ and main_actor as_opt mod_env ds fs up =
 
     (* Compile the declarations *)
     let ae2, decls_codeW = compile_decs_public env ae1 ds v2en
-      (Freevars.captured_vars (Freevars.upgrade up))
+      (Freevars.captured_vars (Freevars.system up))
     in
 
     (* Export the public functions *)
@@ -8791,9 +8791,9 @@ and main_actor as_opt mod_env ds fs up =
 
     (* Export upgrade hooks *)
     Func.define_built_in env "pre_exp" [] [] (fun env ->
-      compile_exp_as env ae2 SR.unit up.pre);
+      compile_exp_as env ae2 SR.unit up.preupgrade);
     Func.define_built_in env "post_exp" [] [] (fun env ->
-      compile_exp_as env ae2 SR.unit up.post);
+      compile_exp_as env ae2 SR.unit up.postupgrade);
     IC.export_upgrade_methods env;
 
     (* Export metadata *)

--- a/src/ir_def/arrange_ir.ml
+++ b/src/ir_def/arrange_ir.ml
@@ -29,12 +29,12 @@ let rec exp e = match e.it with
     "FuncE" $$ [Atom x; func_sort s; control c] @ List.map typ_bind tp @ args as_ @ [ typ (Type.seq ts); exp e]
   | SelfCallE (ts, exp_f, exp_k, exp_r) ->
     "SelfCallE" $$ [typ (Type.seq ts); exp exp_f; exp exp_k; exp exp_r]
-  | ActorE (ds, fs, u, t) -> "ActorE"  $$ List.map dec ds @ fields fs @ [upgrade u; typ t]
+  | ActorE (ds, fs, u, t) -> "ActorE"  $$ List.map dec ds @ fields fs @ [system u; typ t]
   | NewObjE (s, fs, t)  -> "NewObjE" $$ (Arrange_type.obj_sort s :: fields fs @ [typ t])
   | TryE (e, cs)        -> "TryE" $$ [exp e] @ List.map case cs
 
-and upgrade { pre; post; meta } = (* TODO: show meta? *)
-  "Upgrade" $$ ["Pre" $$ [exp pre]; "Post" $$ [exp post]]
+and system { preupgrade; postupgrade; meta } = (* TODO: show meta? *)
+  "System" $$ ["Pre" $$ [exp preupgrade]; "Post" $$ [exp postupgrade]]
 
 and lexp le = match le.it with
   | VarLE i             -> "VarLE" $$ [id i]
@@ -152,7 +152,7 @@ and typ_bind (tb : typ_bind) =
 and comp_unit = function
   | LibU (ds, e) -> "LibU" $$ List.map dec ds @ [ exp e ]
   | ProgU ds -> "ProgU" $$ List.map dec ds
-  | ActorU (None, ds, fs, u, t) -> "ActorU"  $$ List.map dec ds @ fields fs @ [upgrade u; typ t]
-  | ActorU (Some as_, ds, fs, u, t) -> "ActorU"  $$ List.map arg as_ @ List.map dec ds @ fields fs @ [upgrade u; typ t]
+  | ActorU (None, ds, fs, u, t) -> "ActorU"  $$ List.map dec ds @ fields fs @ [system u; typ t]
+  | ActorU (Some as_, ds, fs, u, t) -> "ActorU"  $$ List.map arg as_ @ List.map dec ds @ fields fs @ [system u; typ t]
 
 and prog (cu, _flavor) = comp_unit cu

--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -772,16 +772,16 @@ let rec check_exp env (exp:Ir.exp) : unit =
     typ exp_f <: T.unit;
     typ exp_k <: T.Func (T.Local, T.Returns, [], ts, []);
     typ exp_r <: T.Func (T.Local, T.Returns, [], [T.error], []);
-  | ActorE (ds, fs, { pre; post; meta }, t0) ->
+  | ActorE (ds, fs, { preupgrade; postupgrade; meta }, t0) ->
     (* TODO: check meta *)
     let env' = { env with async = None } in
     let scope1 = gather_block_decs env' ds in
     let env'' = adjoin env' scope1 in
     check_decs env'' ds;
-    check_exp env'' pre;
-    check_exp env'' post;
-    typ pre <: T.unit;
-    typ post <: T.unit;
+    check_exp env'' preupgrade;
+    check_exp env'' postupgrade;
+    typ preupgrade <: T.unit;
+    typ postupgrade <: T.unit;
     check (T.is_obj t0) "bad annotation (object type expected)";
     let (s0, tfs0) = T.as_obj t0 in
     let val_tfs0 = List.filter (fun tf -> not (T.is_typ tf.T.typ)) tfs0 in
@@ -1092,7 +1092,7 @@ let check_comp_unit env = function
     let scope = gather_block_decs env ds in
     let env' = adjoin env scope in
     check_decs env' ds
-  | ActorU (as_opt, ds, fs, { pre; post; meta}, t0) ->
+  | ActorU (as_opt, ds, fs, { preupgrade; postupgrade; meta}, t0) ->
     let check p = check env no_region p in
     let (<:) t1 t2 = check_sub env no_region t1 t2 in
     let env' = match as_opt with
@@ -1105,10 +1105,10 @@ let check_comp_unit env = function
     let scope1 = gather_block_decs env' ds in
     let env'' = adjoin env' scope1 in
     check_decs env'' ds;
-    check_exp env'' pre;
-    check_exp env'' post;
-    typ pre <: T.unit;
-    typ post <: T.unit;
+    check_exp env'' preupgrade;
+    check_exp env'' postupgrade;
+    typ preupgrade <: T.unit;
+    typ postupgrade <: T.unit;
     check (T.is_obj t0) "bad annotation (object type expected)";
     let (s0, tfs0) = T.as_obj t0 in
     let val_tfs0 = List.filter (fun tf -> not (T.is_typ tf.T.typ)) tfs0 in

--- a/src/ir_def/freevars.ml
+++ b/src/ir_def/freevars.ml
@@ -116,9 +116,9 @@ let rec exp e : f = match e.it with
   | TryE (e, cs)        -> exp e ++ cases cs
   | SelfCallE (_, e1, e2, e3) -> under_lambda (exp e1) ++ exp e2 ++ exp e3
 
-and actor ds fs u = close (decs ds +++ fields fs +++ upgrade u)
+and actor ds fs u = close (decs ds +++ fields fs +++ system u)
 
-and upgrade {meta; pre; post} = under_lambda (exp pre) ++ under_lambda (exp post)
+and system {meta; preupgrade; postupgrade} = under_lambda (exp preupgrade) ++ under_lambda (exp postupgrade)
 
 and exps es : f = unions exp es
 

--- a/src/ir_def/ir.ml
+++ b/src/ir_def/ir.ml
@@ -72,14 +72,14 @@ and exp' =
   | FuncE of                                   (* function *)
       string * Type.func_sort * Type.control * typ_bind list * arg list * Type.typ list * exp
   | SelfCallE of Type.typ list * exp * exp * exp (* essentially ICCallPrim (FuncE shared…) *)
-  | ActorE of dec list * field list * upgrade * Type.typ (* actor *)
+  | ActorE of dec list * field list * system * Type.typ (* actor *)
   | NewObjE of Type.obj_sort * field list * Type.typ  (* make an object *)
   | TryE of exp * case list                    (* try/catch *)
 
-and upgrade = {
+and system = {
   meta : meta;
-  pre : exp;
-  post : exp
+  preupgrade : exp;
+  postupgrade : exp
 }
 
 and candid = {
@@ -227,7 +227,7 @@ let full_flavor () : flavor = {
 type comp_unit =
   | LibU of dec list * exp
   | ProgU of dec list
-  | ActorU of arg list option * dec list * field list * upgrade * Type.typ (* actor (class) *)
+  | ActorU of arg list option * dec list * field list * system * Type.typ (* actor (class) *)
 
 type prog = comp_unit * flavor
 

--- a/src/ir_def/rename.ml
+++ b/src/ir_def/rename.ml
@@ -27,12 +27,12 @@ and exp' rho e  = match e with
   | VarE i              -> VarE (id rho i)
   | LitE l              -> e
   | PrimE (p, es)       -> PrimE (prim rho p, List.map (exp rho) es)
-  | ActorE (ds, fs, { meta; pre; post }, t) ->
+  | ActorE (ds, fs, { meta; preupgrade; postupgrade }, t) ->
     let ds', rho' = decs rho ds in
     ActorE
       (ds',
        fields rho' fs,
-       {meta; pre = exp rho' pre; post = exp rho' post},
+       {meta; preupgrade = exp rho' preupgrade; postupgrade = exp rho' postupgrade},
        t)
   | AssignE (e1, e2)    -> AssignE (lexp rho e1, exp rho e2)
   | BlockE (ds, e1)     -> let ds', rho' = decs rho ds
@@ -150,7 +150,7 @@ let comp_unit rho cu = match cu with
   | LibU (ds, e) ->
     let ds', rho' = decs rho ds
     in LibU (ds', exp rho' e)
-  | ActorU (as_opt, ds, fs, { meta; pre; post }, t) ->
+  | ActorU (as_opt, ds, fs, { meta; preupgrade; postupgrade }, t) ->
     let as_opt', rho' = match as_opt with
       | None -> None, rho
       | Some as_ ->
@@ -159,4 +159,4 @@ let comp_unit rho cu = match cu with
     in
     let ds', rho'' = decs rho' ds in
     ActorU (as_opt', ds', fields rho'' fs,
-      { meta; pre = exp rho'' pre; post = exp rho'' post }, t)
+      { meta; preupgrade = exp rho'' preupgrade; postupgrade = exp rho'' postupgrade }, t)

--- a/src/ir_passes/async.ml
+++ b/src/ir_passes/async.ml
@@ -374,8 +374,8 @@ let transform mode prog =
             | Replies,_ -> assert false
           end
       end
-    | ActorE (ds, fs, {meta; pre; post}, typ) ->
-      ActorE (t_decs ds, t_fields fs, {meta; pre = t_exp pre; post = t_exp post}, t_typ typ)
+    | ActorE (ds, fs, {meta; preupgrade; postupgrade}, typ) ->
+      ActorE (t_decs ds, t_fields fs, {meta; preupgrade = t_exp preupgrade; postupgrade = t_exp postupgrade}, t_typ typ)
     | NewObjE (sort, ids, t) ->
       NewObjE (sort, t_fields ids, t_typ t)
     | SelfCallE _ -> assert false
@@ -444,9 +444,9 @@ let transform mode prog =
   and t_comp_unit = function
     | LibU _ -> raise (Invalid_argument "cannot compile library")
     | ProgU ds -> ProgU (t_decs ds)
-    | ActorU (args_opt, ds, fs, {meta; pre; post}, t) ->
+    | ActorU (args_opt, ds, fs, {meta; preupgrade; postupgrade}, t) ->
       ActorU (Option.map t_args args_opt, t_decs ds, t_fields fs,
-        { meta; pre = t_exp pre; post = t_exp post }, t_typ t)
+        { meta; preupgrade = t_exp preupgrade; postupgrade = t_exp postupgrade }, t_typ t)
 
   and t_prog (cu, flavor) = (t_comp_unit cu, { flavor with has_async_typ = false } )
 in

--- a/src/ir_passes/await.ml
+++ b/src/ir_passes/await.ml
@@ -119,11 +119,11 @@ and t_exp' context exp' =
   | FuncE (x, s, c, typbinds, pat, typ, exp) ->
     let context' = LabelEnv.add Return Label LabelEnv.empty in
     FuncE (x, s, c, typbinds, pat, typ,t_exp context' exp)
-  | ActorE (ds, ids, { meta; pre; post }, t) ->
+  | ActorE (ds, ids, { meta; preupgrade; postupgrade }, t) ->
     ActorE (t_decs context ds, ids,
       { meta;
-        pre = t_exp LabelEnv.empty pre;
-        post = t_exp LabelEnv.empty post},
+        preupgrade = t_exp LabelEnv.empty preupgrade;
+        postupgrade = t_exp LabelEnv.empty postupgrade},
       t)
   | NewObjE (sort, ids, typ) -> exp'
   | SelfCallE _ -> assert false
@@ -525,11 +525,11 @@ and t_comp_unit context = function
           expD (c_block context' ds (tupE []) (meta (T.unit) (fun v1 -> tupE [])))
         ]
     end
-  | ActorU (as_opt, ds, ids, { meta; pre; post }, t) ->
+  | ActorU (as_opt, ds, ids, { meta; preupgrade; postupgrade }, t) ->
     ActorU (as_opt, t_decs context ds, ids,
       { meta;
-        pre = t_exp LabelEnv.empty pre;
-        post = t_exp LabelEnv.empty post},
+        preupgrade = t_exp LabelEnv.empty preupgrade;
+        postupgrade = t_exp LabelEnv.empty postupgrade},
       t)
 
 and t_prog (prog, flavor) =

--- a/src/ir_passes/const.ml
+++ b/src/ir_passes/const.ml
@@ -159,11 +159,11 @@ let rec exp lvl (env : env) e : Lbool.t =
       surely_false
     | NewObjE _ -> (* mutable objects *)
       surely_false
-    | ActorE (ds, fs, {meta; pre; post}, _typ) ->
+    | ActorE (ds, fs, {meta; preupgrade; postupgrade}, _typ) ->
       (* this may well be “the” top-level actor, so don’t update lvl here *)
       let (env', _) = decs lvl env ds in
-      exp_ lvl env' pre;
-      exp_ lvl env' post;
+      exp_ lvl env' preupgrade;
+      exp_ lvl env' postupgrade;
       surely_false
   in
   set_lazy_const e lb;
@@ -217,14 +217,14 @@ and block lvl env (ds, body) =
 and comp_unit = function
   | LibU _ -> raise (Invalid_argument "cannot compile library")
   | ProgU ds -> decs_ TopLvl M.empty ds
-  | ActorU (as_opt, ds, fs, {meta; pre; post}, typ) ->
+  | ActorU (as_opt, ds, fs, {meta; preupgrade; postupgrade}, typ) ->
     let env = match as_opt with
       | None -> M.empty
       | Some as_ -> args TopLvl M.empty as_
     in
     let (env', _) = decs TopLvl env ds in
-    exp_ TopLvl env' pre;
-    exp_ TopLvl env' post
+    exp_ TopLvl env' preupgrade;
+    exp_ TopLvl env' postupgrade
 
 let analyze ((cu, _flavor) : prog) =
   ignore (comp_unit cu)

--- a/src/ir_passes/eq.ml
+++ b/src/ir_passes/eq.ml
@@ -250,15 +250,15 @@ and t_exp' env = function
     NewObjE (sort, ids, t)
   | SelfCallE (ts, e1, e2, e3) ->
     SelfCallE (ts, t_exp env e1, t_exp env e2, t_exp env e3)
-  | ActorE (ds, fields, {meta; pre; post}, typ) ->
+  | ActorE (ds, fields, {meta; preupgrade; postupgrade}, typ) ->
     (* Until Actor expressions become their own units,
        we repeat what we do in `comp_unit` below *)
     let env1 = empty_env () in
     let ds' = t_decs env1 ds in
-    let pre' = t_exp env1 pre in
-    let post' = t_exp env1 post in
+    let preupgrade' = t_exp env1 preupgrade in
+    let postupgrade' = t_exp env1 postupgrade in
     let decls = eq_decls !(env1.params) in
-    ActorE (decls @ ds', fields, {meta; pre = pre'; post = post'}, typ)
+    ActorE (decls @ ds', fields, {meta; preupgrade = preupgrade'; postupgrade = postupgrade'}, typ)
 
 and t_lexp env (e : Ir.lexp) = { e with it = t_lexp' env e.it }
 and t_lexp' env = function
@@ -286,13 +286,13 @@ and t_comp_unit = function
     let ds' = t_decs env ds in
     let decls = eq_decls !(env.params) in
     ProgU (decls @ ds')
-  | ActorU (as_opt, ds, fields, {meta; pre; post}, typ) ->
+  | ActorU (as_opt, ds, fields, {meta; preupgrade; postupgrade}, typ) ->
     let env = empty_env () in
     let ds' = t_decs env ds in
-    let pre' = t_exp env pre in
-    let post' = t_exp env post in
+    let preupgrade' = t_exp env preupgrade in
+    let postupgrade' = t_exp env postupgrade in
     let decls = eq_decls !(env.params) in
-    ActorU (as_opt, decls @ ds', fields, {meta; pre = pre'; post = post'}, typ)
+    ActorU (as_opt, decls @ ds', fields, {meta; preupgrade = preupgrade'; postupgrade = postupgrade'}, typ)
 
 (* Entry point for the program transformation *)
 

--- a/src/ir_passes/erase_typ_field.ml
+++ b/src/ir_passes/erase_typ_field.ml
@@ -126,9 +126,9 @@ let transform prog =
       DefineE (id, mut, t_exp exp1)
     | FuncE (x, s, c, typbinds, args, ret_tys, exp) ->
       FuncE (x, s, c, t_typ_binds typbinds, t_args args, List.map t_typ ret_tys, t_exp exp)
-    | ActorE (ds, fs, {meta; pre; post}, typ) ->
+    | ActorE (ds, fs, {meta; preupgrade; postupgrade}, typ) ->
       ActorE (t_decs ds, t_fields fs,
-        {meta; pre = t_exp pre; post = t_exp post}, t_typ typ)
+        {meta; preupgrade = t_exp preupgrade; postupgrade = t_exp postupgrade}, t_typ typ)
     | NewObjE (sort, ids, t) ->
       NewObjE (sort, t_fields ids, t_typ t)
     | SelfCallE _ -> assert false
@@ -200,9 +200,9 @@ let transform prog =
   and t_comp_unit = function
     | LibU _ -> raise (Invalid_argument "cannot compile library")
     | ProgU ds -> ProgU (t_decs ds)
-    | ActorU (args_opt, ds, fs, {meta; pre; post}, t) ->
+    | ActorU (args_opt, ds, fs, {meta; preupgrade; postupgrade}, t) ->
       ActorU (Option.map t_args args_opt, t_decs ds, t_fields fs,
-        { meta; pre = t_exp pre; post = t_exp post }, t_typ t)
+        { meta; preupgrade = t_exp preupgrade; postupgrade = t_exp postupgrade }, t_typ t)
   and t_prog (cu, flavor) = (t_comp_unit cu, { flavor with has_typ_field = false } )
 in
   t_prog prog

--- a/src/ir_passes/show.ml
+++ b/src/ir_passes/show.ml
@@ -292,15 +292,15 @@ and t_exp' env = function
     NewObjE (sort, ids, t)
   | SelfCallE (ts, e1, e2, e3) ->
     SelfCallE (ts, t_exp env e1, t_exp env e2, t_exp env e3)
-  | ActorE (ds, fields, {meta; pre; post}, typ) ->
+  | ActorE (ds, fields, {meta; preupgrade; postupgrade}, typ) ->
     (* Until Actor expressions become their own units,
        we repeat what we do in `comp_unit` below *)
     let env1 = empty_env () in
     let ds' = t_decs env1 ds in
-    let pre' = t_exp env1 pre in
-    let post' = t_exp env1 post in
+    let preupgrade' = t_exp env1 preupgrade in
+    let postupgrade' = t_exp env1 postupgrade in
     let decls = show_decls !(env1.params) in
-    ActorE (decls @ ds', fields, {meta; pre = pre'; post = post'}, typ)
+    ActorE (decls @ ds', fields, {meta; preupgrade = preupgrade'; postupgrade = postupgrade'}, typ)
 
 and t_lexp env (e : Ir.lexp) = { e with it = t_lexp' env e.it }
 and t_lexp' env = function
@@ -328,13 +328,13 @@ and t_comp_unit = function
     let ds' = t_decs env ds in
     let decls = show_decls !(env.params) in
     ProgU (decls @ ds')
-  | ActorU (as_opt, ds, fields, {meta; pre; post}, typ) ->
+  | ActorU (as_opt, ds, fields, {meta; preupgrade; postupgrade}, typ) ->
     let env = empty_env () in
     let ds' = t_decs env ds in
-    let pre' = t_exp env pre in
-    let post' = t_exp env post in
+    let preupgrade' = t_exp env preupgrade in
+    let postupgrade' = t_exp env postupgrade in
     let decls = show_decls !(env.params) in
-    ActorU (as_opt, decls @ ds', fields, {meta; pre = pre'; post = post'}, typ)
+    ActorU (as_opt, decls @ ds', fields, {meta; preupgrade = preupgrade'; postupgrade = postupgrade'}, typ)
 
 (* Entry point for the program transformation *)
 

--- a/src/ir_passes/tailcall.ml
+++ b/src/ir_passes/tailcall.ml
@@ -128,7 +128,7 @@ and exp' env e  : exp' = match e.it with
     let exp3' = exp env exp3 in
     SelfCallE (ts, exp1', exp2', exp3')
   | ActorE (ds, fs, u, t) ->
-    let u = { u with pre = exp env u.pre; post = exp env u.post } in
+    let u = { u with preupgrade = exp env u.preupgrade; postupgrade = exp env u.postupgrade } in
     ActorE (snd (decs env ds), fs, u, t)
   | NewObjE (s,is,t)    -> NewObjE (s, is, t)
   | PrimE (p, es)       -> PrimE (p, List.map (exp env) es)
@@ -258,7 +258,7 @@ and comp_unit env = function
   | LibU _ -> raise (Invalid_argument "cannot compile library")
   | ProgU ds -> ProgU (snd (decs env ds))
   | ActorU (as_opt, ds, fs, u, t)  ->
-    let u = { u with pre = exp env u.pre; post = exp env u.post } in
+    let u = { u with preupgrade = exp env u.preupgrade; postupgrade = exp env u.postupgrade } in
     ActorU (as_opt, snd (decs env ds), fs, u, t)
 
 and prog (cu, flavor) =

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -382,7 +382,7 @@ and build_actor at ts self_id es obj_typ =
   let (interface_d, interface_f) = export_interface candid.I.service in
   I.ActorE (interface_d @ ds', interface_f @ fs,
      { meta;
-       I.pre =
+       I.preupgrade =
        (let vs = fresh_vars "v" (List.map (fun f -> f.T.typ) fields) in
         blockE
           ((match call_system_func_opt "preupgrade" es with
@@ -398,7 +398,7 @@ and build_actor at ts self_id es obj_typ =
                         note = f.T.typ }
                     ) fields vs)
                  ty]));
-        I.post = match call_system_func_opt "postupgrade" es with
+        I.postupgrade = match call_system_func_opt "postupgrade" es with
                  | Some call -> call
                  | None -> tupE []},
     obj_typ)


### PR DESCRIPTION
The "upgrade" record is renamed to "system" so that it can fit more things unrelated to upgrades.