### PR TITLE
Catch error arising in `as_variant_sub` when scrutinee is not variant

### DIFF
--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -119,7 +119,7 @@ let error_codes : (string * string option) list =
     "M0113", None; (* Object pattern cannot consume type *)
     "M0114", None; (* Object pattern cannot consume actor type *)
     "M0115", None; (* Option pattern cannot consume type *)
-    (* "M0116" DEFUNCT Variant pattern cannot consume type *)
+    "M0116", None; (* Variant pattern cannot consume type *)
     "M0117", None; (* Pattern cannot consume type *)
     "M0118", None; (* Tuple pattern size mismatch *)
     "M0119", None; (* Object field is not contained in type *)

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1800,8 +1800,9 @@ and check_pat' env t pat : Scope.val_env =
         display_typ_expand t
     in check_pat env t1 pat1
   | TagP (id, pat1) ->
-    let t1 = try
-     match T.lookup_val_field_opt id.it (T.as_variant_sub id.it t) with
+    let t1 =
+      try
+        match T.lookup_val_field_opt id.it (T.as_variant_sub id.it t) with
         | Some t1 -> t1
         | None -> T.Non
       with Invalid_argument _ ->

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1800,10 +1800,13 @@ and check_pat' env t pat : Scope.val_env =
         display_typ_expand t
     in check_pat env t1 pat1
   | TagP (id, pat1) ->
-    let t1 =
-      match T.lookup_val_field_opt id.it (T.as_variant_sub id.it t) with
-      | Some t1 -> t1
-      | None -> T.Non
+    let t1 = try
+        match T.lookup_val_field_opt id.it (T.as_variant_sub id.it t) with
+        | Some t1 -> t1
+        | None -> T.Non
+      with Invalid_argument _ ->
+        error env pat.at "M0116" "variant pattern cannot consume expected type%a"
+          display_typ_expand t
     in check_pat env t1 pat1
   | AltP (pat1, pat2) ->
     let ve1 = check_pat env t pat1 in

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1801,7 +1801,7 @@ and check_pat' env t pat : Scope.val_env =
     in check_pat env t1 pat1
   | TagP (id, pat1) ->
     let t1 = try
-        match T.lookup_val_field_opt id.it (T.as_variant_sub id.it t) with
+     match T.lookup_val_field_opt id.it (T.as_variant_sub id.it t) with
         | Some t1 -> t1
         | None -> T.Non
       with Invalid_argument _ ->

--- a/test/fail/ok/pat-inconsistent.tc.ok
+++ b/test/fail/ok/pat-inconsistent.tc.ok
@@ -132,3 +132,5 @@ pat-inconsistent.mo:49.8-49.9: type error [M0050], literal of type
   Nat
 does not have expected type
   Bool
+pat-inconsistent.mo:54.9-54.15: type error [M0116], variant pattern cannot consume expected type
+  Bool

--- a/test/fail/ok/pat-inconsistent.tc.ok
+++ b/test/fail/ok/pat-inconsistent.tc.ok
@@ -134,3 +134,9 @@ does not have expected type
   Bool
 pat-inconsistent.mo:54.9-54.15: type error [M0116], variant pattern cannot consume expected type
   Bool
+pat-inconsistent.mo:59.9-59.15: warning [M0146], this pattern is never matched
+pat-inconsistent.mo:58.1-60.2: warning [M0145], this switch of type
+  {#sparrows}
+does not cover value
+  #sparrows
+pat-inconsistent.mo:64.10-64.18: warning [M0146], this pattern is never matched

--- a/test/fail/pat-inconsistent.mo
+++ b/test/fail/pat-inconsistent.mo
@@ -49,3 +49,7 @@ switch (true : Bool) {
   case 1 {};
   case false {};
 };
+
+switch (true : Bool) {
+  case (#geese) {};
+};

--- a/test/fail/pat-inconsistent.mo
+++ b/test/fail/pat-inconsistent.mo
@@ -53,3 +53,13 @@ switch (true : Bool) {
 switch (true : Bool) {
   case (#geese) {};
 };
+
+// Coverage check for disjoint variants
+switch (#sparrows : { #sparrows }) {
+  case (#geese) {};
+};
+
+func absurd(birds : {#}) =
+  switch birds {
+    case (#geese) {};
+  };


### PR DESCRIPTION
Fixes #2934.