### PR TITLE
Add `nixpkgs.fswatch` to the nix shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -707,6 +707,7 @@ rec {
           nixpkgs.ocamlPackages.merlin
           nixpkgs.ocamlformat
           nixpkgs.ocamlPackages.utop
+          nixpkgs.fswatch
           nixpkgs.niv
           nixpkgs.rlwrap # for `rlwrap moc`
         ]


### PR DESCRIPTION
to enable `make -C src DUNE_OPTS=--watch moc`.