### PR TITLE
Make bitmap scanning branchless

### DIFF
--- a/rts/motoko-rts/src/gc/mark_compact/bitmap.rs
+++ b/rts/motoko-rts/src/gc/mark_compact/bitmap.rs
@@ -167,21 +167,14 @@ impl BitmapIter {
 
         // Outer loop iterates 64-bit words
         loop {
-            // Inner conditional examines the least significant bit(s) in the current word
+            // Examine the least significant bit(s) in the current word
             if self.current_word != 0 {
-                if self.current_word & 0b1 != 0 {
-                    let bit_idx = self.current_bit_idx;
-                    self.current_word >>= 1;
-                    self.current_bit_idx += 1;
-                    return bit_idx;
-                } else {
-                    let shift_amt = self.current_word.trailing_zeros();
-                    self.current_word >>= shift_amt;
-                    self.current_word >>= 1;
-                    let bit_idx = self.current_bit_idx + shift_amt;
-                    self.current_bit_idx = bit_idx + 1;
-                    return bit_idx;
-                }
+                let shift_amt = self.current_word.trailing_zeros();
+                self.current_word >>= shift_amt;
+                self.current_word >>= 1;
+                let bit_idx = self.current_bit_idx + shift_amt;
+                self.current_bit_idx = bit_idx + 1;
+                return bit_idx;
             }
 
             // Move on to next word (always 64-bit boundary)


### PR DESCRIPTION
I have rewritten the code which finds the next set bit in the marking bitmap (`BitmapIter::next`) to eliminate the inner `if`. This was suggested in #2952.

Branchless execution indeed gives nice wins in measured cycles:
```
[nix-shell:~/motoko]$ ghc -e "100-27424377/28288331*100"
3.0541002931562105
```
About 3% cycle reduction on GC-heavy code. More benchmarks in the PR.