### PR TITLE
`nix`: don't patch `nixpkgs` if we don't have patches

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,12 +10,22 @@ let
     system = builtins.currentSystem;
   };
 
-  nixpkgs-patched = bootstrap-pkgs.applyPatches {
-    name = "nixpkgs-patched";
-    src = nixpkgs_src;
-    # patches = [
-    # ];
-  };
+  # dump nixpkgs patches here
+  nixpkgs-patches = [];
+
+  nixpkgs-patched =
+    if nixpkgs-patches == []
+    then nixpkgs_src
+    else
+      let
+        bootstrap-pkgs = import nixpkgs_src {
+          system = builtins.currentSystem;
+        };
+      in bootstrap-pkgs.applyPatches {
+        name = "nixpkgs-patched";
+        src = nixpkgs_src;
+        patches = nixpkgs-patches;
+      };
 
   pkgs =
     import nixpkgs-patched {


### PR DESCRIPTION
This should speed up `nix-shell` etc. when we don't apply any patches,
without removing the code to do so.