### PR TITLE
Disable hash updates for `release` branch

### DIFF
--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - master
+      - release
     tags-ignore:
       - '**'
 


### PR DESCRIPTION
The `release` branch  is also off-limits for hash updates.