### PR TITLE
RTS: remove a TODO

### DIFF
--- a/rts/motoko-rts/src/lib.rs
+++ b/rts/motoko-rts/src/lib.rs
@@ -1,7 +1,6 @@
 //! Implements Motoko runtime system
 
 #![no_std]
-// TODO (osa): Some of these are stabilized, we need to update rustc
 #![feature(arbitrary_self_types, core_intrinsics, panic_info_message)]
 
 #[macro_use]


### PR DESCRIPTION
Redundant `#![feature(...)]`s generate warnings as we update rustc, so
no need to add a TODO about removing them.