### PR TITLE
Apply the macOS `nix-2.4` GC treatment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
     - run: cachix watch-store ic-hs-test &
 
     - name: "nix-build"
+      env:
+        GC_DONT_GC: 1 # otherwise `nix` crash on macOS
       run: nix-build-uncached --max-jobs 4 -A all-systems-go
 
     - name: Calculate performance delta


### PR DESCRIPTION
`nix-2.4` has a (memory, Boehm) GC bug on macOS, this PR works around it.

See also #2913.

Also, for background, https://github.com/NixOS/nix/issues/4893.