### PR TITLE
CI: Build tests with nix-build to show logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,15 @@ jobs:
         GC_DONT_GC: 1 # otherwise `nix` crash on macOS
       run: nix-build-uncached --max-jobs 4 -A all-systems-go
 
+    # The above doesn’t show nice logs, due to
+    # https://github.com/Mic92/nix-build-uncached/issues/42
+    # So let’s re-run the tests with nix-build.
+    # In the happy case they have been built above and this is quick.
+    - name: "nix-build tests"
+      env:
+        GC_DONT_GC: 1 # otherwise `nix` crash on macOS
+      run: nix-build -A tests
+
     - name: Calculate performance delta
       if: runner.os == 'Linux' && github.event_name == 'pull_request'
       run: |

--- a/default.nix
+++ b/default.nix
@@ -681,7 +681,7 @@ rec {
       check-grammar
       check-error-codes
     ] ++
-    builtins.attrValues (builtins.removeAttrs tests ["qc"]) ++
+    builtins.attrValues tests ++
     builtins.attrValues js;
   };
 

--- a/default.nix
+++ b/default.nix
@@ -730,10 +730,14 @@ rec {
     CANDID_TESTS = "${nixpkgs.sources.candid}/test";
 
     # allow building this as a derivation, so that hydra builds and caches
-    # the dependencies of shell
-    # Also mention the dependencies in the output, so that after `nix-build -A
-    # shell` (or just `nix-build`) they are guaranteed to be present in the
-    # local nix store.
+    # the dependencies of shell.
+    #
+    # Note that we are using propagatedBuildInputs above, not just buildInputs.
+    # This means that the dependencies end up in the output path, in
+    # /nix/store/13d…da6-motoko-shell/nix-support/propagated-build-inputs
+    # so that after `nix-build -A shell` (or just `nix-build`) they are guaranteed
+    # to be present in the local nix store (else this might just download an
+    # empty build result path from the nix cache.)
     phases = ["installPhase" "fixupPhase"];
     installPhase = ''
       mkdir $out


### PR DESCRIPTION
we are now building them twice, but with caching, so only a problem if
they actually fail.

Also include tests.qc in the default test run. This reverts 41b4fbecc6c78996df146bf26cdda583a5c57ee. It’s against the principle of least surprise if `nix-build` does not build something that `nix-build -A tests` builds. If the QC test runs too long, we should make it run fast by default (few iterations) and maybe add a separate job (daily?) for a long run.
