### PR TITLE
CI: Update the ic bump more rarely

### DIFF
--- a/.github/workflows/niv-updater-trial.yml
+++ b/.github/workflows/niv-updater-trial.yml
@@ -28,7 +28,7 @@ jobs:
       - name: niv-updater-action
         uses: knl/niv-updater-action@60f23607814cf4f2e80a1e32ee74f8323897d09e
         with:
-          whitelist: 'nixpkgs,musl-wasi'
+          whitelist: 'nixpkgs,musl-wasi,ic'
           labels: |
             autoclose
           keep_updating: true

--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -23,7 +23,7 @@ jobs:
         uses: knl/niv-updater-action@60f23607814cf4f2e80a1e32ee74f8323897d09e
         with:
           # might be too noisy
-          blacklist: 'nixpkgs,ic-ref,musl-wasi'
+          blacklist: 'nixpkgs,ic-ref,musl-wasi,ic'
           labels: |
             automerge-squash
           keep_updating: true


### PR DESCRIPTION
now that the replica devs are developing the replica in the open we get
to bump `ic` very often. Most changes are completely irrelevant to us,
but having a daily `niv ic` commit is noisy, and we don’t want to
download `drun` so often.

So let’s treat `ic` like `nixpkgs`: Every week (not day) a bot creats a
PR. If that is green then the new `drun` didn’t break anything. The PR
gets closed, but not merged, automatically. But we’d notice if it
breaks.

When we _do_ want to bump `ic`, we can do it manually, or reopen one of
those PRs.