### PR TITLE
feat: add `motoko:compiler` ICP custom section with version info

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 * motoko (`moc`)
 
-  * Emit new ICP metadata custom section 'motoko:compiler' with compiler release or revision in UTF8 (e.g. "0.6.21"). Default is `icp:private`ax (#3091).
+  * Emit new ICP metadata custom section 'motoko:compiler' with compiler release or revision in UTF8 (e.g. "0.6.21"). Default is `icp:private` (#3091).
   * Generalized `import` supporting pattern matching and selective field imports (#3076).
   * Fix: insert critical overflow checks preventing rare heap corruptions
     in out-of-memory allocation and stable variable serialization (#3077).

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 * motoko (`moc`)
 
+  * Emit new ICP custom section 'motoko:compiler' with compiler release or revision in UTF8 (e.g. "0.6.21"). Default is private.
   * Generalized `import` supporting pattern matching and selective field imports (#3076).
   * Fix: insert critical overflow checks preventing rare heap corruptions
     in out-of-memory allocation and stable variable serialization (#3077).

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 * motoko (`moc`)
 
-  * Emit new ICP custom section 'motoko:compiler' with compiler release or revision in UTF8 (e.g. "0.6.21"). Default is private (#3091).
+  * Emit new ICP metadata custom section 'motoko:compiler' with compiler release or revision in UTF8 (e.g. "0.6.21"). Default is `icp:private`ax (#3091).
   * Generalized `import` supporting pattern matching and selective field imports (#3076).
   * Fix: insert critical overflow checks preventing rare heap corruptions
     in out-of-memory allocation and stable variable serialization (#3077).

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 * motoko (`moc`)
 
-  * Emit new ICP custom section 'motoko:compiler' with compiler release or revision in UTF8 (e.g. "0.6.21"). Default is private.
+  * Emit new ICP custom section 'motoko:compiler' with compiler release or revision in UTF8 (e.g. "0.6.21"). Default is private (#3091).
   * Generalized `import` supporting pattern matching and selective field imports (#3076).
   * Fix: insert critical overflow checks preventing rare heap corruptions
     in out-of-memory allocation and stable variable serialization (#3077).

--- a/doc/modules/language-guide/pages/compiler-ref.adoc
+++ b/doc/modules/language-guide/pages/compiler-ref.adoc
@@ -86,7 +86,7 @@ You can use the following options with the `+moc+` command.
 
 |`+--package <package-name> <package-path>+` |Specifies a package-name package-path pair, separated by a space.
 
-|`+--public-metadata <name>+` |Emit icp custom section <name> (candid:args or candid:service or motoko:stable-types) as `public` (default is `private`)
+|`+--public-metadata <name>+` |Emit icp custom section <name> (candid:args or candid:service or motoko:stable-types or motoko:compiler) as `public` (default is `private`)
 
 |`+--print-deps+` |Prints the dependencies for a given source file.
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -9091,6 +9091,9 @@ and conclude_module env start_fi_o =
       motoko = {
         labels = E.get_labs env;
         stable_types = !(env.E.stable_types);
+        compiler = Some
+         (List.mem "motoko:compiler" !Flags.public_metadata_names,
+          Lib.Option.get Source_id.release Source_id.id)
       };
       candid = {
         args = !(env.E.args);

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -33,7 +33,8 @@ let idl = ref false
 let valid_metadata_names =
     ["candid:args";
      "candid:service";
-     "motoko:stable-types"]
+     "motoko:stable-types";
+     "motoko:compiler"]
 
 let argspec = [
   "-c", Arg.Unit (set_mode Compile), " compile programs to WebAssembly";

--- a/src/wasm-exts/customModule.ml
+++ b/src/wasm-exts/customModule.ml
@@ -41,6 +41,7 @@ type dylink_section = {
 type motoko_sections = {
   labels : string list;
   stable_types : (bool * string) option;
+  compiler : (bool * string) option;
 }
 
 type candid_sections = {
@@ -51,6 +52,7 @@ type candid_sections = {
 let empty_motoko_sections = {
   labels = [];
   stable_types = None;
+  compiler = None;
 }
 
 let empty_candid_sections = {

--- a/src/wasm-exts/customModuleDecode.ml
+++ b/src/wasm-exts/customModuleDecode.ml
@@ -828,7 +828,8 @@ let utf8 sec_end s =
 
 let motoko_sections s =
   let stable_types = icp_custom_section "motoko:stable-types" utf8 None s in
-  custom_section is_motoko motoko_section_content { empty_motoko_sections with stable_types} s
+  let compiler = icp_custom_section "motoko:compiler" utf8 None s in
+  custom_section is_motoko motoko_section_content { empty_motoko_sections with stable_types; compiler} s
 
 (* Candid sections *)
 

--- a/src/wasm-exts/customModuleEncode.ml
+++ b/src/wasm-exts/customModuleEncode.ml
@@ -847,6 +847,7 @@ let encode (em : extended_module) =
 
     let motoko_sections motoko =
       icp_custom_section "motoko:stable-types" utf8 motoko.stable_types;
+      icp_custom_section "motoko:compiler" utf8 motoko.compiler;
       custom_section "motoko" motoko_section_body motoko.labels (motoko.labels <> []) (* TODO: make an icp_section *)
 
     let candid_sections candid =


### PR DESCRIPTION
* version is report as UTF8 release or, if unavailable, git revision, matching moc --version.
* section defaults to private.