### PR TITLE
CI: Publish reports to Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,9 +91,11 @@ jobs:
         edit-mode: replace
 
   reports:
+    # if: github.ref == 'refs/heads/master'
     needs: tests
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
+    steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v16
       with:
@@ -105,7 +107,6 @@ jobs:
     - name: Fetch report
       run: nix-build -A report-site --jobs 0 -o report-site
     - name: Push report to gitub pages
-      # if: github.ref == 'refs/heads/master'
       uses: JamesIves/github-pages-deploy-action@v4.2.5
       with:
         branch: gh-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
       with:
         name: ic-hs-test
     - name: Fetch report
-      run: nix-build -A report-site --max-jobs 0 -o report-site
+      run: nix-build -A report-site -o report-site
     - name: Push report to gitub pages
       uses: JamesIves/github-pages-deploy-action@v4.2.5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,9 @@ jobs:
         edit-mode: replace
 
   reports:
+    # while testing:
     # if: github.ref == 'refs/heads/master'
-    needs: tests
+    #needs: tests
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
@@ -93,7 +94,7 @@ jobs:
       with:
         name: ic-hs-test
     - name: Fetch report
-      run: nix-build -A report-site --jobs 0 -o report-site
+      run: nix-build -A report-site --max-jobs 0 -o report-site
     - name: Push report to gitub pages
       uses: JamesIves/github-pages-deploy-action@v4.2.5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: nix-build -A report-site -o report-site
 
     - name: Push report to gitub pages
-      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/joachim/deploy-reports'
+      if: runner.os == 'Linux' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/joachim/deploy-reports')
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command
 
-    - run: nix-env -iA nix-build-uncached -f nix/
-
     # We are using the ic-hs-test cachix cache that is also used by
     # dfinity/ic-hs. This is partly laziness (on need to set up a separate
     # cache), but also to get the ic-ref-test binary without rebuilding
@@ -34,6 +32,8 @@ jobs:
 
     # until https://github.com/cachix/cachix-action/issues/86 is fixed:
     - run: cachix watch-store ic-hs-test &
+
+    - run: nix-env -iA nix-build-uncached -f nix/
 
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: nix-build -A report-site -o report-site
 
     - name: Push report to gitub pages
-      if: runner.os == 'Linux' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/joachim/deploy-reports')
+      if: "runner.os == 'Linux' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/joachim/deploy-reports')"
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,9 +95,11 @@ jobs:
         name: ic-hs-test
     - name: Fetch report
       run: nix-build -A report-site -o report-site
+    - name: Resolve symlinks
+      run: cp -rL report-site report-site-copy
     - name: Push report to gitub pages
       uses: JamesIves/github-pages-deploy-action@v4.2.5
       with:
         branch: gh-pages
-        folder: report-site
-        single_commit: true
+        folder: report-site-copy
+        single-commit: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: nix-build -A report-site -o report-site
 
     - name: Push report to gitub pages
-      #if: "runner.os == 'Linux' && (github.ref == 'refs/heads/master' || github.head_ref == 'refs/heads/joachim/deploy-reports')"
+      if: runner.os == 'Linux' # && github.ref == 'refs/heads/master'
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: nix-build -A report-site -o report-site
 
     - name: Push report to gitub pages
-      if: "runner.os == 'Linux' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/joachim/deploy-reports')"
+      if: "runner.os == 'Linux' && (github.ref == 'refs/heads/master' || github.head_ref == 'refs/heads/joachim/deploy-reports')"
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,3 +89,25 @@ jobs:
           <!-- perf comment -->
           ${{ steps.perf.outputs.content }}
         edit-mode: replace
+
+  reports:
+    needs: tests
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v16
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command
+    - uses: cachix/cachix-action@v10
+      with:
+        name: ic-hs-test
+    - name: Fetch report
+      run: nix-build -A report-site --jobs 0 -o report-site
+    - name: Push report to gitub pages
+      # if: github.ref == 'refs/heads/master'
+      uses: JamesIves/github-pages-deploy-action@v4.2.5
+      with:
+        branch: gh-pages
+        folder: report-site
+        single_commit: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,15 +41,6 @@ jobs:
     - name: "Pull reports"
       run: nix-build -A report-site -o report-site
 
-    - name: Push report to gitub pages
-      if: runner.os == 'Linux' # && github.ref == 'refs/heads/master'
-      uses: JamesIves/github-pages-deploy-action@releases/v3
-      with:
-        ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: report-site
-        SINGLE_COMMIT: true
-
     - name: Calculate performance delta
       if: runner.os == 'Linux' && github.event_name == 'pull_request'
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,18 @@ jobs:
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 
+    - name: "Pull reports"
+      run: nix-build -A report-site -o report-site
+
+    - name: Push report to gitub pages
+      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/joachim/deploy-reports'
+      uses: JamesIves/github-pages-deploy-action@releases/v3
+      with:
+        ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: report-site
+        SINGLE_COMMIT: true
+
     - name: Calculate performance delta
       if: runner.os == 'Linux' && github.event_name == 'pull_request'
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,6 @@ jobs:
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 
-    - name: "Pull reports"
-      run: nix-build -A report-site -o report-site
-
     - name: Calculate performance delta
       if: runner.os == 'Linux' && github.event_name == 'pull_request'
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,9 +79,8 @@ jobs:
         edit-mode: replace
 
   reports:
-    # while testing:
-    # if: github.ref == 'refs/heads/master'
-    #needs: tests
+    if: github.ref == 'refs/heads/master'
+    needs: tests
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: nix-build -A report-site -o report-site
 
     - name: Push report to gitub pages
-      if: "runner.os == 'Linux' && (github.ref == 'refs/heads/master' || github.head_ref == 'refs/heads/joachim/deploy-reports')"
+      #if: "runner.os == 'Linux' && (github.ref == 'refs/heads/master' || github.head_ref == 'refs/heads/joachim/deploy-reports')"
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/CI.md
+++ b/CI.md
@@ -94,22 +94,28 @@ Mergify reacts to the `automerge-squash` label. Once approved and CI passes, it
 merges master into the branch (using normal merge, which is important for
 stashed PRs) and then squash-merges the PR.
 
-Render and show generated base docs
------------------------------------
+Render and provide various reports
+----------------------------------
 **Use-case:**
-To be able to see and share the effects on the generated documentation for the base library, caused by a change to `mo-doc`, without needing the reviewer to generate the documentation locally.
+Various build artifacts are most useful when available directly in the browser, namely:
+
+ * The motoko user guide
+ * The “overview slides”
+ * The documentation for `motoko-base`, in the version pinned by motoko
+ * Flamegraphs for the programs in `tests/perf`
+
+A stable link to these should exist for `master`, and an easy-to-find link for each PR.
 
 **Implementation (internal):**
-Hydra hosts the build product of the `base-doc` CI job. This can be found via the Hydra job status page, and the there is a stable link for the latest build of `master` and of each PR.
+Hydra hosts the build products of the relevant jobs, and can be found via the
+Hydra job status page, and the there is a stable link for the latest build of
+`master` and of each PR.
 
-Render and show slides
-----------------------
-**Use-case:**
-To be able to see and share the “overview slides”, the rendered version should be hosted somewhere.
-
-**Implementation (internal):**
-Hydra hosts the build product of the `overview-slides` CI job. This can be found via the Hydra job status page, and the there is a stable link for the latest build of `master` and of each PR.
-
+**Implementation (external):**
+The latest `master` version of the file is availble at
+<https://dfinity.github.io/motoko/>.
+The reports are calculated in PRs (so failures would be caught), but are not
+hosted anywhere.
 
 Performance changes are known
 -----------------------------

--- a/default.nix
+++ b/default.nix
@@ -617,7 +617,7 @@ rec {
     '';
   };
 
-  report = nixpkgs.runCommandNoCC "netlify-site" {
+  report-site = nixpkgs.runCommandNoCC "report-site" {
     buildInputs = [ nixpkgs.tree ];
   } ''
     mkdir -p $out
@@ -689,6 +689,7 @@ rec {
       base-tests
       base-doc
       docs
+      report-site
       ic-ref-run
       shell
       check-formatting

--- a/default.nix
+++ b/default.nix
@@ -617,6 +617,22 @@ rec {
     '';
   };
 
+  netlify-site = nixpkgs.runCommandNoCC "netlify-site" {
+    buildInputs = [ nixpkgs.tree ];
+  } ''
+    mkdir -p $out
+    ln -s ${base-doc} $out/base-doc
+    ln -s ${docs} $out/docs
+    ln -s ${tests.profiling-graphs} $out/flamegraphs
+    cd $out;
+    # generate a simple index.html, listing the entry points
+    ( echo docs/overview-slides.html;
+      echo docs/docs/language-guide/motoko.html;
+      echo base-doc/index.html
+      echo flamegraphs/index.html ) | \
+      tree -H . -l --fromfile -T "Motoko build reports" > index.html
+  '';
+
   check-generated = nixpkgs.runCommandNoCC "check-generated" {
       nativeBuildInputs = [ nixpkgs.diffutils ];
       expected = import ./nix/generate.nix { pkgs = nixpkgs; };

--- a/default.nix
+++ b/default.nix
@@ -617,7 +617,7 @@ rec {
     '';
   };
 
-  netlify-site = nixpkgs.runCommandNoCC "netlify-site" {
+  report = nixpkgs.runCommandNoCC "netlify-site" {
     buildInputs = [ nixpkgs.tree ];
   } ''
     mkdir -p $out


### PR DESCRIPTION
This publishes our various reports to https://dfinity.github.io/motoko/. So far, only for `master` (github action doesn’t support PR deployments like netlify would).
