### PR TITLE
Fix #3121

### DIFF
--- a/src/mo_frontend/static.ml
+++ b/src/mo_frontend/static.ml
@@ -104,9 +104,10 @@ and triv m p = match p.it with
   patterns here.
   *)
   | TupP ps -> List.iter (triv m) ps
+  | ObjP fs -> List.iter (fun (f : pat_field) -> triv m f.it.pat) fs
 
   (* TODO:
-    claudio: what about record patterns, singleton variant patterns? These are irrefutable too.
+    claudio: what about singleton variant patterns? These are irrefutable too.
     Andreas suggests simply allowing all patterns: "The worst that can happen is that the program
     is immediately terminated, but that doesn't break anything semantically."
   *)

--- a/src/mo_frontend/static.ml
+++ b/src/mo_frontend/static.ml
@@ -93,18 +93,18 @@ and exp_fields m efs = List.iter (fun (ef : exp_field) -> exp m ef.it.exp) efs
 and dec m d = match d.it with
   | TypD _ | ClassD _ -> ()
   | ExpD e -> exp m e
-  | LetD (p, e) -> triv m p; exp m e
+  | LetD (p, e) -> pat m p; exp m e
   | VarD _ -> err m d.at
 
-and triv m p = match p.it with
+and pat m p = match p.it with
   | (WildP | VarP _) -> ()
 
   (*
   If we allow projections above, then we should allow irrefutable
   patterns here.
   *)
-  | TupP ps -> List.iter (triv m) ps
-  | ObjP fs -> List.iter (fun (f : pat_field) -> triv m f.it.pat) fs
+  | TupP ps -> List.iter (pat m) ps
+  | ObjP fs -> List.iter (fun (f : pat_field) -> pat m f.it.pat) fs
 
   (* TODO:
     claudio: what about singleton variant patterns? These are irrefutable too.

--- a/test/run/3121-imp.mo
+++ b/test/run/3121-imp.mo
@@ -1,1 +1,3 @@
 import { Array_init = init } = "mo:⛔"
+
+module {}

--- a/test/run/ok/3121.tc.ok
+++ b/test/run/ok/3121.tc.ok
@@ -1,1 +1,0 @@
-3121-imp.mo:1.8-1.29: type error [M0015], only trivial patterns allowed in static expressions

--- a/test/run/ok/3121.tc.ret.ok
+++ b/test/run/ok/3121.tc.ret.ok
@@ -1,1 +1,0 @@
-Return code 1


### PR DESCRIPTION
Product patterns like `ObjP` should be allowed to be static (side-effect-free when matching in CBV) so allow them also. Analogous to `TupP`.