### PR TITLE
Make module `Serialization` parametrised in the output streaming direction

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -4197,7 +4197,7 @@ module BumpStream : Stream = struct
     compile_unboxed_const 1l ^^ advance_data_buf get_data_buf
 
   let write_blob env get_data_buf get_x =
-    let (set_len, get_len) = new_local env "len" in
+    let set_len, get_len = new_local env "len" in
     get_x ^^ Blob.len env ^^ set_len ^^
     write_word_leb env get_data_buf get_len ^^
     get_data_buf ^^
@@ -4207,7 +4207,7 @@ module BumpStream : Stream = struct
     get_len ^^ advance_data_buf get_data_buf
 
   let write_text env get_data_buf get_x =
-    let (set_len, get_len) = new_local env "len" in
+    let set_len, get_len = new_local env "len" in
     get_x ^^ Text.size env ^^ set_len ^^
     write_word_leb env get_data_buf get_len ^^
     get_x ^^ get_data_buf ^^ Text.to_buf env ^^

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -4171,8 +4171,8 @@ module type Stream = sig
   val write_word_32 : E.t -> G.t -> G.t -> G.t
   val write_blob : E.t -> G.t -> G.t -> G.t
   val write_text : E.t -> G.t -> G.t -> G.t
-  val write_unsigned : E.t -> G.t -> G.t -> G.t
-  val write_signed : E.t -> G.t -> G.t -> G.t
+  val write_bignum_leb : E.t -> G.t -> G.t -> G.t
+  val write_bignum_sleb : E.t -> G.t -> G.t -> G.t
 
   (* opportunity to flush or update, stream token is on stack *)
   val checkpoint : E.t -> G.t -> G.t
@@ -4224,13 +4224,13 @@ module BumpStream : Stream = struct
     get_x ^^ get_data_buf ^^ Text.to_buf env ^^
     get_len ^^ advance_data_buf get_data_buf
 
-  let write_unsigned env get_data_buf get_x =
+  let write_bignum_leb env get_data_buf get_x =
     get_data_buf ^^
     get_x ^^
     BigNum.compile_store_to_data_buf_unsigned env ^^
     advance_data_buf get_data_buf
 
-  let write_signed env get_data_buf get_x =
+  let write_bignum_sleb env get_data_buf get_x =
     get_data_buf ^^
     get_x ^^
     BigNum.compile_store_to_data_buf_signed env ^^
@@ -4607,7 +4607,7 @@ module MakeSerialization (Strm : Stream) = struct
 
       (* Some combinators for writing values *)
 
-      let write_word, write_word32, write_byte, write_blob, write_text, write_unsigned, write_signed = Strm.(write_word_leb env get_data_buf, write_word_32 env get_data_buf, write_byte env get_data_buf, write_blob env get_data_buf, write_text env get_data_buf, write_unsigned env get_data_buf, write_signed env get_data_buf) in
+      let write_word, write_word32, write_byte, write_blob, write_text, write_unsigned, write_signed = Strm.(write_word_leb env get_data_buf, write_word_32 env get_data_buf, write_byte env get_data_buf, write_blob env get_data_buf, write_text env get_data_buf, write_bignum_leb env get_data_buf, write_bignum_sleb env get_data_buf) in
 
       let write env t =
         get_data_buf ^^

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -4606,8 +4606,9 @@ module MakeSerialization (Strm : Stream) = struct
       let set_ref_buf = G.setter_for get_ref_buf in
 
       (* Some combinators for writing values *)
-
-      let write_word, write_word32, write_byte, write_blob, write_text, write_unsigned, write_signed = Strm.(write_word_leb env get_data_buf, write_word_32 env get_data_buf, write_byte env get_data_buf, write_blob env get_data_buf, write_text env get_data_buf, write_bignum_leb env get_data_buf, write_bignum_sleb env get_data_buf) in
+      let    [write_word;     write_word32;  write_byte; write_blob; write_text; write_unsigned;   write_signed] =
+        Strm.[write_word_leb; write_word_32; write_byte; write_blob; write_text; write_bignum_leb; write_bignum_sleb]
+        |> List.map (fun f -> f env get_data_buf) in
 
       let write env t =
         get_data_buf ^^

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -4188,8 +4188,8 @@ module BumpStream : Stream = struct
 
   let write_word_32 env get_data_buf code =
     get_data_buf ^^ code ^^
-    G.i (Store {ty = I32Type; align = 0; offset = 0l; sz = Some Wasm.Types.Pack8}) ^^
-    compile_unboxed_const 1l ^^ advance_data_buf get_data_buf
+    G.i (Store {ty = I32Type; align = 0; offset = 0l; sz = None}) ^^
+    compile_unboxed_const Heap.word_size ^^ advance_data_buf get_data_buf
 
   let write_byte _env get_data_buf code =
     get_data_buf ^^ code ^^

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -4592,36 +4592,11 @@ module MakeSerialization (Strm : Stream) = struct
     let name = "@serialize_go<" ^ typ_hash t ^ ">" in
     Func.share_code3 env name (("x", I32Type), ("data_buffer", I32Type), ("ref_buffer", I32Type)) [I32Type; I32Type]
     (fun env get_x get_data_buf get_ref_buf ->
-      (*let set_data_buf = G.setter_for get_data_buf in*)
       let set_ref_buf = G.setter_for get_ref_buf in
 
       (* Some combinators for writing values *)
-(*
-      let advance_data_buf =
-        get_data_buf ^^ G.i (Binary (Wasm.Values.I32 I32Op.Add)) ^^ set_data_buf in
- *)
 
       let write_word, write_word32, write_byte, write_blob, write_text, write_unsigned, write_signed = Strm.(write_word_leb env get_data_buf, write_word_32 env get_data_buf, write_byte env get_data_buf, write_blob env get_data_buf, write_text env get_data_buf, write_unsigned env get_data_buf, write_signed env get_data_buf) in
-      (*
-      let write_word code =
-        let set_word, get_word = new_local env "word" in
-        code ^^ set_word ^^
-        I32Leb.compile_store_to_data_buf_unsigned env get_word get_data_buf ^^
-        advance_data_buf
-      in
-
-      let write_word32 code =
-        get_data_buf ^^ code ^^
-        G.i (Store {ty = I32Type; align = 0; offset = 0l; sz = None}) ^^
-        compile_unboxed_const Heap.word_size ^^ advance_data_buf
-      in
-
-      let write_byte code =
-        get_data_buf ^^ code ^^
-        G.i (Store {ty = I32Type; align = 0; offset = 0l; sz = Some Wasm.Types.Pack8}) ^^
-        compile_unboxed_const 1l ^^ advance_data_buf
-      in
-       *)
 
       let write env t =
         get_data_buf ^^
@@ -4678,20 +4653,8 @@ module MakeSerialization (Strm : Stream) = struct
       begin match t with
       | Prim Nat ->
         write_unsigned get_x
-        (*
-        get_data_buf ^^
-        get_x ^^
-        BigNum.compile_store_to_data_buf_unsigned env ^^
-        advance_data_buf
-         *)
       | Prim Int ->
         write_signed get_x
-        (*
-        get_data_buf ^^
-        get_x ^^
-        BigNum.compile_store_to_data_buf_signed env ^^
-        advance_data_buf
-         *)
       | Prim Float ->
         get_data_buf ^^
         get_x ^^ Float.unbox env ^^
@@ -4760,25 +4723,8 @@ module MakeSerialization (Strm : Stream) = struct
           ( E.trap_with env "serialize_go: unexpected variant" )
       | Prim Blob ->
         write_blob get_x
-        (*
-        let (set_len, get_len) = new_local env "len" in
-        get_x ^^ Blob.len env ^^ set_len ^^
-        write_word get_len ^^
-        get_data_buf ^^
-        get_x ^^ Blob.payload_ptr_unskewed ^^
-        get_len ^^
-        Heap.memcpy env ^^
-        get_len ^^ advance_data_buf
-         *)
       | Prim Text ->
         write_text get_x
-        (*
-        let (set_len, get_len) = new_local env "len" in
-        get_x ^^ Text.size env ^^ set_len ^^
-        write_word get_len ^^
-        get_x ^^ get_data_buf ^^ Text.to_buf env ^^
-        get_len ^^ advance_data_buf
-         *)
       | Func _ ->
         write_byte (compile_unboxed_const 1l) ^^
         get_x ^^ Arr.load_field 0l ^^ write env (Obj (Actor, [])) ^^

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -4195,7 +4195,7 @@ module BumpStream : Stream = struct
     let set_word, get_word = new_local env "word" in
     code ^^ set_word ^^
     I32Leb.compile_store_to_data_buf_unsigned env get_word get_data_buf ^^
-        advance_data_buf get_data_buf
+    advance_data_buf get_data_buf
 
   let write_word_32 env get_data_buf code =
     get_data_buf ^^ code ^^

--- a/src/wasm-exts/customModuleEncode.ml
+++ b/src/wasm-exts/customModuleEncode.ml
@@ -832,7 +832,7 @@ let encode (em : extended_module) =
       | None -> ()
       | Some (is_public, x) ->
         section 0 (fun x ->
-          string ("icp:"^ (if is_public then "public " else "private ") ^ name);
+          string ("icp:" ^ (if is_public then "public " else "private ") ^ name); Printf.eprintf "name: %s value: %s\n" name x;
           f x
         ) x true
 

--- a/src/wasm-exts/customModuleEncode.ml
+++ b/src/wasm-exts/customModuleEncode.ml
@@ -832,7 +832,7 @@ let encode (em : extended_module) =
       | None -> ()
       | Some (is_public, x) ->
         section 0 (fun x ->
-          string ("icp:" ^ (if is_public then "public " else "private ") ^ name); Printf.eprintf "name: %s value: %s\n" name x;
+          string ("icp:"^ (if is_public then "public " else "private ") ^ name);
           f x
         ) x true
 


### PR DESCRIPTION
This is a prelude to #3149. It doesn't change the generated code, just introduces a few holes in the serialiser that can be plugged with code fragments from a `Stream`. Later there will be different `Stream` implementations, but for now we only have the legacy `BumpStream` one. (Actually, there is a minor change in the generated code, which reflects how the stream now `reserve`s a small scratch area for writing, whereas previously it would write right away, and bump the pointer thereafter.)

**Big caveat**: The generated functions coming from `Serialization` (by `Func.share_code`) are still named the same. To make the naming sane, the `Stream` needs to bring its own name plumber. Since we only instantiate once in this PR, this is currently not a problem.

TODO: We definitely need two more interfaces to make this work with generic streams:
- `setup`: create the stream token
- `destroy`: flush the stream and terminate the token.

These are not mandatory in this PR, but when the first other stream appears.