### PR TITLE
`perf-delta.nix`: use `--omit-metadata motoko:compiler` to filter out revision fuzz

### DIFF
--- a/perf-delta.nix
+++ b/perf-delta.nix
@@ -32,13 +32,14 @@ let
       src = test-data;
       buildInputs = [ moc ];
       buildPhase = ''
+        moc --version
         for file in */*.mo
         do
           # ignore all errors
           echo -n $file
-          if timeout 10s moc $file --force-gc --compacting-gc -no-check-ir -ref-system-api -o $file.wasm 2>/dev/null
-          then echo " failed (ignored)"
-          else echo " ok"
+          if timeout 10s moc $file --omit-metadata motoko:compiler --force-gc --compacting-gc -no-check-ir -ref-system-api -o $file.wasm 2>/dev/null
+          then echo " ok"
+          else echo " failed (ignored)"
           fi
         done
 


### PR DESCRIPTION
also
-  include the `moc` version into the log
- and fix the ok/fail messages (was inverted)

We still have a lot of ignored compilations, because we probably have to mangle the inputs like `run.sh` does.