### PR TITLE
bug: prim inliner produces unexpected indirect calls when call_as_prim is false.

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -7728,7 +7728,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
            (* ugly case; let's just call this as a function for now *)
            raise (Invalid_argument "call_as_prim was true?")
          end
-      | SR.Const (_, Const.Fun (mk_fi, Const.Complicated)), _ ->
+      | SR.Const (_, Const.Fun (mk_fi, _)), _ ->
          assert (sort = Type.Local);
          StackRep.of_arity return_arity,
 

--- a/test/run-drun/inline.mo
+++ b/test/run-drun/inline.mo
@@ -2,11 +2,14 @@
 import Prim "mo:⛔";
 
 actor {
-  func inline(t : Text) : () = (prim "printText" : Text -> ()) t;
-  func outline(t : Text) : () = (prim "printText" : Text -> ()) "sometext";
+  func inline(t1: Text, t2 : Text) : Text = t1 # t2;
+  func makecalls() : () {
+    let t1 = inline("a","b"); // should be inlined
+    var p = ("c","d");
+    let t2 = inline p; // should not be inlined, but a still direct call
+  };
   public func go() : async () {
-    inline("inline me"); // should be inlined
-    outline("outline me"); // should not be inlined, but a direct call
+    makecalls();
   }
 }
 

--- a/test/run-drun/inline.mo
+++ b/test/run-drun/inline.mo
@@ -1,0 +1,17 @@
+//MOC-ENV MOC_UNLOCK_PRIM=yesplease
+import Prim "mo:⛔";
+
+actor {
+  func inline(t : Text) : () = (prim "printText" : Text -> ()) t;
+  func outline(t : Text) : () = (prim "printText" : Text -> ()) "sometext";
+  public func go() : async () {
+    inline("inline me"); // should be inlined
+    outline("outline me"); // should not be inlined, but a direct call
+  }
+}
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+//SKIP comp-ref
+//CALL ingress go "DIDL\x00\x00"

--- a/test/run-drun/inline.mo
+++ b/test/run-drun/inline.mo
@@ -16,5 +16,8 @@ actor {
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
-//SKIP comp-ref
-//CALL ingress go "DIDL\x00\x00"
+
+
+// CHECK-LABEL: (func $makecalls
+// CHECK-NOT: call_indirect
+// CHECK: call $inline

--- a/test/run-drun/inline.mo
+++ b/test/run-drun/inline.mo
@@ -6,7 +6,7 @@ actor {
   func makecalls() : () {
     let t1 = inline("a","b"); // should be inlined
     var p = ("c","d");
-    let t2 = inline p; // should not be inlined, but a still direct call
+    let t2 = inline p; // should not be inlined, but still just a direct call
   };
   public func go() : async () {
     makecalls();
@@ -16,7 +16,6 @@ actor {
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
-
 
 // CHECK-LABEL: (func $makecalls
 // CHECK-NOT: call_indirect

--- a/test/run-drun/ok/inline.drun-run.ok
+++ b/test/run-drun/ok/inline.drun-run.ok
@@ -1,0 +1,2 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/inline.ic-ref-run.ok
+++ b/test/run-drun/ok/inline.ic-ref-run.ok
@@ -1,0 +1,4 @@
+→ update create_canister(record {settings = null})
+← replied: (record {hymijyo = principal "cvccv-qqaaq-aaaaa-aaaaa-c"})
+→ update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
+← replied: ()


### PR DESCRIPTION
Add a bug repro for #3159
```
//MOC-ENV MOC_UNLOCK_PRIM=yesplease
import Prim "mo:⛔";

actor {
  func inline(t1: Text, t2 : Text) : Text = t1 # t2;
  func makecalls() : () {
    let t1 = inline("a","b"); // should be inlined
    var p = ("c","d");
    let t2 = inline p; // should not be inlined, but a still direct call
  };
  public func go() : async () {
    makecalls();
  }
}

//SKIP run
//SKIP run-ir
//SKIP run-low
//SKIP comp-ref
//CALL ingress go "DIDL\x00\x00"
```
generates 
```
(func $makecalls (type 4) (param $clos i32)
    (local $t1 i32) (local $p i32) (local $t2 i32) (local $clos.1 i32)
    i32.const 66431
    i32.const 66419
    call $text_concat
    local.set $t1
    i32.const 66403
    local.set $p
    i32.const 66367
    local.tee $clos.1
    local.get $p
    call $from_2_tuple
    global.get 2
    global.get 3
    local.get $clos.1
    i32.load offset=5
    call_indirect (type 11)
    local.set $t2)
```

but the last `call_indirect` could be a `call`, I think.

Added https://github.com/dfinity/motoko/pull/3196/commits/81e215e737818f247daaca53a266b73351ae8cf4 as a fix, after which we produce:
```
  (func $makecalls (type 4) (param $clos i32)
    (local $t1 i32) (local $p i32) (local $t2 i32)
    i32.const 66419
    i32.const 66407
    call $text_concat
    local.set $t1
    i32.const 66391
    local.set $p
    i32.const 0
    local.get $p
    call $from_2_tuple
    global.get 2
    global.get 3
    call $inline
    local.set $t2)
```