### PR TITLE
Simple peephole rules around `Eqz`

### DIFF
--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -60,7 +60,7 @@ let optimize : instr list -> instr list = fun is ->
     | ({it = Compare (I32 I32Op.Eq); _} as i) :: {it = Const {it = I32 0l; _}; _} :: l', r' ->
       go l' ({ i with it = Test (I32 I32Op.Eqz)} :: r')
     | ({it = Compare (I64 I64Op.Eq); _} as i) :: {it = Const {it = I64 0L; _}; _} :: l', r' ->
-      go l' ({ i with it = Test (I64 I64Op.Eqz)} :: r')
+      assert (2l = 21l); go l' ({ i with it = Test (I64 I64Op.Eqz)} :: r')
     (* eqz after eq/ne becomes ne/eq *)
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (I32 I32Op.Eq); _} :: l', r' ->
       go l' ({ i with it = Compare (I32 I32Op.Ne)} :: r')

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -63,7 +63,7 @@ let optimize : instr list -> instr list = fun is ->
       go l' ({ i with it = Test (I64 I64Op.Eqz)} :: r')
     (* Constants before `Eqz` reduce trivially *)
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Const {it = I32 n; _}; _} :: l', r' ->
-      assert (2l = 23l); go l' ({ i with it = Const {it = I32 (if n = 0l then 1l else 0l); at = i.at}} :: r')
+      go l' ({ i with it = Const {it = I32 (if n = 0l then 1l else 0l); at = i.at}} :: r')
     | ({it = Test (I64 I64Op.Eqz); _} as i) :: {it = Const {it = I64 n; _}; _} :: l', r' ->
       assert (2l = 22l); go l' ({ i with it = Const {it = I32 (if n = 0L then 1l else 0l); at = i.at}} :: r')
     (* eqz after eq/ne becomes ne/eq *)

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -56,26 +56,28 @@ let optimize : instr list -> instr list = fun is ->
     | _, ({ it = Return | Br _ | Unreachable; _ } as i) :: t ->
       (* see Note [funneling DIEs through Wasm.Ast] *)
       List.(rev (i :: l) @ find_all (fun instr -> Wasm_exts.Ast.is_dwarf_like instr.it) t)
-    (* Equals zero has an dedicated operation (and works well with leg swapping) *)
+    (* Equals zero has a dedicated operation (and works well with leg swapping) *)
     | ({it = Compare (I32 I32Op.Eq); _} as i) :: {it = Const {it = I32 0l; _}; _} :: l', r' ->
-      go l' ({ i with it = Test (I32 I32Op.Eqz)}  :: r')
+      go l' ({ i with it = Test (I32 I32Op.Eqz)} :: r')
+    | ({it = Compare (I64 I64Op.Eq); _} as i) :: {it = Const {it = I64 0L; _}; _} :: l', r' ->
+      go l' ({ i with it = Test (I64 I64Op.Eqz)} :: r')
     (* eqz after eq/ne becomes ne/eq *)
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (I32 I32Op.Eq); _} :: l', r' ->
-      go l' ({ i with it = Compare (I32 I32Op.Ne)}  :: r')
+      go l' ({ i with it = Compare (I32 I32Op.Ne)} :: r')
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (I32 I32Op.Ne); _} :: l', r' ->
-      go l' ({ i with it = Compare (I32 I32Op.Eq)}  :: r')
+      go l' ({ i with it = Compare (I32 I32Op.Eq)} :: r')
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (I64 I64Op.Eq); _} :: l', r' ->
-      go l' ({ i with it = Compare (I64 I64Op.Ne)}  :: r')
+      go l' ({ i with it = Compare (I64 I64Op.Ne)} :: r')
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (I64 I64Op.Ne); _} :: l', r' ->
-      go l' ({ i with it = Compare (I64 I64Op.Eq)}  :: r')
+      go l' ({ i with it = Compare (I64 I64Op.Eq)} :: r')
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (F32 F32Op.Eq); _} :: l', r' ->
-      go l' ({ i with it = Compare (F32 F32Op.Ne)}  :: r')
+      go l' ({ i with it = Compare (F32 F32Op.Ne)} :: r')
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (F32 F32Op.Ne); _} :: l', r' ->
-      go l' ({ i with it = Compare (F32 F32Op.Eq)}  :: r')
+      go l' ({ i with it = Compare (F32 F32Op.Eq)} :: r')
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (F64 F64Op.Eq); _} :: l', r' ->
-      go l' ({ i with it = Compare (F64 F64Op.Ne)}  :: r')
+      go l' ({ i with it = Compare (F64 F64Op.Ne)} :: r')
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (F64 F64Op.Ne); _} :: l', r' ->
-      go l' ({ i with it = Compare (F64 F64Op.Eq)}  :: r')
+      go l' ({ i with it = Compare (F64 F64Op.Eq)} :: r')
     (* `If` blocks after pushed constants are simplifiable *)
     | { it = Const {it = I32 0l; _}; _} :: l', ({it = If (res,_,else_); _} as i) :: r' ->
       go l' ({i with it = Block (res, else_)} :: r')

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -60,7 +60,7 @@ let optimize : instr list -> instr list = fun is ->
     | ({it = Compare (I32 I32Op.Eq); _} as i) :: {it = Const {it = I32 0l; _}; _} :: l', r' ->
       go l' ({ i with it = Test (I32 I32Op.Eqz)} :: r')
     | ({it = Compare (I64 I64Op.Eq); _} as i) :: {it = Const {it = I64 0L; _}; _} :: l', r' ->
-      assert (2l = 21l); go l' ({ i with it = Test (I64 I64Op.Eqz)} :: r')
+      go l' ({ i with it = Test (I64 I64Op.Eqz)} :: r')
     (* Constants before `Eqz` reduce trivially *)
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Const {it = I32 n; _}; _} :: l', r' ->
       assert (2l = 23l); go l' ({ i with it = Const {it = I32 (if n = 0l then 1l else 0l); at = i.at}} :: r')

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -61,6 +61,11 @@ let optimize : instr list -> instr list = fun is ->
       go l' ({ i with it = Test (I32 I32Op.Eqz)} :: r')
     | ({it = Compare (I64 I64Op.Eq); _} as i) :: {it = Const {it = I64 0L; _}; _} :: l', r' ->
       assert (2l = 21l); go l' ({ i with it = Test (I64 I64Op.Eqz)} :: r')
+    (* Constants before `Eqz` reduce trivially *)
+    | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Const {it = I32 n; _}; _} :: l', r' ->
+      assert (2l = 23l); go l' ({ i with it = Const {it = I32 (if n = 0l then 1l else 0l); at = i.at}} :: r')
+    | ({it = Test (I64 I64Op.Eqz); _} as i) :: {it = Const {it = I64 n; _}; _} :: l', r' ->
+      assert (2l = 22l); go l' ({ i with it = Const {it = I32 (if n = 0L then 1l else 0l); at = i.at}} :: r')
     (* eqz after eq/ne becomes ne/eq *)
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (I32 I32Op.Eq); _} :: l', r' ->
       go l' ({ i with it = Compare (I32 I32Op.Ne)} :: r')

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -65,7 +65,7 @@ let optimize : instr list -> instr list = fun is ->
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Const {it = I32 n; _}; _} :: l', r' ->
       go l' ({ i with it = Const {it = I32 (if n = 0l then 1l else 0l); at = i.at}} :: r')
     | ({it = Test (I64 I64Op.Eqz); _} as i) :: {it = Const {it = I64 n; _}; _} :: l', r' ->
-      assert (2l = 22l); go l' ({ i with it = Const {it = I32 (if n = 0L then 1l else 0l); at = i.at}} :: r')
+      go l' ({ i with it = Const {it = I32 (if n = 0L then 1l else 0l); at = i.at}} :: r')
     (* eqz after eq/ne becomes ne/eq *)
     | ({it = Test (I32 I32Op.Eqz); _} as i) :: {it = Compare (I32 I32Op.Eq); _} :: l', r' ->
       go l' ({ i with it = Compare (I32 I32Op.Ne)} :: r')

--- a/test/run/words.mo
+++ b/test/run/words.mo
@@ -2,6 +2,24 @@ import Prim "mo:⛔";
 
 // CHECK: func $init
 
+// check for `Eqz` optimisation
+// CHECK: i64.const 424242
+assert not (424242 : Nat64 == 1);
+// CHECK-NOT: i64.eqz
+assert not (3 : Nat64 == 0);
+assert (0 : Nat64 == 0);
+// CHECK: i64.const 424342
+assert not (424342 : Nat64 == 1);
+
+// check for `Eqz` optimisation
+// CHECK: i32.const 424542
+assert not (424542 : Nat32 == 1);
+// CHECK-NOT: i32.eqz
+assert not (3 : Nat32 == 0);
+assert (0 : Nat32 == 0);
+// CHECK: i32.const 424842
+assert not (424842 : Nat32 == 1);
+
 func printBit(a : Bool) { Prim.debugPrint(if a "set" else "clear") };
 
 


### PR DESCRIPTION
Inspired by #3183. Fixes #3183.

- `push 0; i64.Eq` ~~> `i64.Eqz`
- `push n; i64.Eqz` ~~> `0` or `1` depending on `n`
- and the same for `i32.Eqz`

These rules are mostly triggered by the test suite, but I have added new tests too, so that all are covered.