### PR TITLE
rts: make `Blob` immutable by default

### DIFF
--- a/rts/motoko-rts/src/bigint.rs
+++ b/rts/motoko-rts/src/bigint.rs
@@ -207,7 +207,7 @@ unsafe extern "C" fn bigint_to_word32_trap_with(p: Value, msg: Value) -> u32 {
     let mp_int = p.as_bigint().mp_int_ptr();
 
     if mp_isneg(mp_int) || mp_count_bits(mp_int) > 32 {
-        crate::rts_trap(msg.as_blob().payload_addr(), msg.as_blob().len());
+        crate::rts_trap(msg.as_blob().payload_const(), msg.as_blob().len());
     }
 
     mp_get_u32(mp_int)

--- a/rts/motoko-rts/src/idl.rs
+++ b/rts/motoko-rts/src/idl.rs
@@ -72,7 +72,9 @@ unsafe fn parse_fields(buf: *mut Buf, n_types: u32) {
 
 // NB. This function assumes the allocation does not need to survive GC
 unsafe fn alloc<M: Memory>(mem: &mut M, size: Words<u32>) -> *mut u8 {
-    alloc_blob(mem, size.to_bytes()).as_blob_mut().payload_addr()
+    alloc_blob(mem, size.to_bytes())
+        .as_blob_mut()
+        .payload_addr()
 }
 
 /// This function parses the IDL magic header and type description. It

--- a/rts/motoko-rts/src/idl.rs
+++ b/rts/motoko-rts/src/idl.rs
@@ -72,7 +72,7 @@ unsafe fn parse_fields(buf: *mut Buf, n_types: u32) {
 
 // NB. This function assumes the allocation does not need to survive GC
 unsafe fn alloc<M: Memory>(mem: &mut M, size: Words<u32>) -> *mut u8 {
-    alloc_blob(mem, size.to_bytes()).as_blob().payload_addr()
+    alloc_blob(mem, size.to_bytes()).as_blob_mut().payload_addr()
 }
 
 /// This function parses the IDL magic header and type description. It

--- a/rts/motoko-rts/src/principal_id.rs
+++ b/rts/motoko-rts/src/principal_id.rs
@@ -95,10 +95,10 @@ unsafe fn enc_stash(pump: &mut Pump, data: u8) {
 pub unsafe fn base32_of_checksummed_blob<M: Memory>(mem: &mut M, b: Value) -> Value {
     let checksum = compute_crc32(b);
     let n = b.as_blob().len();
-    let mut data = b.as_blob().payload_addr();
+    let mut data = b.as_blob().payload_const();
 
     let r = alloc_blob(mem, Bytes((n.as_u32() + 4 + 4) / 5 * 8)); // contains padding
-    let blob = r.as_blob();
+    let blob = r.as_blob_mut();
     let dest = blob.payload_addr();
 
     let mut pump = Pump {
@@ -181,11 +181,11 @@ unsafe fn dec_stash(pump: &mut Pump, data: u8) {
 
 pub unsafe fn base32_to_blob<M: Memory>(mem: &mut M, b: Value) -> Value {
     let n = b.as_blob().len();
-    let mut data = b.as_blob().payload_addr();
+    let mut data = b.as_blob().payload_const();
 
     // Every group of 8 characters will yield 5 bytes
     let r = alloc_blob(mem, Bytes(((n.as_u32() + 7) / 8) * 5)); // we deal with padding later
-    let blob = r.as_blob();
+    let blob = r.as_blob_mut();
     let dest = blob.payload_addr();
 
     let mut pump = Pump {
@@ -220,11 +220,11 @@ unsafe fn base32_to_principal<M: Memory>(mem: &mut M, b: Value) -> Value {
     let blob = b.as_blob();
 
     let n = blob.len();
-    let mut data = blob.payload_addr();
+    let mut data = blob.payload_const();
 
     // Every group of 5 characters will yield 6 bytes (due to the hypen)
     let r = alloc_blob(mem, Bytes(((n.as_u32() + 4) / 5) * 6));
-    let blob = r.as_blob();
+    let blob = r.as_blob_mut();
     let mut dest = blob.payload_addr();
 
     let mut n_written = 0;
@@ -269,8 +269,8 @@ pub unsafe fn blob_of_principal<M: Memory>(mem: &mut M, t: Value) -> Value {
 
     let stripped = alloc_blob(mem, bytes_len - Bytes(4));
     memcpy_bytes(
-        stripped.as_blob().payload_addr() as usize,
-        bytes.as_blob().payload_addr().add(4) as usize,
+        stripped.as_blob_mut().payload_addr() as usize,
+        bytes.as_blob().payload_const().add(4) as usize,
         bytes_len - Bytes(4),
     );
 

--- a/rts/motoko-rts/src/text.rs
+++ b/rts/motoko-rts/src/text.rs
@@ -84,7 +84,11 @@ pub unsafe fn text_concat<M: Memory>(mem: &mut M, s1: Value, s2: Value) -> Value
 
         let r = alloc_text_blob(mem, new_len);
         let r_payload: *mut u8 = r.as_blob_mut().payload_addr();
-        memcpy_bytes(r_payload as usize, blob1.payload_const() as usize, blob1_len);
+        memcpy_bytes(
+            r_payload as usize,
+            blob1.payload_const() as usize,
+            blob1_len,
+        );
         memcpy_bytes(
             r_payload.add(blob1_len.as_usize()) as usize,
             blob2.payload_const() as usize,

--- a/rts/motoko-rts/src/text_iter.rs
+++ b/rts/motoko-rts/src/text_iter.rs
@@ -119,7 +119,7 @@ pub unsafe fn text_iter_next<M: Memory>(mem: &mut M, iter: Value) -> u32 {
         }
     } else {
         // We are not at the end, read the next character from the blob
-        let blob_payload = blob.payload_addr();
+        let blob_payload = blob.payload_const();
         let mut step: u32 = 0;
         let char = decode_code_point(blob_payload.add(pos as usize), &mut step as *mut u32);
         iter_array.set(ITER_POS_IDX, Value::from_scalar(pos + step));

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -213,7 +213,7 @@ impl Value {
     /// `Value::get_raw` and `unskew`) in our cost model where every Wasm instruction costs 1
     /// cycle.
     pub fn get(&self) -> PtrOrScalar {
-        if self.0 & 0b1 == 0b1 {
+        if self.0 & 0b1 != 0 {
             PtrOrScalar::Ptr(unskew(self.0 as usize))
         } else {
             PtrOrScalar::Scalar(self.0 >> 1)
@@ -312,7 +312,7 @@ impl Value {
 
 /// Returns whether a raw value is representing a pointer. Useful when using `Value::get_raw`.
 pub fn is_ptr(value: u32) -> bool {
-    value & 0b1 == 0b1
+    value & 0b1 != 0
 }
 
 pub const fn skew(ptr: usize) -> usize {

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -284,7 +284,12 @@ impl Value {
 
     /// Get the pointer as `Blob`. In debug mode panics if the value is not a pointer or the
     /// pointed object is not a `Blob`.
-    pub unsafe fn as_blob(self) -> *mut Blob {
+    pub unsafe fn as_blob(self) -> *const Blob {
+        debug_assert_eq!(self.tag(), TAG_BLOB);
+        self.get_ptr() as *const Blob
+    }
+
+    pub unsafe fn as_blob_mut(self) -> *mut Blob {
         debug_assert_eq!(self.tag(), TAG_BLOB);
         self.get_ptr() as *mut Blob
     }
@@ -460,12 +465,16 @@ impl Blob {
         self.add(1) as *mut u8 // skip closure header
     }
 
-    pub unsafe fn len(self: *mut Self) -> Bytes<u32> {
+    pub unsafe fn payload_const(self: *const Self) -> *const u8 {
+        self.add(1) as *mut u8 // skip closure header
+    }
+
+    pub unsafe fn len(self: *const Self) -> Bytes<u32> {
         (*self).len
     }
 
-    pub unsafe fn get(self: *mut Self, idx: u32) -> u8 {
-        *self.payload_addr().add(idx as usize)
+    pub unsafe fn get(self: *const Self, idx: u32) -> u8 {
+        *self.payload_const().add(idx as usize)
     }
 
     pub unsafe fn set(self: *mut Self, idx: u32, byte: u8) {


### PR DESCRIPTION
In most contexts `Blob` is being read from, so make `const` the default.
`as_blob_mut` is provided to allow write access.