### PR TITLE
rts: micro-optimise `mp_isneg`

### DIFF
--- a/rts/motoko-rts/src/bigint.rs
+++ b/rts/motoko-rts/src/bigint.rs
@@ -143,10 +143,12 @@ unsafe fn mp_get_u64(p: *const mp_int) -> u64 {
 }
 
 pub(crate) unsafe fn mp_isneg(p: *const mp_int) -> bool {
+    debug_assert_eq!((*p).sign, (*p).sign & 1);
     (*p).sign != 0
 }
 
 pub(crate) unsafe fn mp_iszero(p: *const mp_int) -> bool {
+    debug_assert_eq!((*p).used, (*p).used & 1);
     (*p).used == 0
 }
 

--- a/rts/motoko-rts/src/bigint.rs
+++ b/rts/motoko-rts/src/bigint.rs
@@ -143,7 +143,7 @@ unsafe fn mp_get_u64(p: *const mp_int) -> u64 {
 }
 
 pub(crate) unsafe fn mp_isneg(p: *const mp_int) -> bool {
-    (*p).sign == 1
+    (*p).sign != 0
 }
 
 pub(crate) unsafe fn mp_iszero(p: *const mp_int) -> bool {

--- a/rts/motoko-rts/src/bigint.rs
+++ b/rts/motoko-rts/src/bigint.rs
@@ -148,7 +148,6 @@ pub(crate) unsafe fn mp_isneg(p: *const mp_int) -> bool {
 }
 
 pub(crate) unsafe fn mp_iszero(p: *const mp_int) -> bool {
-    debug_assert_eq!((*p).used, (*p).used & 1);
     (*p).used == 0
 }
 


### PR DESCRIPTION
Non-negatives have `sign == 0`, so using inequality. There are only two possibilities:
https://github.com/libtom/libtommath/blob/develop/mtest/mpi.h#L35