### PR TITLE
doc: Candid serialization syntax

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * Add `to_candid`, `from_candid` language constructs for Candid serialization to/from Blobs (#3155)
+
 ## 0.6.26 (2022-04-20)
 
 * motoko (`moc`)

--- a/doc/README.md
+++ b/doc/README.md
@@ -5,7 +5,7 @@ You can build the documentation locally as follows:
 ```
 make
 python3 -m http.server --directory build/site/
-# now open http://0.0.0.0:8000/motoko/language-guide/motoko.html
+# now open http://0.0.0.0:8000/docs/language-guide/motoko.html
 ```
 
 This is somewhat hackish

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -99,12 +99,10 @@ All comments are treated as whitespace.
 The following keywords are reserved and may not be used as identifiers:
 
 ```bnf
-actor and assert await break case
-catch class continue debug debug_show do else flexible
-false for func if ignore in import not null object or
-label let loop private public query return
-shared stable system switch true try
-type var while
+actor and assert await break case catch class continue debug
+debug_show do else flexible false for from_candid func if ignore in
+import not null object or label let loop private public query return
+shared stable system switch to_candid true try type var while
 ```
 
 [[syntax-ids]]
@@ -407,7 +405,7 @@ The syntax of an _import_ `<imp>`  is as follows:
 ```
 
 An import introduces a resource referring to a local source module, module from a package of modules, or canister (imported as an actor).
-The contents of the resource are bound to `<pat>`. 
+The contents of the resource are bound to `<pat>`.
 
 Though typically a simple identifier, `<id>`, `<pat>` can also be any composite pattern binding selective components of the resource.
 
@@ -558,6 +556,8 @@ The syntax of an _expression_ is as follows:
   <exp> !                                        null break
   debug <block-or-exp>                           debug expression
   actor <exp>                                    actor reference
+  to_candid ( <exp>,* )                          Candid serialization
+  from_candid <exp>                              Candid deserialization
   ( <exp> )                                      parentheses
 
 <block-or-exp> ::=
@@ -2299,6 +2299,43 @@ Type annotation may be used to aid the type-checker when it cannot otherwise det
 The result of evaluating `<exp> : <typ>` is the result of evaluating `<exp>`.
 
 NOTE: Type annotations have no-runtime cost and cannot be used to perform the (checked or unchecked) `down-casts` available in other object-oriented languages.
+
+[#candid-serialization]
+=== Candid Serialization
+
+The _Candid serialization_ expression `to_candid ( <exp>,*)` has type `Blob` provided:
+
+* `(<exp>,*)` has type `(T1,...,TN)`, and each `Ti` is _shared_.
+
+
+Expression `+to_candid ( <exp>,* )+` evaluates the expression sequence `+( <exp>,* )_` to a result `r`.
+If `r` is `trap`, evaluation returns `trap`.
+Otherwise, `r` is a sequence of Motoko values `vs`.
+The result of evaluating `to_candid ( <exp>,* )` is some Candid blob `+b = encode((T1,...,TN))(vs)+`, encoding `vs`.
+
+The Candid _deserialization_ expression `from_candid <exp>` had type `?(T1,...,Tn)` provided:
+
+* `?(T1,...,Tn)` is the expected type from the context;
+* `<exp>` has type `Blob`; and
+* `?(T1,...TN)` is _shared_.
+
+Expression `+from_candid <exp>+` evaluates `<exp>` to a result `r`. If `r` is `trap`, evaluation returns `trap`. Otherwise `r` is a binary blob `b`.
+If `b` Candid-decodes to Candid value sequence `Vs` of type `+ea((T1,...,TN))+` then the result of `from_candid` is `?v` where  `+v = decode((T1,...,TN))(Vs)+`.
+If `b` Candid-decodes to a Candid value sequence `Vs` that is not of  Candid type `+ea((T1,...,TN))+` (but well-formed at some other type) then the result is `null`.
+If `b` is not the encoding of any well-typed Candid value, but some arbitrary binary blob, then the result of `from_candid` is a trap.
+
+(Informally, here `ea(_)` is the Motoko-to-Candid type sequence translation and `+encode/decode((T1,...,TN))(_)+` are type-directed Motoko-Candid value translations).
+
+////
+ea(_) is defined in design doc motoko/design/IDL-Motoko.md, but `encode` and `decode` are not explicitly defined anywhere except in the implementation.
+////
+
+
+NOTE: `to_candid` and `from_candid` are syntactic operators, not first-class functions, and must be fully applied in the syntax.
+
+WARNING: the Candid encoding of a value as a blob is not unique and the same value may have many different Candid-representations as a blob.
+For this reason, blobs should never be used to, for instance, compute hashes of values or determine equality, whether across compiler
+versions or even just different programs.
 
 [[exp-decl]]
 === Declaration

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -2307,13 +2307,12 @@ The _Candid serialization_ expression `to_candid ( <exp>,*)` has type `Blob` pro
 
 * `(<exp>,*)` has type `(T1,...,TN)`, and each `Ti` is _shared_.
 
-
-Expression `+to_candid ( <exp>,* )+` evaluates the expression sequence `+( <exp>,* )_` to a result `r`.
+Expression `+to_candid ( <exp>,* )+` evaluates the expression sequence `+( <exp>,* )+` to a result `r`.
 If `r` is `trap`, evaluation returns `trap`.
 Otherwise, `r` is a sequence of Motoko values `vs`.
 The result of evaluating `to_candid ( <exp>,* )` is some Candid blob `+b = encode((T1,...,TN))(vs)+`, encoding `vs`.
 
-The Candid _deserialization_ expression `from_candid <exp>` had type `?(T1,...,Tn)` provided:
+The Candid _deserialization_ expression `from_candid <exp>` has type `?(T1,...,Tn)` provided:
 
 * `?(T1,...,Tn)` is the expected type from the context;
 * `<exp>` has type `Blob`; and
@@ -2324,12 +2323,14 @@ If `b` Candid-decodes to Candid value sequence `Vs` of type `+ea((T1,...,TN))+` 
 If `b` Candid-decodes to a Candid value sequence `Vs` that is not of  Candid type `+ea((T1,...,TN))+` (but well-formed at some other type) then the result is `null`.
 If `b` is not the encoding of any well-typed Candid value, but some arbitrary binary blob, then the result of `from_candid` is a trap.
 
-(Informally, here `ea(_)` is the Motoko-to-Candid type sequence translation and `+encode/decode((T1,...,TN))(_)+` are type-directed Motoko-Candid value translations).
+(Informally, here `ea(_)` is the Motoko-to-Candid type sequence translation and `+encode/decode((T1,...,TN))(_)+` are type-directed Motoko-Candid value translations.)
 
 ////
 ea(_) is defined in design doc motoko/design/IDL-Motoko.md, but `encode` and `decode` are not explicitly defined anywhere except in the implementation.
 ////
 
+
+NOTE: `from_candid` returns `null` when the argument is a valid Candid encoding of the wrong type. It traps if the blob is not a valid Candid encoding at all.
 
 NOTE: `to_candid` and `from_candid` are syntactic operators, not first-class functions, and must be fully applied in the syntax.
 

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -2334,7 +2334,7 @@ NOTE: `from_candid` returns `null` when the argument is a valid Candid encoding 
 
 NOTE: `to_candid` and `from_candid` are syntactic operators, not first-class functions, and must be fully applied in the syntax.
 
-WARNING: the Candid encoding of a value as a blob is not unique and the same value may have many different Candid-representations as a blob.
+WARNING: the Candid encoding of a value as a blob is not unique and the same value may have many different Candid representations as a blob.
 For this reason, blobs should never be used to, for instance, compute hashes of values or determine equality, whether across compiler
 versions or even just different programs.
 

--- a/test/run-drun/call-raw-candid.mo
+++ b/test/run-drun/call-raw-candid.mo
@@ -1,0 +1,103 @@
+import P "mo:⛔";
+// test call-raw using candid serialization
+actor self {
+
+  public shared func unit() : async () {
+    P.debugPrint("unit!");
+  };
+
+  public shared func int(n : Int) : async Int {
+    P.debugPrint(debug_show("int",n));
+    return n;
+  };
+
+  public shared func text(t : Text) : async Text {
+    P.debugPrint(debug_show("text", t));
+    return t;
+  };
+
+  public shared func tuple(n: Nat, b: Bool, c: Char) : async (Nat, Bool, Char) {
+    P.debugPrint(debug_show("text", (n, b, c)));
+    return (n, b, c);
+  };
+
+  public shared func trapInt(n : Int) : async Int {
+    P.trap("ohoh");
+  };
+
+  public shared func supercalifragilisticexpialidocious() : async () {
+    P.debugPrint("supercalifragilisticexpialidocious");
+  };
+
+  public shared func go() : async () {
+    let p = P.principalOfActor(self);
+
+    do {
+      let arg = ();
+      let res : ?() =
+        from_candid(await P.call_raw(p, "unit", to_candid(arg)));
+      assert (res == ?arg);
+    };
+
+    do {
+      let arg : Int = 1;
+      let res : ? Int =
+        from_candid(await P.call_raw(p,"int", to_candid(arg)));
+      assert (res == ?arg);
+     };
+
+    do {
+      let arg : Text = "hello";
+      let res : ?Text =
+        from_candid(await P.call_raw(p,"text", to_candid(arg)));
+      assert (res == ?arg);
+    };
+
+    do {
+      let res : ?(Nat, Bool, Char) =
+        from_candid(await P.call_raw(p,"tuple", to_candid(1, true, 'a')));
+      assert (res == ?(1, true, 'a'));
+    };
+
+    do {
+      let arg /* : ?(Nat, Bool, Char) */ =  (1, true, 'a');
+      try {
+        // expected to fail due to arity mismatch
+        // (passing a 1 triple where 3 args expected)
+        let res : ? (Nat, Bool, Char) =
+          from_candid(await P.call_raw(p,"tuple", to_candid(arg)));
+        assert false;
+      }
+      catch e {
+        P.debugPrint(P.errorMessage(e));
+      }
+    };
+
+
+    do {
+      let arg : Int =  1;
+      try {
+        let res : ? Int =
+          from_candid(await P.call_raw(p,"trapInt", to_candid(arg)));
+        assert false;
+      }
+      catch e {
+        P.debugPrint(P.errorMessage(e));
+      }
+    };
+
+    do {
+      let m = "super"#"cali"#"fragilisticexpialidocious";
+      let res : ?() =
+        from_candid(await P.call_raw(p, m, to_candid()));
+      assert (res == ?());
+    };
+
+  }
+};
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+//CALL ingress go 0x4449444C0000
+

--- a/test/run-drun/ok/call-raw-candid.drun-run.ok
+++ b/test/run-drun/ok/call-raw-candid.drun-run.ok
@@ -1,0 +1,10 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: unit!
+debug.print: ("int", +1)
+debug.print: ("text", "hello")
+debug.print: ("text", (1, true, 'a'))
+debug.print: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: IDL error: too few arguments Nbc
+debug.print: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: ohoh
+debug.print: supercalifragilisticexpialidocious
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/call-raw-candid.ic-ref-run.ok
+++ b/test/run-drun/ok/call-raw-candid.ic-ref-run.ok
@@ -1,0 +1,13 @@
+→ update create_canister(record {settings = null})
+← replied: (record {hymijyo = principal "cvccv-qqaaq-aaaaa-aaaaa-c"})
+→ update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
+← replied: ()
+→ update go()
+debug.print: unit!
+debug.print: ("int", +1)
+debug.print: ("text", "hello")
+debug.print: ("text", (1, true, 'a'))
+debug.print: canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: IDL error: too few arguments Nbc"
+debug.print: canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: ohoh"
+debug.print: supercalifragilisticexpialidocious
+← replied: ()


### PR DESCRIPTION
Finishes off #3232 (which finished off #3155)

In language manual.adoc:
* add syntax
* document semantics

[ ] general, standalone page with simple examples?
