### PR TITLE
Improve support for navigating to definitions in external modules

### DIFF
--- a/test/lsp-int/Main.hs
+++ b/test/lsp-int/Main.hs
@@ -186,6 +186,13 @@ main = do
             (Position 5 31)
             [("mydependency/lib.mo", Range (Position 5 17) (Position 5 24))]
 
+          log "Definition for an imported module alias"
+          definitionsTestCase
+            project
+            doc
+            (Position 1 10)
+            [("lib/list.mo", Range (Position 0 0) (Position 0 0))]
+
         log "Completion tests"
         log "Completing top level definitions"
         withDoc "ListClient.mo" \doc -> do


### PR DESCRIPTION
I rewrote most of `definition_handler` to account for edge cases related to finding definitions in external files. 

- It's now possible to jump to the definition of an import identifier (rather than having to click on a qualified member name). For example, `import M|ap "HashMap"` (where `|` is the cursor) jumps to the top of `HashMap.mo` instead of doing nothing (fixes dfinity/vscode-motoko#17). 

- The new implementation also has a more permissive default behavior for missing declarations. In cases where the module path is known but the qualified symbol is unknown, the language server attempts to direct the user to the relevant module. This is mostly intended as a fallback for situations where the index is missing an expected declaration, such as when the other file has a syntax error. 

Possible future improvements:

- Using the start/end position of the `module` or equivalent keyword (when possible) rather than the top of the file
- Providing the same functionality when the cursor is on the import string literal (and perhaps even the `import` keyword)
- Supporting object pattern-style imports as mentioned in #3078 (currently experimenting with this)

Passes all tests on my WSL setup and works as expected in VSCode with the [official Motoko extension](https://github.com/dfinity/vscode-motoko). 

(@matthewhammer)