### PR TITLE
Add common editor config directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,14 @@ result*
 
 enable-internals
 
+# Editor configuration
+*.swp
+*.swo
+Session.vim
+*.iml
 .idea
 .vscode
+.project
+.cproject
+.favorites.json
+.settings/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ result*
 /samples/**/*.txt
 
 enable-internals
+
+.idea
+.vscode


### PR DESCRIPTION
Ignores project config files and directories generated by VSCode, IntelliJ-based IDEs, Eclipse, Vim, etc. 

Adding as a PR since this tends to be a reasonably common practice for open-source repositories. These specific entries are from the `.gitignore` in [rust-lang/rust](https://github.com/rust-lang/rust/blob/master/.gitignore#L13-L23). 
