### PR TITLE
language-manual: more keywords

### DIFF
--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -99,10 +99,10 @@ All comments are treated as whitespace.
 The following keywords are reserved and may not be used as identifiers:
 
 ```bnf
-actor and assert await break case catch class continue debug
-debug_show do else flexible false for from_candid func if ignore in
-import not null object or label let loop private public query return
-shared stable system switch to_candid true try type var while
+actor and assert async await break case catch class continue debug
+debug_show do else flexible false for from_candid func if ignore import
+in module not null object or label let loop private public query return
+shared stable switch system throw to_candid true try type var while
 ```
 
 [[syntax-ids]]


### PR DESCRIPTION
missed a few keywords... i use these in my code generators so wanted to make sure they're up to date