### PR TITLE
feat: refactor `stableVarQuery` as prim returning an obviously pure (and more efficient) query

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -8797,7 +8797,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
     compile_exp_as env ae SR.UnboxedWord64 e ^^
     StableMem.logical_grow env
 
-  | OtherPrim ("stableVarInfo"), [] ->
+  | OtherPrim ("stableVarQuery"), [] ->
     SR.UnboxedTuple 2,
     IC.get_self_reference env ^^
     Blob.lit env Type.(motoko_stable_var_info_fld.lab)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -8797,6 +8797,11 @@ and compile_prim_invocation (env : E.t) ae p es at =
     compile_exp_as env ae SR.UnboxedWord64 e ^^
     StableMem.logical_grow env
 
+  | OtherPrim ("stableVarInfo"), [] ->
+    SR.UnboxedTuple 2,
+    IC.get_self_reference env ^^
+    Blob.lit env Type.(motoko_stable_var_info_fld.lab)
+
   (* Other prims, binary*)
   | OtherPrim "Array.init", [_;_] ->
     const_sr SR.Vanilla (Arr.init env)

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1090,9 +1090,11 @@ let motoko_async_helper_fld =
     depr = None;
   }
 
-let motoko_stable_var_size_fld =
-  { lab = "__motoko_stable_var_size";
-    typ = Func(Shared Query, Promises, [scope_bind], [], [nat64]);
+let motoko_stable_var_info_fld =
+  { lab = "__motoko_stable_var_info";
+    typ =
+      Func(Shared Query, Promises, [scope_bind], [],
+        [ Obj(Object, [{lab = "size"; typ = nat64; depr = None}]) ]);
     depr = None;
   }
 
@@ -1104,7 +1106,7 @@ let get_candid_interface_fld =
 
 let well_known_actor_fields = [
     motoko_async_helper_fld;
-    motoko_stable_var_size_fld;
+    motoko_stable_var_info_fld;
     get_candid_interface_fld
   ]
 

--- a/src/mo_types/type.mli
+++ b/src/mo_types/type.mli
@@ -240,7 +240,7 @@ val string_of_stab_sig : field list -> string
 (* Well-known fields *)
 
 val motoko_async_helper_fld : field
-val motoko_stable_var_size_fld : field
+val motoko_stable_var_info_fld : field
 val get_candid_interface_fld : field
 
 val well_known_actor_fields : field list

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -411,12 +411,3 @@ func @create_actor_helper(wasm_module_ : Blob, arg_ : Blob) : async Principal = 
 func @call_raw(p : Principal, m : Text, a : Blob) : async Blob {
   await (prim "call_raw" : (Principal, Text, Blob) -> async Blob) (p, m, a);
 };
-
-// stable variable footprint
-func @stable_var_info(self : actor {}) : async { size : Nat64 } {
-  let size =
-    (prim "deserialize" : Blob -> Nat64)
-      (await @call_raw((prim "cast" : (actor {}) -> Principal) self, "__motoko_stable_var_size",
-                       (prim "serialize" : () -> Blob) ()));
-  { size }
-};

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -262,7 +262,7 @@ func principalOfActor(act : actor {}) : Principal = (prim "cast" : (actor {}) ->
 // Untyped dynamic actor creation from blobs
 let createActor : (wasm : Blob, argument : Blob) -> async Principal = @create_actor_helper;
 
-// An async function for querying stable variable statistics
+// Returns a query that computes the current actor's stable variable statistics (for now, the current size, in bytes, of serialized stable variable data).
 func stableVarInfo() : shared query () -> async {size : Nat64} =
   (prim "stableVarInfo" : () -> (shared query () -> async {size : Nat64})) () ;
 

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -263,8 +263,8 @@ func principalOfActor(act : actor {}) : Principal = (prim "cast" : (actor {}) ->
 let createActor : (wasm : Blob, argument : Blob) -> async Principal = @create_actor_helper;
 
 // Returns a query that computes the current actor's stable variable statistics (for now, the current size, in bytes, of serialized stable variable data).
-func stableVarInfo() : shared query () -> async {size : Nat64} =
-  (prim "stableVarInfo" : () -> (shared query () -> async {size : Nat64})) () ;
+func stableVarQuery() : shared query () -> async {size : Nat64} =
+  (prim "stableVarQuery" : () -> (shared query () -> async {size : Nat64})) () ;
 
 func cyclesBalance() : Nat {
   (prim "cyclesBalance" : () -> Nat) ();

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -263,7 +263,8 @@ func principalOfActor(act : actor {}) : Principal = (prim "cast" : (actor {}) ->
 let createActor : (wasm : Blob, argument : Blob) -> async Principal = @create_actor_helper;
 
 // An async function for querying stable variable statistics
-let stableVarInfo = @stable_var_info;
+func stableVarInfo() : shared query () -> async {size : Nat64} =
+  (prim "stableVarInfo" : () -> (shared query () -> async {size : Nat64})) () ;
 
 func cyclesBalance() : Nat {
   (prim "cyclesBalance" : () -> Nat) ();

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -262,10 +262,6 @@ func principalOfActor(act : actor {}) : Principal = (prim "cast" : (actor {}) ->
 // Untyped dynamic actor creation from blobs
 let createActor : (wasm : Blob, argument : Blob) -> async Principal = @create_actor_helper;
 
-// Returns a query that computes the current actor's stable variable statistics (for now, the current size, in bytes, of serialized stable variable data).
-func stableVarQuery() : shared query () -> async {size : Nat64} =
-  (prim "stableVarQuery" : () -> (shared query () -> async {size : Nat64})) () ;
-
 func cyclesBalance() : Nat {
   (prim "cyclesBalance" : () -> Nat) ();
 };
@@ -361,5 +357,9 @@ func stableMemoryLoadBlob(offset : Nat64, size : Nat) : Blob =
 
 func stableMemoryStoreBlob(offset : Nat64, val :  Blob) : () =
   (prim "stableMemoryStoreBlob" : (Nat64, Blob) -> ()) (offset, val);
+
+// Returns a query that computes the current actor's stable variable statistics (for now, the current size, in bytes, of serialized stable variable data).
+func stableVarQuery() : shared query () -> async {size : Nat64} =
+  (prim "stableVarQuery" : () -> (shared query () -> async {size : Nat64})) () ;
 
 let call_raw = @call_raw;

--- a/test/fail/ok/illegal-await.tc.ok
+++ b/test/fail/ok/illegal-await.tc.ok
@@ -24,14 +24,14 @@ illegal-await.mo:24.11: info, start of scope $anon-async-24.11 mentioned in erro
 illegal-await.mo:26.5: info, end of scope $anon-async-24.11 mentioned in error at illegal-await.mo:25.7-25.14
 illegal-await.mo:22.10: info, start of scope $anon-async-22.10 mentioned in error at illegal-await.mo:25.7-25.14
 illegal-await.mo:27.3: info, end of scope $anon-async-22.10 mentioned in error at illegal-await.mo:25.7-25.14
-illegal-await.mo:35.11-35.12: type error [M0087], ill-scoped await: expected async type from current scope $Rec, found async type from other scope $__6
+illegal-await.mo:35.11-35.12: type error [M0087], ill-scoped await: expected async type from current scope $Rec, found async type from other scope $__5
   scope $Rec is illegal-await.mo:33.44-40.2
-  scope $__6 is illegal-await.mo:33.1-40.2
+  scope $__5 is illegal-await.mo:33.1-40.2
 illegal-await.mo:33.44: info, start of scope $Rec mentioned in error at illegal-await.mo:35.5-35.12
 illegal-await.mo:40.1: info, end of scope $Rec mentioned in error at illegal-await.mo:35.5-35.12
-illegal-await.mo:33.1: info, start of scope $__6 mentioned in error at illegal-await.mo:35.5-35.12
-illegal-await.mo:40.1: info, end of scope $__6 mentioned in error at illegal-await.mo:35.5-35.12
+illegal-await.mo:33.1: info, start of scope $__5 mentioned in error at illegal-await.mo:35.5-35.12
+illegal-await.mo:40.1: info, end of scope $__5 mentioned in error at illegal-await.mo:35.5-35.12
 illegal-await.mo:38.20-38.21: type error [M0096], expression of type
-  async<$__6> ()
+  async<$__5> ()
 cannot produce expected type
   async<$Rec> ()

--- a/test/run-drun/ok/query-footprint.ic-ref-run.ok
+++ b/test/run-drun/ok/query-footprint.ic-ref-run.ok
@@ -2,9 +2,9 @@
 ← replied: (record {hymijyo = principal "cvccv-qqaaq-aaaaa-aaaaa-c"})
 → update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
 ← replied: ()
-→ update __motoko_stable_var_size()
+→ update __motoko_stable_var_info()
 ← rejected (RC_CANISTER_ERROR): canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: assertion failed at .:0.1"
-→ query __motoko_stable_var_size()
+→ query __motoko_stable_var_info()
 ← rejected (RC_CANISTER_ERROR): canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: assertion failed at .:0.1"
 → update delegate()
 ← replied: ((6225 : nat64))

--- a/test/run-drun/query-footprint-overflow.mo
+++ b/test/run-drun/query-footprint-overflow.mo
@@ -1,4 +1,4 @@
-import { Array_tabulate; stableVarInfo } = "mo:⛔"
+import { Array_tabulate; stableVarQuery } = "mo:⛔"
 
 actor footprint = {
     let e0 = Array_tabulate<Text>(125, // length 1144 below...
@@ -21,7 +21,8 @@ actor footprint = {
     stable var expl = e15;
 
     public func delegate() : async Nat64 {
-        let { size } = await (stableVarInfo())();
+        let stableVarInfo = stableVarQuery();
+        let { size } = await stableVarInfo();
         size
     };
 

--- a/test/run-drun/query-footprint-overflow.mo
+++ b/test/run-drun/query-footprint-overflow.mo
@@ -21,7 +21,7 @@ actor footprint = {
     stable var expl = e15;
 
     public func delegate() : async Nat64 {
-        let { size } = await stableVarInfo(footprint);
+        let { size } = await (stableVarInfo())();
         size
     };
 

--- a/test/run-drun/query-footprint.mo
+++ b/test/run-drun/query-footprint.mo
@@ -18,7 +18,7 @@ actor footprint = {
     stable var expl = e10;
 
     public func delegate() : async Nat64 {
-        let { size } = await stableVarInfo(footprint);
+        let { size } = await (stableVarInfo())();
         size
     };
 
@@ -27,8 +27,8 @@ actor footprint = {
     }
 };
 
-//CALL ingress __motoko_stable_var_size "DIDL\x00\x00"
-//CALL query __motoko_stable_var_size "DIDL\x00\x00"
+//CALL ingress __motoko_stable_var_info "DIDL\x00\x00"
+//CALL query __motoko_stable_var_info "DIDL\x00\x00"
 //CALL ingress delegate "DIDL\x00\x00"
 //CALL ingress delegate "DIDL\x00\x00"
 //CALL query __get_candid_interface_tmp_hack "DIDL\x00\x00"

--- a/test/run-drun/query-footprint.mo
+++ b/test/run-drun/query-footprint.mo
@@ -1,4 +1,4 @@
-import { stableVarInfo } "mo:⛔";
+import { stableVarQuery } "mo:⛔";
 
 actor footprint = {
     stable var s : Nat64 = 42;
@@ -18,7 +18,8 @@ actor footprint = {
     stable var expl = e10;
 
     public func delegate() : async Nat64 {
-        let { size } = await (stableVarInfo())();
+        let stableVarInfo = stableVarQuery();
+        let { size } = await stableVarInfo();
         size
     };
 


### PR DESCRIPTION
(cherry-picked commits from #3278 before things went south)

The current implementation of `stableVarInfo` is an asynchronous function that:
* has (first-order) type `(actor {}) -> async { size : Nat64 }` 
* is a local, async *update* function
* takes a redundant actor reference,
* takes two hops through the scheduler.
* doesn't reflect that it's essentially pure.

This refactoring, instead, provides a *higher-order* primitive that, when applied, returns an obviously pure *query*:
* has (higher-order) type `() -> (shared query () -> { size : Nat64 })` 
* is a local synchronous function, returning a *query*.
* avoiding the extraneous scheduling,
* simplifying the implementation,
* avoiding the need to pass the actor reference.
 
(The prim is higher-order only because we don't allow primitive values, just local functions. Otherwise I would just provide access to a well-known query value `self.__motoko_stable_var_info`.)

I think we can still do this refactoring since we haven't exposed this facility in motoko-base.

