### PR TITLE
feat: expose `ExperimentalInternetComputer.countInstructions(comp)`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,8 +6,7 @@
     ```motoko
     ExperimentalInternetComputer.countInstruction : (comp : () -> ()) -> Nat64
     ```
-    to count the Wasm instructions performed during execution of `comp()`.
-    (dfinity/motoko-base#381)
+    to count the Wasm instructions performed during execution of `comp()` (dfinity/motoko-base#381).
 
   * Add
     ```motoko

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,13 @@
 
   * Add
     ```motoko
+    ExperimentalInternetComputer.countInstruction : (comp : () -> ()) -> Nat64
+    ```
+    to count the Wasm instructions performed during execution of `comp()`.
+    (dfinity/motoko-base#381)
+
+  * Add
+    ```motoko
     ExperimentalStableMemory.stableVarQuery : () -> (shared query () -> async {size : Nat64})
     ```
     for estimating stable variable storage requirements during

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -64,10 +64,10 @@
         "homepage": null,
         "owner": "dfinity",
         "repo": "motoko-base",
-        "rev": "1f807c12e7a8ee3cdbebc20229c44e15b83db923",
-        "sha256": "1fvjzgdv00yp3xd8isxazh3fcr7gsw60yg9j40cgy986ajppihyb",
+        "rev": "3045d02ab72d23e2435cf77324a72548d010c980",
+        "sha256": "11qn32kdz79v2f873h49kbdi2aaldkcpiv91rcd5xna390fvm06g",
         "type": "tarball",
-        "url": "https://github.com/dfinity/motoko-base/archive/1f807c12e7a8ee3cdbebc20229c44e15b83db923.tar.gz",
+        "url": "https://github.com/dfinity/motoko-base/archive/3045d02ab72d23e2435cf77324a72548d010c980.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "motoko-matchers": {


### PR DESCRIPTION
```
public func countInstructions(comp : () -> ()) : Nat64
```

Given computation, `comp`, counts the number of actual and (for IC system calls) notional WebAssembly instructions performed during the execution of `comp()`.

More precisely, returns the difference between the state of the IC instruction counter (_performance counter_0) before and after executing `comp()` (see [Performance Counter](https://internetcomputer.org/docs/current/references/ic-interface-spec/#system-api-performance-counter)).

NB: `countInstructions(comp)` will not account for any deferred garbage collection costs incurred by `comp()`.