### PR TITLE
Abolish `UnboxedBool` stack representation

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1141,15 +1141,14 @@ module BitTagged = struct
      signed numbers as well.
 
      Boolean false is a non-pointer by construction.
-     Boolean true (1) needs to be shifted to be a non-pointer.
-     No unshifting necessary before a branch.
+     Boolean true (1) needs not be shifted as GC will not consider it.
 
      Summary:
 
        0b…11: A pointer
        0b…x0: A shifted scalar
        0b000: `false`
-       0b010: `true`
+       0b001: `true`
 
      Note that {Nat,Int}{8,16} do not need to be explicitly bit-tagged:
      The bytes are stored in the _most_ significant byte(s) of the `i32`,

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -5035,7 +5035,7 @@ module MakeSerialization (Strm : Stream) = struct
       | Prim (Int8|Nat8) ->
         write_byte env get_data_buf (get_x ^^ TaggedSmallWord.lsb_adjust Nat8)
       | Prim Bool ->
-        write_byte env get_data_buf (get_x ^^ BoxedSmallWord.unbox env) (* essentially SR.adjust SR.Vanilla SR.bool *)
+        write_byte env get_data_buf get_x
       | Tup [] -> (* e(()) = null *)
         G.nop
       | Tup ts ->
@@ -5496,8 +5496,7 @@ module MakeSerialization (Strm : Stream) = struct
           read_byte_tagged
             [ Bool.lit false
             ; Bool.lit true
-            ] ^^
-          BoxedSmallWord.box env (* essentially SR.adjust SR.bool SR.Vanilla *)
+            ]
         end
       | Prim Null ->
         with_prim_typ t (Opt.null_lit env)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1108,14 +1108,11 @@ module Bool = struct
      because the "zero page" never contains GC-ed objects
   *)
 
-  (* in SR.Bool *)
-  let lit = function
-    | false -> compile_unboxed_const 0l
-    | true -> compile_unboxed_const 1l
-
   let vanilla_lit = function
     | false -> 0l
     | true -> 1l
+
+  let lit b = compile_unboxed_const (vanilla_lit b)
 
   let neg = G.i (Test (Wasm.Values.I32 I32Op.Eqz))
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1106,8 +1106,9 @@ end (* ContinuationTable *)
 
 module Bool = struct
   (* Boolean literals are either 0 or 1,
-     at StackRep UnboxedWord32
-     They need to be shifted before put in the heap
+     at StackRep UnboxedBool
+     They need not be shifted before put in the heap,
+     because the "zero page" never contains GC-ed objects
   *)
 
   (* in SR.Bool *)
@@ -1117,7 +1118,7 @@ module Bool = struct
 
   let vanilla_lit = function
     | false -> 0l
-    | true -> 2l
+    | true -> 1l
 
   let neg = G.i (Test (Wasm.Values.I32 I32Op.Eqz))
 
@@ -6487,8 +6488,8 @@ module StackRep = struct
     | UnboxedTuple n, Vanilla -> Tuple.from_stack env n
     | Vanilla, UnboxedTuple n -> Tuple.to_stack env n
 
-    | UnboxedBool, Vanilla -> BitTagged.tag_i32
-    | Vanilla, UnboxedBool -> BitTagged.untag_i32
+    | UnboxedBool, Vanilla
+    | Vanilla, UnboxedBool -> G.nop
 
     | UnboxedWord64, Vanilla -> BoxedWord64.box env
     | Vanilla, UnboxedWord64 -> BoxedWord64.unbox env

--- a/test/run/array.mo
+++ b/test/run/array.mo
@@ -85,3 +85,9 @@ for (n in b.vals()) {
   i += 1;
 };
 assert(i == b.size());
+
+let heterogeneous : Any = [1, 2 : Int8, 3 : Nat16, false, true];
+let homogeneous = [true, false, true];
+
+assert not homogeneous[1];
+assert homogeneous[2]

--- a/test/run/ok/array.tc.ok
+++ b/test/run/ok/array.tc.ok
@@ -1,0 +1,3 @@
+array.mo:89.27-89.64: warning [M0074], this array has type
+  [Any]
+because elements have inconsistent types


### PR DESCRIPTION
Abolish `UnboxedBool` in favour of `Vanilla`. We now always use {`0`, `1`} for `Bool` values, since they never get dereferenced, and GC avoids visiting everything that is not in the dynamic heap (e.g. small constants, pointers into the first page etc.)

Resolves #2906.