### PR TITLE
bugfix: improve pretty printing of function types to reflect arity differences (issue #3318)

### DIFF
--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1299,6 +1299,12 @@ and pp_typ_pre vs ppf t =
   | t ->
     pp_typ_un vs ppf t
 
+and sequence ts =
+  match ts with
+  | [Tup _] ->
+    Tup ts
+  | ts -> seq ts
+
 and pp_typ_nobin vs ppf t =
   match t with
   | Func (s, c, tbs, ts1, ts2) ->
@@ -1314,7 +1320,7 @@ and pp_typ_nobin vs ppf t =
     fprintf ppf "@[<2>%s%a%a ->@ %a@]"
       (string_of_func_sort s)
       (pp_binds (vs'vs) vs'') tbs'
-      (pp_typ_un (vs'vs)) (seq ts1)
+      (pp_typ_un (vs'vs)) (sequence ts1)
       (pp_control_cod sugar c (vs'vs)) ts2
   | t ->
      pp_typ_pre vs ppf t
@@ -1325,11 +1331,11 @@ and pp_control_cod sugar c vs ppf ts =
   | Returns, [Async (_,t)] when sugar ->
     fprintf ppf "@[<2>async@ %a@]" (pp_typ_pre vs) t
   | Promises, ts ->
-    fprintf ppf "@[<2>async@ %a@]" (pp_typ_pre vs) (seq ts)
+    fprintf ppf "@[<2>async@ %a@]" (pp_typ_pre vs) (sequence ts)
   | Returns, _ ->
-    pp_typ_nobin vs ppf (seq ts)
+    pp_typ_nobin vs ppf (sequence ts)
   | Replies, _ ->
-    fprintf ppf "@[<2>replies@ %a@]" (pp_typ_nobin vs) (seq ts)
+    fprintf ppf "@[<2>replies@ %a@]" (pp_typ_nobin vs) (sequence ts)
 
 and pp_typ' vs ppf t =
   match t with

--- a/test/fail/issue-3318.mo
+++ b/test/fail/issue-3318.mo
@@ -1,0 +1,8 @@
+
+func h<A,B>(f: A -> B) { };
+type T = (Int, Int);
+func f(x: (Nat, Nat)) : (Int, Int) { x };
+func g(x: (Nat, Nat)) : T { x };
+h<(Nat,Nat),(Int,Int)>(f); // reject
+h<(Nat,Nat),(Int,Int)>(g); // accept
+

--- a/test/fail/ok/issue-3318.tc.ok
+++ b/test/fail/ok/issue-3318.tc.ok
@@ -1,4 +1,4 @@
 issue-3318.mo:6.24-6.25: type error [M0096], expression of type
-  (Nat, Nat) -> (Int, Int)
+  ((Nat, Nat),) -> (Int, Int)
 cannot produce expected type
-  (Nat, Nat) -> (Int, Int)
+  ((Nat, Nat),) -> ((Int, Int),)

--- a/test/fail/ok/issue-3318.tc.ok
+++ b/test/fail/ok/issue-3318.tc.ok
@@ -1,0 +1,4 @@
+issue-3318.mo:6.24-6.25: type error [M0096], expression of type
+  (Nat, Nat) -> (Int, Int)
+cannot produce expected type
+  (Nat, Nat) -> (Int, Int)

--- a/test/fail/ok/issue-3318.tc.ret.ok
+++ b/test/fail/ok/issue-3318.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1


### PR DESCRIPTION
Our type pretty printer (the bane of my life) was suppressing arity differences between functions types. This fixes that by parenthesizing an argument/result sequence when it is a unary sequence containing a single tuple type.

Fixes issue #3318.

Let's hope it passes CI.