### PR TITLE
Quicker test for `i32` taggability and more tagging opportunities

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1205,14 +1205,14 @@ module BitTagged = struct
     compile_shrS_const 1l ^^
     G.i (Convert (Wasm.Values.I64 I64Op.ExtendSI32))
 
-  (* 32 bit numbers, dynamic *)
+  (* 32 bit numbers, dynamic, w.r.t `Int` *)
 
   let if_can_tag_i32 env retty is1 is2 =
     Func.share_code1 env "can_tag_i32" ("x", I32Type) [I32Type] (fun env get_x ->
-      (* checks that all but the low 30 bits are either all 0 or all 1 *)
-      get_x ^^ compile_shl_const 1l ^^
-      get_x ^^ G.i (Binary (Wasm.Values.I32 I32Op.Xor)) ^^
-      compile_shrU_const 31l
+      (* checks that all but the low 30 bits are both either 0 or 1 *)
+      get_x ^^ compile_shrU_const 30l ^^
+      G.i (Unary (Wasm.Values.I32 I32Op.Popcnt)) ^^
+      G.i (Unary (Wasm.Values.I32 I32Op.Ctz))
     ) ^^
     E.if_ env retty is2 is1 (* NB: swapped branches *)
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1208,7 +1208,7 @@ module BitTagged = struct
   (* 32 bit numbers, dynamic, w.r.t `Int` *)
 
   let if_can_tag_i32 env retty is1 is2 =
-    Func.share_code1 env "can_tag_i32" ("x", I32Type) [I32Type] (fun env get_x ->
+    Func.share_code1 env "cannot_tag_i32" ("x", I32Type) [I32Type] (fun env get_x ->
       (* checks that all but the low 30 bits are both either 0 or 1 *)
       get_x ^^ compile_shrU_const 30l ^^
       G.i (Unary (Wasm.Values.I32 I32Op.Popcnt)) ^^

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1705,8 +1705,9 @@ module BoxedSmallWord = struct
     get_i
 
   let box env = Func.share_code1 env "box_i32" ("n", I32Type) [I32Type] (fun env get_n ->
-      get_n ^^ compile_unboxed_const (Int32.of_int (1 lsl 30)) ^^
-      G.i (Compare (Wasm.Values.I32 I32Op.LtU)) ^^
+      get_n ^^ compile_shrU_const 30l ^^
+      G.i (Unary (Wasm.Values.I32 I32Op.Popcnt)) ^^
+      G.i (Unary (Wasm.Values.I32 I32Op.Ctz)) ^^
       G.if1 I32Type
         (get_n ^^ BitTagged.tag_i32)
         (compile_box env get_n)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1214,7 +1214,7 @@ module BitTagged = struct
       G.i (Unary (Wasm.Values.I32 I32Op.Popcnt)) ^^
       G.i (Unary (Wasm.Values.I32 I32Op.Ctz))
     ) ^^
-    E.if_ env retty is2 is1 (* NB: swapped branches *)
+    E.if_ env retty is1 is2
 
   let if_can_tag_u32 env retty is1 is2 =
     compile_shrU_const 30l ^^

--- a/test/run/conversions.mo
+++ b/test/run/conversions.mo
@@ -136,15 +136,15 @@ func wrap_Int_Int32(n1 : Int, n2 : Int32) {
   if (n1_wrapped >= 2**31) n1_wrapped -= 2**32;
   assert(Prim.intToInt32 n1_wrapped == n2);
   assert(Prim.intToInt32Wrap n1 == n2);
-  //assert(n1_wrapped == Prim.int32ToInt n2);
+  assert(n1_wrapped == Prim.int32ToInt n2);
 };
 
 test_Int_Int32(0, 0);
 test_Int_Int32(1, 1);
 test_Int_Int32(-1, -1);
-//test_Int_Int32(0x7fffffff, 0x7fffffff);
-//test_Int_Int32(-0x7fffffff, -0x7fffffff);
-//test_Int_Int32(-0x80000000, -0x80000000);
+test_Int_Int32(0x7fffffff, 0x7fffffff);
+test_Int_Int32(-0x7fffffff, -0x7fffffff);
+test_Int_Int32(-0x80000000, -0x80000000);
 wrap_Int_Int32(0x80000000, -0x80000000);
 wrap_Int_Int32(0x80000001, -0x7fffffff);
 

--- a/test/run/conversions.mo
+++ b/test/run/conversions.mo
@@ -136,15 +136,15 @@ func wrap_Int_Int32(n1 : Int, n2 : Int32) {
   if (n1_wrapped >= 2**31) n1_wrapped -= 2**32;
   assert(Prim.intToInt32 n1_wrapped == n2);
   assert(Prim.intToInt32Wrap n1 == n2);
-  assert(n1_wrapped == Prim.int32ToInt n2);
+  //assert(n1_wrapped == Prim.int32ToInt n2);
 };
 
 test_Int_Int32(0, 0);
 test_Int_Int32(1, 1);
 test_Int_Int32(-1, -1);
-test_Int_Int32(0x7fffffff, 0x7fffffff);
-test_Int_Int32(-0x7fffffff, -0x7fffffff);
-test_Int_Int32(-0x80000000, -0x80000000);
+//test_Int_Int32(0x7fffffff, 0x7fffffff);
+//test_Int_Int32(-0x7fffffff, -0x7fffffff);
+//test_Int_Int32(-0x80000000, -0x80000000);
 wrap_Int_Int32(0x80000000, -0x80000000);
 wrap_Int_Int32(0x80000001, -0x7fffffff);
 


### PR DESCRIPTION
see https://github.com/dfinity/motoko/pull/3330#discussion_r907673478

`"can_tag_i32"` is now one instruction shorter
`"box_i32"` is now keeping more values tagged and less go to the heap

TODO:
- write a hashing-heavy benchmark