### PR TITLE
Claudio/markdown docs comments

### DIFF
--- a/doc/convert.sh
+++ b/doc/convert.sh
@@ -21,9 +21,8 @@ for f in $(find $1 -name '*.adoc'); do
   asciidoctor -a IC="Internet Computer" -a proglang=Motoko -a company-id=DFINITY -b docbook -a leveloffset=+1 -o $2/$(basename $f .adoc).xml $f
   pandoc -t gfm  --no-highlight --wrap=none -f docbook $2/$(basename $f .adoc).xml \
   > $2/$(basename $f .adoc).md || true
-  sed -i 's/``` COMMENT/<!---/g' $2/$(basename $f .adoc).md
-  sed -i -z 's/ENDCOMMENT\n```/--->/g' $2/$(basename $f .adoc).md
-  #sed -i -z 's/\nINCLUDE::\.\([a-zA-Z0-9\.\/\_\-]*\)\[\]/ file=\1/g' $2/$(basename $f .adoc).md
+  sed -i 's/``` COMMENT/<!--/g' $2/$(basename $f .adoc).md
+  sed -i -z 's/ENDCOMMENT\n```/-->/g' $2/$(basename $f .adoc).md
   sed -i -z 's/\nINCLUDE::\.\([^[]*\)\[\]/ file=\1/g' $2/$(basename $f .adoc).md
   sed -i -z 's/\nINCLUDE::\.\([^[]*\)\[lines=\([0-9]*\)\.\.\([0-9]*\)\]/ file=\1\#L\2-L\3/g' $2/$(basename $f .adoc).md
   sed -i 's/KOMMA/,/g' $2/$(basename $f .adoc).md #undo German HACK above

--- a/doc/convert.sh
+++ b/doc/convert.sh
@@ -16,9 +16,13 @@ for f in $(find $1 -name '*.adoc'); do
   sed -i 's/\[source\#\([a-zA-Z]*\)\.include\_\([a-zA-Z]*\), *motoko\]/\[source, motoko name=\1 include\=\2\]/g' $f
   sed -i 's/\[source\#\([a-zA-Z]*\)\.include\_\([a-zA-Z]*\)\_\([a-zA-Z]*\), *motoko\]/\[source, motoko name=\1 include\=\2KOMMA\3\]/g' $f #dirty German hack
   sed -i 's/include::/INCLUDE::/g' $f
+  sed -i -z 's/\n\n\/\/\/\//\n\n```COMMENT/g' $f
+  sed -i -z 's/\n\/\/\/\//\nENDCOMMENT\n```/g' $f
   asciidoctor -a IC="Internet Computer" -a proglang=Motoko -a company-id=DFINITY -b docbook -a leveloffset=+1 -o $2/$(basename $f .adoc).xml $f
   pandoc -t gfm  --no-highlight --wrap=none -f docbook $2/$(basename $f .adoc).xml \
   > $2/$(basename $f .adoc).md || true
+  sed -i 's/``` COMMENT/<!---/g' $2/$(basename $f .adoc).md
+  sed -i -z 's/ENDCOMMENT\n```/--->/g' $2/$(basename $f .adoc).md
   #sed -i -z 's/\nINCLUDE::\.\([a-zA-Z0-9\.\/\_\-]*\)\[\]/ file=\1/g' $2/$(basename $f .adoc).md
   sed -i -z 's/\nINCLUDE::\.\([^[]*\)\[\]/ file=\1/g' $2/$(basename $f .adoc).md
   sed -i -z 's/\nINCLUDE::\.\([^[]*\)\[lines=\([0-9]*\)\.\.\([0-9]*\)\]/ file=\1\#L\2-L\3/g' $2/$(basename $f .adoc).md

--- a/doc/md/actors-async.md
+++ b/doc/md/actors-async.md
@@ -17,6 +17,22 @@ Consider the following actor declaration:
 ``` motoko file=./examples/counter-actor.mo
 ```
 
+<!---
+actor Counter {
+
+  var count = 0;
+
+  public shared func inc() : async () { count += 1 };
+
+  public shared func read() : async Nat { count };
+
+  public shared func bump() : async Nat {
+    count += 1;
+    count;
+  };
+};
+--->
+
 The `Counter` actor declares one field and three public, *shared* functions:
 
 -   the field `count` is mutable, initialized to zero and implicitly `private`.
@@ -189,6 +205,10 @@ The `async` construct is only allowed in an asynchronous context.
 It is only possible to `throw` or `try/catch` errors in an asynchronous context. This is because structured error handling is supported for messaging errors only and, like messaging itself, confined to asynchronous contexts.
 
 These rules also mean that local functions cannot, in general, directly call shared functions or `await` futures. This limitation can sometimes be awkward: we hope to extend the type system to be more permissive in future.
+
+<!---
+TODO: scoped awaits (if at all)
+--->
 
 ## Actor classes generalize actors
 

--- a/doc/md/actors-async.md
+++ b/doc/md/actors-async.md
@@ -17,7 +17,7 @@ Consider the following actor declaration:
 ``` motoko file=./examples/counter-actor.mo
 ```
 
-<!---
+<!--
 actor Counter {
 
   var count = 0;
@@ -31,7 +31,7 @@ actor Counter {
     count;
   };
 };
---->
+-->
 
 The `Counter` actor declares one field and three public, *shared* functions:
 
@@ -206,9 +206,9 @@ It is only possible to `throw` or `try/catch` errors in an asynchronous context.
 
 These rules also mean that local functions cannot, in general, directly call shared functions or `await` futures. This limitation can sometimes be awkward: we hope to extend the type system to be more permissive in future.
 
-<!---
+<!--
 TODO: scoped awaits (if at all)
---->
+-->
 
 ## Actor classes generalize actors
 

--- a/doc/md/advanced-discussion.md
+++ b/doc/md/advanced-discussion.md
@@ -1,1 +1,13 @@
 # Advanced discussion topics
+
+<!---
+To do:
+
+-[ ] discuss: no race conditions
+
+-[ ] discuss: no null-pointer exceptions
+
+-[ ] discuss: Subtypes and the `Null` type
+
+-[ ] discuss: Types are structural
+--->

--- a/doc/md/advanced-discussion.md
+++ b/doc/md/advanced-discussion.md
@@ -1,6 +1,6 @@
 # Advanced discussion topics
 
-<!---
+<!--
 To do:
 
 -[ ] discuss: no race conditions
@@ -10,4 +10,4 @@ To do:
 -[ ] discuss: Subtypes and the `Null` type
 
 -[ ] discuss: Types are structural
---->
+-->

--- a/doc/md/basic-concepts.md
+++ b/doc/md/basic-concepts.md
@@ -197,6 +197,10 @@ Aside from mathematical clarity, the chief practical benefit of lexical scoping 
 
 ## Values and evaluation
 
+<!---
+TODO: retitle and improve
+--->
+
 Once a Motoko expression receives the program’s (single) thread of control, it evaluates eagerly until it reduces to a *result value*.
 
 In so doing, it will generally pass control to sub-expressions, and to sub-routines before it gives up control from the *ambient control stack*.
@@ -226,6 +230,10 @@ There are no unchecked, uncaught overflows in Motoko, except in well-defined sit
 The [language quick reference](language-manual.md) contains a complete list of [primitive types](language-manual.md#primitive-types).
 
 ### Non-primitive values
+
+<!---
+TODO: records and modules, improve
+--->
 
 Building on the primitive values and types above, the language permits user-defined types, and each of the following non-primitive value forms and associated types:
 
@@ -337,6 +345,10 @@ These error messages will evolve over time, and for this reason, we will not inc
 
 ### The Motoko base library
 
+<!---
+TODO: replace library by package
+--->
+
 For various practical language engineering reasons, the design of Motoko strives to minimize builtin types and operations.
 
 Instead, whenever possible, the Motoko base library provides the types and operations that make the language feel complete. ***However**, this base library is still under development, and is still incomplete*.
@@ -418,6 +430,10 @@ P.unreachable()
 ```
 
 As in the situations above, this function type-checks in all contexts, and when evaluated, traps in all contexts.
+
+<!---
+TODO: add more general intro to traps, including section on prelude functions, reference that instead
+--->
 
 ### Traps due to faults
 

--- a/doc/md/basic-concepts.md
+++ b/doc/md/basic-concepts.md
@@ -197,9 +197,9 @@ Aside from mathematical clarity, the chief practical benefit of lexical scoping 
 
 ## Values and evaluation
 
-<!---
+<!--
 TODO: retitle and improve
---->
+-->
 
 Once a Motoko expression receives the program’s (single) thread of control, it evaluates eagerly until it reduces to a *result value*.
 
@@ -231,9 +231,9 @@ The [language quick reference](language-manual.md) contains a complete list of [
 
 ### Non-primitive values
 
-<!---
+<!--
 TODO: records and modules, improve
---->
+-->
 
 Building on the primitive values and types above, the language permits user-defined types, and each of the following non-primitive value forms and associated types:
 
@@ -345,9 +345,9 @@ These error messages will evolve over time, and for this reason, we will not inc
 
 ### The Motoko base library
 
-<!---
+<!--
 TODO: replace library by package
---->
+-->
 
 For various practical language engineering reasons, the design of Motoko strives to minimize builtin types and operations.
 
@@ -431,9 +431,9 @@ P.unreachable()
 
 As in the situations above, this function type-checks in all contexts, and when evaluated, traps in all contexts.
 
-<!---
+<!--
 TODO: add more general intro to traps, including section on prelude functions, reference that instead
---->
+-->
 
 ### Traps due to faults
 

--- a/doc/md/caller-id.md
+++ b/doc/md/caller-id.md
@@ -6,6 +6,10 @@ You can use the **principal** associated with the caller of a function to implem
 
 In Motoko, the `shared` keyword is used to declare a shared function. The shared function can also declare an optional parameter of type `{caller : Principal}`.
 
+<!---
+(The type is a record to accommodate future extension.)
+--->
+
 To illustrate how to access the caller of a shared function, consider the following:
 
 ``` motoko

--- a/doc/md/caller-id.md
+++ b/doc/md/caller-id.md
@@ -6,9 +6,9 @@ You can use the **principal** associated with the caller of a function to implem
 
 In Motoko, the `shared` keyword is used to declare a shared function. The shared function can also declare an optional parameter of type `{caller : Principal}`.
 
-<!---
+<!--
 (The type is a record to accommodate future extension.)
---->
+-->
 
 To illustrate how to access the caller of a shared function, consider the following:
 

--- a/doc/md/control-flow.md
+++ b/doc/md/control-flow.md
@@ -83,9 +83,9 @@ The option block, `do ? <block>`, produces a value of type `?T`, when block `<bl
 
 As realistic example, we give the definition of a simple function `eval`uating numeric `Exp`ressions built from natural numbers, division and a zero test, encoded as a variant type:
 
-<!---
+<!--
 TODO: make interactive
---->
+-->
 
 ``` motoko file=./examples/option-block.mo
 ```

--- a/doc/md/control-flow.md
+++ b/doc/md/control-flow.md
@@ -83,6 +83,10 @@ The option block, `do ? <block>`, produces a value of type `?T`, when block `<bl
 
 As realistic example, we give the definition of a simple function `eval`uating numeric `Exp`ressions built from natural numbers, division and a zero test, encoded as a variant type:
 
+<!---
+TODO: make interactive
+--->
+
 ``` motoko file=./examples/option-block.mo
 ```
 

--- a/doc/md/language-manual.md
+++ b/doc/md/language-manual.md
@@ -1,6 +1,6 @@
 # Language quick reference
 
-<!---
+<!--
 * targetting release 0.5.4
 * [X] Categorise primitives and operations as arithmetic (A), logical (L), bitwise (B) and relational (R) and use these categories to concisely present categorized operators (unop, binop, relop, a(ssigning)op) etc.
 * [ ] Various inline TBCs and TBRs and TODOs
@@ -25,7 +25,7 @@
 * [X] Update ErrorCode section
 * [Floats] Literals type and operations
 * [ ] Re-section so headings appear in content outline
---->
+-->
 
 This section serves as a technical reference for the previous chapters and has specific technical information for readers with specific interests. For example, this section provides technical details of interest to the following audiences:
 
@@ -601,9 +601,9 @@ Although many of these types have linguistic support for literals and operators,
 
 The type `Bool` of category L (Logical) has values `true` and `false` and is supported by one and two branch `if _ <exp> (else <exp>)?`, `not <exp>`, `_ and _` and `_ or _` expressions. Expressions `if`, `and` and `or` are short-circuiting.
 
-<!---
+<!--
 TODO: Comparison.
---->
+-->
 
 ### Type `Char`
 
@@ -615,9 +615,9 @@ Base library function `Char.toNat32(c)` converts a `Char` value, `c` to its `Nat
 
 The type `Text` of categories T and O (Text, Ordered) represents sequences of Unicode characters (i.e. strings). Function `t.size` returns the number of characters in `Text` value `t`. Operations on text values include concatenation (`_ # _`) and sequential iteration over characters via `t.chars` as in `for (c : Char in t.chars()) { …​ c …​ }`.
 
-<!---
+<!--
 TODO: Comparison.
---->
+-->
 
 ### Type `Float`
 
@@ -1270,9 +1270,9 @@ The declaration `<exp>` evaluates to the result of evaluating `<exp>` (typically
 
 Note that if `<exp>` appears within a sequence of declarations, but not as the last declaration of that sequence, then `T` must be `()`.
 
-<!---
+<!--
 TBR
---->
+-->
 
 ### Let declaration
 
@@ -1477,9 +1477,9 @@ A pattern is *static* if it is:
 
 -   type annotation with a static pattern.
 
-<!---
+<!--
 why not record patterns?
---->
+-->
 
 Static phrases are designed to be side-effect free, allowing the coalescing of duplicate library imports (a.k.a deduplication).
 
@@ -2132,9 +2132,9 @@ Expression `from_candid <exp>` evaluates `<exp>` to a result `r`. If `r` is `tra
 
 (Informally, here `ea(_)` is the Motoko-to-Candid type sequence translation and `encode/decode((T1,...,Tn))(_)` are type-directed Motoko-Candid value translations.)
 
-<!---
+<!--
 ea(_) is defined in design doc motoko/design/IDL-Motoko.md, but `encode` and `decode` are not explicitly defined anywhere except in the implementation.
---->
+-->
 
 :::note
 

--- a/doc/md/language-manual.md
+++ b/doc/md/language-manual.md
@@ -1,5 +1,32 @@
 # Language quick reference
 
+<!---
+* targetting release 0.5.4
+* [X] Categorise primitives and operations as arithmetic (A), logical (L), bitwise (B) and relational (R) and use these categories to concisely present categorized operators (unop, binop, relop, a(ssigning)op) etc.
+* [ ] Various inline TBCs and TBRs and TODOs
+* [ ] Typing of patterns
+* [X] Variants
+* [X] Object patterns
+* [X] Import expressions
+* [X] Complete draft of Try/Throw expressions and primitive Error/ErrorCode type
+* [ ] Prelude
+* [ ] Modules and static restriction
+* [X] Type components and paths
+* [ ] Prelude (move scattered descriptions of assorted prims like charToText here)
+* [X] Split category R into E (Equality) and O (Ordering) if we don't want Bool to support O. (Actually renamed R to O, and defined ==/!= on _shared_ types.
+* [X] Include actual grammar (extracted from menhir) in appendix?
+* [ ] Prose description of definedness checks
+* [ ] Platform changes: remove async expressions (and perhaps types); restrict await to shared calls.
+* [X] Queries
+* [X] Remove Shared type
+* [X] Explain dot keys, dot vals and iterators
+* [X] Debug expressions
+* [X] Document punning in type record patterns: https://github.com/dfinity/motoko/pull/964
+* [X] Update ErrorCode section
+* [Floats] Literals type and operations
+* [ ] Re-section so headings appear in content outline
+--->
+
 This section serves as a technical reference for the previous chapters and has specific technical information for readers with specific interests. For example, this section provides technical details of interest to the following audiences:
 
 -   Authors providing the higher-level documentation about the Motoko programming language.
@@ -574,6 +601,10 @@ Although many of these types have linguistic support for literals and operators,
 
 The type `Bool` of category L (Logical) has values `true` and `false` and is supported by one and two branch `if _ <exp> (else <exp>)?`, `not <exp>`, `_ and _` and `_ or _` expressions. Expressions `if`, `and` and `or` are short-circuiting.
 
+<!---
+TODO: Comparison.
+--->
+
 ### Type `Char`
 
 A `Char` of category O (Ordered) represents a character as a code point in the Unicode character set.
@@ -583,6 +614,10 @@ Base library function `Char.toNat32(c)` converts a `Char` value, `c` to its `Nat
 ### Type `Text`
 
 The type `Text` of categories T and O (Text, Ordered) represents sequences of Unicode characters (i.e. strings). Function `t.size` returns the number of characters in `Text` value `t`. Operations on text values include concatenation (`_ # _`) and sequential iteration over characters via `t.chars` as in `for (c : Char in t.chars()) { …​ c …​ }`.
+
+<!---
+TODO: Comparison.
+--->
 
 ### Type `Float`
 
@@ -1235,6 +1270,10 @@ The declaration `<exp>` evaluates to the result of evaluating `<exp>` (typically
 
 Note that if `<exp>` appears within a sequence of declarations, but not as the last declaration of that sequence, then `T` must be `()`.
 
+<!---
+TBR
+--->
+
 ### Let declaration
 
 The let declaration `let <pat> = <exp>` has type `T` and declares the bindings in `<pat>` provided:
@@ -1437,6 +1476,10 @@ A pattern is *static* if it is:
 -   a tuple of static patterns, or
 
 -   type annotation with a static pattern.
+
+<!---
+why not record patterns?
+--->
 
 Static phrases are designed to be side-effect free, allowing the coalescing of duplicate library imports (a.k.a deduplication).
 
@@ -2088,6 +2131,10 @@ The Candid *deserialization* expression `from_candid <exp>` has type `?(T1,…�
 Expression `from_candid <exp>` evaluates `<exp>` to a result `r`. If `r` is `trap`, evaluation returns `trap`. Otherwise `r` is a binary blob `b`. If `b` Candid-decodes to Candid value sequence `Vs` of type `ea((T1,...,Tn))` then the result of `from_candid` is `?v` where `v = decode((T1,...,Tn))(Vs)`. If `b` Candid-decodes to a Candid value sequence `Vs` that is not of Candid type `ea((T1,...,Tn))` (but well-formed at some other type) then the result is `null`. If `b` is not the encoding of any well-typed Candid value, but some arbitrary binary blob, then the result of `from_candid` is a trap.
 
 (Informally, here `ea(_)` is the Motoko-to-Candid type sequence translation and `encode/decode((T1,...,Tn))(_)` are type-directed Motoko-Candid value translations.)
+
+<!---
+ea(_) is defined in design doc motoko/design/IDL-Motoko.md, but `encode` and `decode` are not explicitly defined anywhere except in the implementation.
+--->
 
 :::note
 

--- a/doc/md/language-manual.md
+++ b/doc/md/language-manual.md
@@ -249,7 +249,7 @@ Equality and inequality are structural and based on the observable content of th
 | `<binop>` | Category |                                                |
 |-----------|----------|------------------------------------------------|
 | `&`       | B        | bitwise and                                    |
-| `|`       | B        | bitwise or                                     |
+| `\|`      | B        | bitwise or                                     |
 | `^`       | B        | exclusive or                                   |
 | `<<`      | B        | shift left                                     |
 | `␣>>`     | B        | shift right *(must be preceded by whitespace)* |
@@ -278,7 +278,7 @@ Equality and inequality are structural and based on the observable content of th
 | `%=`                        | A        | in place modulo                            |
 | `**=`                       | A        | in place exponentiation                    |
 | `&=`                        | B        | in place logical and                       |
-| `|=`                        | B        | in place logical or                        |
+| `\|=`                       | B        | in place logical or                        |
 | `^=`                        | B        | in place exclusive or                      |
 | `<<=`                       | B        | in place shift left                        |
 | `>>=`                       | B        | in place shift right                       |
@@ -296,22 +296,22 @@ The category of a compound assignment `<unop>=`/`<binop>=` is given by the categ
 
 The following table defines the relative precedence and associativity of operators and tokens, ordered from lowest to highest precedence. Tokens on the same line have equal precedence with the indicated associativity.
 
-| Precedence | Associativity | Token                                                                                                                        |
-|------------|---------------|------------------------------------------------------------------------------------------------------------------------------|
-| LOWEST     | none          | `if _ _` (no `else`), `loop _` (no `while`)                                                                                  |
-| (higher)   | none          | `else`, `while`                                                                                                              |
-| (higher)   | right         | `:=`, `+=`, `-=`, `*=`, `/=`, `%=`, `**=`, `#=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, `<<>=`, `<>>=`, `+%=`, `-%=`, `*%=`, `**%=` |
-| (higher)   | left          | `:`                                                                                                                          |
-| (higher)   | left          | `or`                                                                                                                         |
-| (higher)   | left          | `and`                                                                                                                        |
-| (higher)   | none          | `==`, `!=`, `<`, `>`, `<=`, `>`, `>=`                                                                                        |
-| (higher)   | left          | `+`, `-`, `#`, `+%`, `-%`                                                                                                    |
-| (higher)   | left          | `*`, `/`, `%`, `*%`                                                                                                          |
-| (higher)   | left          | `|`                                                                                                                          |
-| (higher)   | left          | `&`                                                                                                                          |
-| (higher)   | left          | `^`                                                                                                                          |
-| (higher)   | none          | `<<`, `>>`, `<<>`, `<>>`                                                                                                     |
-| HIGHEST    | left          | `**`, `**%`                                                                                                                  |
+| Precedence | Associativity | Token                                                                                                                         |
+|------------|---------------|-------------------------------------------------------------------------------------------------------------------------------|
+| LOWEST     | none          | `if _ _` (no `else`), `loop _` (no `while`)                                                                                   |
+| (higher)   | none          | `else`, `while`                                                                                                               |
+| (higher)   | right         | `:=`, `+=`, `-=`, `*=`, `/=`, `%=`, `**=`, `#=`, `&=`, `\|=`, `^=`, `<<=`, `>>=`, `<<>=`, `<>>=`, `+%=`, `-%=`, `*%=`, `**%=` |
+| (higher)   | left          | `:`                                                                                                                           |
+| (higher)   | left          | `or`                                                                                                                          |
+| (higher)   | left          | `and`                                                                                                                         |
+| (higher)   | none          | `==`, `!=`, `<`, `>`, `<=`, `>`, `>=`                                                                                         |
+| (higher)   | left          | `+`, `-`, `#`, `+%`, `-%`                                                                                                     |
+| (higher)   | left          | `*`, `/`, `%`, `*%`                                                                                                           |
+| (higher)   | left          | `\|`                                                                                                                          |
+| (higher)   | left          | `&`                                                                                                                           |
+| (higher)   | left          | `^`                                                                                                                           |
+| (higher)   | none          | `<<`, `>>`, `<<>`, `<>>`                                                                                                      |
+| HIGHEST    | left          | `**`, `**%`                                                                                                                   |
 
 ### Programs
 
@@ -1361,9 +1361,11 @@ A set of mutually recursive type or class declarations will be rejected if the s
 
 Expansiveness is a syntactic criterion. To determine whether a set of singly or mutually recursive type definitions, say
 
-      type C<...,Xi,...> = T;
-      ...
-      type D<...,Yj,...> = U,
+``` motoko no-repl
+  type C<...,Xi,...> = T;
+  ...
+  type D<...,Yj,...> = U;
+```
 
 is expansive, construct a directed graph whose vertices are the formal type parameters (identified by position), `C#i`, with the following `{0,1}`-labeled edges:
 
@@ -1376,13 +1378,13 @@ The graph is expansive if, and only if, it contains a cycle with at least one ex
 For example, the type definition:
 
 ``` motoko no-repl
-  type List<T> = ?(T, List<T>),
+  type List<T> = ?(T, List<T>);
 ```
 
 that recursively instantiates `List` at the same parameter `T`, is non-expansive and accepted, but the similar looking definition:
 
 ``` motoko no-repl
-  type Seq<T> = ?(T, Seq<[T]>),
+  type Seq<T> = ?(T, Seq<[T]>);
 ```
 
 that recursively instantiates `Seq` with a larger type, `[T]`, containing `T`, is *expansive* and rejected.

--- a/doc/md/local-objects-classes.md
+++ b/doc/md/local-objects-classes.md
@@ -1,5 +1,9 @@
 # Local objects and classes
 
+<!---
+TODO: Move examples into doc/modules/language-guide/examples
+--->
+
 In Motoko, an `object` may encapsulate local state (`var`-bound variables) by packaging this state with `public` methods that access and update it.
 
 As in other typed languages, Motoko programs benefit from the ability to encapsulate state as objects with abstract types.
@@ -111,7 +115,7 @@ The object `bumpCounter` has the following object type, exposing exactly one ope
 ``` motoko no-repl
 {
   bump : () -> Nat ;
- }
+}
 ```
 
 This type exposes the most common operation, and one that only permits certain behavior. For instance, the counter can only ever increase, and can never decrease or be set to an arbitrary value.

--- a/doc/md/local-objects-classes.md
+++ b/doc/md/local-objects-classes.md
@@ -1,8 +1,8 @@
 # Local objects and classes
 
-<!---
+<!--
 TODO: Move examples into doc/modules/language-guide/examples
---->
+-->
 
 In Motoko, an `object` may encapsulate local state (`var`-bound variables) by packaging this state with `public` methods that access and update it.
 

--- a/doc/md/overview.md
+++ b/doc/md/overview.md
@@ -888,7 +888,7 @@ let t = toText(employee); // also works, since Employee <: Person
 
     -   `mo_ide` (LSP language server for VSCode, emacs etc)
 
-<!---
+<!--
 == Old slides
 
 === Classes
@@ -1029,4 +1029,4 @@ charlie received goodbye from charlie
 alice received goodbye from charlie
 bob received goodbye from charlie
 ....
---->
+-->

--- a/doc/md/overview.md
+++ b/doc/md/overview.md
@@ -887,3 +887,146 @@ let t = toText(employee); // also works, since Employee <: Person
     -   `vessel` (package manager)
 
     -   `mo_ide` (LSP language server for VSCode, emacs etc)
+
+<!---
+== Old slides
+
+=== Classes
+
+Classes as functions returning objects:
+
+....
+ class Counter(init : Int) {
+    private var state : Int = init;
+    public func inc() { state += 1; };
+    public func get() : Int { state; };
+  }
+....
+
+Class instantiation as function call (no `new`):
+
+....
+let c = Counter(666);
+c.inc();
+let 667 = c.get();
+....
+
+=== Generic Classes
+
+....
+class Dict< K, V > (cmp : (K,K)-> Int ) {
+  add(k: K, v: V) { ... };
+  find(k: K) : ? V { ... };
+};
+....
+
+....
+let d = Dict<Int,Text> (func (i:Int, j:Int) : Int = i - j);
+d.add(1,"Alice");
+let ? name = d.find(1);
+....
+
+=== Language prelude
+
+* connects internal primitives with surface syntax (types, operations)
+* conversions like `intToNat32`
+* side-effecting operations `debugPrintInt` (tie into execution
+environment)
+* utilities like `hashInt`, `clzNat32`
+
+== Sample App
+
+=== Implementing _Chat_
+
+* type example
+* one server actor
+* multiple clients, each an instance of (actor) class Client.
+
+=== Chat Server
+
+....
+actor Server {
+  private var clients : List<Client> = null;
+
+  private shared broadcast(message : Text) {
+    var next = clients;
+    loop {
+      switch next {
+        case null { return; }
+        case (?l) { l.head.send(message); next := l.tail; };
+      };
+    };
+  };
+....
+
+....
+  public func subscribe(client : Client) : async Post {
+    let cs = {head = client; var tail = clients};
+    clients := ?cs;
+    return broadcast;
+  };
+};
+....
+
+=== Example: The client class
+
+....
+type Server = actor {subscribe : Client -> async Post};
+
+actor class Client() = this {
+  private var name : Text = "";
+  public func start(n : Text , s : Server) {
+    name := n;
+    let _ = async {
+       let post = await s.subscribe(this);
+       post("hello from " # name);
+       post("goodbye from " # name);
+    }
+  };
+....
+
+....
+  public func send(msg : Text) {
+    debugPrint(name # " received " # msg # "\n");
+  };
+};
+....
+
+=== Example: test
+
+test
+
+....
+let bob = Client();
+let alice = Client();
+let charlie = Client();
+
+bob.start("Bob", Server);
+alice.start("Alice", Server);
+charlie.start("Charlie", Server);
+....
+
+output
+
+....
+[nix-shell:~/motoko/guide]$ ../src/moc -r chat.mo
+charlie received hello from bob
+alice received hello from bob
+bob received hello from bob
+charlie received goodbye from bob
+alice received goodbye from bob
+bob received goodbye from bob
+charlie received hello from alice
+alice received hello from alice
+bob received hello from alice
+charlie received goodbye from alice
+alice received goodbye from alice
+bob received goodbye from alice
+charlie received hello from charlie
+alice received hello from charlie
+bob received hello from charlie
+charlie received goodbye from charlie
+alice received goodbye from charlie
+bob received goodbye from charlie
+....
+--->

--- a/doc/md/stablememory.md
+++ b/doc/md/stablememory.md
@@ -2,6 +2,10 @@
 
 The `ExperimentalStableMemory` library provides low-level access to Internet Computer stable memory.
 
+<!---
+TODO: extend example to illustrate stableVarQuery
+--->
+
 :::danger
 
 The `ExperimentalStableMemory` library is experimental, subject to change and may be replaced by safer alternatives in later versions of Motoko. Use at your own risk and discretion.

--- a/doc/md/stablememory.md
+++ b/doc/md/stablememory.md
@@ -2,9 +2,9 @@
 
 The `ExperimentalStableMemory` library provides low-level access to Internet Computer stable memory.
 
-<!---
+<!--
 TODO: extend example to illustrate stableVarQuery
---->
+-->
 
 :::danger
 

--- a/doc/md/style.md
+++ b/doc/md/style.md
@@ -892,3 +892,7 @@ Rationale: `g[1]` in particular will be misparsed as an indexing operation.
 -   Where applicable, name modules after the main type or class they implement or provide functions for.
 
 -   Limit each module to a single main concept/type/class or closely entangled family of concepts/types/classes.
+
+<!---
+=== To be extended
+--->

--- a/doc/md/style.md
+++ b/doc/md/style.md
@@ -893,6 +893,6 @@ Rationale: `g[1]` in particular will be misparsed as an indexing operation.
 
 -   Limit each module to a single main concept/type/class or closely entangled family of concepts/types/classes.
 
-<!---
+<!--
 === To be extended
---->
+-->

--- a/doc/md/upgrades.md
+++ b/doc/md/upgrades.md
@@ -12,9 +12,9 @@ For applications written in Motoko, the language provides high-level support for
 
 Utilizing stable storage depends on you — as the application programmer — anticipating and indicating the data you want to retain after an upgrade. Depending on the application, the data you decide to persist might be some, all, or none of a given actor’s state.
 
-<!---
+<!--
 To enable {proglang} to migrate the current state of variables when a canister is upgraded, you must identify those variables as containing data that must be preserved.
---->
+-->
 
 ## Declaring stable variables
 
@@ -22,14 +22,14 @@ In an actor, you can nominate a variable for stable storage (in Internet Compute
 
 More precisely, every `let` and `var` variable declaration in an actor can specify whether the variable is `stable` or `flexible`. If you don’t provide a modifier, the variable is declared as `flexible` by default.
 
-<!---
+<!--
 Concretely, you use the following syntax to declare stable or flexible variables in an actor:
 
 ....
 <dec-field> ::=
   (public|private)? (stable|flexible)? dec
 ....
---->
+-->
 
 The following is a simple example of how to declare a stable counter that can be upgraded while preserving the counter’s value:
 

--- a/doc/md/upgrades.md
+++ b/doc/md/upgrades.md
@@ -12,11 +12,24 @@ For applications written in Motoko, the language provides high-level support for
 
 Utilizing stable storage depends on you — as the application programmer — anticipating and indicating the data you want to retain after an upgrade. Depending on the application, the data you decide to persist might be some, all, or none of a given actor’s state.
 
+<!---
+To enable {proglang} to migrate the current state of variables when a canister is upgraded, you must identify those variables as containing data that must be preserved.
+--->
+
 ## Declaring stable variables
 
 In an actor, you can nominate a variable for stable storage (in Internet Computer stable memory) by using the `stable` keyword as a modifier in the variable’s declaration.
 
 More precisely, every `let` and `var` variable declaration in an actor can specify whether the variable is `stable` or `flexible`. If you don’t provide a modifier, the variable is declared as `flexible` by default.
+
+<!---
+Concretely, you use the following syntax to declare stable or flexible variables in an actor:
+
+....
+<dec-field> ::=
+  (public|private)? (stable|flexible)? dec
+....
+--->
 
 The following is a simple example of how to declare a stable counter that can be upgraded while preserving the counter’s value:
 

--- a/doc/modules/language-guide/pages/basic-concepts.adoc
+++ b/doc/modules/language-guide/pages/basic-concepts.adoc
@@ -222,7 +222,9 @@ Specifically, {proglang} gives very strong composition properties. For example, 
 [#values-and-evaluation]
 == Values and evaluation
 
-// TODO: retitle and improve
+////
+TODO: retitle and improve
+////
 
 Once a {proglang} expression receives the program's (single) thread of control, it evaluates eagerly until it reduces to a _result value_.
 
@@ -258,7 +260,9 @@ The link:language-manual{outfilesuffix}[language quick reference] contains a com
 
 === Non-primitive values
 
-// TODO: records and modules, improve
+////
+TODO: records and modules, improve
+////
 
 Building on the primitive values and types above, the language permits user-defined types, and each of the following non-primitive value forms and associated types:
 
@@ -385,7 +389,9 @@ Instead, we will attempt to explain each code example in its surrounding prose.
 [#the-motoko-base-library]
 === The {proglang} base library
 
-// TODO: replace library by package
+////
+TODO: replace library by package
+////
 
 For various practical language engineering reasons, the design of {proglang} strives to minimize builtin types and operations.
 
@@ -486,7 +492,9 @@ P.unreachable()
 
 As in the situations above, this function type-checks in all contexts, and when evaluated, traps in all contexts.
 
-// TODO: add more general intro to traps, including section on prelude functions, reference that instead
+////
+TODO: add more general intro to traps, including section on prelude functions, reference that instead
+////
 
 [#traps-due-to-faults]
 === Traps due to faults

--- a/doc/modules/language-guide/pages/caller-id.adoc
+++ b/doc/modules/language-guide/pages/caller-id.adoc
@@ -10,6 +10,7 @@ You can use the **principal** associated with the caller of a function to implem
 
 In {proglang}, the `+shared+` keyword is used to declare a shared function.
 The shared function can also declare an optional parameter of type `+{caller : Principal}+`.
+
 ////
 (The type is a record to accommodate future extension.)
 ////

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -644,7 +644,10 @@ For example, the link:../../../../references/motoko-ref/text{outfilesuffix}[`Tex
 
 The type `Bool` of category L (Logical) has values `true` and `false` and is supported by one and two branch `if _ <exp> (else <exp>)?`, `not <exp>`, `+_ and _+` and `+_ or _+` expressions. Expressions `if`,  `and` and `or` are short-circuiting.
 
-// Comparison TODO.
+
+////
+TODO: Comparison.
+////
 
 === Type `Char`
 
@@ -662,7 +665,9 @@ The type `Text` of categories T and O (Text, Ordered) represents sequences of Un
 Function `t.size` returns the number of characters in `Text` value `t`.
 Operations on text values include concatenation (`_ # _`) and sequential iteration over characters via `t.chars` as in `for (c : Char in t.chars()) { ... c ... }`.
 
-// Comparison TODO.
+////
+TODO: Comparison.
+////
 
 === Type `Float`
 
@@ -1382,7 +1387,9 @@ The declaration `<exp>` evaluates to the result of evaluating `<exp>` (typically
 
 Note that if `<exp>` appears within a sequence of declarations, but not as the last declaration of that sequence, then `T` must be `()`.
 
-// TBR
+////
+TBR
+////
 
 === Let declaration
 
@@ -1580,6 +1587,7 @@ A pattern is _static_ if it is:
 * a wildcard, or
 * a tuple of static patterns, or
 * type annotation with a static pattern.
+
 ////
 why not record patterns?
 ////

--- a/doc/modules/language-guide/pages/language-manual.adoc
+++ b/doc/modules/language-guide/pages/language-manual.adoc
@@ -271,7 +271,7 @@ Equality and inequality are structural and based on the observable content of th
 | `<binop>` | Category |
 
 | `&`   | B | bitwise and
-| `\|`   | B | bitwise or
+| `\\|`   | B | bitwise or
 | `^`   | B | exclusive or
 | `<<`  | B | shift left
 | `␣>>` | B | shift right _(must be preceded by whitespace)_
@@ -306,7 +306,7 @@ Equality and inequality are structural and based on the observable content of th
 | `+%=+`   | A | in place modulo
 | `+**=+`  | A | in place exponentiation
 | `+&=+`   | B | in place logical and
-| `+\|=+`   | B | in place logical or
+| `\\|=`   | B | in place logical or
 | `+^=+`   | B | in place exclusive or
 | `+<<=+`  | B | in place shift left
 | `+>>=+`  | B | in place shift right
@@ -331,14 +331,14 @@ Tokens on the same line have equal precedence with the indicated associativity.
 
 | LOWEST  | none | `if _ _` (no `else`), `loop _` (no `while`)
 |(higher)| none | `else`, `while`
-|(higher)| right | `:=`, `+=`, `-=`, `+*=+`, `+/=+`, `+%=+`, `+**=+`, `+#=+`, `+&=+`, `+\|=+`, `+^=+`, `+<<=+`, `+>>=+`, `+<<>=+`, `+<>>=+`, `+%=`, `-%=`, `+*%=+`, `**%=`
+|(higher)| right | `:=`, `+=`, `-=`, `+*=+`, `+/=+`, `+%=+`, `+**=+`, `+#=+`, `+&=+`, `+\\|=+`, `+^=+`, `+<<=+`, `+>>=+`, `+<<>=+`, `+<>>=+`, `+%=`, `-%=`, `+*%=+`, `**%=`
 |(higher)| left | `:`
 |(higher)| left | `or`
 |(higher)| left | `and`
 |(higher)| none | `+==+`, `+!=+`, `<`, `>`, `+<=+`, `>`, `+>=+`
 |(higher)| left | `+`, `-`, `#`, `+%`, `-%`
 |(higher)| left | `+*+`, `/`, `%`, `+*%+`
-|(higher)| left | `\|`
+|(higher)| left | `\\|`
 |(higher)| left | `+&+`
 |(higher)| left | `+^+`
 |(higher)| none | `<<`, `>>`, `<<>`, `<>>`
@@ -1482,11 +1482,12 @@ A set of mutually recursive type or class declarations will be rejected if the s
 
 Expansiveness is a syntactic criterion. To determine whether a set of singly or mutually recursive type definitions, say
 
-```
+[source.no-repl,motoko]
+....
   type C<...,Xi,...> = T;
   ...
-  type D<...,Yj,...> = U,
-```
+  type D<...,Yj,...> = U;
+....
 
 is expansive, construct a directed graph whose vertices are the formal type parameters (identified by position), `C#i`, with the following `{0,1}`-labeled edges:
 
@@ -1500,14 +1501,14 @@ For example, the type definition:
 
 [source.no-repl,motoko]
 ....
-  type List<T> = ?(T, List<T>),
+  type List<T> = ?(T, List<T>);
 ....
 
 that recursively instantiates `List` at the same parameter `T`, is non-expansive and accepted, but the similar looking definition:
 
 [source.no-repl,motoko]
 ....
-  type Seq<T> = ?(T, Seq<[T]>),
+  type Seq<T> = ?(T, Seq<[T]>);
 ....
 
 that recursively instantiates `Seq` with a larger type, `[T]`, containing `T`, is _expansive_ and rejected.

--- a/doc/modules/language-guide/pages/local-objects-classes.adoc
+++ b/doc/modules/language-guide/pages/local-objects-classes.adoc
@@ -1,9 +1,11 @@
-// TODO - Move examples into doc/modules/language-guide/examples
-// Use this syntax to include the files here:
-// include::example$file-name.mo[]
 = Local objects and classes
 :proglang: Motoko
 :company-id: DFINITY
+
+////
+TODO: Move examples into doc/modules/language-guide/examples
+////
+
 
 In {proglang}, an `object` may encapsulate local state (`var`-bound variables) by packaging this state with `public` methods that access and update it.
 
@@ -127,10 +129,10 @@ To illustrate the role and use of object subtyping in {proglang}, consider imple
 [source, motoko]
 ....
 object bumpCounter {
-  var c = 0; 
-  public func bump() : Nat { 
-    c += 1; 
-    c 
+  var c = 0;
+  public func bump() : Nat {
+    c += 1;
+    c
   };
 };
 ....
@@ -139,9 +141,9 @@ The object `bumpCounter` has the following object type, exposing exactly one ope
 
 [source.no-repl, motoko]
 ....
-{ 
+{
   bump : () -> Nat ;
- }
+}
 ....
 
 This type exposes the most common operation, and one that only permits certain behavior.

--- a/doc/modules/language-guide/pages/overview.adoc
+++ b/doc/modules/language-guide/pages/overview.adoc
@@ -1012,6 +1012,5 @@ charlie received goodbye from charlie
 alice received goodbye from charlie
 bob received goodbye from charlie
 ....
-
 ////
 


### PR DESCRIPTION
- Adapt script to preserve adoc block comments as markdown html comments (to preserve todos etc)
- Fix markdown rendering of operators involving `|` (problematic in tables)
- Fix other rendering bugs 