### PR TITLE
feat: record instruction costs of mutator and collector

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
       Prim.rts_mutator_instructions : () -> Nat
       Prim.rts_collector_instructions : () -> Nat
     ```
-    to report appoximate IC instruction costs of last message
+    to report approximate IC instruction costs of last message
     due to mutation (computation) and collection (GC), respectively (#3381).
 
 ## 0.6.29 (2022-06-10)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,15 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * add primitives
+    ```motoko
+      Prim.rts_mutator_instructions : () -> Nat
+      Prim.rts_collector_instructions : () -> Nat
+    ```
+    to report appoximate IC instruction costs of last message
+    due to mutation (computation) and collection (GC), respectively (#3381).
+
 ## 0.6.29 (2022-06-10)
 
 * motoko (`moc`)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -937,6 +937,50 @@ module RTS = struct
 
 end (* RTS *)
 
+module GC = struct
+  (* Record mutator/gc instructions counts *)
+
+  let instruction_counter env =
+    compile_unboxed_zero ^^
+    E.call_import env "ic0" "performance_counter"
+
+  let register_globals env =
+    (E.add_global64 env "__mutator_instructions" Mutable 0L;
+     E.add_global64 env "__collector_instructions" Mutable 0L)
+
+  let get_mutator_instructions env =
+    G.i (GlobalGet (nr (E.get_global env "__mutator_instructions")))
+  let set_mutator_instructions env =
+    G.i (GlobalSet (nr (E.get_global env "__mutator_instructions")))
+
+  let get_collector_instructions env =
+    G.i (GlobalGet (nr (E.get_global env "__collector_instructions")))
+  let set_collector_instructions env =
+    G.i (GlobalSet (nr (E.get_global env "__collector_instructions")))
+
+  let record_mutator_instructions env =
+    match E.mode env with
+    | Flags.ICMode | Flags.RefMode  ->
+      instruction_counter env ^^
+      set_mutator_instructions env
+    | _ -> G.nop
+
+  let record_collector_instructions env =
+    match E.mode env with
+    | (Flags.ICMode | Flags.RefMode)  ->
+        instruction_counter env ^^
+        get_mutator_instructions env ^^
+        G.i (Binary (Wasm.Values.I64 I64Op.Sub)) ^^
+        set_collector_instructions env
+    | _ -> G.nop
+
+  let collect_garbage env =
+    record_mutator_instructions env ^^
+    E.collect_garbage env ^^
+    record_collector_instructions env
+
+end (* GC *)
+
 module Heap = struct
   (* General heap object functionality (allocation, setting fields, reading fields) *)
 
@@ -3796,7 +3840,7 @@ module IC = struct
       Lifecycle.trans env Lifecycle.InInit ^^
 
       G.i (Call (nr (E.built_in env "init"))) ^^
-      E.collect_garbage env ^^
+      GC.collect_garbage env ^^
 
       Lifecycle.trans env Lifecycle.Idle
     ) in
@@ -3811,7 +3855,7 @@ module IC = struct
     let fi = E.add_fun env "canister_heartbeat"
       (Func.of_body env [] [] (fun env ->
         G.i (Call (nr (E.built_in env "heartbeat_exp"))) ^^
-        E.collect_garbage env))
+        GC.collect_garbage env))
     in
     E.add_export env (nr {
       name = Wasm.Utf8.decode "canister_heartbeat";
@@ -3865,7 +3909,7 @@ module IC = struct
       Lifecycle.trans env Lifecycle.InPostUpgrade ^^
       G.i (Call (nr (E.built_in env "post_exp"))) ^^
       Lifecycle.trans env Lifecycle.Idle ^^
-      E.collect_garbage env
+      GC.collect_garbage env
     )) in
 
     E.add_export env (nr {
@@ -4174,6 +4218,7 @@ module Cycles = struct
     )
 
 end (* Cycles *)
+
 
 module StableMem = struct
 
@@ -6401,8 +6446,7 @@ module Stabilization = struct
     | _ -> assert false
 end
 
-module GC = struct
-
+module GCRoots = struct
   let register env static_roots =
 
     let get_static_roots = E.add_fun env "get_static_roots" (Func.of_body env [] [I32Type] (fun env ->
@@ -6417,7 +6461,7 @@ module GC = struct
   let store_static_roots env =
     Arr.vanilla_lit env (E.get_static_roots env)
 
-end (* GC *)
+end (* GCRoots *)
 
 module StackRep = struct
   open SR
@@ -6851,7 +6895,7 @@ module FuncDec = struct
 
   let message_cleanup env sort = match sort with
       | Type.Shared Type.Write ->
-        E.collect_garbage env ^^
+        GC.collect_garbage env ^^
         Lifecycle.trans env Lifecycle.Idle
       | Type.Shared Type.Query ->
         Lifecycle.trans env Lifecycle.PostQuery
@@ -8499,7 +8543,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
 
   | ICPerformGC, [] ->
     SR.unit,
-    E.collect_garbage env
+    GC.collect_garbage env
 
   | ICStableSize t, [e] ->
     SR.UnboxedWord64,
@@ -8705,6 +8749,14 @@ and compile_prim_invocation (env : E.t) ae p es at =
   | OtherPrim "rts_callback_table_size", [] ->
     SR.Vanilla,
     ContinuationTable.size env ^^ Prim.prim_word32toNat env
+
+  | OtherPrim "rts_mutator_instructions", [] ->
+    SR.Vanilla,
+    GC.get_collector_instructions env ^^ BigNum.from_word64 env
+
+  | OtherPrim "rts_collector_instructions", [] ->
+    SR.Vanilla,
+    GC.get_collector_instructions env ^^ BigNum.from_word64 env
 
   | OtherPrim "crc32Hash", [e] ->
     SR.UnboxedWord32,
@@ -9731,7 +9783,7 @@ and conclude_module env start_fi_o =
 
   FuncDec.export_async_method env;
 
-  let static_roots = GC.store_static_roots env in
+  let static_roots = GCRoots.store_static_roots env in
   (* declare before building GC *)
 
   (* add beginning-of-heap pointer, may be changed by linker *)
@@ -9740,7 +9792,7 @@ and conclude_module env start_fi_o =
   E.export_global env "__heap_base";
 
   Heap.register env;
-  GC.register env static_roots;
+  GCRoots.register env static_roots;
   IC.register env;
 
   set_heap_base (E.get_end_of_static_memory env);
@@ -9823,6 +9875,7 @@ let compile mode rts (prog : Ir.prog) : Wasm_exts.CustomModule.extended_module =
   let env = E.mk_global mode rts IC.trap_with Lifecycle.end_ in
 
   Stack.register_globals env;
+  GC.register_globals env;
   StableMem.register_globals env;
 
   IC.system_imports env;

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -8752,7 +8752,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
 
   | OtherPrim "rts_mutator_instructions", [] ->
     SR.Vanilla,
-    GC.get_collector_instructions env ^^ BigNum.from_word64 env
+    GC.get_mutator_instructions env ^^ BigNum.from_word64 env
 
   | OtherPrim "rts_collector_instructions", [] ->
     SR.Vanilla,

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -960,18 +960,18 @@ module GC = struct
 
   let record_mutator_instructions env =
     match E.mode env with
-    | Flags.ICMode | Flags.RefMode  ->
+    | Flags.(ICMode | RefMode)  ->
       instruction_counter env ^^
       set_mutator_instructions env
     | _ -> G.nop
 
   let record_collector_instructions env =
     match E.mode env with
-    | (Flags.ICMode | Flags.RefMode)  ->
-        instruction_counter env ^^
-        get_mutator_instructions env ^^
-        G.i (Binary (Wasm.Values.I64 I64Op.Sub)) ^^
-        set_collector_instructions env
+    | Flags.(ICMode | RefMode)  ->
+      instruction_counter env ^^
+      get_mutator_instructions env ^^
+      G.i (Binary (Wasm.Values.I64 I64Op.Sub)) ^^
+      set_collector_instructions env
     | _ -> G.nop
 
   let collect_garbage env =

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -196,9 +196,16 @@ let prim =
   | "trap" -> fun _ v k ->
     raise (Invalid_argument ("explicit trap: "^ (as_text v)))
   | "rts_version" -> fun _ v k -> as_unit v; k (Text "0.1")
-  | "rts_heap_size" -> fun _ v k -> as_unit v; k (Int (Int.of_int 0))
-  | "rts_total_allocation" -> fun _ v k -> as_unit v; k (Int (Int.of_int 0))
-  | "rts_outstanding_callbacks" -> fun _ v k -> as_unit v; k (Int (Int.of_int 0))
+  | (  "rts_memory_size"
+     | "rts_heap_size"
+     | "rts_total_allocation"
+     | "rts_reclaimed"
+     | "rts_max_live_size"
+     | "rts_callback_table_count"
+     | "rts_callback_table_size"
+     | "rts_mutator_instructions"
+     | "rts_collector_instructions") ->
+        fun _ v k -> as_unit v; k (Int (Int.of_int 0))
   | "time" -> fun _ v k -> as_unit v; k (Value.Nat64 (Numerics.Nat64.of_int 42))
   | "idlHash" -> fun _ v k ->
     let s = as_text v in

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -66,6 +66,8 @@ func rts_reclaimed() : Nat { (prim "rts_reclaimed" : () -> Nat) () };
 func rts_max_live_size() : Nat { (prim "rts_max_live_size" : () -> Nat) () };
 func rts_callback_table_count() : Nat { (prim "rts_callback_table_count" : () -> Nat) () };
 func rts_callback_table_size() : Nat { (prim "rts_callback_table_size" : () -> Nat) () };
+func rts_mutator_instructions() : Nat { (prim "rts_mutator_instructions" : () -> Nat) () };
+func rts_collector_instructions() : Nat { (prim "rts_collector_instructions" : () -> Nat) () };
 
 // Hashing
 

--- a/test/run-drun/empty-actor.mo
+++ b/test/run-drun/empty-actor.mo
@@ -6,7 +6,15 @@ actor {};
 // CHECK:  (func $canister_init
 // CHECK-NEXT:    call $trans_state
 // CHECK-NEXT:    call $init
+// CHECK-NEXT:    i32.const 0
+// CHECK-NEXT:    call 30
+// CHECK-NEXT:    global.set 1
 // CHECK-NEXT:    call ${{copying_gc|compacting_gc}}
+// CHECK-NEXT:    i32.const 0
+// CHECK-NEXT:    call 30
+// CHECK-NEXT:    global.get 1
+// CHECK-NEXT:    i64.sub
+// CHECK-NEXT:    global.set 2
 // CHECK-NEXT:    call $trans_state
 
 // CHECK:  (export "canister_init" (func $canister_init))

--- a/test/run-drun/ok/rts_gc_instructions.drun-run.ok
+++ b/test/run-drun/ok/rts_gc_instructions.drun-run.ok
@@ -1,0 +1,20 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: (196_608, 196_608)
+debug.print: {collector_instructions = 18_092; memory_size = 196_608; mutator_instructions = 1_788}
+debug.print: {collector_instructions = 8_800_801; memory_size = 1_245_184; mutator_instructions = 6_817_539}
+debug.print: {collector_instructions = 26_365_337; memory_size = 3_342_336; mutator_instructions = 13_633_304}
+debug.print: {collector_instructions = 52_711_694; memory_size = 6_488_064; mutator_instructions = 20_449_041}
+debug.print: {collector_instructions = 87_839_878; memory_size = 12_779_520; mutator_instructions = 27_264_785}
+debug.print: {collector_instructions = 131_749_876; memory_size = 21_168_128; mutator_instructions = 34_080_529}
+debug.print: {collector_instructions = 184_441_708; memory_size = 31_653_888; mutator_instructions = 40_896_273}
+debug.print: {collector_instructions = 245_915_354; memory_size = 44_236_800; mutator_instructions = 47_712_017}
+debug.print: {collector_instructions = 316_170_834; memory_size = 58_916_864; mutator_instructions = 54_527_761}
+debug.print: {collector_instructions = 395_208_128; memory_size = 75_694_080; mutator_instructions = 61_343_505}
+debug.print: {collector_instructions = 483_027_249; memory_size = 94_568_448; mutator_instructions = 68_159_249}
+debug.print: {collector_instructions = 579_628_198; memory_size = 115_539_968; mutator_instructions = 74_974_993}
+debug.print: {collector_instructions = 685_010_967; memory_size = 138_608_640; mutator_instructions = 81_790_737}
+debug.print: {collector_instructions = 799_175_557; memory_size = 163_774_464; mutator_instructions = 88_606_481}
+debug.print: {collector_instructions = 922_121_974; memory_size = 191_037_440; mutator_instructions = 95_422_225}
+debug.print: {collector_instructions = 1_053_850_219; memory_size = 220_397_568; mutator_instructions = 102_237_969}
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/rts_gc_instructions.drun-run.ok
+++ b/test/run-drun/ok/rts_gc_instructions.drun-run.ok
@@ -1,20 +1,3 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (196_608, 196_608)
-debug.print: {collector_instructions = 18_092; memory_size = 196_608; mutator_instructions = 1_788}
-debug.print: {collector_instructions = 8_800_801; memory_size = 1_245_184; mutator_instructions = 6_817_539}
-debug.print: {collector_instructions = 26_365_337; memory_size = 3_342_336; mutator_instructions = 13_633_304}
-debug.print: {collector_instructions = 52_711_694; memory_size = 6_488_064; mutator_instructions = 20_449_041}
-debug.print: {collector_instructions = 87_839_878; memory_size = 12_779_520; mutator_instructions = 27_264_785}
-debug.print: {collector_instructions = 131_749_876; memory_size = 21_168_128; mutator_instructions = 34_080_529}
-debug.print: {collector_instructions = 184_441_708; memory_size = 31_653_888; mutator_instructions = 40_896_273}
-debug.print: {collector_instructions = 245_915_354; memory_size = 44_236_800; mutator_instructions = 47_712_017}
-debug.print: {collector_instructions = 316_170_834; memory_size = 58_916_864; mutator_instructions = 54_527_761}
-debug.print: {collector_instructions = 395_208_128; memory_size = 75_694_080; mutator_instructions = 61_343_505}
-debug.print: {collector_instructions = 483_027_249; memory_size = 94_568_448; mutator_instructions = 68_159_249}
-debug.print: {collector_instructions = 579_628_198; memory_size = 115_539_968; mutator_instructions = 74_974_993}
-debug.print: {collector_instructions = 685_010_967; memory_size = 138_608_640; mutator_instructions = 81_790_737}
-debug.print: {collector_instructions = 799_175_557; memory_size = 163_774_464; mutator_instructions = 88_606_481}
-debug.print: {collector_instructions = 922_121_974; memory_size = 191_037_440; mutator_instructions = 95_422_225}
-debug.print: {collector_instructions = 1_053_850_219; memory_size = 220_397_568; mutator_instructions = 102_237_969}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/rts_gc_instructions.mo
+++ b/test/run-drun/rts_gc_instructions.mo
@@ -10,20 +10,29 @@ actor {
    };
 
    public func go() : async () {
-     var i = 0;
+     var i = 1;
      var pre = Prim.rts_memory_size();
-     Prim.debugPrint(debug_show((pre,Prim.natToNat32(pre))));
+     var preMutatorInstructions = 0;
+     var preCollectorInstructions = 0;
      while(i < 16) {
        assert(Prim.rts_memory_size() >=
          Prim.rts_heap_size());
        let size = await grow(i);
+       let mutatorInstructions = Prim.rts_mutator_instructions();
+       let collectorInstructions = Prim.rts_collector_instructions();
+/* too noisy for comparison across gc flavours
        Prim.debugPrint(debug_show({
          memory_size = size;
-         mutator_instructions = Prim.rts_mutator_instructions();
-         collector_instructions = Prim.rts_collector_instructions()
+         mutator_instructions  = mutatorInstructions;
+         collector_instructions = collectorInstructions
        }));
+*/
        assert (pre <= size);
+       assert (preMutatorInstructions < mutatorInstructions);
+       assert (preCollectorInstructions < collectorInstructions);
        pre := size;
+       preMutatorInstructions := mutatorInstructions;
+       preCollectorInstructions := collectorInstructions;
        i += 1;
      };
    }
@@ -35,4 +44,5 @@ actor {
 //SKIP run
 //SKIP run-low
 //SKIP run-ir
+// too slow in ic-ref
 //SKIP ic-ref-run

--- a/test/run-drun/rts_gc_instructions.mo
+++ b/test/run-drun/rts_gc_instructions.mo
@@ -1,0 +1,38 @@
+import Prim "mo:⛔";
+
+actor {
+   type List = ?([var Int], List);
+   var list : List = null;
+
+   public func grow(n : Nat) : async Nat {
+     list := ?(Prim.Array_init(n * 1024 * 256, 0),list);
+     return  Prim.rts_memory_size();
+   };
+
+   public func go() : async () {
+     var i = 0;
+     var pre = Prim.rts_memory_size();
+     Prim.debugPrint(debug_show((pre,Prim.natToNat32(pre))));
+     while(i < 16) {
+       assert(Prim.rts_memory_size() >=
+         Prim.rts_heap_size());
+       let size = await grow(i);
+       Prim.debugPrint(debug_show({
+         memory_size = size;
+         mutator_instructions = Prim.rts_mutator_instructions();
+         collector_instructions = Prim.rts_collector_instructions()
+       }));
+       assert (pre <= size);
+       pre := size;
+       i += 1;
+     };
+   }
+};
+
+//CALL ingress go "DIDL\x00\x00"
+
+// no point running these in the interpreter
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+//SKIP ic-ref-run

--- a/test/run-drun/rts_gc_instructions.mo
+++ b/test/run-drun/rts_gc_instructions.mo
@@ -1,6 +1,6 @@
 import Prim "mo:⛔";
 
-actor {
+actor a {
    type List = ?([var Int], List);
    var list : List = null;
 
@@ -28,8 +28,8 @@ actor {
        }));
 */
        assert (pre <= size);
-       assert (preMutatorInstructions < mutatorInstructions);
-       assert (preCollectorInstructions < collectorInstructions);
+       assert (preMutatorInstructions <= mutatorInstructions);
+       assert (preCollectorInstructions <= collectorInstructions);
        pre := size;
        preMutatorInstructions := mutatorInstructions;
        preCollectorInstructions := collectorInstructions;
@@ -38,12 +38,7 @@ actor {
    }
 };
 
-//CALL ingress go "DIDL\x00\x00"
-
-// no point running these in the interpreter
-//SKIP run
-//SKIP run-low
-//SKIP run-ir
+await a.go(); //OR-CALL ingress go "DIDL\x00\x00"
 
 // too slow in ic-ref
 //SKIP ic-ref-run


### PR DESCRIPTION
Instrument calls to the collector to record IC instruction count just before and after collection, reporting the first number as instructions due to mutator (computation) and the difference as the instructions due to GC (may be low when scheduled selectively).

Exposes two new prims:
* rts_mutator_instructions: () -> Nat
* rts_collector_instructions : () -> Nat

Both return the stats for the *previous* messages.

(NB. We can't obtain these numbers using the user-level performance_counter since that always excludes GC times).

Intended for internal benchmarking of GC.
