### PR TITLE
Only consider minimised `*.min.js` files for the tarball

### DIFF
--- a/release-files.nix
+++ b/release-files.nix
@@ -25,7 +25,7 @@ let
     nixpkgs.runCommandNoCC "${name}-${releaseVersion}.js" {
       allowedRequisites = [];
     } ''
-      cp -v ${derivation}/bin/* $out
+      cp -v ${derivation}/bin/*.min.js $out
     '';
 
   release =


### PR DESCRIPTION
This should fix the `release` action that failed the last time.

Verified that the result contains `...motoko-release-0.6.30/moc-0.6.30.js` and it looks like a minified `.js` file to me.