### PR TITLE
Introduce and use `with` keyword

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -141,7 +141,7 @@
 <exp_obj> ::= 
     '{' <list(<exp_field>, ';')> '}'
     '{' <exp_post> 'and' <exp_post> ('and' <exp_post>)* '}'
-    '{' <exp_post> ('and' <exp_post>)* WITH <list(<exp_field>, ';')> '}'
+    '{' <exp_post> ('and' <exp_post>)* WITH <list1(<exp_field>, ';')> '}'
 
 <exp_plain> ::= 
     <lit>

--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -141,7 +141,7 @@
 <exp_obj> ::= 
     '{' <list(<exp_field>, ';')> '}'
     '{' <exp_post> 'and' <exp_post> ('and' <exp_post>)* '}'
-    '{' <exp_post> ('and' <exp_post>)* '|' <list(<exp_field>, ';')> '}'
+    '{' <exp_post> ('and' <exp_post>)* WITH <list(<exp_field>, ';')> '}'
 
 <exp_plain> ::= 
     <lit>

--- a/emacs/motoko-mode.el
+++ b/emacs/motoko-mode.el
@@ -1,3 +1,4 @@
+
 ;; Motoko major mode for Emacs
 ;; initially based on Swift Mode.
 
@@ -40,6 +41,7 @@
                  "catch"
                  "class"
                  "continue"
+                 "do"
                  "debug"
                  "else"
                  "flexible"
@@ -64,6 +66,7 @@
                  "system"
                  "try"
                  "throw"
+                 "with"
                  "query"
                  "type"
                  "var"

--- a/src/mo_frontend/error_reporting.ml
+++ b/src/mo_frontend/error_reporting.ml
@@ -30,6 +30,7 @@ let terminal2token (type a) (symbol : a terminal) : token =
       | T_SEMICOLON -> SEMICOLON
       | T_STABLE -> STABLE
       | T_SYSTEM -> SYSTEM
+      | T_WITH -> WITH
       | T_RPAR -> RPAR
       | T_ROTROP -> ROTROP
       | T_ROTRASSIGN -> ROTRASSIGN

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -267,7 +267,7 @@ and objblock s dec_fields =
 %type<Mo_def.Syntax.pat list> seplist(pat_bin,COMMA)
 %type<Mo_def.Syntax.dec list> seplist(imp,semicolon) seplist(imp,SEMICOLON) seplist(dec,semicolon) seplist(dec,SEMICOLON)
 %type<Mo_def.Syntax.exp list> seplist(exp_nonvar(ob),COMMA) seplist(exp(ob),COMMA)
-%type<Mo_def.Syntax.exp_field list> seplist(exp_field,semicolon)
+%type<Mo_def.Syntax.exp_field list> seplist1(exp_field,semicolon) seplist(exp_field,semicolon)
 %type<Mo_def.Syntax.exp list> separated_nonempty_list(AND, exp_post(ob))
 %type<Mo_def.Syntax.dec_field list> seplist(dec_field,semicolon) obj_body
 %type<Mo_def.Syntax.case list> seplist(case,semicolon)
@@ -552,7 +552,7 @@ exp_obj :
     { ObjE (efs, []) @? at $sloc }
   | LCURLY base=exp_post(ob) AND bases=separated_nonempty_list(AND, exp_post(ob)) RCURLY
     { ObjE ([], base :: bases) @? at $sloc }
-  | LCURLY bases=separated_nonempty_list(AND, exp_post(ob)) WITH efs=seplist(exp_field, semicolon) RCURLY
+  | LCURLY bases=separated_nonempty_list(AND, exp_post(ob)) WITH efs=seplist1(exp_field, semicolon) RCURLY
     { ObjE (efs, bases) @? at $sloc }
 
 exp_plain :

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -203,7 +203,7 @@ and objblock s dec_fields =
 %token LET VAR
 %token LPAR RPAR LBRACKET RBRACKET LCURLY RCURLY
 %token AWAIT ASYNC BREAK CASE CATCH CONTINUE DO LABEL DEBUG
-%token IF IGNORE IN ELSE SWITCH LOOP WHILE FOR RETURN TRY THROW
+%token IF IGNORE IN ELSE SWITCH LOOP WHILE FOR RETURN TRY THROW WITH
 %token ARROW ASSIGN
 %token FUNC TYPE OBJECT ACTOR CLASS PUBLIC PRIVATE SHARED SYSTEM QUERY
 %token SEMICOLON SEMICOLON_EOL COMMA COLON SUB DOT QUEST BANG
@@ -552,7 +552,7 @@ exp_obj :
     { ObjE (efs, []) @? at $sloc }
   | LCURLY base=exp_post(ob) AND bases=separated_nonempty_list(AND, exp_post(ob)) RCURLY
     { ObjE ([], base :: bases) @? at $sloc }
-  | LCURLY bases=separated_nonempty_list(AND, exp_post(ob)) OROP efs=seplist(exp_field, semicolon)  RCURLY
+  | LCURLY bases=separated_nonempty_list(AND, exp_post(ob)) WITH efs=seplist(exp_field, semicolon) RCURLY
     { ObjE (efs, bases) @? at $sloc }
 
 exp_plain :

--- a/src/mo_frontend/printers.ml
+++ b/src/mo_frontend/printers.ml
@@ -190,6 +190,7 @@ let string_of_symbol = function
   | X (N N_seplist_dec_field_semicolon_) -> "seplist(<dec_field>,<semicolon>)"
   | X (N N_seplist_exp_ob__COMMA_) -> "seplist(<exp(ob)>,,)"
   | X (N N_seplist_exp_field_semicolon_) -> "seplist(<exp_field>,<semicolon>)"
+  | X (N N_seplist1_exp_field_semicolon_) -> "seplist1(<exp_field>,<semicolon>)"
   | X (N N_separated_nonempty_list_AND_exp_post_ob__) -> "seplist+(<exp_post(ob)>,and)"
   | X (N N_seplist_exp_nonvar_ob__COMMA_) -> "seplist(<exp_nonvar(ob)>,,)"
   | X (N N_seplist_imp_SEMICOLON_) -> "seplist(<imp>,;)"

--- a/src/mo_frontend/printers.ml
+++ b/src/mo_frontend/printers.ml
@@ -37,6 +37,7 @@ let string_of_symbol = function
   | X (T T_SEMICOLON_EOL) -> ";" (* suppress the \n *)
   | X (T T_SEMICOLON) -> ";"
   | X (T T_SYSTEM) -> "system"
+  | X (T T_WITH) -> "with"
   | X (T T_RPAR) -> ")"
   | X (T T_ROTROP) -> binop "<>>"
   | X (T T_ROTRASSIGN) -> binassign "<>>="

--- a/src/mo_frontend/source_lexer.mll
+++ b/src/mo_frontend/source_lexer.mll
@@ -229,7 +229,7 @@ rule token mode = parse
   | "system" { SYSTEM }
   | "try" { TRY }
   | "throw" { THROW }
-  | "with" { with }
+  | "with" { WITH }
   | "debug_show" { DEBUG_SHOW }
   | "to_candid" { TO_CANDID }
   | "from_candid" { FROM_CANDID }

--- a/src/mo_frontend/source_lexer.mll
+++ b/src/mo_frontend/source_lexer.mll
@@ -229,6 +229,7 @@ rule token mode = parse
   | "system" { SYSTEM }
   | "try" { TRY }
   | "throw" { THROW }
+  | "with" { with }
   | "debug_show" { DEBUG_SHOW }
   | "to_candid" { TO_CANDID }
   | "from_candid" { FROM_CANDID }

--- a/src/mo_frontend/source_token.ml
+++ b/src/mo_frontend/source_token.ml
@@ -34,6 +34,7 @@ type token =
   | STABLE
   | TRY
   | THROW
+  | WITH
   | ARROW
   | ASSIGN
   | FUNC
@@ -153,6 +154,7 @@ let to_parser_token :
   | RETURN -> Ok Parser.RETURN
   | TRY -> Ok Parser.TRY
   | THROW -> Ok Parser.THROW
+  | WITH -> Ok Parser.WITH
   | ARROW -> Ok Parser.ARROW
   | ASSIGN -> Ok Parser.ASSIGN
   | FUNC -> Ok Parser.FUNC
@@ -273,6 +275,7 @@ let string_of_parser_token = function
   | Parser.RETURN -> "RETURN"
   | Parser.TRY -> "TRY"
   | Parser.THROW -> "THROW"
+  | Parser.WITH -> "WITH"
   | Parser.ARROW -> "ARROW"
   | Parser.ASSIGN -> "ASSIGN"
   | Parser.FUNC -> "FUNC"

--- a/test/fail/bad-obj-base.mo
+++ b/test/fail/bad-obj-base.mo
@@ -1,4 +1,4 @@
-{ true | a = 3 };
+{ true with a = 3 };
 let act = actor {};
-{ act | a = 3 };
-{ { y = 3; z = "H" } and { zx = 3 : Nat64 } and { zx = 3 : Nat64 } | y = -25 };
+{ act with a = 3 };
+{ { y = 3; z = "H" } and { zx = 3 : Nat64 } and { zx = 3 : Nat64 } with y = -25 };

--- a/test/fail/check-record.mo
+++ b/test/fail/check-record.mo
@@ -21,4 +21,4 @@ do {
   { a = a; b = a; c = 1; d = c}; // reject (c not bound)
 };
 
-ignore ({ {} | a = 1  } : { b : Nat }); // reject
+ignore ({ {} with a = 1  } : { b : Nat }); // reject

--- a/test/fail/obj-empty-with.mo
+++ b/test/fail/obj-empty-with.mo
@@ -2,5 +2,5 @@ import Prim "mo:⛔";
 
 // syntax
 let b = { b = 6 };
-let wrong = { b with };
+let wrong = { b with }; // syntax error
 

--- a/test/fail/obj-empty-with.mo
+++ b/test/fail/obj-empty-with.mo
@@ -1,0 +1,6 @@
+import Prim "mo:⛔";
+
+// syntax
+let b = { b = 6 };
+let wrong = { b with };
+

--- a/test/fail/obj-with.mo
+++ b/test/fail/obj-with.mo
@@ -1,0 +1,10 @@
+import Prim "mo:⛔";
+
+// syntax
+let b = { b = 6 };
+let ba = { b with a = 8 };
+let ba_semi = { b with a = 8;};
+
+let bac = { b with a = 8; c = true};
+let bac_semi = { b with a = 8; c = true ;};
+

--- a/test/fail/obj-with.mo
+++ b/test/fail/obj-with.mo
@@ -1,10 +1,11 @@
 import Prim "mo:⛔";
 
 // syntax
+// trailing semis optional
 let b = { b = 6 };
 let ba = { b with a = 8 };
-let ba_semi = { b with a = 8;};
+let ba_semi = { b with a = 8; };
 
-let bac = { b with a = 8; c = true};
-let bac_semi = { b with a = 8; c = true ;};
+let bac = { b with a = 8; c = true };
+let bac_semi = { b with a = 8; c = true; };
 

--- a/test/fail/ok/check-record.tc.ok
+++ b/test/fail/ok/check-record.tc.ok
@@ -10,7 +10,7 @@ but found immutable field (insert 'var'?)
 check-record.mo:14.9-14.11: type error [M0151], object literal is missing field a from expected type
   {a : Nat}
 check-record.mo:21.30-21.31: type error [M0057], unbound variable c
-check-record.mo:24.9-24.24: type error [M0096], expression of type
+check-record.mo:24.9-24.27: type error [M0096], expression of type
   {a : Nat}
 cannot produce expected type
   {b : Nat}

--- a/test/fail/ok/obj-empty-with.tc.ok
+++ b/test/fail/ok/obj-empty-with.tc.ok
@@ -1,0 +1,2 @@
+obj-empty-with.mo:5.22-5.23: syntax error [M0001], unexpected token '}', expected one of token or <phrase> sequence:
+  seplist1(<exp_field>,<semicolon>) }

--- a/test/fail/ok/obj-empty-with.tc.ret.ok
+++ b/test/fail/ok/obj-empty-with.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/repl/object-ext.sh
+++ b/test/repl/object-ext.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Tests that fields completely override base fields
 moc -i <<__END__
-{ { x = 42 : Nat } | x = -25 };
+{ { x = 42 : Nat } with x = -25 };
 
 module X {public let a = 7};
-{ { y = 3; z = "H" } and X | y = -25 };
+{ { y = 3; z = "H" } and X with y = -25 };
 __END__

--- a/test/run-drun/obj-ext-await.mo
+++ b/test/run-drun/obj-ext-await.mo
@@ -1,8 +1,8 @@
 actor a {
     public func go() : async () {
         let r = async ({ b = 42 });
-        let s : { b : Nat; c : Char } = { (await r) | c = 'C' };
-        let t : { b : Nat; cs : Text } = { (await async s) | cs = await async "Hi"  };
+        let s : { b : Nat; c : Char } = { (await r) with c = 'C' };
+        let t : { b : Nat; cs : Text } = { (await async s) with cs = await async "Hi"  };
         return;
     }
 };

--- a/test/run/object-extend.mo
+++ b/test/run/object-extend.mo
@@ -3,26 +3,26 @@ import Prim "mo:⛔";
 // synthesis
 let b = { b = 6 };
 module m { public let b = 6 };
-Prim.debugPrint (debug_show { b | a = 8 });
-Prim.debugPrint (debug_show { b and m | b = 8 });
-Prim.debugPrint (debug_show { { b = 6; c = "C" } | a = 8 });
-Prim.debugPrint (debug_show { { c = 'C'; d = "D" } | a = 8; b = 6 });
+Prim.debugPrint (debug_show { b with a = 8 });
+Prim.debugPrint (debug_show { b and m with b = 8 });
+Prim.debugPrint (debug_show { { b = 6; c = "C" } with a = 8 });
+Prim.debugPrint (debug_show { { c = 'C'; d = "D" } with a = 8; b = 6 });
 
 // analysis
-ignore ({ b | a = 8 } : { a : Nat });
-ignore ({ b | a = 8 } : { a : Nat; b : Nat });
-ignore ({ b and m | a = 8 : Int; b = 'X'} : { a : Int; b : Char });
-ignore ({ b and m and m | a = 8 : Int; b = 'X' } : { a : Int; b : Char });
-ignore ({ b and m and m and b | a = 8 : Int; b = 'X' } : { a : Int; b : Char });
+ignore ({ b with a = 8 } : { a : Nat });
+ignore ({ b with a = 8 } : { a : Nat; b : Nat });
+ignore ({ b and m with a = 8 : Int; b = 'X'} : { a : Int; b : Char });
+ignore ({ b and m and m with a = 8 : Int; b = 'X' } : { a : Int; b : Char });
+ignore ({ b and m and m and b with a = 8 : Int; b = 'X' } : { a : Int; b : Char });
 
 // var fields
 let c = { var c = 25 };
 
-let d = { c | var c = c.c };
+let d = { c with var c = c.c };
 c.c += 1;
 assert c.c == d.c + 1;
 
-let e = { c | e = 42 };
+let e = { c with e = 42 };
 c.c += 1;
 assert c.c == e.c;
 

--- a/test/run/objects-order.mo
+++ b/test/run/objects-order.mo
@@ -7,11 +7,11 @@ assert (x == 2);
 let base = {b = x := 3; c = 42; a = x := 4};
 assert (x == 4);
 
-let result = {base | b = x := 5; a = x := 6 };
+let result = {base with b = x := 5; a = x := 6 };
 assert (x == 6);
 assert (result == {a = (); b = (); c = 42});
 
-let _ = {(do { x := 7; base }) | b = x := 8 };
+let _ = {(do { x := 7; base }) with b = x := 8 };
 assert (x == 8);
 
 let _ = { (do { x := 9; base }) and (do { x := 10; object { let a = 5 } })};


### PR DESCRIPTION
On top of #3367.

Introduces the `with` keyword for functional object extension.

Due to popular request this implements the `{ base and bases with field = value; ... }` syntax.

TODO:
- update GitHub syntax description (check `and` too!)
- update VSCode syntax description (https://github.com/dfinity/vscode-motoko/blob/master/syntaxes/Major.tmLanguage)