### PR TITLE
Make overwriting of `var` fields from bases obligatory

### DIFF
--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -154,9 +154,9 @@ let argspec = [
   Arg.Set_int Flags.max_stable_pages,
   "<n>  set maximum number of pages available for library `ExperimentalStableMemory.mo` (default " ^ (Int.to_string Flags.max_stable_pages_default) ^ ")";
 
-  "--experimental-references",
-  Arg.Unit (fun () -> Flags.experimental_references := true),
-  " enable (experimental, limited) support for var references"
+  "--experimental-field-aliasing",
+  Arg.Unit (fun () -> Flags.experimental_field_aliasing := true),
+  " enable experimental support for aliasing of var fields"
   ]
 
   @  Args.inclusion_args

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -152,7 +152,7 @@ let argspec = [
 
   "--max-stable-pages",
   Arg.Set_int Flags.max_stable_pages,
-  "<n>  set maximum number of pages available for library `ExperimentStableMemory.mo` (default " ^ (Int.to_string Flags.max_stable_pages_default) ^ ")";
+  "<n>  set maximum number of pages available for library `ExperimentalStableMemory.mo` (default " ^ (Int.to_string Flags.max_stable_pages_default) ^ ")";
 
   "--experimental-references",
   Arg.Unit (fun () -> Flags.experimental_references := true),

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -152,9 +152,12 @@ let argspec = [
 
   "--max-stable-pages",
   Arg.Set_int Flags.max_stable_pages,
-  "<n>  set maximum number of pages available for library `ExperimentStableMemory.mo` (default " ^ (Int.to_string Flags.max_stable_pages_default) ^ ")"
-  ]
+  "<n>  set maximum number of pages available for library `ExperimentStableMemory.mo` (default " ^ (Int.to_string Flags.max_stable_pages_default) ^ ")";
 
+  "--experimental-references",
+  Arg.Unit (fun () -> Flags.experimental_references := true),
+  " enable (experimental, limited) support for var references"
+  ]
 
   @  Args.inclusion_args
 

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -182,4 +182,5 @@ let error_codes : (string * string option) list =
     "M0176", None; (* from_candid requires known type from context *)
     "M0177", None; (* Bases of record extensions must not have common fields that are not overwritten *)
     "M0178", None; (* Bases of record extensions must be either objects or modules *)
+    "M0179", None; (* Mutable (var) fields from bases must be overwritten explicitly *)
   ]

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -40,4 +40,4 @@ let error_detail = ref 2
 let sanity = ref false
 let gc_strategy = ref Copying
 let force_gc = ref false
-let experimental_references = ref false
+let experimental_field_aliasing = ref false

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -40,3 +40,4 @@ let error_detail = ref 2
 let sanity = ref false
 let gc_strategy = ref Copying
 let force_gc = ref false
+let experimental_references = ref false

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1070,7 +1070,7 @@ and infer_exp'' env exp : T.typ =
       if s = T.Actor then
         error env base.at "M0178"
           "actors cannot serve as bases in record extensions";
-      T.(Obj (Object, filter (fun ft -> not (List.exists (homonymous_fields ft) fts)) base_fts))
+      T.(Obj (Object, filter (fun ft -> not (exists (homonymous_fields ft) fts)) base_fts))
     in
     let stripped_bases = map strip bases in
 
@@ -1090,7 +1090,7 @@ and infer_exp'' env exp : T.typ =
       | (h, h_exp) :: t ->
         let avoid ft =
           let avoid_fields b b_fts =
-            if List.exists (ambiguous_fields ft) b_fts then
+            if exists (ambiguous_fields ft) b_fts then
               begin
                 let frag_typ, frag_sug = match ft.T.typ with
                   | T.Typ c -> "type ", ""
@@ -1117,8 +1117,8 @@ and infer_exp'' env exp : T.typ =
                    display_lab ft.lab;
                  info env b_exp.at "overwrite field to resolve error"
                end in
-           List.iter constant_field (as_obj b_typ |> snd) in
-         List.iter2 immutable_base stripped_bases exp_bases);
+           iter constant_field (as_obj b_typ |> snd) in
+         iter2 immutable_base stripped_bases exp_bases);
 
     let t_base = T.(fold_left glb (Obj (Object, [])) stripped_bases) in
     T.(glb t_base (Obj (Object, sort T.compare_field fts)))

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1107,7 +1107,7 @@ and infer_exp'' env exp : T.typ =
     disjoint (map2 (fun b_t b -> b_t, b) stripped_bases exp_bases);
 
     (* do not allow var fields for now (to avoid aliasing) *)
-    if not (env.pre || !Flags.experimental_references) then
+    if not (env.pre || !Flags.experimental_field_aliasing) then
       T.(let immutable_base b_typ b_exp =
            let constant_field (ft : field) =
              if (is_mut ft.typ) then

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1106,6 +1106,19 @@ and infer_exp'' env exp : T.typ =
         disjoint t in
     disjoint (map2 (fun b_t b -> b_t, b) stripped_bases exp_bases);
 
+    (* do not allow var fields for now (to avoid aliasing) *)
+    let no_alias b b_exp =
+      let var_field (ft : T.field) =
+        if T.(is_mut ft.typ) then
+          begin
+            local_error env b_exp.at "M0177" (*FIXME*)
+              "base has var field %a"
+              display_lab ft.T.lab;
+            info env b_exp.at "overwrite field to resolve error"
+          end in
+      List.iter var_field (T.as_obj b |> snd) in
+    List.iter2 no_alias stripped_bases exp_bases;
+
     let t_base = T.(fold_left glb (Obj (Object, [])) stripped_bases) in
     T.(glb t_base (Obj (Object, sort T.compare_field fts)))
   | DotE (exp1, id) ->

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1084,7 +1084,7 @@ and infer_exp'' env exp : T.typ =
          | _ -> true)
     in
 
-    (* label disjointness of stripped bases *)
+    (* field disjointness of stripped bases *)
     let rec disjoint = function
       | [] | [_] -> ()
       | (h, h_exp) :: t ->

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1113,7 +1113,7 @@ and infer_exp'' env exp : T.typ =
              if (is_mut ft.typ) then
                begin
                  local_error env b_exp.at "M0179"
-                   "base has var field%a"
+                   "base has non-aliasable var field%a"
                    display_lab ft.lab;
                  info env b_exp.at "overwrite field to resolve error"
                end in

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -989,7 +989,7 @@ and infer_exp'' env exp : T.typ =
     if not env.pre then begin
         let ts = List.map (infer_exp env) exps in
         if not (T.shared (T.seq ts)) then
-          error env exp.at "M0175" "to_candid argument must have shared type, but instead has non-shared type %a"
+          error env exp.at "M0175" "to_candid argument must have shared type, but instead has non-shared type%a"
             display_typ_expand (T.seq ts);
       end;
     T.Prim T.Blob
@@ -1472,10 +1472,10 @@ and check_exp' env0 t exp : T.typ =
     if not env.pre then begin
       let ts = List.map (infer_exp env) exps in
       if not (T.sub (T.Prim T.Blob) t) then
-        error env exp.at "M0172" "to_candid produces a Blob that is not a subtype of %a"
+        error env exp.at "M0172" "to_candid produces a Blob that is not a subtype of%a"
           display_typ_expand t;
       if not (T.shared (T.seq ts)) then
-          error env exp.at "M0173" "to_candid argument must have shared type, but instead has non-shared type %a"
+          error env exp.at "M0173" "to_candid argument must have shared type, but instead has non-shared type%a"
           display_typ_expand (T.seq ts);
       end;
     T.Prim T.Blob

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1107,13 +1107,13 @@ and infer_exp'' env exp : T.typ =
     disjoint (map2 (fun b_t b -> b_t, b) stripped_bases exp_bases);
 
     (* do not allow var fields for now (to avoid aliasing) *)
-    if not !Flags.experimental_references then
+    if not (env.pre || !Flags.experimental_references) then
       T.(let immutable_base b_typ b_exp =
            let constant_field (ft : field) =
              if (is_mut ft.typ) then
                begin
                  local_error env b_exp.at "M0179"
-                   "base has var field %a"
+                   "base has var field%a"
                    display_lab ft.lab;
                  info env b_exp.at "overwrite field to resolve error"
                end in

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1113,7 +1113,7 @@ and infer_exp'' env exp : T.typ =
           let var_field (ft : T.field) =
             if T.(is_mut ft.typ) then
               begin
-                local_error env b_exp.at "M0177" (*FIXME*)
+                local_error env b_exp.at "M0179"
                   "base has var field %a"
                   display_lab ft.T.lab;
                 info env b_exp.at "overwrite field to resolve error"

--- a/test/fail/object-ext-var-base.mo
+++ b/test/fail/object-ext-var-base.mo
@@ -1,0 +1,9 @@
+object has_var {
+    public var v = 42
+};
+
+object no_var {
+    public let w = 25
+};
+
+let _ = { has_var and no_var }

--- a/test/fail/object-ext-var-base.mo
+++ b/test/fail/object-ext-var-base.mo
@@ -6,4 +6,8 @@ object no_var {
     public let w = 25
 };
 
+// analysis
+let _ : {var v : Nat; w : Nat } = { has_var and no_var };
+
+//synthesis
 let _ = { has_var and no_var }

--- a/test/fail/ok/M0172.tc.ok
+++ b/test/fail/ok/M0172.tc.ok
@@ -1,2 +1,2 @@
-M0172.mo:1.1-1.13: type error [M0172], to_candid produces a Blob that is not a subtype of 
+M0172.mo:1.1-1.13: type error [M0172], to_candid produces a Blob that is not a subtype of
   Nat

--- a/test/fail/ok/M0173.tc.ok
+++ b/test/fail/ok/M0173.tc.ok
@@ -1,2 +1,2 @@
-M0173.mo:1.1-1.20: type error [M0173], to_candid argument must have shared type, but instead has non-shared type 
+M0173.mo:1.1-1.20: type error [M0173], to_candid argument must have shared type, but instead has non-shared type
   [var Nat]

--- a/test/fail/ok/M0175.tc.ok
+++ b/test/fail/ok/M0175.tc.ok
@@ -1,2 +1,2 @@
-M0175.mo:1.1-1.20: type error [M0175], to_candid argument must have shared type, but instead has non-shared type 
+M0175.mo:1.1-1.20: type error [M0175], to_candid argument must have shared type, but instead has non-shared type
   [var Nat]

--- a/test/fail/ok/object-ext-var-base.tc.ok
+++ b/test/fail/ok/object-ext-var-base.tc.ok
@@ -1,6 +1,6 @@
-object-ext-var-base.mo:10.37-10.44: type error [M0179], base has var field
+object-ext-var-base.mo:10.37-10.44: type error [M0179], base has non-aliasable var field
   v
 object-ext-var-base.mo:10.37-10.44: info, overwrite field to resolve error
-object-ext-var-base.mo:13.11-13.18: type error [M0179], base has var field
+object-ext-var-base.mo:13.11-13.18: type error [M0179], base has non-aliasable var field
   v
 object-ext-var-base.mo:13.11-13.18: info, overwrite field to resolve error

--- a/test/fail/ok/object-ext-var-base.tc.ok
+++ b/test/fail/ok/object-ext-var-base.tc.ok
@@ -1,6 +1,6 @@
-object-ext-var-base.mo:9.11-9.18: type error [M0179], base has var field 
+object-ext-var-base.mo:10.37-10.44: type error [M0179], base has var field
   v
-object-ext-var-base.mo:9.11-9.18: info, overwrite field to resolve error
-object-ext-var-base.mo:9.11-9.18: type error [M0179], base has var field 
+object-ext-var-base.mo:10.37-10.44: info, overwrite field to resolve error
+object-ext-var-base.mo:13.11-13.18: type error [M0179], base has var field
   v
-object-ext-var-base.mo:9.11-9.18: info, overwrite field to resolve error
+object-ext-var-base.mo:13.11-13.18: info, overwrite field to resolve error

--- a/test/fail/ok/object-ext-var-base.tc.ok
+++ b/test/fail/ok/object-ext-var-base.tc.ok
@@ -1,0 +1,6 @@
+object-ext-var-base.mo:9.11-9.18: type error [M0179], base has var field 
+  v
+object-ext-var-base.mo:9.11-9.18: info, overwrite field to resolve error
+object-ext-var-base.mo:9.11-9.18: type error [M0179], base has var field 
+  v
+object-ext-var-base.mo:9.11-9.18: info, overwrite field to resolve error

--- a/test/fail/ok/object-ext-var-base.tc.ret.ok
+++ b/test/fail/ok/object-ext-var-base.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/run/object-extend.mo
+++ b/test/run/object-extend.mo
@@ -1,4 +1,4 @@
-//MOC-FLAG --experimental-references
+//MOC-FLAG --experimental-field-aliasing
 import Prim "mo:⛔";
 
 // synthesis

--- a/test/run/object-extend.mo
+++ b/test/run/object-extend.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG --experimental-references
 import Prim "mo:⛔";
 
 // synthesis


### PR DESCRIPTION
Make mutable field aliasing (when extending/merging records) an experimental opt-in feature, and hide it behind a feature flag. When the flag is not supplied, an error is emitted that instructs the user to overwrite all `var` fields from bases explicitly. When `--experimental-field-aliasing` is given no such error gets emitted, and the mutable cells of bases are aliased in the resulting record.

See discussion in #3084 why this is a necessity.

Also contains a few minor tweaks.