### PR TITLE
fix for #3405

### DIFF
--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -576,7 +576,7 @@ and obj obj_typ efs bases =
     let base_var = fresh_var "base" base_t in
     let base_dec = letD base_var base_exp in
     let pick l =
-      if exists (fun { T.lab; _ } -> lab = l) (T.as_obj (T.promote base_t) |> snd)
+      if exists (fun { T.lab; _ } -> lab = l) T.(promote base_t |> as_obj |> snd)
       then [base_var] else [] in
     base_dec, pick in
 

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -576,7 +576,7 @@ and obj obj_typ efs bases =
     let base_var = fresh_var "base" base_t in
     let base_dec = letD base_var base_exp in
     let pick l =
-      if exists (fun { T.lab; _ } -> lab = l) (T.as_obj base_t |> snd)
+      if exists (fun { T.lab; _ } -> lab = l) (T.as_obj (T.promote base_t) |> snd)
       then [base_var] else [] in
     base_dec, pick in
 

--- a/test/run/object-extend.mo
+++ b/test/run/object-extend.mo
@@ -60,7 +60,7 @@ func mox<A <: { a : Int }, B <: { b : Char }>(a : A, b : B) : { a : Int } and { 
     { a and b with c = "Right" };
 
 func mux<A <: { a : Int }, B <: { b : Char }>(a : A, b : B) : { a : Int; b : Char; c : Text } =
-    { a and b  with c = "Yeah"  };
+    { a and b with c = "Yeah" };
 
 
 // extending iterators

--- a/test/run/object-extend.mo
+++ b/test/run/object-extend.mo
@@ -50,9 +50,6 @@ assert t.l;
 
 // some allowed polymorphism
 
-/* issue #3405
-these all give: Fatal error: exception (Invalid_argument Type.as_obj)
-
 type A0 = { a : Int };
 type B0 = { b : Char };
 
@@ -63,8 +60,8 @@ func mox<A <: { a : Int }, B <: { b : Char }>(a : A, b : B) : { a : Int } and { 
     { a and b with c = "Right" };
 
 func mux<A <: { a : Int }, B <: { b : Char }>(a : A, b : B) : { a : Int; b : Char; c : Text } =
-    { a and b with c = "Yeah" }
-*/
+    { a and b  with c = "Yeah"  };
+
 
 // extending iterators
 let tb_ok : { next : () -> ?Char; bar : Nat } = { "Text base".chars() with bar = 42 };


### PR DESCRIPTION
Builds on #3084.

(The lowering phase also need to promote the type of bases, not just typing. Infer_exp_promote doesn't promote the annotation on the expression, so you need to do it  manually in lowering again).

Fixes #3405.