### PR TITLE
fix a small issue in quicksort samples

### DIFF
--- a/samples/hoare.mo
+++ b/samples/hoare.mo
@@ -16,6 +16,8 @@ func partition(a : [var Int], lo : Nat, hi : Nat) : Nat {
     while (a[j] > pivot) j -= 1;
     if (i >= j) return j;
     swap(a, i, j);
+    i += 1;
+    j -= 1;
   };
 };
 
@@ -27,5 +29,5 @@ func quicksort(a : [var Int], lo : Nat, hi : Nat) {
 	};
 };
 
-let a : [var Int] = [var 8, 3, 9, 5, 2];
-quicksort(a, 0, 4);
+let a : [var Int] = [var 8, 8, 3, 9, 5, 2];
+quicksort(a, 0, a.size() - 1);

--- a/samples/quicksort.mo
+++ b/samples/quicksort.mo
@@ -30,19 +30,18 @@ class QS<T>(cmp : (T, T) -> Int) {
       while (cmp(a[i], pivot) < 0) {
         i += 1;
       };
-
       while (cmp(a[j], pivot) > 0) {
         j -= 1;
       };
-
       if (i >= j) return j;
-
       swap(a, i, j);
+      i += 1;
+      j -= 1;
     };
   };
 };
 
 func cmpi(i : Int, j : Int) : Int = i - j;
 let qs = QS<Int>(cmpi);
-let a : Array<Int> = [var 8, 3, 9, 5, 2];
-qs.quicksort(a, 0, 4);
+let a : Array<Int> = [var 8, 8, 3, 9, 5, 2];
+qs.quicksort(a, 0, a.size() - 1);

--- a/test/fail/ok/syntax7.tc.ok
+++ b/test/fail/ok/syntax7.tc.ok
@@ -1,3 +1,3 @@
-syntax7.mo:30.1-30.4: syntax error [M0001], unexpected token 'let', expected one of token or <phrase> sequence:
+syntax7.mo:32.1-32.4: syntax error [M0001], unexpected token 'let', expected one of token or <phrase> sequence:
   <eof>
   ; seplist(<dec>,<semicolon>)

--- a/test/fail/syntax7.mo
+++ b/test/fail/syntax7.mo
@@ -16,6 +16,8 @@ func partition(a : [var Int], lo : Nat, hi : Nat) : Nat {
     while (a[j] > pivot) j -= 1;
     if (i >= j) return j;
     swap(a, i, j);
+    i += 1;
+    j -= 1;
   };
 };
 
@@ -27,5 +29,5 @@ func quicksort(a : [var Int], lo : Nat, hi : Nat) {
 	};
 } /*;*/
 
-let a : [var Int] = [var 8, 3, 9, 5, 2];
-quicksort(a, 0, 4);
+let a : [var Int] = [var 8, 8, 3, 9, 5, 2];
+quicksort(a, 0, a.size() - 1);

--- a/test/run/hoare.mo
+++ b/test/run/hoare.mo
@@ -15,6 +15,8 @@ func partition(a : [var Int], lo : Nat, hi : Nat) : Nat {
     while (a[j] > pivot) j -= 1;
     if (i >= j) return j;
     swap(a, i, j);
+    i += 1;
+    j -= 1;
   };
 };
 
@@ -26,12 +28,13 @@ func quicksort(a : [var Int], lo : Nat, hi : Nat) {
 	};
 };
 
-let a : [var Int] = [var 8, 3, 9, 5, 2];
+let a : [var Int] = [var 8, 8, 3, 9, 5, 2];
 
-quicksort(a, 0, 4);
+quicksort(a, 0, a.size() - 1);
 
 assert(a[0] == 2);
 assert(a[1] == 3);
 assert(a[2] == 5);
 assert(a[3] == 8);
-assert(a[4] == 9);
+assert(a[4] == 8);
+assert(a[5] == 9);

--- a/test/run/quicksort.mo
+++ b/test/run/quicksort.mo
@@ -20,19 +20,17 @@ class QS<T>(cmp : (T, T) -> Int) {
     let pivot = a[lo];
     var i = lo;
     var j = hi;
-
     loop {
       while (cmp(a[i], pivot) < 0) {
         i += 1;
       };
-
       while (cmp(a[j], pivot) > 0) {
         j -= 1;
       };
-
       if (i >= j) return j;
-
       swap(a, i, j);
+      i += 1;
+      j -= 1;
     };
   };
 };
@@ -41,12 +39,13 @@ func cmpi(i : Int, j : Int) : Int = i - j;
 
 let qs = QS<Int>(cmpi);
 
-let a : [var Int] = [var 8, 3, 9, 5, 2];
+let a : [var Int] = [var 8, 8, 3, 9, 5, 2];
 
-qs.quicksort(a, 0, 4);
+qs.quicksort(a, 0, a.size() - 1);
 
 assert(a[0] == 2);
 assert(a[1] == 3);
 assert(a[2] == 5);
 assert(a[3] == 8);
-assert(a[4] == 9);
+assert(a[4] == 8);
+assert(a[5] == 9);


### PR DESCRIPTION
Fix a small issue in the quicksort samples and test cases, such that it does not run in an endless loop in certain cases (e.g. in the presence of duplicates that are chosen as pivot).