### PR TITLE
bump timeout for `niv-updater-action` to 3 mins

### DIFF
--- a/.github/workflows/niv-updater-trial.yml
+++ b/.github/workflows/niv-updater-trial.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   niv-updater:
     name: 'Check for updates'
-    timeout-minutes: 2 # if this takes more than 2 minutes then something's wrong
+    timeout-minutes: 3 # if this takes more than 3 minutes then something's wrong
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v16
+    - uses: cachix/install-nix-action@v17
       with:
         extra_nix_config: |
           experimental-features = nix-command
@@ -79,7 +79,7 @@ jobs:
     needs: [ changelog, build ]
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v16
+    - uses: cachix/install-nix-action@v17
     - uses: cachix/cachix-action@v10
       with:
         name: ic-hs-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
         # fetch PR commit, not predicted merge commit
         ref: ${{ github.event.pull_request.head.sha }}
-    - uses: cachix/install-nix-action@v16
+    - uses: cachix/install-nix-action@v17
       with:
         extra_nix_config: |
           experimental-features = nix-command
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v16
+    - uses: cachix/install-nix-action@v17
       with:
         extra_nix_config: |
           experimental-features = nix-command

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         # This is needed to be able to push and trigger CI with that push
         token: ${{ secrets.NIV_UPDATER_TOKEN }}
-    - uses: cachix/install-nix-action@v16
+    - uses: cachix/install-nix-action@v17
       with:
         nix_path: nixpkgs=channel:nixos-21.11
     - uses: cachix/cachix-action@v10


### PR DESCRIPTION
This after I've nudging the thing endlessly and it always timed out on me...

For now this is only affecting the `trial` updates, but I've seen the others failing too.