### PR TITLE
chore: fix CI deprecation warnings, bump to `node16`

### DIFF
--- a/.github/workflows/niv-updater-trial.yml
+++ b/.github/workflows/niv-updater-trial.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   niv-updater:
     name: 'Check for updates'
-    timeout-minutes: 2 # if this takes more than 2 minutes then something's wrong
+    timeout-minutes: 3 # if this takes more than 3 minutes then something's wrong
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   changelog:
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get the version
       id: get_version
@@ -49,7 +49,7 @@ jobs:
     needs: changelog
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v16
       with:
         extra_nix_config: |
@@ -78,7 +78,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs: [ changelog, build ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v16
     - uses: cachix/cachix-action@v10
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Read performance delta
       if: runner.os == 'Linux' && github.event_name == 'pull_request'
       id: perf
-      uses: juliangruber/read-file-action@v1
+      uses: juliangruber/read-file-action@v1.1.5
       with:
         path: ./perf-delta.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         # fetch full history so that git merge-base works
         fetch-depth: 0
@@ -84,7 +84,7 @@ jobs:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v16
       with:
         extra_nix_config: |

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -27,7 +27,7 @@ jobs:
         cd nix
         nix --extra-experimental-features nix-command shell -f . nix-update -c nix-update --version=skip drun
     - name: Commit changes
-      uses: EndBug/add-and-commit@v9.1.0
+      uses: EndBug/add-and-commit@v9.1.1
       with:
         author_name: Nix hash updater
         author_email: "<nobody@example.com>"

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -27,7 +27,7 @@ jobs:
         cd nix
         nix --extra-experimental-features nix-command shell -f . nix-update -c nix-update --version=skip drun
     - name: Commit changes
-      uses: EndBug/add-and-commit@v9.1
+      uses: EndBug/add-and-commit@v9.1.0
       with:
         author_name: Nix hash updater
         author_email: "<nobody@example.com>"

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -27,7 +27,7 @@ jobs:
         cd nix
         nix --extra-experimental-features nix-command shell -f . nix-update -c nix-update --version=skip drun
     - name: Commit changes
-      uses: EndBug/add-and-commit@v7.5.0
+      uses: EndBug/add-and-commit@v9.1
       with:
         author_name: Nix hash updater
         author_email: "<nobody@example.com>"

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -11,7 +11,7 @@ jobs:
   update-hash:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         # This is needed to be able to push and trigger CI with that push
         token: ${{ secrets.NIV_UPDATER_TOKEN }}


### PR DESCRIPTION
<img width="1294" alt="Screenshot 2022-10-11 at 17 19 17" src="https://user-images.githubusercontent.com/1312006/195132110-d3885fac-c03e-4b13-9993-99601ceec3f5.png">

Still waiting for releases w.r.t.
- [ ] https://github.com/cachix/cachix-action/commit/9f3d463dd7e0aeaba0cbf68209aa3b0120cd67de
- [ ] `install-nix-action` (doesn't yet seem to have a corresponding commit)
- [x] https://github.com/juliangruber/read-file-action/pull/24 — DONE
- [x] https://github.com/EndBug/add-and-commit/pull/440 — DONE.