### PR TITLE
chore: bump `cachix-action` to v11 and `install-nix-action` to v18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v17
+    - uses: cachix/install-nix-action@v18
       with:
         extra_nix_config: |
           experimental-features = nix-command
@@ -79,7 +79,7 @@ jobs:
     needs: [ changelog, build ]
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v17
+    - uses: cachix/install-nix-action@v18
     - uses: cachix/cachix-action@v11
       with:
         name: ic-hs-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,12 @@ jobs:
       with:
         extra_nix_config: |
           experimental-features = nix-command
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v11
       if: startsWith(github.ref, 'refs/heads/')
       with:
         name: ic-hs-test
         # NB: No auth token, we don’t want to push new stuff here
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v11
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name: ic-hs-test
@@ -80,7 +80,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v17
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v11
       with:
         name: ic-hs-test
         # NB: No auth token, we don’t expect to push new stuff here

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     # We are using the ic-hs-test cachix cache that is also used by
     # dfinity/ic-hs. This is partly laziness (on need to set up a separate
     # cache), but also to get the ic-ref-test binary without rebuilding
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v11
       with:
         name: ic-hs-test
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -89,7 +89,7 @@ jobs:
       with:
         extra_nix_config: |
           experimental-features = nix-command
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v11
       with:
         name: ic-hs-test
     - name: Fetch report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
         # fetch PR commit, not predicted merge commit
         ref: ${{ github.event.pull_request.head.sha }}
-    - uses: cachix/install-nix-action@v17
+    - uses: cachix/install-nix-action@v18
       with:
         extra_nix_config: |
           experimental-features = nix-command
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v17
+    - uses: cachix/install-nix-action@v18
       with:
         extra_nix_config: |
           experimental-features = nix-command

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         # This is needed to be able to push and trigger CI with that push
         token: ${{ secrets.NIV_UPDATER_TOKEN }}
-    - uses: cachix/install-nix-action@v17
+    - uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-21.11
     - uses: cachix/cachix-action@v11

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: cachix/install-nix-action@v17
       with:
         nix_path: nixpkgs=channel:nixos-21.11
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v11
       with:
         name: ic-hs-test
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'


### PR DESCRIPTION
This is an afterburner to #3482.

Alas, more warnings appeared:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/