### PR TITLE
viper: `moc.js` endpoint for VS Code

### DIFF
--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -112,6 +112,12 @@ let js_parse_candid s =
     Js.some (js_of_sexpr ast)
   )
 
+let js_viper filenames =
+  let parse_result = Pipeline.viper_files (filenames |> Array.to_list |> List.map Js.to_string) in
+  js_result parse_result (fun result ->
+    Js.some (Js.string result)
+  )
+
 let js_save_file filename content =
   let filename = Js.to_string filename in
   let content = Js.to_string content in

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -60,6 +60,12 @@ let js_run list source =
   let list = Js.to_array list |> Array.to_list |> List.map Js.to_string in
   ignore (Pipeline.run_stdin_from_file list (Js.to_string source))
 
+let js_viper filenames =
+  let result = Pipeline.viper_files (filenames |> Array.to_list |> List.map Js.to_string) in
+  js_result result (fun s ->
+    Js.some (Js.string s)
+  )
+
 let js_candid source =
   js_result (Pipeline.generate_idl [Js.to_string source])
     (fun prog ->
@@ -110,12 +116,6 @@ let js_parse_candid s =
   js_result parse_result (fun (prog, _) ->
     let ast = Idllib.Arrange_idl.prog prog in
     Js.some (js_of_sexpr ast)
-  )
-
-let js_viper filenames =
-  let parse_result = Pipeline.viper_files (filenames |> Array.to_list |> List.map Js.to_string) in
-  js_result parse_result (fun result ->
-    Js.some (Js.string result)
   )
 
 let js_save_file filename content =

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -61,7 +61,7 @@ let js_run list source =
   ignore (Pipeline.run_stdin_from_file list (Js.to_string source))
 
 let js_viper filenames =
-  let result = Pipeline.viper_files (filenames |> Array.to_list |> List.map Js.to_string) in
+  let result = Pipeline.viper_files (Js.to_array filenames |> Array.to_list |> List.map Js.to_string) in
   js_result result (fun s ->
     Js.some (Js.string s)
   )

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -29,4 +29,5 @@ let () =
       method compileWasm mode s = Flags.compiled := true; js_compile_wasm mode s
       method parseMotoko s = js_parse_motoko s
       method parseCandid s = js_parse_candid s
+      method viper s = js_viper s
      end);

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -24,10 +24,10 @@ let () =
       method gcFlags option = gc_flags option
       method run list s = Flags.compiled := false; wrap_output (fun _ -> js_run list s)
       method check s = Flags.compiled := false; js_check s
+      method viper filenames = js_viper filenames
       method candid s = Flags.compiled := true; js_candid s
       method stableCompatible pre post = js_stable_compatible pre post
       method compileWasm mode s = Flags.compiled := true; js_compile_wasm mode s
       method parseMotoko s = js_parse_motoko s
       method parseCandid s = js_parse_candid s
-      method viper s = js_viper s
      end);


### PR DESCRIPTION
Adds a `Motoko.viper()` function in `moc.js` (used in https://github.com/dfinity/vscode-motoko/pull/78). 
