### PR TITLE
chore: try fixing the NO-PULL problem in `update-hash`

### DIFF
--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         author_name: Nix hash updater
         author_email: "<nobody@example.com>"
-        token: ${{ secrets.NIV_UPDATER_TOKEN }}
+        github_token: ${{ secrets.NIV_UPDATER_TOKEN }}
         message: "Updating nix hashes"
         # do not pull: if this branch is behind, then we might as well let
         # the pushing fail

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         author_name: Nix hash updater
         author_email: "<nobody@example.com>"
+        token: ${{ secrets.NIV_UPDATER_TOKEN }}
         message: "Updating nix hashes"
         # do not pull: if this branch is behind, then we might as well let
         # the pushing fail


### PR DESCRIPTION
See the failure in #3509.

Looks like there is a new field:
<img width="804" alt="hash-updater" src="https://user-images.githubusercontent.com/1312006/197383914-032b92b8-37a0-4032-a557-a3e9c24678e8.png">
