### PR TITLE
Performance Improvement: Array.init and Array.tabulate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 * motoko (`moc`)
 
  * Statically reject shared functions and function types with type parameters (#3519, #3522)
+ * Performance improvement: `Array.init` and `Array.tabulate` (#3526)
 
 * motoko-base
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3411,7 +3411,6 @@ module Arr = struct
       idx env
   )
 
-
   let vanilla_lit env ptrs =
     E.add_static env StaticBytes.[
       I32 Tagged.(int_of_tag Array);
@@ -3428,50 +3427,76 @@ module Arr = struct
   (* Does not initialize the fields! *)
   let alloc env = E.call_import env "rts" "alloc_array"
 
+  let iterate env get_array body = 
+    let (set_boundary, get_boundary) = new_local env "boundary" in
+    let (set_pointer, get_pointer) = new_local env "pointer" in
+    
+    (* Initial element pointer, skewed *)
+    compile_unboxed_const header_size ^^
+    compile_mul_const element_size ^^
+    get_array ^^
+    G.i (Binary (Wasm.Values.I32 I32Op.Add)) ^^
+    set_pointer ^^
+    
+    (* Upper pointer boundary, skewed *)
+    get_array ^^ Heap.load_field len_field ^^
+    compile_mul_const element_size ^^
+    get_pointer ^^
+    G.i (Binary (Wasm.Values.I32 I32Op.Add)) ^^
+    set_boundary ^^
+
+    (* Loop through all elements *)
+    compile_while env
+    ( get_pointer ^^
+      get_boundary ^^
+      G.i (Compare (Wasm.Values.I32 I32Op.LtU))
+    ) (
+      body get_pointer ^^      
+
+      (* Next element pointer, skewed *)
+      get_pointer ^^
+      compile_add_const element_size ^^
+      set_pointer
+    )
+
   (* The primitive operations *)
   (* No need to wrap them in RTS functions: They occur only once, in the prelude. *)
   let init env =
-    let (set_len, get_len) = new_local env "len" in
     let (set_x, get_x) = new_local env "x" in
     let (set_r, get_r) = new_local env "r" in
     set_x ^^
-    BigNum.to_word32 env ^^
-    set_len ^^
-
+    
     (* Allocate *)
-    get_len ^^
+    BigNum.to_word32 env ^^
     alloc env ^^
     set_r ^^
 
-    (* Write fields *)
-    get_len ^^
-    from_0_to_n env (fun get_i ->
-      get_r ^^
-      get_i ^^
-      idx env ^^
+    (* Write elements *)
+    iterate env get_r (fun get_pointer -> 
+      get_pointer ^^
       get_x ^^
       store_ptr
     ) ^^
     get_r
 
   let tabulate env =
-    let (set_len, get_len) = new_local env "len" in
     let (set_f, get_f) = new_local env "f" in
     let (set_r, get_r) = new_local env "r" in
+    let (set_i, get_i) = new_local env "i" in
     set_f ^^
-    BigNum.to_word32 env ^^
-    set_len ^^
-
+    
     (* Allocate *)
-    get_len ^^
+    BigNum.to_word32 env ^^
     alloc env ^^
     set_r ^^
 
-    (* Write fields *)
-    get_len ^^
-    from_0_to_n env (fun get_i ->
-      (* Where to store *)
-      get_r ^^ get_i ^^ idx env ^^
+    (* Initial index *)
+    compile_unboxed_const 0l ^^
+    set_i ^^
+
+    (* Write elements *)
+    iterate env get_r (fun get_pointer -> 
+      get_pointer ^^
       (* The closure *)
       get_f ^^
       (* The arg *)
@@ -3481,7 +3506,12 @@ module Arr = struct
       get_f ^^
       (* Call *)
       Closure.call_closure env 1 1 ^^
-      store_ptr
+      store_ptr ^^
+
+      (* Increment index *)
+      get_i ^^
+      compile_add_const 1l ^^
+      set_i
     ) ^^
     get_r
 

--- a/test/bench/ok/heap-32.drun-run.ok
+++ b/test/bench/ok/heap-32.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +91_377_860, 1_447_975_750)
-debug.print: (50_070, +102_586_000, 1_521_068_304)
+debug.print: (50_227, +91_377_860, 1_446_975_760)
+debug.print: (50_070, +102_586_000, 1_520_068_314)
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run/array-gen.mo
+++ b/test/run/array-gen.mo
@@ -14,3 +14,34 @@ for (i in b.keys()) {
   assert (b[i] == i);
 };
 
+func init(length: Nat) {
+    let array1 = Prim.Array_init<Nat>(length, 42);
+    assert array1.size() == length;
+    var index = 0;
+    while (index < length) {
+        assert array1[index] == 42;
+        index += 1;
+    }
+};
+
+init(0);
+init(1);
+init(2);
+init(1000);
+init(1000_000);
+
+func tabulate(length: Nat) {
+    let array2 = Prim.Array_tabulate<Nat>(length, func i { 1 + 2 * i });
+    assert array2.size() == length;
+    var index = 0;
+    while (index < length) {
+        assert array2[index] == 1 + 2 * index;
+        index += 1
+    }
+};
+
+tabulate(0);
+tabulate(1);
+tabulate(2);
+tabulate(1000);
+tabulate(1000_000);


### PR DESCRIPTION
# Faster Array Init and Tabulate

* Eliminating unnecessary repeated array index bounds check while initializing an array.
* Faster iteration through new array on initialization by advancing an element pointer.

Applies to `Array.init` and `Array.tabulate`.

## Performance Improvement

**More than 2x faster array initialization**

### Micro-Benchmark

Measuring the number of mutator instructions with an array of 10_000_000 Nat elements. Tabulate uses `x -> x`.

Operation   | Unoptimized   | Optimized | Speedup
------------|---------------|-----------|-----------
`init`      | 260e6         | 120e6     | 2.17     
`tabulate`  | 380e6         | 280e6     | 1.36

### GC Benchmark

Measuring the number of mutator instructions in GC benchmark. 

Benchmark Case      | Unoptimized   | Optimized | Speedup
--------------------|---------------|-----------|-----------
`blobs`             | 4.56e7        | 4.44e7    | 1.03
`buffer`            | 2.06e10       | 2.04e10   | 1.01
`graph`             | 1.09e10       | 1.02e10   | 1.07
`random-maze`       | 2.51e8        | 2.47e8    | 1.02
`sha256`            | 3.31e10       | 2.97e10   | 1.14

No relevant improvement for the other benchmark cases.

On GC benchmark, the optimization improves performance by **3.4%** on average.

### Testing

1. Mototoko `test/run` and `test/run-drun` test cases with sanity checks.

    * Extended the test case `test/run/array-gen.mo` with larger arrays and edge cases (size 0, 1).

3. Special branch `luc/array-init-checks` with extensive sanity checks:

    * Full memory sanity check after every `Array.init` and `Array.tabulate` call.
    * Checking the bounds of every element access during `Array.init` and `Array.tabulate`.

    