### PR TITLE
chore: remove use of `set-output` from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,7 @@ jobs:
         cat changelog-extract.md
         # need to mangle to use with $GITHUB_OUTPUT (previously: set-output),
         # see https://github.com/svenstaro/upload-release-action/pull/49/files
-        r="$(cat changelog-extract.md)"
-        r="${r//'%'/'%25'}"
-        r="${r//$'\n'/'%0A'}"
-        r="${r//$'\r'/'%0D'}"
-        echo "release_body=$r" >> $GITHUB_OUTPUT
+        echo "release_body=$(perl -0777 -p -e 's/%/%25/g; s/\n/%0A/g; s/\r/%0D/g' changelog-extract.md)" >> $GITHUB_OUTPUT
 
     outputs:
       release_body: ${{ steps.read_changelog.outputs.release_body }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=version::${{ github.ref_name }}
+      run: echo version=${{ github.ref_name }} >> $GITHUB_OUTPUT
 
     - name: Extract changelog
       id: read_changelog
@@ -31,12 +31,13 @@ jobs:
         export VERSION='${{ steps.get_version.outputs.version }}'
         perl -0777 -ne '/^# Motoko compiler changelog\n\n## (??{quotemeta($ENV{VERSION})}) \(\d\d\d\d-\d\d-\d\d\)\n\n(.*?)^##/sm or die "Changelog does not look right for this version\n" ; print $1' Changelog.md > changelog-extract.md
         cat changelog-extract.md
-        # need to mangle to use with set-output, see https://github.com/svenstaro/upload-release-action/pull/49/files
+        # need to mangle to use with $GITHUB_OUTPUT (previously: set-output),
+        # see https://github.com/svenstaro/upload-release-action/pull/49/files
         r="$(cat changelog-extract.md)"
         r="${r//'%'/'%25'}"
         r="${r//$'\n'/'%0A'}"
         r="${r//$'\r'/'%0D'}"
-        echo "::set-output name=release_body::$r"
+        echo "release_body=$r" >> $GITHUB_OUTPUT
 
     outputs:
       release_body: ${{ steps.read_changelog.outputs.release_body }}


### PR DESCRIPTION
Removes warnings as noted in
https://github.com/dfinity/motoko/pull/3483#issue-1406029328

resolved according to
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands

_N.B._: we do not use `save-state`, so nothing to do on that front.

Also changes some convoluted shell substitutions to `perl`.