### PR TITLE
experimentally try using the GH-generated token

### DIFF
--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         author_name: Nix hash updater
         author_email: "<nobody@example.com>"
-        github_token: ${{ secrets.NIV_UPDATER_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         message: "Updating nix hashes"
         # do not pull: if this branch is behind, then we might as well let
         # the pushing fail


### PR DESCRIPTION
The `NIV_UPDATER_TOKEN` is not up to the task pushing to the repo. Let's see if this gets better.

See: https://dev.to/github/the-githubtoken-in-github-actions-how-it-works-change-permissions-customizations-3cgp