### PR TITLE
Multi-value emulation: Use globals, not allocated tuples

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -6525,15 +6525,14 @@ module StackRep = struct
     | p -> todo "StackRep.of_type" (Arrange_ir.typ p) Vanilla
 
   (* The env looks unused, but will be needed once we can use multi-value, to register
-     the complex types in the environment *)
+     the complex types in the environment.
+     For now, multi-value block returns are handled via FakeMultiVal. *)
   let to_block_type env = function
     | Vanilla -> [I32Type]
     | UnboxedWord64 -> [I64Type]
     | UnboxedWord32 -> [I32Type]
     | UnboxedFloat64 -> [F64Type]
-    | UnboxedTuple n ->
-      if n > 1 then assert !Flags.multi_value;
-      Lib.List.make n I32Type
+    | UnboxedTuple n -> Lib.List.make n I32Type
     | Const _ -> []
     | Unreachable -> []
 
@@ -6563,15 +6562,6 @@ module StackRep = struct
     | _, _ ->
       Printf.eprintf "Invalid stack rep join (%s, %s)\n"
         (to_string sr1) (to_string sr2); sr1
-
-  (* This is used when two blocks join, e.g. in an if. In that
-     case, they cannot return multiple values. *)
-  let relax =
-    if !Flags.multi_value
-    then fun sr -> sr
-    else function
-      | UnboxedTuple n when n > 1 -> Vanilla
-      | sr -> sr
 
   let drop env (sr_in : t) =
     match sr_in with
@@ -9157,13 +9147,14 @@ and compile_exp (env : E.t) ae exp =
     let code_scrut = compile_exp_as_test env ae scrut in
     let sr1, code1 = compile_exp env ae e1 in
     let sr2, code2 = compile_exp env ae e2 in
-    let sr = StackRep.relax (StackRep.join sr1 sr2) in
+    let sr = StackRep.join sr1 sr2 in
+    let bt = StackRep.to_block_type env sr in
     sr,
     code_scrut ^^
-    E.if_ env
-      (StackRep.to_block_type env sr)
-      (code1 ^^ StackRep.adjust env sr1 sr)
-      (code2 ^^ StackRep.adjust env sr2 sr)
+    E.if_ env (FakeMultiVal.ty bt)
+      (code1 ^^ StackRep.adjust env sr1 sr ^^ FakeMultiVal.store env bt)
+      (code2 ^^ StackRep.adjust env sr2 sr ^^ FakeMultiVal.store env bt) ^^
+   FakeMultiVal.load env bt
   | BlockE (decs, exp) ->
     let captured = Freevars.captured_vars (Freevars.exp exp) in
     let ae', codeW1 = compile_decs env ae decs captured in


### PR DESCRIPTION
So far, the IC does not support wasm using multi-value returns from functions and blocks (see #1459). The backend was originally written with that feature in mind, and later we added a work-around (module `FakeMultiVal`).

For functions we work around it by storing multiple values in fixed globals, and reading them after the call. No allocations needed.

For blocks with multiple values, however, we allocate a tuple (array) on the heap, write the values there, and read them later. This adds unnecessary heap churn and fills up memory faster.

So this PR uses the mechanism from the functions also for blocks.

Goes well with #3556

Here is a (particularly bad) example:

In
```motoko
func multi_value_blocks(n : Nat) : (Nat, Nat) {
  return (
    if (n == 0) {
      returns_tuple()
    } else {
      if (n == 1) {
        returns_tuple()
      } else {
        returns_tuple()
      }
   }
 );
};
```
Now no allocation happens (and all the reads and writes to the global variables are eliminated due to #3556):

```diff
   (func $multi_value_blocks (type 1) (param $clos i32) (param $n i32)
     local.get $n
     i32.const 0
     call $B_eq
-    if (result i32)  ;; label = @1
+    if  ;; label = @1
       i32.const 0
       call $returns_tuple
-      global.get 4
-      global.get 5
-      call $to_2_tuple
     else
       local.get $n
       i32.const 2
       call $B_eq
-      if (result i32)  ;; label = @2
+      if  ;; label = @2
         i32.const 0
         call $returns_tuple
-        global.get 4
-        global.get 5
-        call $to_2_tuple
       else
         i32.const 0
         call $returns_tuple
-        global.get 4
-        global.get 5
-        call $to_2_tuple
       end
     end
-    call $from_2_tuple
     return)
```