### PR TITLE
viper: switch to stable server

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -753,8 +753,8 @@ rec {
   };
 
   viperServer = nixpkgs.fetchurl {
-    url = https://github.com/viperproject/viperserver/releases/download/v-2022-11-16-0717/viperserver.jar;
-    sha256 = "sha256:03y612gqcz671ch3m9yhsm4vcg6vfhh1h2sp5hx6xh0azi4k6z69";
+    url = https://github.com/viperproject/viperserver/releases/download/v.22.11-release/viperserver.jar;
+    sha256 = "sha256-debC8ZpbIjgpEeISCISU0EVySJvf+WsUkUaLuJ526wA=";
   };
 
   shell = stdenv.mkDerivation {

--- a/test/viper/ok/assertions.silicon.ok
+++ b/test/viper/ok/assertions.silicon.ok
@@ -1,4 +1,2 @@
   [0] Postcondition of __init__ might not hold. Assertion $Self.u might not hold. (assertions.vpr@10.13--10.24)
-
   [1] Assert might fail. Assertion $Self.u ==> $Self.v > 0 might not hold. (assertions.vpr@28.15--28.44)
-

--- a/test/viper/ok/async.silicon.ok
+++ b/test/viper/ok/async.silicon.ok
@@ -1,2 +1,1 @@
   [0] Exhale might fail. Assertion $Self.$message_async <= 1 might not hold. (async.vpr@33.15--33.42)
-

--- a/test/viper/ok/claim-broken.silicon.ok
+++ b/test/viper/ok/claim-broken.silicon.ok
@@ -1,2 +1,1 @@
   [0] Exhale might fail. Assertion $Self.$message_async == 1 ==> $Self.claimed && $Self.count == 0 might not hold. (claim-broken.vpr@31.20--31.47)
-

--- a/test/viper/ok/invariant.silicon.ok
+++ b/test/viper/ok/invariant.silicon.ok
@@ -1,2 +1,1 @@
   [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@7.13--7.24)
-


### PR DESCRIPTION
It still has somewhat outdated backends, but we never had problems with those.

But this gives a non-moving download URL, so that's a win!