### PR TITLE
fix: thread the mode into the parser

### DIFF
--- a/src/languageServer/imports.ml
+++ b/src/languageServer/imports.ml
@@ -9,7 +9,10 @@ type import = string * string
 
 let parse_with mode lexbuf parser =
   let tokenizer, _ = Lexer.tokenizer mode lexbuf in
-  Ok (Parsing.parse Lexer_lib.mode 0 (parser lexbuf.Lexing.lex_curr_p) tokenizer lexbuf)
+  Ok
+    (Parsing.parse Lexer_lib.mode 0
+       (parser lexbuf.Lexing.lex_curr_p)
+       tokenizer lexbuf)
 
 let parse_string s =
   try

--- a/src/languageServer/imports.ml
+++ b/src/languageServer/imports.ml
@@ -9,7 +9,7 @@ type import = string * string
 
 let parse_with mode lexbuf parser =
   let tokenizer, _ = Lexer.tokenizer mode lexbuf in
-  Ok (Parsing.parse 0 (parser lexbuf.Lexing.lex_curr_p) tokenizer lexbuf)
+  Ok (Parsing.parse Lexer_lib.mode 0 (parser lexbuf.Lexing.lex_curr_p) tokenizer lexbuf)
 
 let parse_string s =
   try

--- a/src/mo_frontend/assertions.mly
+++ b/src/mo_frontend/assertions.mly
@@ -14,14 +14,14 @@
 
 %public exp_nondec(B) :
   | ASSERT COLON SYSTEM e=exp_nest
-    { is_verification &&& AssertE(Static, e) @? at $sloc }
+    { is_verification () &&& AssertE(Static, e) @? at $sloc }
   | ASSERT COLON INVARIANT e=exp_nest
-    { is_verification &&& AssertE(Invariant, e) @? at $sloc }
+    { is_verification () &&& AssertE(Invariant, e) @? at $sloc }
   | ASSERT COLON FUNC e=exp_nest
-    { is_verification &&& AssertE(Precondition, e) @? at $sloc }
+    { is_verification () &&& AssertE(Precondition, e) @? at $sloc }
   | ASSERT COLON RETURN e=exp_nest
-    { is_verification &&& AssertE(Postcondition, e) @? at $sloc }
+    { is_verification () &&& AssertE(Postcondition, e) @? at $sloc }
   | ASSERT COLON s=NAT COLON ASYNC e=exp_nest
-    { is_verification &&& AssertE(Concurrency s, e) @? at $sloc }
+    { is_verification () &&& AssertE(Concurrency s, e) @? at $sloc }
 
 %%

--- a/src/mo_frontend/assertions.mly
+++ b/src/mo_frontend/assertions.mly
@@ -1,4 +1,26 @@
-(* Viper only tokens and productions *)
+%{
+
+let verification_syntax_error at code msg =
+  Diag.add_msg (Option.get !Parser_lib.msg_store)
+    (Diag.error_message at code "verification syntax" msg)
+
+(* Verification mode only *)
+
+let (&&&) cond (action : Mo_def.Syntax.exp) =
+  if not cond then
+    verification_syntax_error
+      action.Source.at
+      "M0181" "verification assertions not permitted in normal mode";
+  action
+
+let is_verification () =
+  match !Parser_lib.mode with
+  | None -> assert false
+  | Some mode -> mode.Lexer_lib.verification
+
+%}
+
+(* Viper-only tokens and productions *)
 
 %token INVARIANT
 %token IMPLIES

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -205,7 +205,10 @@ let (&&&) cond action =
   if not cond then syntax_error action.at "M0181" "verification assertions not permitted in normal mode";
   action
 
-let is_verification = Lexer_lib.(mode.verification)
+let is_verification () =
+  match !Parser_lib.mode with
+  | None -> assert false
+  | Some mode -> mode.Lexer_lib.verification
 
 %}
 

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -199,17 +199,6 @@ and objblock s dec_fields =
     | _ -> ()) dec_fields;
   ObjBlockE(s, dec_fields)
 
-(* Verification mode only *)
-
-let (&&&) cond action =
-  if not cond then syntax_error action.at "M0181" "verification assertions not permitted in normal mode";
-  action
-
-let is_verification () =
-  match !Parser_lib.mode with
-  | None -> assert false
-  | Some mode -> mode.Lexer_lib.verification
-
 %}
 
 %token EOF DISALLOWED

--- a/src/mo_frontend/parser_lib.ml
+++ b/src/mo_frontend/parser_lib.ml
@@ -2,5 +2,6 @@ exception Imports of Mo_def.Syntax.dec list
 
 (* Temporary hack! *)
 let msg_store : Diag.msg_store option ref = ref None
+let mode : Lexer_lib.mode option ref = ref None
 
 let triv_table : Mo_def.Trivia.triv_table ref = ref Mo_def.Trivia.empty_triv_table

--- a/src/mo_frontend/parsing.ml
+++ b/src/mo_frontend/parsing.ml
@@ -70,11 +70,12 @@ let slice_lexeme lexbuf i1 i2 =
   then "<unknown>" (* Too rare to care *)
   else Bytes.sub_string lexbuf.lex_buffer offset len
 
-let parse error_detail checkpoint lexer lexbuf =
+let parse mode error_detail checkpoint lexer lexbuf =
   Diag.with_message_store (fun m ->
     try
       (* Temporary hack! *)
       Parser_lib.msg_store := Some m;
+      Parser_lib.mode := Some mode;
       Some (E.entry checkpoint lexer)
     with E.Error ((start, end_), explanations) ->
       let at =

--- a/src/mo_frontend/parsing.mli
+++ b/src/mo_frontend/parsing.mli
@@ -8,7 +8,8 @@ type error_detail = int  (* TODO: make this a datatype! *)
 
 exception Error of string * Lexing.position * Lexing.position
 
-val parse : error_detail ->
+val parse : Lexer_lib.mode ->
+            error_detail ->
             'a Parser.MenhirInterpreter.checkpoint ->
             Parser.MenhirInterpreter.supplier ->
             Lexing.lexbuf ->

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -96,7 +96,7 @@ let generic_parse_with mode lexer parser name : _ Diag.result =
   let* mk_syntax =
     try
       Parser_lib.triv_table := triv_table;
-      Parsing.parse (!Flags.error_detail) (parser lexer.Lexing.lex_curr_p) tokenizer lexer
+      Parsing.parse mode (!Flags.error_detail) (parser lexer.Lexing.lex_curr_p) tokenizer lexer
     with Lexer.Error (at, msg) -> Diag.error at"M0002" "syntax" msg
   in
   let phrase = mk_syntax name in

--- a/test/fail/ok/verification-asserts.tc.ok
+++ b/test/fail/ok/verification-asserts.tc.ok
@@ -1,7 +1,7 @@
-verification-asserts.mo:1.1-1.19: syntax error [M0181], verification assertions not permitted in normal mode
-verification-asserts.mo:2.1-2.20: syntax error [M0181], verification assertions not permitted in normal mode
-verification-asserts.mo:3.1-3.17: syntax error [M0181], verification assertions not permitted in normal mode
-verification-asserts.mo:4.1-4.19: syntax error [M0181], verification assertions not permitted in normal mode
+verification-asserts.mo:1.1-1.19: verification syntax error [M0181], verification assertions not permitted in normal mode
+verification-asserts.mo:2.1-2.20: verification syntax error [M0181], verification assertions not permitted in normal mode
+verification-asserts.mo:3.1-3.17: verification syntax error [M0181], verification assertions not permitted in normal mode
+verification-asserts.mo:4.1-4.19: verification syntax error [M0181], verification assertions not permitted in normal mode
 verification-asserts.mo:7.8-7.17: syntax error [M0001], unexpected token 'invariant', expected one of token or <phrase> sequence:
   system <exp_nest>
   return <exp_nest>


### PR DESCRIPTION
Turns out I was doing a bunch of things wrong. Now we make the relevant `Lexer_lib.mode` accessible from the parser productions (previously it just accessed a constant thing).

This makes `--viper` to select the `verification` mode in the parser too (lexer was already fine).