### PR TITLE
resort to one-element mutable arrays as a workaround for aliased `var` field

### DIFF
--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -230,11 +230,7 @@ let check_builtin what src senv0 : Syntax.prog * stat_env =
 let prelude, initial_stat_env0 =
   check_builtin "prelude" Prelude.prelude Typing.initial_scope
 let internals, initial_stat_env =
-  let aliasing = !Flags.experimental_field_aliasing in
-  Flags.experimental_field_aliasing := true;
-  let checked = check_builtin "internals" Prelude.internals initial_stat_env0 in
-  Flags.experimental_field_aliasing := aliasing;
-  checked
+  check_builtin "internals" Prelude.internals initial_stat_env0
 
 (* Stable compatibility *)
 


### PR DESCRIPTION
This is a response to the review comment about better not use experimental features in production code.

Personally I am not sure this is an issue :-)