### PR TITLE
feat: add configurable interpreter step limit for `moc.js`

### DIFF
--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -59,6 +59,9 @@ let js_check source =
   Mo_types.Cons.session (fun _ -> 
     js_result (Pipeline.check_files [Js.to_string source]) (fun _ -> Js.null))
 
+let js_set_run_step_limit limit =
+  Mo_interpreter.Interpret.step_limit := limit
+
 let js_run list source =
   Mo_types.Cons.session (fun _ -> 
     let list = Js.to_array list |> Array.to_list |> List.map Js.to_string in

--- a/src/js/moc_interpreter.ml
+++ b/src/js/moc_interpreter.ml
@@ -20,5 +20,6 @@ let () =
       method clearPackage () = clear_package ()
       method setCandidPath path = set_candid_path path
       method setActorAliases entries = set_actor_aliases entries
+      method setRunStepLimit limit = js_set_run_step_limit limit
       method run list s = wrap_output (fun _ -> js_run list s)
      end);

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -24,6 +24,7 @@ let () =
       method setCandidPath path = set_candid_path path
       method setActorAliases entries = set_actor_aliases entries
       method setPublicMetadata entries = set_public_metadata entries
+      method setRunStepLimit limit = js_set_run_step_limit limit
       method gcFlags option = gc_flags option
       method run list s = Flags.compiled := false; wrap_output (fun _ -> js_run list s)
       method check s = Flags.compiled := false; js_check s

--- a/src/mo_interpreter/interpret.mli
+++ b/src/mo_interpreter/interpret.mli
@@ -18,6 +18,8 @@ type scope =
 val empty_scope : scope
 val adjoin_scope : scope -> scope -> scope
 
+val step_limit : int ref
+
 exception Trap of Source.region * string
 
 val interpret_prog : flags -> scope -> Syntax.prog -> (V.value * scope) option

--- a/test/test-moc_interpreter.js
+++ b/test/test-moc_interpreter.js
@@ -9,6 +9,7 @@ const moc = require('moc_interpreter.js');
 moc.Motoko.saveFile('empty.mo', '');
 moc.Motoko.saveFile('ok.mo', '1');
 moc.Motoko.saveFile('bad.mo', '1+');
+moc.Motoko.saveFile('limit.mo', 'var i = 0; while (i < 10000) { i += 1 }; i');
 
 assert.deepStrictEqual(moc.Motoko.run([], 'ok.mo'), {
   result: 0,
@@ -20,4 +21,18 @@ assert.deepStrictEqual(moc.Motoko.run([], 'bad.mo'), {
   result: 0,
   stderr: 'bad.mo:1.3: syntax error [M0001], unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>\n',
   stdout: '',
+});
+
+assert.deepStrictEqual(moc.Motoko.run([], 'limit.mo'), {
+  result: 0,
+  stderr: '',
+  stdout: '10_000 : Nat\n'
+});
+
+moc.Motoko.setRunStepLimit(5000);
+
+assert.deepStrictEqual(moc.Motoko.run([], 'limit.mo'), {
+  result: 0,
+  stderr: 'cancelled: interpreter reached step limit\n',
+  stdout: ''
 });


### PR DESCRIPTION
Adds an optional deterministic step limit to the `moc.js` interpreter. 

This feature will protect users from accidentally crashing the browser with a code snippet such as `while true {}` now that we are using a trampoline (#3541), so I suppose this is a nice problem to have.
