### PR TITLE
feat: add doc comments to `moc.js` parse output

### DIFF
--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -132,6 +132,7 @@ let js_parse_motoko s =
     let module Arrange = Mo_def.Arrange.Make (struct
       let include_sources = true
       let include_types = false
+      let include_docs = Some prog
       let main_file = Some main_file
     end)
     in Js.some (js_of_sexpr (Arrange.prog prog)))
@@ -146,6 +147,7 @@ let js_parse_motoko_typed paths =
     let module Arrange_sources_types = Mo_def.Arrange.Make (struct
       let include_sources = true
       let include_types = true
+      let include_docs = Some prog
       let main_file = Some prog.at.left.file
     end)
     in object%js

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -129,10 +129,11 @@ let js_parse_motoko s =
   let main_file = "" in
   let parse_result = Pipeline.parse_string main_file (Js.to_string s) in
   js_result parse_result (fun (prog, _) ->
-    let module Arrange = Mo_def.Arrange.Make (struct
+    let open Mo_def in
+    let module Arrange = Arrange.Make (struct
       let include_sources = true
       let include_types = false
-      let include_docs = Some prog
+      let include_docs = Some prog.note.Syntax.trivia
       let main_file = Some main_file
     end)
     in Js.some (js_of_sexpr (Arrange.prog prog)))
@@ -144,10 +145,11 @@ let js_parse_motoko_typed paths =
   in
   js_result load_result (fun (libs, progs, senv) ->
   progs |> List.map (fun prog ->
-    let module Arrange_sources_types = Mo_def.Arrange.Make (struct
+    let open Mo_def in
+    let module Arrange_sources_types = Arrange.Make (struct
       let include_sources = true
       let include_types = true
-      let include_docs = Some prog
+      let include_docs = Some prog.note.Syntax.trivia
       let main_file = Some prog.at.left.file
     end)
     in object%js

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -8,7 +8,7 @@ open Wasm.Sexpr
 module type Config = sig
   val include_sources : bool
   val include_types : bool
-  val include_docs : Syntax.prog option
+  val include_docs : Trivia.trivia_info Trivia.PosHashtbl.t option
   val main_file : string option
 end
 
@@ -35,9 +35,9 @@ module Make (Cfg : Config) = struct
   
   let trivia at it =
     match Cfg.include_docs with
-    | Some prog ->
+    | Some table ->
       let rec lookup_trivia (line, column) =
-        Trivia.PosHashtbl.find_opt prog.note.Syntax.trivia Trivia.{ line; column }
+        Trivia.PosHashtbl.find_opt table Trivia.{ line; column }
       and find_trivia (parser_pos : Source.region) : Trivia.trivia_info =
         lookup_trivia Source.(parser_pos.left.line, parser_pos.left.column) |> Option.get
       in

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -8,12 +8,14 @@ open Wasm.Sexpr
 module type Config = sig
   val include_sources : bool
   val include_types : bool
+  val include_docs : Syntax.prog option
   val main_file : string option
 end
 
 module Default = struct
   let include_sources = false
   let include_types = false
+  let include_docs = None
   let main_file = None
 end
 
@@ -29,10 +31,21 @@ module Make (Cfg : Config) = struct
     in "Pos" $$ [Atom file; Atom (string_of_int p.line); Atom (string_of_int p.column)]
   let source at it = if Cfg.include_sources && at <> Source.no_region then "@" $$ [pos at.left; pos at.right; it] else it
 
-  let typ typ = Atom (Type_pretty.string_of_typ typ)
-  (* let typ typ = Atom (Type.string_of_typ typ) *)
-  (* let typ = Mo_types.Arrange_type.typ *)
+  let typ t = Atom (Type_pretty.string_of_typ t)
   
+  let trivia at it =
+    match Cfg.include_docs with
+    | Some prog ->
+      let rec lookup_trivia (line, column) =
+        Trivia.PosHashtbl.find_opt prog.note.Syntax.trivia Trivia.{ line; column }
+      and find_trivia (parser_pos : Source.region) : Trivia.trivia_info =
+        lookup_trivia Source.(parser_pos.left.line, parser_pos.left.column) |> Option.get
+      in
+      (match Trivia.doc_comment_of_trivia_info (find_trivia at) with
+      | Some s -> "*" $$ [Atom s; it]
+      | None -> it)
+    | None -> it
+
   let eff (eff : Mo_types.Type.eff) = match eff with
   | Mo_types.Type.Triv -> Atom "Triv"
   | Mo_types.Type.Await -> Atom "Await"
@@ -205,7 +218,7 @@ module Make (Cfg : Config) = struct
     = source tb.at (tb.it.var.it $$ [typ tb.it.bound])
 
   and dec_field (df : dec_field)
-    = source df.at ("DecField" $$ [dec df.it.dec; vis df.it.vis; stab df.it.stab])
+    = trivia df.at (source df.at ("DecField" $$ [dec df.it.dec; vis df.it.vis; stab df.it.stab]))
 
   and exp_field (ef : exp_field)
     = source ef.at ("ExpField" $$ [mut ef.it.mut; id ef.it.id; exp ef.it.exp])
@@ -231,7 +244,7 @@ module Make (Cfg : Config) = struct
   | ParT t -> "ParT" $$ [typ t]
   | NamedT (id, t) -> "NamedT" $$ [Atom id.it; typ t]))
 
-  and dec d = source d.at (match d.it with
+  and dec d = trivia d.at (source d.at (match d.it with
     | ExpD e -> "ExpD" $$ [exp e ]
     | LetD (p, e) -> "LetD" $$ [pat p; exp e]
     | VarD (x, e) -> "VarD" $$ [id x; exp e]
@@ -242,7 +255,7 @@ module Make (Cfg : Config) = struct
         pat p;
         (match rt with None -> Atom "_" | Some t -> typ t);
         obj_sort s; id i'
-      ] @ List.map dec_field dfs)
+      ] @ List.map dec_field dfs))
 
   and prog p = "Prog" $$ List.map dec p.it
 end

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -15,6 +15,24 @@ moc.Motoko.saveFile(
   "actor.mo",
   'actor { type A<B> = B; public query func main() : async A<Text> { "abc" } }'
 );
+moc.Motoko.saveFile(
+  "ast.mo",
+  `
+  /// Module
+  module {
+    /// Variable
+    let x = 0;
+    /// Type
+    public type A<B> = B;
+    /** Function */
+    public query func main() {};
+    /// Sub-module
+    module M {
+      /// Class
+      public class C() {};
+    };
+  }`
+);
 
 assert.equal(moc.Motoko.readFile("empty.mo"), "");
 assert.equal(moc.Motoko.readFile("ok.mo"), "1");
@@ -117,7 +135,19 @@ assert.deepStrictEqual(moc.Motoko.check("bad.mo"), {
   code: null,
 });
 
-// // Check WASM reproducibility
+const astString = JSON.stringify(
+  moc.Motoko.parseMotoko(moc.Motoko.readFile("ast.mo"))
+);
+
+// Check doc comments
+assert.match(astString, /"name":"\*","args":\["Module"/);
+assert.match(astString, /"name":"\*","args":\["Variable"/);
+assert.match(astString, /"name":"\*","args":\["Type"/);
+assert.match(astString, /"name":"\*","args":\["Function"/);
+assert.match(astString, /"name":"\*","args":\["Sub-module"/);
+assert.match(astString, /"name":"\*","args":\["Class"/);
+
+// // Check Wasm reproducibility
 // assert.deepStrictEqual(
 //   moc.Motoko.compileWasm("ic", "actor.mo").code.wasm,
 //   moc.Motoko.compileWasm("ic", "actor.mo").code.wasm


### PR DESCRIPTION
Makes it possible to extract and display Markdown doc comments in the VS Code extension and other JS environments. 
