### PR TITLE
Add Blocks Editor to the readme under "Community resources"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A safe, simple, actor-based programming language for authoring [Internet Compute
 ## Community resources
 
 * [Awesome Motoko](https://github.com/motoko-unofficial/awesome-motoko#readme)
+* [Blocks - an online low-code editor for Motoko](https://github.com/Blocks-Editor/blocks)
+* [MOPS - a Motoko package manager hosted on the IC](https://j4mwm-bqaaa-aaaam-qajbq-cai.ic0.app/)
 * [Motoko Bootcamp](https://github.com/motoko-bootcamp/bootcamp#readme) &middot; ([YouTube channel](https://www.youtube.com/channel/UCa7_xHjvOESf9v281VU4qVw))
 * [Motoko library starter template](https://github.com/ByronBecker/motoko-library-template)
-* [MOPS - a Motoko package manager hosted on the IC](https://j4mwm-bqaaa-aaaam-qajbq-cai.ic0.app/#/)


### PR DESCRIPTION
Adds [Blocks](https://github.com/blocks-editor/blocks) to the community resource list as a response to various requests (e.g. [this recent forum post](https://forum.dfinity.org/t/in-defense-of-dom-and-the-dfinity-team-there-is-a-future-for-the-internet-computer/17241/)) for low-code canister builders in the IC. 
