### PR TITLE
chore: bump `rustc` stable to 1.66

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -95,9 +95,9 @@ let
           };
         })
 
-        # Rust 1.62
+        # Rust 1.66
         (self: super: let
-          rust-channel = self.moz_overlay.rustChannelOf { date = "2022-06-30"; channel = "stable"; };
+          rust-channel = self.moz_overlay.rustChannelOf { date = "2022-12-15"; channel = "stable"; };
         in {
           rustPlatform_moz_stable = self.makeRustPlatform {
             rustc = rust-channel.rust;


### PR DESCRIPTION
Recent `drun` builds require 1.65, so let's leapfrog!