### PR TITLE
`niv-updater-action` bump (experiment)

### DIFF
--- a/.github/workflows/niv-updater-trial.yml
+++ b/.github/workflows/niv-updater-trial.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@v10
+        uses: knl/niv-updater-action@d1c37728deda061bda1d1459ad8193b887fa0eab
         with:
           whitelist: 'nixpkgs,musl-wasi,ic'
           labels: |


### PR DESCRIPTION
This is a test balloon for gaining experience with the `main` revision of the GH action. As soon this hits our `master` branch I can test it by triggering the action via nudging.

If it doesn't work, no biggie, the action will need another update.

_Context_: https://github.com/knl/niv-updater-action/issues/56