### PR TITLE
fix flaky timer test

### DIFF
--- a/test/run-drun/timer-cancel.mo
+++ b/test/run-drun/timer-cancel.mo
@@ -19,7 +19,7 @@ actor {
 
   let second : Nat64 = 1_000_000_000;
 
-  ignore setTimer(2 * second, false,
+  ignore setTimer(3 * second, false,
     func () : async () {
       t := setTimer(2 * second, true, remind);
       await remind();


### PR DESCRIPTION
It seemed flaky with compacting-gc. Increased the initial timer's duration to 3 seconds.