### PR TITLE
fix(mo-doc): add constructors to Markdown output

### DIFF
--- a/doc/md/base/Array.md
+++ b/doc/md/base/Array.md
@@ -480,3 +480,23 @@ sum
 Runtime: O(1)
 
 Space: O(1)
+
+## Function `size`
+``` motoko no-repl
+func size<X>(array : [X]) : Nat
+```
+
+Returns the size of `array`.
+
+NOTE: You can also use `array.size()` instead of this function. See example
+below.
+
+```motoko include=import
+
+let array = [10, 11, 12];
+let size = Array.size(array);
+```
+
+Runtime: O(1)
+
+Space: O(1)

--- a/doc/md/base/Buffer.md
+++ b/doc/md/base/Buffer.md
@@ -35,7 +35,11 @@ Runtime: O(initCapacity)
 
 Space: O(initCapacity)
 
-## `class Buffer<X>`
+## Class `Buffer<X>`
+
+``` motoko no-repl
+class Buffer<X>(initCapacity : Nat)
+```
 
 
 ### Function `size`
@@ -47,7 +51,7 @@ Returns the current number of elements in the buffer.
 
 Example:
 ```motoko include=initialize
-buffer.size()
+buffer.size() // => 0
 ```
 
 Runtime: O(1)
@@ -70,7 +74,7 @@ buffer.add(0); // add 0 to buffer
 buffer.add(1);
 buffer.add(2);
 buffer.add(3); // causes underlying array to increase in capacity
-Buffer.toArray(buffer)
+Buffer.toArray(buffer) // => [0, 1, 2, 3]
 ```
 
 Amortized Runtime: O(1), Worst Case Runtime: O(size)
@@ -90,7 +94,7 @@ Example:
 
 buffer.add(10);
 buffer.add(11);
-let x = buffer.get(0); // evaluates to 10
+buffer.get(0); // => 10
 ```
 
 Runtime: O(1)
@@ -111,8 +115,8 @@ Example:
 
 buffer.add(10);
 buffer.add(11);
-let x = buffer.getOpt(0); // evaluates to ?10
-let y = buffer.getOpt(2); // evaluates to null
+let x = buffer.getOpt(0); // => ?10
+let y = buffer.getOpt(2); // => null
 ```
 
 Runtime: O(1)
@@ -133,7 +137,7 @@ Example:
 
 buffer.add(10);
 buffer.put(0, 20); // overwrites 10 at index 0 with 20
-Buffer.toArray(buffer)
+Buffer.toArray(buffer) // => [20]
 ```
 
 Runtime: O(1)
@@ -154,7 +158,7 @@ Example:
 
 buffer.add(10);
 buffer.add(11);
-let x = buffer.removeLast(); // evaluates to ?11
+buffer.removeLast(); // => ?11
 ```
 
 Amortized Runtime: O(1), Worst Case Runtime: O(size)
@@ -184,7 +188,7 @@ buffer.add(10);
 buffer.add(11);
 buffer.add(12);
 let x = buffer.remove(1); // evaluates to 11. 11 no longer in list.
-Buffer.toArray(buffer)
+Buffer.toArray(buffer) // => [10, 12]
 ```
 
 Runtime: O(size)
@@ -206,7 +210,7 @@ buffer.add(10);
 buffer.add(11);
 buffer.add(12);
 buffer.clear(); // buffer is now empty
-Buffer.toArray(buffer)
+Buffer.toArray(buffer) // => []
 ```
 
 Runtime: O(1)
@@ -230,7 +234,7 @@ buffer.add(10);
 buffer.add(11);
 buffer.add(12);
 buffer.filterEntries(func(_, x) = x % 2 == 0); // only keep even elements
-Buffer.toArray(buffer)
+Buffer.toArray(buffer) // => [10, 12]
 ```
 
 Runtime: O(size)
@@ -250,10 +254,10 @@ Example:
 
 let buffer = Buffer.Buffer<Nat>(2); // underlying array has capacity 2
 buffer.add(10);
-let c1 = buffer.capacity(); // evaluates to 2
+let c1 = buffer.capacity(); // => 2
 buffer.add(11);
 buffer.add(12); // causes capacity to increase by factor of 1.5
-let c2 = buffer.capacity(); // evaluates to 3
+let c2 = buffer.capacity(); // => 3
 ```
 
 Runtime: O(1)
@@ -273,7 +277,7 @@ Changes the capacity to `capacity`. Traps if `capacity` < `size`.
 buffer.reserve(4);
 buffer.add(10);
 buffer.add(11);
-let c = buffer.capacity(); // evaluates to 4
+buffer.capacity(); // => 4
 ```
 
 Runtime: O(capacity)
@@ -296,7 +300,7 @@ buffer1.add(11);
 buffer2.add(12);
 buffer2.add(13);
 buffer1.append(buffer2); // adds elements from buffer2 to buffer1
-Buffer.toArray(buffer1)
+Buffer.toArray(buffer1) // => [10, 11, 12, 13]
 ```
 
 Amortized Runtime: O(size2), Worst Case Runtime: O(size1 + size2)
@@ -318,7 +322,7 @@ let buffer2 = Buffer.Buffer<Nat>(2);
 buffer.add(10);
 buffer.add(11);
 buffer.insert(1, 9);
-Buffer.toArray(buffer)
+Buffer.toArray(buffer) // => [10, 9, 11]
 ```
 
 Runtime: O(size)
@@ -342,7 +346,7 @@ buffer1.add(11);
 buffer2.add(12);
 buffer2.add(13);
 buffer1.insertBuffer(1, buffer2);
-Buffer.toArray(buffer1)
+Buffer.toArray(buffer1) // => [10, 12, 13, 11]
 ```
 
 Runtime: O(size)
@@ -366,7 +370,7 @@ buffer.add(11);
 buffer.add(12);
 buffer.add(10);
 buffer.sort(Nat.compare);
-Buffer.toArray(buffer)
+Buffer.toArray(buffer) // => [10, 11, 12]
 ```
 
 Runtime: O(size * log(size))
@@ -393,7 +397,7 @@ var sum = 0;
 for (element in buffer.vals()) {
   sum += element;
 };
-sum
+sum // => 33
 ```
 
 Runtime: O(1)
@@ -429,7 +433,19 @@ func toVarArray() : [var X]
 func isEmpty<X>(buffer : Buffer<X>) : Bool
 ```
 
-Returns true iff the buffer is empty.
+Returns true if and only if the buffer is empty.
+
+Example:
+```motoko include=initialize
+buffer.add(2);
+buffer.add(0);
+buffer.add(3);
+Buffer.isEmpty(buffer); // => false
+```
+
+```motoko include=initialize
+Buffer.isEmpty(buffer); // => true
+```
 
 Runtime: O(1)
 
@@ -442,6 +458,17 @@ func contains<X>(buffer : Buffer<X>, element : X, equal : (X, X) -> Bool) : Bool
 
 Returns true iff `buffer` contains `element` with respect to equality
 defined by `equal`.
+
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(2);
+buffer.add(0);
+buffer.add(3);
+Buffer.contains<Nat>(buffer, 2, Nat.equal); // => true
+```
 
 Runtime: O(size)
 
@@ -456,6 +483,16 @@ func clone<X>(buffer : Buffer<X>) : Buffer<X>
 
 Returns a copy of `buffer`, with the same capacity.
 
+
+Example:
+```motoko include=initialize
+
+buffer.add(1);
+
+let clone = Buffer.clone(buffer);
+Buffer.toArray(clone); // => [1]
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -467,6 +504,17 @@ func max<X>(buffer : Buffer<X>, compare : (X, X) -> Order) : ?X
 
 Finds the greatest element in `buffer` defined by `compare`.
 Returns `null` if `buffer` is empty.
+
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+
+Buffer.max(buffer, Nat.compare); // => ?2
+```
 
 Runtime: O(size)
 
@@ -481,6 +529,16 @@ func min<X>(buffer : Buffer<X>, compare : (X, X) -> Order) : ?X
 
 Finds the least element in `buffer` defined by `compare`.
 Returns `null` if `buffer` is empty.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+
+Buffer.min(buffer, Nat.compare); // => ?1
+```
 
 Runtime: O(size)
 
@@ -498,6 +556,22 @@ buffers. Returns true iff the two buffers are of the same size, and `equal`
 evaluates to true for every pair of elements in the two buffers of the same
 index.
 
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+let buffer1 = Buffer.Buffer<Nat>(2);
+buffer1.add(1);
+buffer1.add(2);
+
+let buffer2 = Buffer.Buffer<Nat>(5);
+buffer2.add(1);
+buffer2.add(2);
+
+Buffer.equal(buffer1, buffer2, Nat.equal); // => true
+```
+
 Runtime: O(size)
 
 Space: O(1)
@@ -512,6 +586,22 @@ func compare<X>(buffer1 : Buffer<X>, buffer2 : Buffer<X>, compare : (X, X) -> Or
 Defines comparison for two buffers, using `compare` to recursively compare elements in the
 buffers. Comparison is defined lexicographically.
 
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+let buffer1 = Buffer.Buffer<Nat>(2);
+buffer1.add(1);
+buffer1.add(2);
+
+let buffer2 = Buffer.Buffer<Nat>(3);
+buffer2.add(3);
+buffer2.add(4);
+
+Buffer.compare<Nat>(buffer1, buffer2, Nat.compare); // => #less
+```
+
 Runtime: O(size)
 
 Space: O(1)
@@ -525,6 +615,18 @@ func toText<X>(buffer : Buffer<X>, toText : X -> Text) : Text
 
 Creates a textual representation of `buffer`, using `toText` to recursively
 convert the elements into Text.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+Buffer.toText(buffer, Nat.toText); // => "[1, 2, 3, 4]"
+```
 
 Runtime: O(size)
 
@@ -541,6 +643,18 @@ Hashes `buffer` using `hash` to hash the underlying elements.
 The deterministic hash function is a function of the elements in the Buffer, as well
 as their ordering.
 
+Example:
+```motoko include=initialize
+import Hash "mo:base/Hash";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(1000);
+
+Buffer.hash<Nat>(buffer, Hash.hash); // => 2_872_640_342
+```
+
 Runtime: O(size)
 
 Space: O(1)
@@ -554,6 +668,18 @@ func indexOf<X>(element : X, buffer : Buffer<X>, equal : (X, X) -> Bool) : ?Nat
 
 Finds the first index of `element` in `buffer` using equality of elements defined
 by `equal`. Returns `null` if `element` is not found.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+Buffer.indexOf<Nat>(3, buffer, Nat.equal); // => ?2
+```
 
 Runtime: O(size)
 
@@ -569,6 +695,20 @@ func lastIndexOf<X>(element : X, buffer : Buffer<X>, equal : (X, X) -> Bool) : ?
 Finds the last index of `element` in `buffer` using equality of elements defined
 by `equal`. Returns `null` if `element` is not found.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+buffer.add(2);
+buffer.add(2);
+
+Buffer.lastIndexOf<Nat>(2, buffer, Nat.equal); // => ?5
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -581,6 +721,25 @@ func indexOfBuffer<X>(subBuffer : Buffer<X>, buffer : Buffer<X>, equal : (X, X) 
 ```
 
 Searches for `subBuffer` in `buffer`, and returns the starting index if it is found.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+buffer.add(5);
+buffer.add(6);
+
+let sub = Buffer.Buffer<Nat>(2);
+sub.add(4);
+sub.add(5);
+sub.add(6);
+
+Buffer.indexOfBuffer<Nat>(sub, buffer, Nat.equal); // => ?3
+```
 
 Runtime: O(size of buffer + size of subBuffer)
 
@@ -597,6 +756,18 @@ Similar to indexOf, but runs in logarithmic time. Assumes that `buffer` is sorte
 Behavior is undefined if `buffer` is not sorted. Uses `compare` to
 perform the search. Returns an index of `element` if it is found.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(4);
+buffer.add(5);
+buffer.add(6);
+
+Buffer.binarySearch<Nat>(5, buffer, Nat.compare); // => ?2
+```
+
 Runtime: O(log(size))
 
 Space: O(1)
@@ -612,6 +783,21 @@ Returns the sub-buffer of `buffer` starting at index `start`
 of length `length`. Traps if `start` is out of bounds, or `start + length`
 is greater than the size of `buffer`.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+buffer.add(5);
+buffer.add(6);
+
+let sub = Buffer.subBuffer(buffer, 3, 2);
+Buffer.toText(sub, Nat.toText); // => [4, 5]
+```
+
 Runtime: O(length)
 
 Space: O(length)
@@ -623,6 +809,23 @@ func isSubBufferOf<X>(subBuffer : Buffer<X>, buffer : Buffer<X>, equal : (X, X) 
 
 Checks if `subBuffer` is a sub-Buffer of `buffer`. Uses `equal` to
 compare elements.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+buffer.add(5);
+buffer.add(6);
+
+let sub = Buffer.Buffer<Nat>(2);
+sub.add(2);
+sub.add(3);
+Buffer.isSubBufferOf(sub, buffer, Nat.equal); // => true
+```
 
 Runtime: O(size of subBuffer + size of buffer)
 
@@ -639,6 +842,21 @@ Checks if `subBuffer` is a strict subBuffer of `buffer`, i.e. `subBuffer` must b
 strictly contained inside both the first and last indices of `buffer`.
 Uses `equal` to compare elements.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+let sub = Buffer.Buffer<Nat>(2);
+sub.add(2);
+sub.add(3);
+Buffer.isStrictSubBufferOf(sub, buffer, Nat.equal); // => true
+```
+
 Runtime: O(size of subBuffer + size of buffer)
 
 Space: O(size of subBuffer)
@@ -653,6 +871,19 @@ func prefix<X>(buffer : Buffer<X>, length : Nat) : Buffer<X>
 Returns the prefix of `buffer` of length `length`. Traps if `length`
 is greater than the size of `buffer`.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+let pre = Buffer.prefix(buffer, 3); // => [1, 2, 3]
+Buffer.toText(pre, Nat.toText);
+```
+
 Runtime: O(length)
 
 Space: O(length)
@@ -664,6 +895,21 @@ func isPrefixOf<X>(prefix : Buffer<X>, buffer : Buffer<X>, equal : (X, X) -> Boo
 
 Checks if `prefix` is a prefix of `buffer`. Uses `equal` to
 compare elements.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+let pre = Buffer.Buffer<Nat>(2);
+pre.add(1);
+pre.add(2);
+Buffer.isPrefixOf(pre, buffer, Nat.equal); // => true
+```
 
 Runtime: O(size of prefix)
 
@@ -679,6 +925,22 @@ func isStrictPrefixOf<X>(prefix : Buffer<X>, buffer : Buffer<X>, equal : (X, X) 
 Checks if `prefix` is a strict prefix of `buffer`. Uses `equal` to
 compare elements.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+let pre = Buffer.Buffer<Nat>(3);
+pre.add(1);
+pre.add(2);
+pre.add(3);
+Buffer.isStrictPrefixOf(pre, buffer, Nat.equal); // => true
+```
+
 Runtime: O(size of prefix)
 
 Space: O(size of prefix)
@@ -693,6 +955,19 @@ func suffix<X>(buffer : Buffer<X>, length : Nat) : Buffer<X>
 Returns the suffix of `buffer` of length `length`.
 Traps if `length`is greater than the size of `buffer`.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+let suf = Buffer.suffix(buffer, 3); // => [2, 3, 4]
+Buffer.toText(suf, Nat.toText);
+```
+
 Runtime: O(length)
 
 Space: O(length)
@@ -704,6 +979,22 @@ func isSuffixOf<X>(suffix : Buffer<X>, buffer : Buffer<X>, equal : (X, X) -> Boo
 
 Checks if `suffix` is a suffix of `buffer`. Uses `equal` to compare
 elements.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+let suf = Buffer.Buffer<Nat>(3);
+suf.add(2);
+suf.add(3);
+suf.add(4);
+Buffer.isSuffixOf(suf, buffer, Nat.equal); // => true
+```
 
 Runtime: O(length of suffix)
 
@@ -719,6 +1010,22 @@ func isStrictSuffixOf<X>(suffix : Buffer<X>, buffer : Buffer<X>, equal : (X, X) 
 Checks if `suffix` is a strict suffix of `buffer`. Uses `equal` to compare
 elements.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+let suf = Buffer.Buffer<Nat>(3);
+suf.add(2);
+suf.add(3);
+suf.add(4);
+Buffer.isStrictSuffixOf(suf, buffer, Nat.equal); // => true
+```
+
 Runtime: O(length of suffix)
 
 Space: O(length of suffix)
@@ -731,6 +1038,16 @@ func forAll<X>(buffer : Buffer<X>, predicate : X -> Bool) : Bool
 ```
 
 Returns true iff every element in `buffer` satisfies `predicate`.
+
+Example:
+```motoko include=initialize
+
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+Buffer.forAll<Nat>(buffer, func x { x > 1 }); // => true
+```
 
 Runtime: O(size)
 
@@ -745,6 +1062,16 @@ func forSome<X>(buffer : Buffer<X>, predicate : X -> Bool) : Bool
 
 Returns true iff some element in `buffer` satisfies `predicate`.
 
+Example:
+```motoko include=initialize
+
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+Buffer.forSome<Nat>(buffer, func x { x > 3 }); // => true
+```
+
 Runtime: O(size)
 
 Space: O(1)
@@ -757,6 +1084,16 @@ func forNone<X>(buffer : Buffer<X>, predicate : X -> Bool) : Bool
 ```
 
 Returns true iff no element in `buffer` satisfies `predicate`.
+
+Example:
+```motoko include=initialize
+
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+
+Buffer.forNone<Nat>(buffer, func x { x == 0 }); // => true
+```
 
 Runtime: O(size)
 
@@ -771,6 +1108,17 @@ func toArray<X>(buffer : Buffer<X>) : [X]
 
 Creates an array containing elements from `buffer`.
 
+Example:
+```motoko include=initialize
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.toArray<Nat>(buffer); // => [1, 2, 3]
+
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -781,6 +1129,16 @@ func toVarArray<X>(buffer : Buffer<X>) : [var X]
 ```
 
 Creates a mutable array containing elements from `buffer`.
+
+Example:
+```motoko include=initialize
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.toVarArray<Nat>(buffer); // => [1, 2, 3]
+```
 
 Runtime: O(size)
 
@@ -793,6 +1151,16 @@ func fromArray<X>(array : [X]) : Buffer<X>
 
 Creates a buffer containing elements from `array`.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+let array = [2, 3];
+
+let buf = Buffer.fromArray<Nat>(array); // => [2, 3]
+Buffer.toText(buf, Nat.toText);
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -803,6 +1171,16 @@ func fromVarArray<X>(array : [var X]) : Buffer<X>
 ```
 
 Creates a buffer containing elements from `array`.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+let array = [var 1, 2, 3];
+
+let buf = Buffer.fromVarArray<Nat>(array); // => [1, 2, 3]
+Buffer.toText(buf, Nat.toText);
+```
 
 Runtime: O(size)
 
@@ -815,6 +1193,17 @@ func fromIter<X>(iter : { next : () -> ?X }) : Buffer<X>
 
 Creates a buffer containing elements from `iter`.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+let array = [1, 1, 1];
+let iter = array.vals();
+
+let buf = Buffer.fromIter<Nat>(iter); // => [1, 1, 1]
+Buffer.toText(buf, Nat.toText);
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -826,6 +1215,18 @@ func trimToSize<X>(buffer : Buffer<X>)
 
 Reallocates the array underlying `buffer` such that capacity == size.
 
+Example:
+```motoko include=initialize
+
+let buffer = Buffer.Buffer<Nat>(10);
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.trimToSize<Nat>(buffer);
+buffer.capacity(); // => 3
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -836,6 +1237,18 @@ func map<X, Y>(buffer : Buffer<X>, f : X -> Y) : Buffer<Y>
 ```
 
 Creates a new buffer by applying `f` to each element in `buffer`.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+let newBuf = Buffer.map<Nat, Nat>(buffer, func (x) { x + 1 });
+Buffer.toText(newBuf, Nat.toText); // => [2, 3, 4]
+```
 
 Runtime: O(size)
 
@@ -850,6 +1263,20 @@ func iterate<X>(buffer : Buffer<X>, f : X -> ())
 
 Applies `f` to each element in `buffer`.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+import Debug "mo:base/Debug";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.iterate<Nat>(buffer, func (x) {
+  Debug.print(Nat.toText(x)); // prints each element in buffer
+});
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -862,6 +1289,18 @@ func mapEntries<X, Y>(buffer : Buffer<X>, f : (Nat, X) -> Y) : Buffer<Y>
 ```
 
 Applies `f` to each element in `buffer` and its index.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+let newBuf = Buffer.mapEntries<Nat, Nat>(buffer, func (x, i) { x + i + 1 });
+Buffer.toText(newBuf, Nat.toText); // => [2, 4, 6]
+```
 
 Runtime: O(size)
 
@@ -876,6 +1315,24 @@ func mapFilter<X, Y>(buffer : Buffer<X>, f : X -> ?Y) : Buffer<Y>
 
 Creates a new buffer by applying `f` to each element in `buffer`,
 and keeping all non-null elements.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+let newBuf = Buffer.mapFilter<Nat, Nat>(buffer, func (x) {
+  if (x > 1) {
+    ?(x * 2);
+  } else {
+    null;
+  }
+});
+Buffer.toText(newBuf, Nat.toText); // => [4, 6]
+```
 
 Runtime: O(size)
 
@@ -892,6 +1349,25 @@ Creates a new buffer by applying `f` to each element in `buffer`.
 If any invocation of `f` produces an `#err`, returns an `#err`. Otherwise
 Returns an `#ok` containing the new buffer.
 
+Example:
+```motoko include=initialize
+import Result "mo:base/Result";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+let result = Buffer.mapResult<Nat, Nat, Text>(buffer, func (k) {
+  if (k > 0) {
+    #ok(k);
+  } else {
+    #err("One or more elements are negative.");
+  }
+});
+
+Result.mapOk<Buffer.Buffer<Nat>, [Nat], Text>(result, func buffer = Buffer.toArray(buffer)) // => #ok([1, 2, 3])
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -906,6 +1382,23 @@ func chain<X, Y>(buffer : Buffer<X>, k : X -> Buffer<Y>) : Buffer<Y>
 Creates a new buffer by applying `k` to each element in `buffer`,
 and concatenating the resulting buffers in order. This operation
 is similar to what in other functional languages is known as monadic bind.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+let chain = Buffer.chain<Nat, Nat>(buffer, func (x) {
+  let b = Buffer.Buffer<Nat>(2);
+  b.add(x);
+  b.add(x * 2);
+  return b;
+});
+Buffer.toText(chain, Nat.toText); // => [1, 2, 2, 4, 3, 6]
+```
 
 Runtime: O(size)
 
@@ -922,6 +1415,17 @@ Collapses the elements in `buffer` into a single value by starting with `base`
 and progessively combining elements into `base` with `combine`. Iteration runs
 left to right.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.foldLeft<Text, Nat>(buffer, "", func (acc, x) { acc # Nat.toText(x)}); // => "123"
+```
+
 Runtime: O(size)
 
 Space: O(1)
@@ -937,6 +1441,17 @@ Collapses the elements in `buffer` into a single value by starting with `base`
 and progessively combining elements into `base` with `combine`. Iteration runs
 right to left.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.foldRight<Nat, Text>(buffer, "", func (x, acc) { Nat.toText(x) # acc }); // => "123"
+```
+
 Runtime: O(size)
 
 Space: O(1)
@@ -950,6 +1465,16 @@ func first<X>(buffer : Buffer<X>) : X
 
 Returns the first element of `buffer`. Traps if `buffer` is empty.
 
+Example:
+```motoko include=initialize
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.first(buffer); // => 1
+```
+
 Runtime: O(1)
 
 Space: O(1)
@@ -960,6 +1485,16 @@ func last<X>(buffer : Buffer<X>) : X
 ```
 
 Returns the last element of `buffer`. Traps if `buffer` is empty.
+
+Example:
+```motoko include=initialize
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.last(buffer); // => 3
+```
 
 Runtime: O(1)
 
@@ -972,6 +1507,14 @@ func make<X>(element : X) : Buffer<X>
 
 Returns a new buffer with capacity and size 1, containing `element`.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+let buffer = Buffer.make<Nat>(1);
+Buffer.toText(buffer, Nat.toText); // => [1]
+```
+
 Runtime: O(1)
 
 Space: O(1)
@@ -982,6 +1525,18 @@ func reverse<X>(buffer : Buffer<X>)
 ```
 
 Reverses the order of elements in `buffer`.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.reverse(buffer);
+Buffer.toText(buffer, Nat.toText); // => [3, 2, 1]
+```
 
 Runtime: O(size)
 
@@ -995,6 +1550,24 @@ func merge<X>(buffer1 : Buffer<X>, buffer2 : Buffer<X>, compare : (X, X) -> Orde
 Merges two sorted buffers into a single sorted buffer, using `compare` to define
 the ordering. The final ordering is stable. Behavior is undefined if either
 `buffer1` or `buffer2` is not sorted.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+let buffer1 = Buffer.Buffer<Nat>(2);
+buffer1.add(1);
+buffer1.add(2);
+buffer1.add(4);
+
+let buffer2 = Buffer.Buffer<Nat>(2);
+buffer2.add(2);
+buffer2.add(4);
+buffer2.add(6);
+
+let merged = Buffer.merge<Nat>(buffer1, buffer2, Nat.compare);
+Buffer.toText(merged, Nat.toText); // => [1, 2, 2, 4, 4, 6]
+```
 
 Runtime: O(size1 + size2)
 
@@ -1010,6 +1583,21 @@ func removeDuplicates<X>(buffer : Buffer<X>, compare : (X, X) -> Order)
 Eliminates all duplicate elements in `buffer` as defined by `compare`.
 Elimination is stable with respect to the original ordering of the elements.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+Buffer.removeDuplicates<Nat>(buffer, Nat.compare);
+Buffer.toText(buffer, Nat.toText); // => [1, 2, 3]
+```
+
 Runtime: O(size * log(size))
 
 Space: O(size)
@@ -1021,6 +1609,21 @@ func partition<X>(buffer : Buffer<X>, predicate : X -> Bool) : (Buffer<X>, Buffe
 
 Splits `buffer` into a pair of buffers where all elements in the left
 buffer satisfy `predicate` and all elements in the right buffer do not.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+buffer.add(5);
+buffer.add(6);
+
+let partitions = Buffer.partition<Nat>(buffer, func (x) { x % 2 == 0 });
+(Buffer.toArray(partitions.0), Buffer.toArray(partitions.1)) // => ([2, 4, 6], [1, 3, 5])
+```
 
 Runtime: O(size)
 
@@ -1038,6 +1641,21 @@ all elements with indices less than `index`, and the right buffer contains all
 elements with indices greater than or equal to `index`. Traps if `index` is out
 of bounds.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+buffer.add(5);
+buffer.add(6);
+
+let split = Buffer.split<Nat>(buffer, 3);
+(Buffer.toArray(split.0), Buffer.toArray(split.1)) // => ([1, 2, 3], [4, 5, 6])
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -1053,6 +1671,21 @@ Breaks up `buffer` into buffers of size `size`. The last chunk may
 have less than `size` elements if the number of elements is not divisible
 by the chunk size.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+buffer.add(4);
+buffer.add(5);
+buffer.add(6);
+
+let chunks = Buffer.chunk<Nat>(buffer, 3);
+Buffer.toText<Buffer.Buffer<Nat>>(chunks, func buf = Buffer.toText(buf, Nat.toText)); // => [[1, 2, 3], [4, 5, 6]]
+```
+
 Runtime: O(number of elements in buffer)
 
 Space: O(number of elements in buffer)
@@ -1063,6 +1696,21 @@ func groupBy<X>(buffer : Buffer<X>, equal : (X, X) -> Bool) : Buffer<Buffer<X>>
 ```
 
 Groups equal and adjacent elements in the list into sub lists.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(2);
+buffer.add(4);
+buffer.add(5);
+buffer.add(5);
+
+let grouped = Buffer.groupBy<Nat>(buffer, func (x, y) { x == y });
+Buffer.toText<Buffer.Buffer<Nat>>(grouped, func buf = Buffer.toText(buf, Nat.toText)); // => [[1], [2, 2], [4], [5, 5]]
+```
 
 Runtime: O(size)
 
@@ -1077,6 +1725,28 @@ func flatten<X>(buffer : Buffer<Buffer<X>>) : Buffer<X>
 
 Flattens the buffer of buffers into a single buffer.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+let buffer = Buffer.Buffer<Buffer.Buffer<Nat>>(1);
+
+let inner1 = Buffer.Buffer<Nat>(2);
+inner1.add(1);
+inner1.add(2);
+
+let inner2 = Buffer.Buffer<Nat>(2);
+inner2.add(3);
+inner2.add(4);
+
+buffer.add(inner1);
+buffer.add(inner2);
+// buffer = [[1, 2], [3, 4]]
+
+let flat = Buffer.flatten<Nat>(buffer);
+Buffer.toText<Nat>(flat, Nat.toText); // => [1, 2, 3, 4]
+```
+
 Runtime: O(number of elements in buffer)
 
 Space: O(number of elements in buffer)
@@ -1089,6 +1759,22 @@ func zip<X, Y>(buffer1 : Buffer<X>, buffer2 : Buffer<Y>) : Buffer<(X, Y)>
 Combines the two buffers into a single buffer of pairs, pairing together
 elements with the same index. If one buffer is longer than the other, the
 remaining elements from the longer buffer are not included.
+
+Example:
+```motoko include=initialize
+
+let buffer1 = Buffer.Buffer<Nat>(2);
+buffer1.add(1);
+buffer1.add(2);
+buffer1.add(3);
+
+let buffer2 = Buffer.Buffer<Nat>(2);
+buffer2.add(4);
+buffer2.add(5);
+
+let zipped = Buffer.zip(buffer1, buffer2);
+Buffer.toArray(zipped); // => [(1, 4), (2, 5)]
+```
 
 Runtime: O(min(size1, size2))
 
@@ -1104,6 +1790,23 @@ elements with the same index and combining them using `zip`. If
 one buffer is longer than the other, the remaining elements from
 the longer buffer are not included.
 
+Example:
+```motoko include=initialize
+
+let buffer1 = Buffer.Buffer<Nat>(2);
+buffer1.add(1);
+buffer1.add(2);
+buffer1.add(3);
+
+let buffer2 = Buffer.Buffer<Nat>(2);
+buffer2.add(4);
+buffer2.add(5);
+buffer2.add(6);
+
+let zipped = Buffer.zipWith<Nat, Nat, Nat>(buffer1, buffer2, func (x, y) { x + y });
+Buffer.toArray(zipped) // => [5, 7, 9]
+```
+
 Runtime: O(min(size1, size2))
 
 Space: O(min(size1, size2))
@@ -1118,6 +1821,18 @@ func takeWhile<X>(buffer : Buffer<X>, predicate : X -> Bool) : Buffer<X>
 Creates a new buffer taking elements in order from `buffer` until predicate
 returns false.
 
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+let newBuf = Buffer.takeWhile<Nat>(buffer, func (x) { x < 3 });
+Buffer.toText(newBuf, Nat.toText); // => [1, 2]
+```
+
 Runtime: O(size)
 
 Space: O(size)
@@ -1131,6 +1846,18 @@ func dropWhile<X>(buffer : Buffer<X>, predicate : X -> Bool) : Buffer<X>
 
 Creates a new buffer excluding elements in order from `buffer` until predicate
 returns false.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+buffer.add(1);
+buffer.add(2);
+buffer.add(3);
+
+let newBuf = Buffer.dropWhile<Nat>(buffer, func x { x < 3 }); // => [3]
+Buffer.toText(newBuf, Nat.toText);
+```
 
 Runtime: O(size)
 

--- a/doc/md/base/CertifiedData.md
+++ b/doc/md/base/CertifiedData.md
@@ -20,6 +20,21 @@ Set the certified data.
 Must be called from an update method, else traps.
 Must be passed a blob of at most 32 bytes, else traps.
 
+Example:
+```motoko no-repl
+import CertifiedData "mo:base/CertifiedData";
+import Blob "mo:base/Blob";
+
+// Must be in an update call
+
+let array : [Nat8] = [1, 2, 3];
+let blob = Blob.fromArray(array);
+CertifiedData.set(blob);
+```
+
+See a full example on how to use certified variables here: https://github.com/dfinity/examples/tree/master/motoko/cert-var
+
+
 ## Value `getCertificate`
 ``` motoko no-repl
 let getCertificate : () -> ?Blob
@@ -30,3 +45,13 @@ Gets a certificate
 Returns `null` if no certificate is available, e.g. when processing an
 update call or inter-canister call. This returns a non-`null` value only
 when processing a query call.
+
+Example:
+```motoko no-repl
+import CertifiedData "mo:base/CertifiedData";
+// Must be in a query call
+
+CertifiedData.getCertificate();
+```
+See a full example on how to use certified variables here: https://github.com/dfinity/examples/tree/master/motoko/cert-var
+

--- a/doc/md/base/Deque.md
+++ b/doc/md/base/Deque.md
@@ -1,65 +1,227 @@
 # Deque
-Functions for persistent, double-ended queues.
+Double-ended queue (deque) of a generic element type `T`.
+
+The interface to deques is purely functional, not imperative, and deques are immutable values.
+In particular, deque operations such as push and pop do not update their input deque but,  instead, return the
+value of the modified deque, alongside any other data.
+The input deque is left unchanged.
+
+Examples of use-cases:
+Queue (FIFO) by using `pushBack()` and `popFront()`.
+Stack (LIFO) by using `pushFront()` and `popFront()`.
+
+A deque is internally implemented as two lists, a head access list and a (reversed) tail access list,
+that are dynamically size-balanced by splitting.
+
+Construction: Create a new deque with the `empty<T>()` function.
+
+Note on the costs of push and pop functions:
+* Runtime: `O(1) amortized costs, `O(n)` worst case cost per single call.
+* Space: `O(1) amortized costs, `O(n)` worst case cost per single call.
+
+`n` denotes the number of elements stored in the deque.
 
 ## Type `Deque`
 ``` motoko no-repl
 type Deque<T> = (List<T>, List<T>)
 ```
 
-Double-ended queue
+Double-ended queue (deque) data type.
 
 ## Function `empty`
 ``` motoko no-repl
 func empty<T>() : Deque<T>
 ```
 
-Empty queue
+Create a new empty deque.
+
+Example:
+```motoko
+import Deque "mo:base/Deque";
+
+Deque.empty<Nat>()
+```
+
+Runtime: `O(1)`.
+
+Space: `O(1)`.
 
 ## Function `isEmpty`
 ``` motoko no-repl
-func isEmpty<T>(q : Deque<T>) : Bool
+func isEmpty<T>(deque : Deque<T>) : Bool
 ```
 
-True when the queue is empty
+Determine whether a deque is empty.
+Returns true if `deque` is empty, otherwise `false`.
+
+Example:
+```motoko
+import Deque "mo:base/Deque";
+
+let deque = Deque.empty<Nat>();
+Deque.isEmpty(deque) // => true
+```
+
+Runtime: `O(1)`.
+
+Space: `O(1)`.
 
 ## Function `pushFront`
 ``` motoko no-repl
-func pushFront<T>(q : Deque<T>, x : T) : Deque<T>
+func pushFront<T>(deque : Deque<T>, element : T) : Deque<T>
 ```
 
-Insert a new element on the front end of the queue
+Insert a new element on the front end of a deque.
+Returns the new deque with `element` in the front followed by the elements of `deque`.
+
+This may involve dynamic rebalancing of the two, internally used lists.
+
+Example:
+```motoko
+import Deque "mo:base/Deque";
+
+Deque.pushFront(Deque.pushFront(Deque.empty<Nat>(), 2), 1) // deque with elements [1, 2]
+```
+
+Runtime: `O(n)` worst-case, amortized to `O(1)`.
+
+Space: `O(n)` worst-case, amortized to `O(1)`.
+
+`n` denotes the number of elements stored in the deque.
 
 ## Function `peekFront`
 ``` motoko no-repl
-func peekFront<T>(q : Deque<T>) : ?T
+func peekFront<T>(deque : Deque<T>) : ?T
 ```
 
-Inspect the (optional) first element on the front end of the queue
+Inspect the optional element on the front end of a deque.
+Returns `null` if `deque` is empty. Otherwise, the front element of `deque`.
+
+Example:
+```motoko
+import Deque "mo:base/Deque";
+
+let deque = Deque.pushFront(Deque.pushFront(Deque.empty<Nat>(), 2), 1);
+Deque.peekFront(deque) // => ?1
+```
+
+Runtime: `O(1)`.
+
+Space: `O(1)`.
+
 
 ## Function `popFront`
 ``` motoko no-repl
-func popFront<T>(q : Deque<T>) : ?(T, Deque<T>)
+func popFront<T>(deque : Deque<T>) : ?(T, Deque<T>)
 ```
 
-Remove the first element on the front end of the queue; Returns null when empty.
+Remove the element on the front end of a deque.
+Returns `null` if `deque` is empty. Otherwise, it returns a pair of
+the first element and a new deque that contains all the remaining elements of `deque`.
+
+This may involve dynamic rebalancing of the two, internally used lists.
+
+Example:
+```motoko
+import Deque "mo:base/Deque";
+import Debug "mo:base/Debug";
+let initial = Deque.pushFront(Deque.pushFront(Deque.empty<Nat>(), 2), 1);
+// initial deque with elements [1, 2]
+let reduced = Deque.popFront(initial);
+switch reduced {
+  case null {
+    Debug.trap "Empty queue impossible"
+  };
+  case (?result) {
+    let removedElement = result.0; // 1
+    let reducedDeque = result.1; // deque with element [2].
+  }
+}
+```
+
+Runtime: `O(n)` worst-case, amortized to `O(1)`.
+
+Space: `O(n)` worst-case, amortized to `O(1)`.
+
+`n` denotes the number of elements stored in the deque.
 
 ## Function `pushBack`
 ``` motoko no-repl
-func pushBack<T>(q : Deque<T>, x : T) : Deque<T>
+func pushBack<T>(deque : Deque<T>, element : T) : Deque<T>
 ```
 
-Insert a new element on the back end of the queue
+Insert a new element on the back end of a deque.
+Returns the new deque with all the elements of `deque`, followed by `element` on the back.
+
+This may involve dynamic rebalancing of the two, internally used lists.
+
+Example:
+```motoko
+import Deque "mo:base/Deque";
+
+Deque.pushBack(Deque.pushBack(Deque.empty<Nat>(), 1), 2) // deque with elements [1, 2]
+```
+
+Runtime: `O(n)` worst-case, amortized to `O(1)`.
+
+Space: `O(n)` worst-case, amortized to `O(1)`.
+
+`n` denotes the number of elements stored in the deque.
 
 ## Function `peekBack`
 ``` motoko no-repl
-func peekBack<T>(q : Deque<T>) : ?T
+func peekBack<T>(deque : Deque<T>) : ?T
 ```
 
-Inspect the (optional) first element on the back end of the queue
+Inspect the optional element on the back end of a deque.
+Returns `null` if `deque` is empty. Otherwise, the back element of `deque`.
+
+Example:
+```motoko
+import Deque "mo:base/Deque";
+
+let deque = Deque.pushBack(Deque.pushBack(Deque.empty<Nat>(), 1), 2);
+Deque.peekBack(deque) // => ?2
+```
+
+Runtime: `O(1)`.
+
+Space: `O(1)`.
+
 
 ## Function `popBack`
 ``` motoko no-repl
-func popBack<T>(q : Deque<T>) : ?(Deque<T>, T)
+func popBack<T>(deque : Deque<T>) : ?(Deque<T>, T)
 ```
 
-Remove the first element on the back end of the queue; Returns null when empty.
+Remove the element on the back end of a deque.
+Returns `null` if `deque` is empty. Otherwise, it returns a pair of
+a new deque that contains the remaining elements of `deque`
+and, as the second pair item, the removed back element.
+
+This may involve dynamic rebalancing of the two, internally used lists.
+
+Example:
+```motoko
+import Deque "mo:base/Deque";
+import Debug "mo:base/Debug";
+
+let initial = Deque.pushBack(Deque.pushBack(Deque.empty<Nat>(), 1), 2);
+// initial deque with elements [1, 2]
+let reduced = Deque.popBack(initial);
+switch reduced {
+  case null {
+    Debug.trap "Empty queue impossible"
+  };
+  case (?result) {
+    let reducedDeque = result.0; // deque with element [1].
+    let removedElement = result.1; // 2
+  }
+}
+```
+
+Runtime: `O(n)` worst-case, amortized to `O(1)`.
+
+Space: `O(n)` worst-case, amortized to `O(1)`.
+
+`n` denotes the number of elements stored in the deque.

--- a/doc/md/base/Error.md
+++ b/doc/md/base/Error.md
@@ -29,8 +29,11 @@ type ErrorCode = {
   #canister_reject;
   // Canister trapped.
   #canister_error;
-  // Future error code (with unrecognized numeric code)
+  // Future error code (with unrecognized numeric code).
   #future : Nat32;
+  // Error issuing inter-canister call
+  // (indicating destination queue full or freezing threshold crossed).
+  #call_error : { err_code :  Nat32 }
 };
 ```
 

--- a/doc/md/base/ExperimentalCycles.md
+++ b/doc/md/base/ExperimentalCycles.md
@@ -1,15 +1,39 @@
 # ExperimentalCycles
-Managing cycles
+Managing cycles within actors on the Internet Computer (IC).
 
-Usage of the Internet Computer is measured, and paid for, in _cycles_.
-This library provides imperative operations for observing cycles, transferring cycles and
+The usage of the Internet Computer is measured, and paid for, in _cycles_.
+This library provides imperative operations for observing cycles, transferring cycles, and
 observing refunds of cycles.
 
 **WARNING:** This low-level API is **experimental** and likely to change or even disappear.
 Dedicated syntactic support for manipulating cycles may be added to the language in future, obsoleting this library.
 
-**NOTE:** Since cycles measure computational resources, the value of
-`balance()` can change from one call to the next.
+**NOTE:** Since cycles measure computational resources, the value of  `balance()` can change from one call to the next.
+
+Example for use on IC:
+```motoko no-repl
+import Cycles "mo:base/ExperimentalCycles";
+import Debug "mo:base/Debug";
+
+actor {
+  public func main() : async() {
+    Debug.print("Main balance: " # debug_show(Cycles.balance()));
+    Cycles.add(15_000_000);
+    await operation(); // accepts 10_000_000 cycles
+    Debug.print("Main refunded: " # debug_show(Cycles.refunded())); // 5_000_000
+    Debug.print("Main balance: " # debug_show(Cycles.balance())); // decreased by around 10_000_000
+  };
+
+  func operation() : async() {
+    Debug.print("Operation balance: " # debug_show(Cycles.balance()));
+    Debug.print("Operation available: " # debug_show(Cycles.available()));
+    let obtained = Cycles.accept(10_000_000);
+    Debug.print("Operation obtained: " # debug_show(obtained)); // => 10_000_000
+    Debug.print("Operation balance: " # debug_show(Cycles.balance())); // increased by 10_000_000
+    Debug.print("Operation available: " # debug_show(Cycles.available())); // decreased by 10_000_000
+  }
+}
+```
 
 ## Value `balance`
 ``` motoko no-repl
@@ -17,6 +41,19 @@ let balance : () -> (amount : Nat)
 ```
 
 Returns the actor's current balance of cycles as `amount`.
+
+Example for use on the IC:
+```motoko no-repl
+import Cycles "mo:base/ExperimentalCycles";
+import Debug "mo:base/Debug";
+
+actor {
+  public func main() : async() {
+    let balance = Cycles.balance();
+    Debug.print("Balance: " # debug_show(balance));
+  }
+}
+```
 
 ## Value `available`
 ``` motoko no-repl
@@ -26,9 +63,21 @@ let available : () -> (amount : Nat)
 Returns the currently available `amount` of cycles.
 The amount available is the amount received in the current call,
 minus the cumulative amount `accept`ed by this call.
-On exit from the current shared function or async expression via `return` or `throw`
-any remaining available amount is automatically
-refunded to the caller/context.
+On exit from the current shared function or async expression via `return` or `throw`,
+any remaining available amount is automatically refunded to the caller/context.
+
+Example for use on the IC:
+```motoko no-repl
+import Cycles "mo:base/ExperimentalCycles";
+import Debug "mo:base/Debug";
+
+actor {
+  public func main() : async() {
+    let available = Cycles.available();
+    Debug.print("Available: " # debug_show(available));
+  }
+}
+```
 
 ## Value `accept`
 ``` motoko no-repl
@@ -39,6 +88,24 @@ Transfers up to `amount` from `available()` to `balance()`.
 Returns the amount actually transferred, which may be less than
 requested, for example, if less is available, or if canister balance limits are reached.
 
+Example for use on the IC (for simplicity, only transferring cycles to itself):
+```motoko no-repl
+import Cycles "mo:base/ExperimentalCycles";
+import Debug "mo:base/Debug";
+
+actor {
+  public func main() : async() {
+    Cycles.add(15_000_000);
+    await operation(); // accepts 10_000_000 cycles
+  };
+
+  func operation() : async() {
+    let obtained = Cycles.accept(10_000_000);
+    Debug.print("Obtained: " # debug_show(obtained)); // => 10_000_000
+  }
+}
+```
+
 ## Value `add`
 ``` motoko no-repl
 let add : (amount : Nat) -> ()
@@ -47,13 +114,29 @@ let add : (amount : Nat) -> ()
 Indicates additional `amount` of cycles to be transferred in
 the next call, that is, evaluation of a shared function call or
 async expression.
-Traps if the current total would exceed 2^128 cycles.
+Traps if the current total would exceed `2 ** 128` cycles.
 Upon the call, but not before, the total amount of cycles ``add``ed since
 the last call is deducted from `balance()`.
 If this total exceeds `balance()`, the caller traps, aborting the call.
 
-**Note**: the implicit register of added amounts is reset to zero on entry to
+**Note**: The implicit register of added amounts is reset to zero on entry to
 a shared function and after each shared function call or resume from an await.
+
+Example for use on the IC (for simplicity, only transferring cycles to itself):
+```motoko no-repl
+import Cycles "mo:base/ExperimentalCycles";
+
+actor {
+  func operation() : async() {
+    ignore Cycles.accept(10_000_000);
+  };
+
+  public func main() : async() {
+    Cycles.add(15_000_000);
+    await operation();
+  }
+}
+```
 
 ## Value `refunded`
 ``` motoko no-repl
@@ -65,3 +148,21 @@ context, or zero if no await has occurred yet.
 Calling `refunded()` is solely informational and does not affect `balance()`.
 Instead, refunds are automatically added to the current balance,
 whether or not `refunded` is used to observe them.
+
+Example for use on the IC (for simplicity, only transferring cycles to itself):
+```motoko no-repl
+import Cycles "mo:base/ExperimentalCycles";
+import Debug "mo:base/Debug";
+
+actor {
+  func operation() : async() {
+    ignore Cycles.accept(10_000_000);
+  };
+
+  public func main() : async() {
+    Cycles.add(15_000_000);
+    await operation(); // accepts 10_000_000 cycles
+    Debug.print("Refunded: " # debug_show(Cycles.refunded())); // 5_000_000
+  }
+}
+```

--- a/doc/md/base/ExperimentalStableMemory.md
+++ b/doc/md/base/ExperimentalStableMemory.md
@@ -30,8 +30,13 @@ NB: The IC's actual stable memory size (`ic0.stable_size`) may exceed the
 page size reported by Motoko function `size()`.
 This (and the cap on growth) are to accommodate Motoko's stable variables.
 Applications that plan to use Motoko stable variables sparingly or not at all can
-increase `--max-stable-pages` as desired, approaching the IC maximum (currently 8GiB).
+increase `--max-stable-pages` as desired, approaching the IC maximum (initially 8GiB, then 32Gib, currently 48Gib).
 All applications should reserve at least one page for stable variable data, even when no stable variables are used.
+
+Usage:
+```motoko no-repl
+import StableMemory "mo:base/ExperimentalStableMemory";
+```
 
 ## Value `size`
 ``` motoko no-repl
@@ -44,18 +49,38 @@ Initially `0`.
 Preserved across upgrades, together with contents of allocated
 stable memory.
 
-## Value `grow`
-``` motoko no-repl
-let grow : (new_pages : Nat64) -> (oldpages : Nat64)
+Example:
+```motoko no-repl
+let beforeSize = StableMemory.size();
+ignore StableMemory.grow(10);
+let afterSize = StableMemory.size();
+afterSize - beforeSize // => 10
 ```
 
-Grow current `size` of stable memory by `pagecount` pages.
+## Value `grow`
+``` motoko no-repl
+let grow : (newPages : Nat64) -> (oldPages : Nat64)
+```
+
+Grow current `size` of stable memory by the given number of pages.
 Each page is 64KiB (65536 bytes).
-Returns previous `size` when able to grow.
+Returns the previous `size` when able to grow.
 Returns `0xFFFF_FFFF_FFFF_FFFF` if remaining pages insufficient.
-Every new page is zero-initialized, containing byte 0 at every offset.
+Every new page is zero-initialized, containing byte 0x00 at every offset.
 Function `grow` is capped by a soft limit on `size` controlled by compile-time flag
  `--max-stable-pages <n>` (the default is 65536, or 4GiB).
+
+Example:
+```motoko no-repl
+import Error "mo:base/Error";
+
+let beforeSize = StableMemory.grow(10);
+if (beforeSize == 0xFFFF_FFFF_FFFF_FFFF) {
+  throw Error.reject("Out of memory");
+};
+let afterSize = StableMemory.size();
+afterSize - beforeSize // => 10
+```
 
 ## Value `stableVarQuery`
 ``` motoko no-repl
@@ -69,113 +94,307 @@ The query computes the estimate by running the first half of an upgrade, includi
 Like any other query, its state changes are discarded so no actual upgrade (or other state change) takes place.
 The query can only be called by the enclosing actor and will trap for other callers.
 
+Example:
+```motoko no-repl
+actor {
+  stable var state = "";
+  public func example() : async Text {
+    let memoryUsage = StableMemory.stableVarQuery();
+    let beforeSize = (await memoryUsage()).size;
+    state #= "abcdefghijklmnopqrstuvwxyz";
+    let afterSize = (await memoryUsage()).size;
+    debug_show (afterSize - beforeSize)
+  };
+};
+```
+
 ## Value `loadNat32`
 ``` motoko no-repl
 let loadNat32 : (offset : Nat64) -> Nat32
 ```
 
+Loads a `Nat32` value from stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeNat32(offset, value);
+StableMemory.loadNat32(offset) // => 123
+```
 
 ## Value `storeNat32`
 ``` motoko no-repl
 let storeNat32 : (offset : Nat64, value : Nat32) -> ()
 ```
 
+Stores a `Nat32` value in stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeNat32(offset, value);
+StableMemory.loadNat32(offset) // => 123
+```
 
 ## Value `loadNat8`
 ``` motoko no-repl
 let loadNat8 : (offset : Nat64) -> Nat8
 ```
 
+Loads a `Nat8` value from stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeNat8(offset, value);
+StableMemory.loadNat8(offset) // => 123
+```
 
 ## Value `storeNat8`
 ``` motoko no-repl
 let storeNat8 : (offset : Nat64, value : Nat8) -> ()
 ```
 
+Stores a `Nat8` value in stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeNat8(offset, value);
+StableMemory.loadNat8(offset) // => 123
+```
 
 ## Value `loadNat16`
 ``` motoko no-repl
 let loadNat16 : (offset : Nat64) -> Nat16
 ```
 
+Loads a `Nat16` value from stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeNat16(offset, value);
+StableMemory.loadNat16(offset) // => 123
+```
 
 ## Value `storeNat16`
 ``` motoko no-repl
 let storeNat16 : (offset : Nat64, value : Nat16) -> ()
 ```
 
+Stores a `Nat16` value in stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeNat16(offset, value);
+StableMemory.loadNat16(offset) // => 123
+```
 
 ## Value `loadNat64`
 ``` motoko no-repl
 let loadNat64 : (offset : Nat64) -> Nat64
 ```
 
+Loads a `Nat64` value from stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeNat64(offset, value);
+StableMemory.loadNat64(offset) // => 123
+```
 
 ## Value `storeNat64`
 ``` motoko no-repl
 let storeNat64 : (offset : Nat64, value : Nat64) -> ()
 ```
 
+Stores a `Nat64` value in stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeNat64(offset, value);
+StableMemory.loadNat64(offset) // => 123
+```
 
 ## Value `loadInt32`
 ``` motoko no-repl
 let loadInt32 : (offset : Nat64) -> Int32
 ```
 
+Loads an `Int32` value from stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeInt32(offset, value);
+StableMemory.loadInt32(offset) // => 123
+```
 
 ## Value `storeInt32`
 ``` motoko no-repl
 let storeInt32 : (offset : Nat64, value : Int32) -> ()
 ```
 
+Stores an `Int32` value in stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeInt32(offset, value);
+StableMemory.loadInt32(offset) // => 123
+```
 
 ## Value `loadInt8`
 ``` motoko no-repl
 let loadInt8 : (offset : Nat64) -> Int8
 ```
 
+Loads an `Int8` value from stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeInt8(offset, value);
+StableMemory.loadInt8(offset) // => 123
+```
 
 ## Value `storeInt8`
 ``` motoko no-repl
 let storeInt8 : (offset : Nat64, value : Int8) -> ()
 ```
 
+Stores an `Int8` value in stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeInt8(offset, value);
+StableMemory.loadInt8(offset) // => 123
+```
 
 ## Value `loadInt16`
 ``` motoko no-repl
 let loadInt16 : (offset : Nat64) -> Int16
 ```
 
+Loads an `Int16` value from stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeInt16(offset, value);
+StableMemory.loadInt16(offset) // => 123
+```
 
 ## Value `storeInt16`
 ``` motoko no-repl
 let storeInt16 : (offset : Nat64, value : Int16) -> ()
 ```
 
+Stores an `Int16` value in stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeInt16(offset, value);
+StableMemory.loadInt16(offset) // => 123
+```
 
 ## Value `loadInt64`
 ``` motoko no-repl
 let loadInt64 : (offset : Nat64) -> Int64
 ```
 
+Loads an `Int64` value from stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeInt64(offset, value);
+StableMemory.loadInt64(offset) // => 123
+```
 
 ## Value `storeInt64`
 ``` motoko no-repl
 let storeInt64 : (offset : Nat64, value : Int64) -> ()
 ```
 
+Stores an `Int64` value in stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 123;
+StableMemory.storeInt64(offset, value);
+StableMemory.loadInt64(offset) // => 123
+```
 
 ## Value `loadFloat`
 ``` motoko no-repl
 let loadFloat : (offset : Nat64) -> Float
 ```
 
+Loads a `Float` value from stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 1.25;
+StableMemory.storeFloat(offset, value);
+StableMemory.loadFloat(offset) // => 1.25
+```
 
 ## Value `storeFloat`
 ``` motoko no-repl
 let storeFloat : (offset : Nat64, value : Float) -> ()
 ```
 
+Stores a `Float` value in stable memory at the given `offset`.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+let offset = 0;
+let value = 1.25;
+StableMemory.storeFloat(offset, value);
+StableMemory.loadFloat(offset) // => 1.25
+```
 
 ## Value `loadBlob`
 ``` motoko no-repl
@@ -183,7 +402,18 @@ let loadBlob : (offset : Nat64, size : Nat) -> Blob
 ```
 
 Load `size` bytes starting from `offset` as a `Blob`.
-Traps on out-of-bounds access.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+import Blob "mo:base/Blob";
+
+let offset = 0;
+let value = Blob.fromArray([1, 2, 3]);
+let size = value.size();
+StableMemory.storeBlob(offset, value);
+Blob.toArray(StableMemory.loadBlob(offset, size)) // => [1, 2, 3]
+```
 
 ## Value `storeBlob`
 ``` motoko no-repl
@@ -191,4 +421,15 @@ let storeBlob : (offset : Nat64, value : Blob) -> ()
 ```
 
 Write bytes of `blob` beginning at `offset`.
-Traps on out-of-bounds access.
+Traps on an out-of-bounds access.
+
+Example:
+```motoko no-repl
+import Blob "mo:base/Blob";
+
+let offset = 0;
+let value = Blob.fromArray([1, 2, 3]);
+let size = value.size();
+StableMemory.storeBlob(offset, value);
+Blob.toArray(StableMemory.loadBlob(offset, size)) // => [1, 2, 3]
+```

--- a/doc/md/base/Float.md
+++ b/doc/md/base/Float.md
@@ -1,12 +1,51 @@
 # Float
-64-bit Floating-point numbers
+Double precision (64-bit) floating-point numbers in IEEE 754 representation.
+
+This module contains common floating-point constants and utility functions.
+
+Notation for special values in the documentation below:
+`+inf`: Positive infinity
+`-inf`: Negative infinity
+`NaN`: "not a number" (can have different sign bit values, but `NaN != NaN` regardless of the sign).
+
+Note:
+Floating point numbers have limited precision and operations may inherently result in numerical errors.
+
+Examples of numerical errors:
+  ```motoko
+  0.1 + 0.1 + 0.1 == 0.3 // => false
+  ```
+
+  ```motoko
+ 1e16 + 1.0 != 1e16 // => false
+  ```
+
+ (and many more cases)
+
+Advice:
+* Floating point number comparisons by `==` or `!=` are discouraged. Instead, it is better to compare
+  floating-point numbers with a numerical tolerance, called epsilon.
+
+  Example:
+  ```motoko
+  import Float "mo:base/Float";
+  let x = 0.1 + 0.1 + 0.1;
+  let y = 0.3;
+
+  let epsilon = 1e-6; // This depends on the application case (needs a numerical error analysis).
+  Float.equalWithin(x, y, epsilon) // => true
+  ```
+
+* For absolute precision, it is recommened to encode the fraction number as a pair of a Nat for the base
+  and a Nat for the exponent (decimal point).
+
 
 ## Type `Float`
 ``` motoko no-repl
 type Float = Prim.Types.Float
 ```
 
-64-bit floating point numbers.
+64-bit floating point number type.
 
 ## Value `pi`
 ``` motoko no-repl
@@ -14,6 +53,7 @@ let pi : Float
 ```
 
 Ratio of the circumference of a circle to its diameter.
+Note: Limited precision.
 
 ## Value `e`
 ``` motoko no-repl
@@ -21,6 +61,25 @@ let e : Float
 ```
 
 Base of the natural logarithm.
+Note: Limited precision.
+
+## Function `isNaN`
+``` motoko no-repl
+func isNaN(number : Float) : Bool
+```
+
+Determines whether the `number` is a `NaN` ("not a number" in the floating point representation).
+Notes:
+* Equality test of `NaN` with itself or another number is always `false`.
+* There exist many internal `NaN` value representations, such as positive and negative NaN,
+  signalling and quiet nans, each with many different bit representations.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.isNaN(0.0/0.0) // => true
+```
 
 ## Value `abs`
 ``` motoko no-repl
@@ -29,12 +88,42 @@ let abs : (x : Float) -> Float
 
 Returns the absolute value of `x`.
 
+Special cases:
+```
+abs(+inf) => +inf
+abs(-inf) => +inf
+abs(NaN)  => NaN
+abs(-0.0) => 0.0
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.abs(-1.2) // => 1.2
+```
+
 ## Value `sqrt`
 ``` motoko no-repl
 let sqrt : (x : Float) -> Float
 ```
 
 Returns the square root of `x`.
+
+Special cases:
+```
+sqrt(+inf) => +inf
+sqrt(-0.0) => -0.0
+sqrt(x)    => NaN if x < 0.0
+sqrt(NaN)  => NaN
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.sqrt(6.25) // => 2.5
+```
 
 ## Value `ceil`
 ``` motoko no-repl
@@ -43,6 +132,22 @@ let ceil : (x : Float) -> Float
 
 Returns the smallest integral float greater than or equal to `x`.
 
+Special cases:
+```
+ceil(+inf) => +inf
+ceil(-inf) => -inf
+ceil(NaN)  => NaN
+ceil(0.0)  => 0.0
+ceil(-0.0) => -0.0
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.ceil(1.2) // => 2.0
+```
+
 ## Value `floor`
 ``` motoko no-repl
 let floor : (x : Float) -> Float
@@ -50,12 +155,45 @@ let floor : (x : Float) -> Float
 
 Returns the largest integral float less than or equal to `x`.
 
+Special cases:
+```
+floor(+inf) => +inf
+floor(-inf) => -inf
+floor(NaN)  => NaN
+floor(0.0)  => 0.0
+floor(-0.0) => -0.0
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.floor(1.2) // => 1.0
+```
+
 ## Value `trunc`
 ``` motoko no-repl
 let trunc : (x : Float) -> Float
 ```
 
 Returns the nearest integral float not greater in magnitude than `x`.
+This is equilvent to returning `x` with truncating its decimal places.
+
+Special cases:
+```
+trunc(+inf) => +inf
+trunc(-inf) => -inf
+trunc(NaN)  => NaN
+trunc(0.0)  => 0.0
+trunc(-0.0) => -0.0
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.trunc(2.75) // => 2.0
+```
 
 ## Value `nearest`
 ``` motoko no-repl
@@ -63,6 +201,24 @@ let nearest : (x : Float) -> Float
 ```
 
 Returns the nearest integral float to `x`.
+A decimal place of exactly .5 is rounded up for `x > 0`
+and rounded down for `x < 0`
+
+Special cases:
+```
+nearest(+inf) => +inf
+nearest(-inf) => -inf
+nearest(NaN)  => NaN
+nearest(0.0)  => 0.0
+nearest(-0.0) => -0.0
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.nearest(2.75) // => 3.0
+```
 
 ## Value `copySign`
 ``` motoko no-repl
@@ -71,12 +227,34 @@ let copySign : (x : Float, y : Float) -> Float
 
 Returns `x` if `x` and `y` have same sign, otherwise `x` with negated sign.
 
+The sign bit of zero, infinity, and `NaN` is considered.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.copySign(1.2, -2.3) // => -1.2
+```
+
 ## Value `min`
 ``` motoko no-repl
 let min : (x : Float, y : Float) -> Float
 ```
 
 Returns the smaller value of `x` and `y`.
+
+Special cases:
+```
+min(NaN, y) => NaN for any Float y
+min(x, NaN) => NaN for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.min(1.2, -2.3) // => -2.3 (with numerical imprecision)
+```
 
 ## Value `max`
 ``` motoko no-repl
@@ -85,12 +263,39 @@ let max : (x : Float, y : Float) -> Float
 
 Returns the larger value of `x` and `y`.
 
+Special cases:
+```
+max(NaN, y) => NaN for any Float y
+max(x, NaN) => NaN for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.max(1.2, -2.3) // => 1.2
+```
+
 ## Value `sin`
 ``` motoko no-repl
 let sin : (x : Float) -> Float
 ```
 
 Returns the sine of the radian angle `x`.
+
+Special cases:
+```
+sin(+inf) => NaN
+sin(-inf) => NaN
+sin(NaN) => NaN
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.sin(Float.pi / 2) // => 1.0
+```
 
 ## Value `cos`
 ``` motoko no-repl
@@ -99,12 +304,40 @@ let cos : (x : Float) -> Float
 
 Returns the cosine of the radian angle `x`.
 
+Special cases:
+```
+cos(+inf) => NaN
+cos(-inf) => NaN
+cos(NaN)  => NaN
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.cos(Float.pi / 2) // => 0.0 (with numerical imprecision)
+```
+
 ## Value `tan`
 ``` motoko no-repl
 let tan : (x : Float) -> Float
 ```
 
 Returns the tangent of the radian angle `x`.
+
+Special cases:
+```
+tan(+inf) => NaN
+tan(-inf) => NaN
+tan(NaN)  => NaN
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.tan(Float.pi / 4) // => 1.0 (with numerical imprecision)
+```
 
 ## Value `arcsin`
 ``` motoko no-repl
@@ -113,12 +346,40 @@ let arcsin : (x : Float) -> Float
 
 Returns the arc sine of `x` in radians.
 
+Special cases:
+```
+arcsin(x)   => NaN if x > 1.0
+arcsin(x)   => NaN if x < -1.0
+arcsin(NaN) => NaN
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.arcsin(1.0) // => Float.pi / 2
+```
+
 ## Value `arccos`
 ``` motoko no-repl
 let arccos : (x : Float) -> Float
 ```
 
 Returns the arc cosine of `x` in radians.
+
+Special cases:
+```
+arccos(x)  => NaN if x > 1.0
+arccos(x)  => NaN if x < -1.0
+arcos(NaN) => NaN
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.arccos(1.0) // => 0.0
+```
 
 ## Value `arctan`
 ``` motoko no-repl
@@ -127,12 +388,48 @@ let arctan : (x : Float) -> Float
 
 Returns the arc tangent of `x` in radians.
 
+Special cases:
+```
+arctan(+inf) => pi / 2
+arctan(-inf) => -pi / 2
+arctan(NaN)  => NaN
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.arctan(1.0) // => Float.pi / 4
+```
+
 ## Value `arctan2`
 ``` motoko no-repl
 let arctan2 : (y : Float, x : Float) -> Float
 ```
 
 Given `(y,x)`, returns the arc tangent in radians of `y/x` based on the signs of both values to determine the correct quadrant.
+
+Special cases:
+```
+arctan2(0.0, 0.0)   => 0.0
+arctan2(-0.0, 0.0)  => -0.0
+arctan2(0.0, -0.0)  => pi
+arctan2(-0.0, -0.0) => -pi
+arctan2(+inf, +inf) => pi / 4
+arctan2(+inf, -inf) => 3 * pi / 4
+arctan2(-inf, +inf) => -pi / 4
+arctan2(-inf, -inf) => -3 * pi / 4
+arctan2(NaN, x)     => NaN for any Float x
+arctan2(y, NaN)     => NaN for any Float y
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+let sqrt2over2 = Float.sqrt(2) / 2;
+Float.arctan2(sqrt2over2, sqrt2over2) // => Float.pi / 4
+```
 
 ## Value `exp`
 ``` motoko no-repl
@@ -141,12 +438,42 @@ let exp : (x : Float) -> Float
 
 Returns the value of `e` raised to the `x`-th power.
 
+Special cases:
+```
+exp(+inf) => +inf
+exp(-inf) => 0.0
+exp(NaN)  => NaN
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.exp(1.0) // => Float.e
+```
+
 ## Value `log`
 ``` motoko no-repl
 let log : (x : Float) -> Float
 ```
 
 Returns the natural logarithm (base-`e`) of `x`.
+
+Special cases:
+```
+log(0.0)  => -inf
+log(-0.0) => -inf
+log(x)    => NaN if x < 0.0
+log(+inf) => +inf
+log(NaN)  => NaN
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.log(Float.e) // => 1.0
+```
 
 ## Function `format`
 ``` motoko no-repl
@@ -162,12 +489,36 @@ formatting directive `fmt`, which can take one of the following forms:
 * `#hex prec` as hexadecimal format with `prec` digits
 * `#exact` as exact format that can be decoded without loss.
 
+`-0.0` is formatted with negative sign bit.
+Positive infinity is formatted as `inf`.
+Negative infinity is formatted as `-inf`.
+`NaN` is formatted as `NaN` or `-NaN` depending on its sign bit.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.format(#exp 3, 123.0) // => "1.230e+02"
+```
+
 ## Value `toText`
 ``` motoko no-repl
 let toText : Float -> Text
 ```
 
 Conversion to Text. Use `format(fmt, x)` for more detailed control.
+
+`-0.0` is formatted with negative sign bit.
+Positive infinity is formatted as `inf`.
+Negative infinity is formatted as `-inf`.
+`NaN` is formatted as `NaN` or `-NaN` depending on its sign bit.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.toText(0.12) // => "0.12"
+```
 
 ## Value `toInt64`
 ``` motoko no-repl
@@ -176,12 +527,31 @@ let toInt64 : Float -> Int64
 
 Conversion to Int64 by truncating Float, equivalent to `toInt64(trunc(f))`
 
+Traps if the floating point number is larger or smaller than the representable Int64.
+Also traps for `inf`, `-inf`, and `NaN`.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.toInt64(-12.3) // => -12
+```
+
 ## Value `fromInt64`
 ``` motoko no-repl
 let fromInt64 : Int64 -> Float
 ```
 
 Conversion from Int64.
+
+Note: The floating point number may be imprecise for large or small Int64.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.fromInt64(-42) // => -42.0
+```
 
 ## Value `toInt`
 ``` motoko no-repl
@@ -190,6 +560,15 @@ let toInt : Float -> Int
 
 Conversion to Int.
 
+Traps for `inf`, `-inf`, and `NaN`.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.toInt(1.2e6) // => +1_200_000
+```
+
 ## Value `fromInt`
 ``` motoko no-repl
 let fromInt : Int -> Float
@@ -197,12 +576,24 @@ let fromInt : Int -> Float
 
 Conversion from Int. May result in `Inf`.
 
+Note: The floating point number may be imprecise for large or small Int values.
+Returns `inf` if the integer is greater than the maximum floating point number.
+Returns `-inf` if the integer is less than the minimum floating point number.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.fromInt(-123) // => -123.0
+```
+
 ## Function `equal`
 ``` motoko no-repl
 func equal(x : Float, y : Float) : Bool
 ```
 
 Returns `x == y`.
+@deprecated Use `Float.equalWithin()` as this function does not consider numerical errors.
 
 ## Function `notEqual`
 ``` motoko no-repl
@@ -210,6 +601,65 @@ func notEqual(x : Float, y : Float) : Bool
 ```
 
 Returns `x != y`.
+@deprecated Use `Float.notEqualWithin()` as this function does not consider numerical errors.
+
+## Function `equalWithin`
+``` motoko no-repl
+func equalWithin(x : Float, y : Float, epsilon : Float) : Bool
+```
+
+Determines whether `x` is equal to `y` within the defined tolerance of `epsilon`.
+The `epsilon` considers numerical erros, see comment above.
+Equivalent to `Float.abs(x - y) <= epsilon` for a non-negative epsilon.
+
+Traps if `epsilon` is negative or `NaN`.
+
+Special cases:
+```
+equal(+0.0, -0.0, epsilon) => true for any `epsilon >= 0.0`
+equal(-0.0, +0.0, epsilon) => true for any `epsilon >= 0.0`
+equal(+inf, +inf, epsilon) => true for any `epsilon >= 0.0`
+equal(-inf, -inf, epsilon) => true for any `epsilon >= 0.0`
+equal(x, NaN, epsilon)     => false for any x and `epsilon >= 0.0`
+equal(NaN, y, epsilon)     => false for any y and `epsilon >= 0.0`
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+let epsilon = 1e-6;
+Float.equal(-12.3, -1.23e1, epsilon) // => true
+```
+
+## Function `notEqualWithin`
+``` motoko no-repl
+func notEqualWithin(x : Float, y : Float, epsilon : Float) : Bool
+```
+
+Determines whether `x` is not equal to `y` within the defined tolerance of `epsilon`.
+The `epsilon` considers numerical erros, see comment above.
+Equivalent to `not equal(x, y, epsilon)`.
+
+Traps if `epsilon` is negative or `NaN`.
+
+Special cases:
+```
+notEqual(+0.0, -0.0, epsilon) => false for any `epsilon >= 0.0`
+notEqual(-0.0, +0.0, epsilon) => false for any `epsilon >= 0.0`
+notEqual(+inf, +inf, epsilon) => false for any `epsilon >= 0.0`
+notEqual(-inf, -inf, epsilon) => false for any `epsilon >= 0.0`
+notEqual(x, NaN, epsilon)     => true for any x and `epsilon >= 0.0`
+notEqual(NaN, y, epsilon)     => true for any y and `epsilon >= 0.0`
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+let epsilon = 1e-6;
+Float.notEqual(-12.3, -1.23e1, epsilon) // => false
+```
 
 ## Function `less`
 ``` motoko no-repl
@@ -218,12 +668,42 @@ func less(x : Float, y : Float) : Bool
 
 Returns `x < y`.
 
+Special cases:
+```
+less(+0.0, -0.0) => false
+less(-0.0, +0.0) => false
+less(NaN, y)     => false for any Float y
+less(x, NaN)     => false for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.less(Float.e, Float.pi) // => true
+```
+
 ## Function `lessOrEqual`
 ``` motoko no-repl
 func lessOrEqual(x : Float, y : Float) : Bool
 ```
 
 Returns `x <= y`.
+
+Special cases:
+```
+lessOrEqual(+0.0, -0.0) => true
+lessOrEqual(-0.0, +0.0) => true
+lessOrEqual(NaN, y)     => false for any Float y
+lessOrEqual(x, NaN)     => false for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.lessOrEqual(0.123, 0.1234) // => true
+```
 
 ## Function `greater`
 ``` motoko no-repl
@@ -232,6 +712,21 @@ func greater(x : Float, y : Float) : Bool
 
 Returns `x > y`.
 
+Special cases:
+```
+greater(+0.0, -0.0) => false
+greater(-0.0, +0.0) => false
+greater(NaN, y)     => false for any Float y
+greater(x, NaN)     => false for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.greater(Float.pi, Float.e) // => true
+```
+
 ## Function `greaterOrEqual`
 ``` motoko no-repl
 func greaterOrEqual(x : Float, y : Float) : Bool
@@ -239,19 +734,68 @@ func greaterOrEqual(x : Float, y : Float) : Bool
 
 Returns `x >= y`.
 
+Special cases:
+```
+greaterOrEqual(+0.0, -0.0) => true
+greaterOrEqual(-0.0, +0.0) => true
+greaterOrEqual(NaN, y)     => false for any Float y
+greaterOrEqual(x, NaN)     => false for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.greaterOrEqual(0.1234, 0.123) // => true
+```
+
 ## Function `compare`
 ``` motoko no-repl
 func compare(x : Float, y : Float) : {#less; #equal; #greater}
 ```
 
-Returns the order of `x` and `y`.
+Defines a total order of `x` and `y` for use in sorting.
 
-## Function `neq`
+Note: Using this operation to determine equality or inequality is discouraged for two reasons:
+* It does not consider numerical errors, see comment above. Use `equal(x, y)` or
+  `notEqual(x, y)` to test for equality or inequality, respectively.
+* `NaN` are here considered equal if their sign matches, which is different to the standard equality
+   by `==` or when using `equal()` or `notEqual()`.
+
+Total order:
+* negative NaN (no distinction between signalling and quiet negative NaN)
+* negative infinity
+* negative numbers (including negative subnormal numbers in standard order)
+* negative zero (`-0.0`)
+* positive zero (`+0.0`)
+* positive numbers (including positive subnormal numbers in standard order)
+* positive infinity
+* positive NaN (no distinction between signalling and quiet positive NaN)
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.compare(0.123, 0.1234) // => #less
+```
+
+## Function `neg`
 ``` motoko no-repl
-func neq(x : Float) : Float
+func neg(x : Float) : Float
 ```
 
 Returns the negation of `x`, `-x` .
+
+Changes the sign bit for infinity.
+Issue: Inconsistent behavior for zero and `NaN`. Probably related to
+https://github.com/dfinity/motoko/issues/3646
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.neg(1.23) // => -1.23
+```
 
 ## Function `add`
 ``` motoko no-repl
@@ -260,12 +804,51 @@ func add(x : Float, y : Float) : Float
 
 Returns the sum of `x` and `y`, `x + y`.
 
+Note: Numerical errors may occur, see comment above.
+
+Special cases:
+```
+add(+inf, y)    => +inf if y is any Float except -inf and NaN
+add(-inf, y)    => -inf if y is any Float except +inf and NaN
+add(+inf, -inf) => NaN
+add(NaN, y)     => NaN for any Float y
+```
+The same cases apply commutatively, i.e. for `add(y, x)`.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.add(1.23, 0.123) // => 1.353
+```
+
 ## Function `sub`
 ``` motoko no-repl
 func sub(x : Float, y : Float) : Float
 ```
 
 Returns the difference of `x` and `y`, `x - y`.
+
+Note: Numerical errors may occur, see comment above.
+
+Special cases:
+```
+sub(+inf, y)    => +inf if y is any Float except +inf or NaN
+sub(-inf, y)    => -inf if y is any Float except -inf and NaN
+sub(x, +inf)    => -inf if x is any Float except +inf and NaN
+sub(x, -inf)    => +inf if x is any Float except -inf and NaN
+sub(+inf, +inf) => NaN
+sub(-inf, -inf) => NaN
+sub(NaN, y)     => NaN for any Float y
+sub(x, NaN)     => NaN for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.sub(1.23, 0.123) // => 1.107
+```
 
 ## Function `mul`
 ``` motoko no-repl
@@ -274,6 +857,27 @@ func mul(x : Float, y : Float) : Float
 
 Returns the product of `x` and `y`, `x * y`.
 
+Note: Numerical errors may occur, see comment above.
+
+Special cases:
+```
+mul(+inf, y) => +inf if y > 0.0
+mul(-inf, y) => -inf if y > 0.0
+mul(+inf, y) => -inf if y < 0.0
+mul(-inf, y) => +inf if y < 0.0
+mul(+inf, 0.0) => NaN
+mul(-inf, 0.0) => NaN
+mul(NaN, y) => NaN for any Float y
+```
+The same cases apply commutatively, i.e. for `mul(y, x)`.
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.mul(1.23, 1e2) // => 123.0
+```
+
 ## Function `div`
 ``` motoko no-repl
 func div(x : Float, y : Float) : Float
@@ -281,12 +885,59 @@ func div(x : Float, y : Float) : Float
 
 Returns the division of `x` by `y`, `x / y`.
 
+Note: Numerical errors may occur, see comment above.
+
+Special cases:
+```
+div(0.0, 0.0) => NaN
+div(x, 0.0)   => +inf for x > 0.0
+div(x, 0.0)   => -inf for x < 0.0
+div(x, +inf)  => 0.0 for any x except +inf, -inf, and NaN
+div(x, -inf)  => 0.0 for any x except +inf, -inf, and NaN
+div(+inf, y)  => +inf if y >= 0.0
+div(+inf, y)  => -inf if y < 0.0
+div(-inf, y)  => -inf if y >= 0.0
+div(-inf, y)  => +inf if y < 0.0
+div(NaN, y)   => NaN for any Float y
+div(x, NaN)   => NaN for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.div(1.23, 1e2) // => 0.0123
+```
+
 ## Function `rem`
 ``` motoko no-repl
 func rem(x : Float, y : Float) : Float
 ```
 
-Returns the remainder of `x` divided by `y`, `x % y`.
+Returns the floating point division remainder `x % y`,
+which is defined as `x - trunc(x / y) * y`.
+
+Note: Numerical errors may occur, see comment above.
+
+Special cases:
+```
+rem(0.0, 0.0) => NaN
+rem(x, y)     => +inf if sign(x) == sign(y) for any x and y not being +inf, -inf, or NaN
+rem(x, y)     => -inf if sign(x) != sign(y) for any x and y not being +inf, -inf, or NaN
+rem(x, +inf)  => x for any x except +inf, -inf, and NaN
+rem(x, -inf)  => x for any x except +inf, -inf, and NaN
+rem(+inf, y)  => NaN for any Float y
+rem(-inf, y)  => NaN for any Float y
+rem(NaN, y)   => NaN for any Float y
+rem(x, NaN)   => NaN for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.rem(7.2, 2.3) // => 0.3 (with numerical imprecision)
+```
 
 ## Function `pow`
 ``` motoko no-repl
@@ -294,3 +945,33 @@ func pow(x : Float, y : Float) : Float
 ```
 
 Returns `x` to the power of `y`, `x ** y`.
+
+Note: Numerical errors may occur, see comment above.
+
+Special cases:
+```
+pow(+inf, y)    => +inf for any y > 0.0 including +inf
+pow(+inf, 0.0)  => 1.0
+pow(+inf, y)    => 0.0 for any y < 0.0 including -inf
+pow(x, +inf)    => +inf if x > 0.0 or x < 0.0
+pow(0.0, +inf)  => 0.0
+pow(x, -inf)    => 0.0 if x > 0.0 or x < 0.0
+pow(0.0, -inf)  => +inf
+pow(x, y)       => NaN if x < 0.0 and y is a non-integral Float
+pow(-inf, y)    => +inf if y > 0.0 and y is a non-integral or an even integral Float
+pow(-inf, y)    => -inf if y > 0.0 and y is an odd integral Float
+pow(-inf, 0.0)  => 1.0
+pow(-inf, y)    => 0.0 if y < 0.0
+pow(-inf, +inf) => +inf
+pow(-inf, -inf) => 1.0
+pow(NaN, y)     => NaN if y != 0.0
+pow(NaN, 0.0)   => 1.0
+pow(x, NaN)     => NaN for any Float x
+```
+
+Example:
+```motoko
+import Float "mo:base/Float";
+
+Float.pow(2.5, 2.0) // => 6.25
+```

--- a/doc/md/base/Func.md
+++ b/doc/md/base/Func.md
@@ -1,5 +1,5 @@
 # Func
-Functions on functions
+Functions on functions, creating functions from simpler inputs.
 
 (Most commonly used when programming in functional style using higher-order
 functions.)
@@ -9,10 +9,19 @@ functions.)
 func compose<A, B, C>(f : B -> C, g : A -> B) : A -> C
 ```
 
+Import from the base library to use this module.
+
+```motoko name=import
+import { compose; const; identity } = "mo:base/Func";
+import Text = "mo:base/Text";
+import Char = "mo:base/Char";
+```
 The composition of two functions `f` and `g` is a function that applies `g` and then `f`.
 
-```
-compose(f, g)(x) = f(g(x))
+Example:
+```motoko include=import
+let textFromNat32 = compose(Text.fromChar, Char.fromNat32);
+assert textFromNat32(65) == "A";
 ```
 
 ## Function `identity`
@@ -21,10 +30,10 @@ func identity<A>(x : A) : A
 ```
 
 The `identity` function returns its argument.
-```motoko
-import Func "mo:base/Func";
-assert(Func.identity(10) == 10);
-assert(Func.identity(true) == true);
+Example:
+```motoko include=import
+assert identity(10) == 10;
+assert identity(true) == true;
 ```
 
 ## Function `const`
@@ -36,8 +45,8 @@ The const function is a _curried_ function that accepts an argument `x`,
 and then returns a function that discards its argument and always returns
 the `x`.
 
-```motoko
-import Func "mo:base/Func";
-assert(Func.const<Nat, Text>(10)("hello") == 10);
-assert(Func.const<Bool, Nat>(true)(20) == true);
+Example:
+```motoko include=import
+assert const<Nat, Text>(10)("hello") == 10;
+assert const(true)(20) == true;
 ```

--- a/doc/md/base/HashMap.md
+++ b/doc/md/base/HashMap.md
@@ -1,72 +1,164 @@
 # HashMap
-Mutable hash map (aka Hashtable)
-
-This module defines an imperative hash map (hash table), with a general key and value type.
-
-It has a minimal object-oriented interface: `get`, `set`, `delete`, `count` and `entries`.
-
+Class `HashMap<K, V>` provides a hashmap from keys of type `K` to values of type `V`.
 The class is parameterized by the key's equality and hash functions,
-and an initial capacity.  However, as with the `Buffer` class, no array allocation
-happens until the first `set`.
+and an initial capacity.  However, the underlying allocation happens only when
+the first key-value entry is inserted.
 
-Internally, table growth policy is very simple, for now:
- Double the current capacity when the expected bucket list size grows beyond a certain constant.
+Internally, the map is represented as an array of `AssocList` (buckets).
+The growth policy of the underyling array is very simple, for now: double
+the current capacity when the expected bucket list size grows beyond a
+certain constant.
 
-## `class HashMap<K, V>`
+WARNING: Certain operations are amortized O(1) time, such as `put`, but run
+in worst case O(size) time. These worst case runtimes may exceed the cycles limit
+per message if the size of the map is large enough. Further, this runtime analysis
+assumes that the hash functions uniformly maps keys over the hash space. Grow these structures
+with discretion, and with good hash functions. All amortized operations
+below also list the worst case runtime.
 
-An imperative HashMap with a minimal object-oriented interface.
-Maps keys of type `K` to values of type `V`.
+For maps without amortization, see `TrieMap`.
+
+Note on the constructor:
+The argument `initCapacity` determines the initial number of buckets in the
+underyling array. Also, the runtime and space anlyses in this documentation
+assumes that the equality and hash functions for keys used to construct the
+map run in O(1) time and space.
+
+Example:
+```motoko name=initialize
+import HashMap "mo:base/HashMap";
+import Text "mo:base/Text";
+
+let map = HashMap.HashMap<Text, Nat>(5, Text.equal, Text.hash);
+```
+
+Runtime: O(1)
+
+Space: O(1)
+
+## Class `HashMap<K, V>`
+
+``` motoko no-repl
+class HashMap<K, V>(initCapacity : Nat, keyEq : (K, K) -> Bool, keyHash : K -> Hash.Hash)
+```
+
 
 ### Function `size`
 ``` motoko no-repl
 func size() : Nat
 ```
 
-Returns the number of entries in this HashMap.
+Returns the current number of key-value entries in the map.
 
-
-### Function `delete`
-``` motoko no-repl
-func delete(k : K)
+Example:
+```motoko include=initialize
+map.size() // => 0
 ```
 
-Deletes the entry with the key `k`. Doesn't do anything if the key doesn't
-exist.
+Runtime: O(1)
 
-
-### Function `remove`
-``` motoko no-repl
-func remove(k : K) : ?V
-```
-
-Removes the entry with the key `k` and returns the associated value if it
-existed or `null` otherwise.
+Space: O(1)
 
 
 ### Function `get`
 ``` motoko no-repl
-func get(k : K) : ?V
+func get(key : K) : (value : ?V)
 ```
 
-Gets the entry with the key `k` and returns its associated value if it
-existed or `null` otherwise.
+Returns the value assocaited with key `key` if present and `null` otherwise.
+
+Example:
+```motoko include=initialize
+map.put("key", 3);
+map.get("key") // => ?3
+```
+
+Expected Runtime: O(1), Worst Case Runtime: O(size)
+
+Space: O(1)
 
 
 ### Function `put`
 ``` motoko no-repl
-func put(k : K, v : V)
+func put(key : K, value : V)
 ```
 
-Insert the value `v` at key `k`. Overwrites an existing entry with key `k`
+Insert the value `value` with key `key`. Overwrites any existing entry with key `key`.
+
+Example:
+```motoko include=initialize
+map.put("key", 3);
+map.get("key") // => ?3
+```
+
+Expected Amortized Runtime: O(1), Worst Case Runtime: O(size)
+
+Expected Amortized Space: O(1), Worst Case Space: O(size)
+
+Note: If this is the first entry into this map, this operation will cause
+the initial allocation of the underlying array.
 
 
 ### Function `replace`
 ``` motoko no-repl
-func replace(k : K, v : V) : ?V
+func replace(key : K, value : V) : (oldValue : ?V)
 ```
 
-Insert the value `v` at key `k` and returns the previous value stored at
-`k` or `null` if it didn't exist.
+Insert the value `value` with key `key`. Returns the previous value
+associated with key `key` or `null` if no such value exists.
+
+Example:
+```motoko include=initialize
+map.put("key", 3);
+ignore map.replace("key", 2); // => ?3
+map.get("key") // => ?2
+```
+
+Expected Amortized Runtime: O(1), Worst Case Runtime: O(size)
+
+Expected Amortized Space: O(1), Worst Case Space: O(size)
+
+Note: If this is the first entry into this map, this operation will cause
+the initial allocation of the underlying array.
+
+
+### Function `delete`
+``` motoko no-repl
+func delete(key : K)
+```
+
+Deletes the entry with the key `key`. Has no effect if `key` is not
+present in the map.
+
+Example:
+```motoko include=initialize
+map.put("key", 3);
+map.delete("key");
+map.get("key"); // => null
+```
+
+Expected Runtime: O(1), Worst Case Runtime: O(size)
+
+Expected Space: O(1), Worst Case Space: O(size)
+
+
+### Function `remove`
+``` motoko no-repl
+func remove(key : K) : (oldValue : ?V)
+```
+
+Deletes the entry with the key `key`. Returns the previous value
+associated with key `key` or `null` if no such value exists.
+
+Example:
+```motoko include=initialize
+map.put("key", 3);
+map.remove("key"); // => ?3
+```
+
+Expected Runtime: O(1), Worst Case Runtime: O(size)
+
+Expected Space: O(1), Worst Case Space: O(size)
 
 
 ### Function `keys`
@@ -74,7 +166,29 @@ Insert the value `v` at key `k` and returns the previous value stored at
 func keys() : Iter.Iter<K>
 ```
 
-An `Iter` over the keys.
+Returns an Iterator (`Iter`) over the keys of the map.
+Iterator provides a single method `next()`, which returns
+keys in no specific order, or `null` when out of keys to iterate over.
+
+Example:
+```motoko include=initialize
+
+map.put("key1", 1);
+map.put("key2", 2);
+map.put("key3", 3);
+
+var keys = "";
+for (key in map.keys()) {
+  keys := key # " " # keys
+};
+keys // => "key3 key2 key1 "
+```
+
+Cost of iteration over all keys:
+
+Runtime: O(size)
+
+Space: O(1)
 
 
 ### Function `vals`
@@ -82,7 +196,29 @@ An `Iter` over the keys.
 func vals() : Iter.Iter<V>
 ```
 
-An `Iter` over the values.
+Returns an Iterator (`Iter`) over the values of the map.
+Iterator provides a single method `next()`, which returns
+values in no specific order, or `null` when out of values to iterate over.
+
+Example:
+```motoko include=initialize
+
+map.put("key1", 1);
+map.put("key2", 2);
+map.put("key3", 3);
+
+var sum = 0;
+for (value in map.vals()) {
+  sum += value;
+};
+sum // => 6
+```
+
+Cost of iteration over all values:
+
+Runtime: O(size)
+
+Space: O(1)
 
 
 ### Function `entries`
@@ -90,32 +226,126 @@ An `Iter` over the values.
 func entries() : Iter.Iter<(K, V)>
 ```
 
-Returns an iterator over the key value pairs in this
-`HashMap`. Does _not_ modify the `HashMap`.
+Returns an Iterator (`Iter`) over the key-value pairs in the map.
+Iterator provides a single method `next()`, which returns
+pairs in no specific order, or `null` when out of pairs to iterate over.
+
+Example:
+```motoko include=initialize
+import Nat "mo:base/Nat";
+
+map.put("key1", 1);
+map.put("key2", 2);
+map.put("key3", 3);
+
+var pairs = "";
+for ((key, value) in map.entries()) {
+  pairs := "(" # key # ", " # Nat.toText(value) # ") " # pairs
+};
+pairs // => "(key3, 3) (key2, 2) (key1, 1)"
+```
+
+Cost of iteration over all pairs:
+
+Runtime: O(size)
+
+Space: O(1)
 
 ## Function `clone`
 ``` motoko no-repl
-func clone<K, V>(h : HashMap<K, V>, keyEq : (K, K) -> Bool, keyHash : K -> Hash.Hash) : HashMap<K, V>
+func clone<K, V>(map : HashMap<K, V>, keyEq : (K, K) -> Bool, keyHash : K -> Hash.Hash) : HashMap<K, V>
 ```
 
-clone cannot be an efficient object method,
-...but is still useful in tests, and beyond.
+Returns a copy of `map`, initializing the copy with the provided equality
+and hash functions.
+
+Example:
+```motoko include=initialize
+map.put("key1", 1);
+map.put("key2", 2);
+map.put("key3", 3);
+
+let map2 = HashMap.clone(map, Text.equal, Text.hash);
+map2.get("key1") // => ?1
+```
+
+Expected Runtime: O(size), Worst Case Runtime: O(size * size)
+
+Expected Space: O(size), Worst Case Space: O(size)
 
 ## Function `fromIter`
 ``` motoko no-repl
 func fromIter<K, V>(iter : Iter.Iter<(K, V)>, initCapacity : Nat, keyEq : (K, K) -> Bool, keyHash : K -> Hash.Hash) : HashMap<K, V>
 ```
 
-Clone from any iterator of key-value pairs
+Returns a new map, containing all entries given by the iterator `iter`.
+The new map is initialized with the provided initial capacity, equality,
+and hash functions.
+
+Example:
+```motoko include=initialize
+let entries = [("key3", 3), ("key2", 2), ("key1", 1)];
+let iter = entries.vals();
+
+let map2 = HashMap.fromIter<Text, Nat>(iter, entries.size(), Text.equal, Text.hash);
+map2.get("key1") // => ?1
+```
+
+Expected Runtime: O(size), Worst Case Runtime: O(size * size)
+
+Expected Space: O(size), Worst Case Space: O(size)
 
 ## Function `map`
 ``` motoko no-repl
-func map<K, V1, V2>(h : HashMap<K, V1>, keyEq : (K, K) -> Bool, keyHash : K -> Hash.Hash, mapFn : (K, V1) -> V2) : HashMap<K, V2>
+func map<K, V1, V2>(hashMap : HashMap<K, V1>, keyEq : (K, K) -> Bool, keyHash : K -> Hash.Hash, f : (K, V1) -> V2) : HashMap<K, V2>
 ```
 
+Creates a new map by applying `f` to each entry in `hashMap`. Each entry
+`(k, v)` in the old map is transformed into a new entry `(k, v2)`, where
+the new value `v2` is created by applying `f` to `(k, v)`.
+
+```motoko include=initialize
+map.put("key1", 1);
+map.put("key2", 2);
+map.put("key3", 3);
+
+let map2 = HashMap.map<Text, Nat, Nat>(map, Text.equal, Text.hash, func (k, v) = v * 2);
+map2.get("key2") // => ?4
+```
+
+Expected Runtime: O(size), Worst Case Runtime: O(size * size)
+
+Expected Space: O(size), Worst Case Space: O(size)
+
+*Runtime and space assumes that `f` runs in O(1) time and space.
 
 ## Function `mapFilter`
 ``` motoko no-repl
-func mapFilter<K, V1, V2>(h : HashMap<K, V1>, keyEq : (K, K) -> Bool, keyHash : K -> Hash.Hash, mapFn : (K, V1) -> ?V2) : HashMap<K, V2>
+func mapFilter<K, V1, V2>(hashMap : HashMap<K, V1>, keyEq : (K, K) -> Bool, keyHash : K -> Hash.Hash, f : (K, V1) -> ?V2) : HashMap<K, V2>
 ```
 
+Creates a new map by applying `f` to each entry in `hashMap`. For each entry
+`(k, v)` in the old map, if `f` evaluates to `null`, the entry is discarded.
+Otherwise, the entry is transformed into a new entry `(k, v2)`, where
+the new value `v2` is the result of applying `f` to `(k, v)`.
+
+```motoko include=initialize
+map.put("key1", 1);
+map.put("key2", 2);
+map.put("key3", 3);
+
+let map2 =
+  HashMap.mapFilter<Text, Nat, Nat>(
+    map,
+    Text.equal,
+    Text.hash,
+    func (k, v) = if (v == 2) { null } else { ?(v * 2)}
+);
+map2.get("key3") // => ?6
+```
+
+Expected Runtime: O(size), Worst Case Runtime: O(size * size)
+
+Expected Space: O(size), Worst Case Space: O(size)
+
+*Runtime and space assumes that `f` runs in O(1) time and space.

--- a/doc/md/base/Heap.md
+++ b/doc/md/base/Heap.md
@@ -9,7 +9,11 @@ type Tree<T> = ?(Int, T, Tree<T>, Tree<T>)
 ```
 
 
-## `class Heap<T>`
+## Class `Heap<T>`
+
+``` motoko no-repl
+class Heap<T>(ord : (T, T) -> O.Order)
+```
 
 
 ### Function `share`

--- a/doc/md/base/Int.md
+++ b/doc/md/base/Int.md
@@ -1,8 +1,8 @@
 # Int
-Integer numbers
+Signed integer numbers with infinite precision (also called big integers).
 
-Most operations on integers (e.g. addition) are available as built-in operators (e.g. `1 + 1`).
-This module provides equivalent functions and `Text` conversion.
+Common integer functions.
+Most operations on integers (e.g. addition) are also available as built-in operators (e.g. `1 + 1`).
 
 ## Type `Int`
 ``` motoko no-repl
@@ -13,17 +13,32 @@ Infinite precision signed integers.
 
 ## Value `abs`
 ``` motoko no-repl
-let abs : Int -> Nat
+let abs : (x : Int) -> Nat
 ```
 
-Returns the absolute value of the number
+Returns the absolute value of `x`.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.abs(-12) // => 12
+```
 
 ## Value `toText`
 ``` motoko no-repl
 let toText : Int -> Text
 ```
 
-Conversion.
+Conversion to Text.
+Formats the integer in decimal representation without underscore separators for blocks of thousands.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.toText(-1234) // => "-1234"
+```
 
 ## Function `min`
 ``` motoko no-repl
@@ -32,12 +47,26 @@ func min(x : Int, y : Int) : Int
 
 Returns the minimum of `x` and `y`.
 
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.min(+2, -3) // => -3
+```
+
 ## Function `max`
 ``` motoko no-repl
 func max(x : Int, y : Int) : Int
 ```
 
 Returns the maximum of `x` and `y`.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.max(+2, -3) // => 2
+```
 
 ## Function `hash`
 ``` motoko no-repl
@@ -52,7 +81,8 @@ Computes a hash from the least significant 32-bits of `i`, ignoring other bits.
 func hashAcc(h1 : Hash.Hash, i : Int) : Hash.Hash
 ```
 
-@deprecated This function will be removed in future.
+Computes an accumulated hash from `h1` and the least significant 32-bits of `i`, ignoring other bits in `i`.
+@deprecated For large `Int` values consider using a bespoke hash function that considers all of the argument's bits.
 
 ## Function `equal`
 ``` motoko no-repl
@@ -61,12 +91,26 @@ func equal(x : Int, y : Int) : Bool
 
 Returns `x == y`.
 
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.equal(123, 123) // => true
+```
+
 ## Function `notEqual`
 ``` motoko no-repl
 func notEqual(x : Int, y : Int) : Bool
 ```
 
 Returns `x != y`.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.notEqual(123, 123) // => false
+```
 
 ## Function `less`
 ``` motoko no-repl
@@ -75,12 +119,26 @@ func less(x : Int, y : Int) : Bool
 
 Returns `x < y`.
 
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.less(123, 1234) // => true
+```
+
 ## Function `lessOrEqual`
 ``` motoko no-repl
 func lessOrEqual(x : Int, y : Int) : Bool
 ```
 
 Returns `x <= y`.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.lessOrEqual(123, 1234) // => true
+```
 
 ## Function `greater`
 ``` motoko no-repl
@@ -89,12 +147,26 @@ func greater(x : Int, y : Int) : Bool
 
 Returns `x > y`.
 
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.greater(1234, 123) // => true
+```
+
 ## Function `greaterOrEqual`
 ``` motoko no-repl
 func greaterOrEqual(x : Int, y : Int) : Bool
 ```
 
 Returns `x >= y`.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.greaterOrEqual(1234, 123) // => true
+```
 
 ## Function `compare`
 ``` motoko no-repl
@@ -103,12 +175,26 @@ func compare(x : Int, y : Int) : {#less; #equal; #greater}
 
 Returns the order of `x` and `y`.
 
-## Function `neq`
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.compare(123, 1234) // => #less
+```
+
+## Function `neg`
 ``` motoko no-repl
-func neq(x : Int) : Int
+func neg(x : Int) : Int
 ```
 
 Returns the negation of `x`, `-x` .
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.neg(123) // => -123
+```
 
 ## Function `add`
 ``` motoko no-repl
@@ -117,12 +203,30 @@ func add(x : Int, y : Int) : Int
 
 Returns the sum of `x` and `y`, `x + y`.
 
+No overflow since `Int` has infinite precision.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.add(1234, 123) // => 1_357
+```
+
 ## Function `sub`
 ``` motoko no-repl
 func sub(x : Int, y : Int) : Int
 ```
 
 Returns the difference of `x` and `y`, `x - y`.
+
+No overflow since `Int` has infinite precision.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.sub(1234, 123) // => 1_111
+```
 
 ## Function `mul`
 ``` motoko no-repl
@@ -131,21 +235,48 @@ func mul(x : Int, y : Int) : Int
 
 Returns the product of `x` and `y`, `x * y`.
 
+No overflow since `Int` has infinite precision.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.mul(123, 100) // => 12_300
+```
+
 ## Function `div`
 ``` motoko no-repl
 func div(x : Int, y : Int) : Int
 ```
 
-Returns the division of `x` by `y`,  `x / y`.
+Returns the signed integer division of `x` by `y`,  `x / y`.
+Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.div(123, 10) // => 12
+```
 
 ## Function `rem`
 ``` motoko no-repl
 func rem(x : Int, y : Int) : Int
 ```
 
-Returns the remainder of `x` divided by `y`, `x % y`.
+Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
+which is defined as `x - x / y * y`.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.rem(123, 10) // => 3
+```
 
 ## Function `pow`
 ``` motoko no-repl
@@ -153,3 +284,13 @@ func pow(x : Int, y : Int) : Int
 ```
 
 Returns `x` to the power of `y`, `x ** y`.
+
+Traps when `y` is negative or `y > 2 ** 32 - 1`.
+No overflow since `Int` has infinite precision.
+
+Example:
+```motoko
+import Int "mo:base/Int";
+
+Int.pow(2, 10) // => 1_024
+```

--- a/doc/md/base/Int16.md
+++ b/doc/md/base/Int16.md
@@ -1,6 +1,7 @@
 # Int16
-16-bit signed integers with checked arithmetic
+16-bit signed integers with checked arithmetic.
 
+Common 16-bit integer functions.
 Most operations are available as built-in operators (e.g. `1 + 1`).
 
 ## Type `Int16`
@@ -8,42 +9,99 @@ Most operations are available as built-in operators (e.g. `1 + 1`).
 type Int16 = Prim.Types.Int16
 ```
 
-16-bit signed integers
+16-bit signed integers.
+
+## Value `minimumValue`
+``` motoko no-repl
+let minimumValue : Int16
+```
+
+Minimum 16-bit integer value, `-2 ** 15`.
+
+## Value `maximumValue`
+``` motoko no-repl
+let maximumValue : Int16
+```
+
+Maximum 16-bit integer value, `+2 ** 15 - 1`.
 
 ## Value `toInt`
 ``` motoko no-repl
 let toInt : Int16 -> Int
 ```
 
-Conversion.
+Converts a 16-bit signed integer to a signed integer with infinite precision.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.toInt(12_345) // => 12_345 : Int
+```
 
 ## Value `fromInt`
 ``` motoko no-repl
 let fromInt : Int -> Int16
 ```
 
-Conversion. Traps on overflow/underflow.
+Converts a signed integer with infinite precision to a 16-bit signed integer.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.fromInt(12_345) // => +12_345 : Int16
+```
 
 ## Value `fromIntWrap`
 ``` motoko no-repl
 let fromIntWrap : Int -> Int16
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts a signed integer with infinite precision to a 16-bit signed integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.fromIntWrap(-12_345) // => -12_345 : Int
+```
 
 ## Value `fromNat16`
 ``` motoko no-repl
 let fromNat16 : Nat16 -> Int16
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts an unsigned 16-bit integer to a signed 16-bit integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.fromNat16(12_345) // => +12_345 : Int16
+```
 
 ## Value `toNat16`
 ``` motoko no-repl
 let toNat16 : Int16 -> Nat16
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts a signed 16-bit integer to an unsigned 16-bit integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.toNat16(-1) // => 65_535 : Nat16 // underflow
+```
 
 ## Function `toText`
 ``` motoko no-repl
@@ -51,13 +109,30 @@ func toText(x : Int16) : Text
 ```
 
 Returns the Text representation of `x`.
+Formats the integer in decimal representation without underscore separators for thousand figures.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.toText(-12345) // => "-12345"
+```
 
 ## Function `abs`
 ``` motoko no-repl
 func abs(x : Int16) : Int16
 ```
 
-Returns the absolute value of `x`. Traps when `x = -2^15`.
+Returns the absolute value of `x`.
+
+Traps when `x == -2 ** 15` (the minimum `Int16` value).
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.abs(-12345) // => +12_345
+```
 
 ## Function `min`
 ``` motoko no-repl
@@ -66,12 +141,26 @@ func min(x : Int16, y : Int16) : Int16
 
 Returns the minimum of `x` and `y`.
 
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.min(+2, -3) // => -3
+```
+
 ## Function `max`
 ``` motoko no-repl
 func max(x : Int16, y : Int16) : Int16
 ```
 
 Returns the maximum of `x` and `y`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.max(+2, -3) // => +2
+```
 
 ## Function `equal`
 ``` motoko no-repl
@@ -80,12 +169,26 @@ func equal(x : Int16, y : Int16) : Bool
 
 Returns `x == y`.
 
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.equal(123, 123) // => true
+```
+
 ## Function `notEqual`
 ``` motoko no-repl
 func notEqual(x : Int16, y : Int16) : Bool
 ```
 
 Returns `x != y`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.notEqual(123, 123) // => false
+```
 
 ## Function `less`
 ``` motoko no-repl
@@ -94,12 +197,26 @@ func less(x : Int16, y : Int16) : Bool
 
 Returns `x < y`.
 
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.less(123, 1234) // => true
+```
+
 ## Function `lessOrEqual`
 ``` motoko no-repl
 func lessOrEqual(x : Int16, y : Int16) : Bool
 ```
 
 Returns `x <= y`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.lessOrEqual(123, 1234) // => true
+```
 
 ## Function `greater`
 ``` motoko no-repl
@@ -108,12 +225,26 @@ func greater(x : Int16, y : Int16) : Bool
 
 Returns `x > y`.
 
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.greater(1234, 123) // => true
+```
+
 ## Function `greaterOrEqual`
 ``` motoko no-repl
 func greaterOrEqual(x : Int16, y : Int16) : Bool
 ```
 
 Returns `x >= y`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.greaterOrEqual(1234, 123) // => true
+```
 
 ## Function `compare`
 ``` motoko no-repl
@@ -122,140 +253,319 @@ func compare(x : Int16, y : Int16) : {#less; #equal; #greater}
 
 Returns the order of `x` and `y`.
 
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.compare(123, 1234) // => #less
+```
+
 ## Function `neg`
 ``` motoko no-repl
 func neg(x : Int16) : Int16
 ```
 
-Returns the negation of `x`, `-x`. Traps on overflow.
+Returns the negation of `x`, `-x`.
+
+Traps on overflow, i.e. for `neg(-2 ** 15)`.
+
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.neg(123) // => -123
+```
 
 ## Function `add`
 ``` motoko no-repl
 func add(x : Int16, y : Int16) : Int16
 ```
 
-Returns the sum of `x` and `y`, `x + y`. Traps on overflow.
+Returns the sum of `x` and `y`, `x + y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.add(1234, 123) // => +1_357
+```
 
 ## Function `sub`
 ``` motoko no-repl
 func sub(x : Int16, y : Int16) : Int16
 ```
 
-Returns the difference of `x` and `y`, `x - y`. Traps on underflow.
+Returns the difference of `x` and `y`, `x - y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.sub(1234, 123) // => +1_111
+```
 
 ## Function `mul`
 ``` motoko no-repl
 func mul(x : Int16, y : Int16) : Int16
 ```
 
-Returns the product of `x` and `y`, `x * y`. Traps on overflow.
+Returns the product of `x` and `y`, `x * y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.mul(123, 100) // => +12_300
+```
 
 ## Function `div`
 ``` motoko no-repl
 func div(x : Int16, y : Int16) : Int16
 ```
 
-Returns the division of `x by y`, `x / y`.
+Returns the signed integer division of `x` by `y`, `x / y`.
+Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.div(123, 10) // => +12
+```
 
 ## Function `rem`
 ``` motoko no-repl
 func rem(x : Int16, y : Int16) : Int16
 ```
 
-Returns the remainder of `x` divided by `y`, `x % y`.
+Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
+which is defined as `x - x / y * y`.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.rem(123, 10) // => +3
+```
 
 ## Function `pow`
 ``` motoko no-repl
 func pow(x : Int16, y : Int16) : Int16
 ```
 
-Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
+Returns `x` to the power of `y`, `x ** y`.
+
+Traps on overflow/underflow and when `y < 0 or y >= 16`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.pow(2, 10) // => +1_024
+```
 
 ## Function `bitnot`
 ``` motoko no-repl
-func bitnot(x : Int16, y : Int16) : Int16
+func bitnot(x : Int16) : Int16
 ```
 
 Returns the bitwise negation of `x`, `^x`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitnot(-256 /* 0xff00 */) // => +255 // 0xff
+```
 
 ## Function `bitand`
 ``` motoko no-repl
 func bitand(x : Int16, y : Int16) : Int16
 ```
 
-Returns the bitwise and of `x` and `y`, `x & y`.
+Returns the bitwise "and" of `x` and `y`, `x & y`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitand(0x0fff, 0x00f0) // => +240 // 0xf0
+```
 
 ## Function `bitor`
 ``` motoko no-repl
 func bitor(x : Int16, y : Int16) : Int16
 ```
 
-Returns the bitwise or of `x` and `y`, `x \| y`.
+Returns the bitwise "or" of `x` and `y`, `x | y`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitor(0x0f0f, 0x00f0) // => +4_095 // 0x0fff
+```
 
 ## Function `bitxor`
 ``` motoko no-repl
 func bitxor(x : Int16, y : Int16) : Int16
 ```
 
-Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+Returns the bitwise "exclusive or" of `x` and `y`, `x ^ y`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitxor(0x0fff, 0x00f0) // => +3_855 // 0x0f0f
+```
 
 ## Function `bitshiftLeft`
 ``` motoko no-repl
 func bitshiftLeft(x : Int16, y : Int16) : Int16
 ```
 
-Returns the bitwise shift left of `x` by `y`, `x << y`.
+Returns the bitwise left shift of `x` by `y`, `x << y`.
+The right bits of the shift filled with zeros.
+Left-overflowing bits, including the sign bit, are discarded.
+
+For `y >= 16`, the semantics is the same as for `bitshiftLeft(x, y % 16)`.
+For `y < 0`,  the semantics is the same as for `bitshiftLeft(x, y + y % 16)`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitshiftLeft(1, 8) // => +256 // 0x100 equivalent to `2 ** 8`.
+```
 
 ## Function `bitshiftRight`
 ``` motoko no-repl
 func bitshiftRight(x : Int16, y : Int16) : Int16
 ```
 
-Returns the bitwise shift right of `x` by `y`, `x >> y`.
+Returns the signed bitwise right shift of `x` by `y`, `x >> y`.
+The sign bit is retained and the left side is filled with the sign bit.
+Right-underflowing bits are discarded, i.e. not rotated to the left side.
+
+For `y >= 16`, the semantics is the same as for `bitshiftRight(x, y % 16)`.
+For `y < 0`,  the semantics is the same as for `bitshiftRight (x, y + y % 16)`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitshiftRight(1024, 8) // => +4 // equivalent to `1024 / (2 ** 8)`
+```
 
 ## Function `bitrotLeft`
 ``` motoko no-repl
 func bitrotLeft(x : Int16, y : Int16) : Int16
 ```
 
-Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+Returns the bitwise left rotatation of `x` by `y`, `x <<> y`.
+Each left-overflowing bit is inserted again on the right side.
+The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
+
+Changes the direction of rotation for negative `y`.
+For `y >= 16`, the semantics is the same as for `bitrotLeft(x, y % 16)`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitrotLeft(0x2001, 4) // => +18 // 0x12.
+```
 
 ## Function `bitrotRight`
 ``` motoko no-repl
 func bitrotRight(x : Int16, y : Int16) : Int16
 ```
 
-Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+Returns the bitwise right rotation of `x` by `y`, `x <>> y`.
+Each right-underflowing bit is inserted again on the right side.
+The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
+
+Changes the direction of rotation for negative `y`.
+For `y >= 16`, the semantics is the same as for `bitrotRight(x, y % 16)`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitrotRight(0x2010, 8) // => +4_128 // 0x01020.
+```
 
 ## Function `bittest`
 ``` motoko no-repl
 func bittest(x : Int16, p : Nat) : Bool
 ```
 
-Returns the value of bit `p mod 16` in `x`, `(x & 2^(p mod 16)) == 2^(p mod 16)`.
+Returns the value of bit `p` in `x`, `x & 2**p == 2**p`.
+If `p >= 16`, the semantics is the same as for `bittest(x, p % 16)`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bittest(128, 7) // => true
+```
 
 ## Function `bitset`
 ``` motoko no-repl
 func bitset(x : Int16, p : Nat) : Int16
 ```
 
-Returns the value of setting bit `p mod 16` in `x` to `1`.
+Returns the value of setting bit `p` in `x` to `1`.
+If `p >= 16`, the semantics is the same as for `bitset(x, p % 16)`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitset(0, 7) // => +128
+```
 
 ## Function `bitclear`
 ``` motoko no-repl
 func bitclear(x : Int16, p : Nat) : Int16
 ```
 
-Returns the value of clearing bit `p mod 16` in `x` to `0`.
+Returns the value of clearing bit `p` in `x` to `0`.
+If `p >= 16`, the semantics is the same as for `bitclear(x, p % 16)`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitclear(-1, 7) // => -129
+```
 
 ## Function `bitflip`
 ``` motoko no-repl
 func bitflip(x : Int16, p : Nat) : Int16
 ```
 
-Returns the value of flipping bit `p mod 16` in `x`.
+Returns the value of flipping bit `p` in `x`.
+If `p >= 16`, the semantics is the same as for `bitclear(x, p % 16)`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitflip(255, 7) // => +127
+```
 
 ## Value `bitcountNonZero`
 ``` motoko no-repl
@@ -264,12 +574,26 @@ let bitcountNonZero : (x : Int16) -> Int16
 
 Returns the count of non-zero bits in `x`.
 
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitcountNonZero(0xff) // => +8
+```
+
 ## Value `bitcountLeadingZero`
 ``` motoko no-repl
 let bitcountLeadingZero : (x : Int16) -> Int16
 ```
 
 Returns the count of leading zero bits in `x`.
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitcountLeadingZero(0x80) // => +8
+```
 
 ## Value `bitcountTrailingZero`
 ``` motoko no-repl
@@ -278,19 +602,46 @@ let bitcountTrailingZero : (x : Int16) -> Int16
 
 Returns the count of trailing zero bits in `x`.
 
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.bitcountTrailingZero(0x0100) // => +8
+```
+
 ## Function `addWrap`
 ``` motoko no-repl
 func addWrap(x : Int16, y : Int16) : Int16
 ```
 
-Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+Returns the sum of `x` and `y`, `x +% y`.
+
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.addWrap(2 ** 14, 2 ** 14) // => -32_768 // overflow
+```
 
 ## Function `subWrap`
 ``` motoko no-repl
 func subWrap(x : Int16, y : Int16) : Int16
 ```
 
-Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+Returns the difference of `x` and `y`, `x -% y`.
+
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.subWrap(-2 ** 15, 1) // => +32_767 // underflow
+```
 
 ## Function `mulWrap`
 ``` motoko no-repl
@@ -299,9 +650,30 @@ func mulWrap(x : Int16, y : Int16) : Int16
 
 Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
 
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.mulWrap(2 ** 8, 2 ** 8) // => 0 // overflow
+```
+
 ## Function `powWrap`
 ``` motoko no-repl
 func powWrap(x : Int16, y : Int16) : Int16
 ```
 
-Returns `x` to the power of `y`, `x **% y`. Wraps on overflow. Traps if `y < 0`.
+Returns `x` to the power of `y`, `x **% y`.
+
+Wraps on overflow/underflow.
+Traps if `y < 0 or y >= 16`.
+
+
+Example:
+```motoko
+import Int16 "mo:base/Int16";
+
+Int16.powWrap(2, 15) // => -32_768 // overflow
+```

--- a/doc/md/base/Int32.md
+++ b/doc/md/base/Int32.md
@@ -1,6 +1,7 @@
 # Int32
-32-bit signed integers with checked arithmetic
+32-bit signed integers with checked arithmetic.
 
+Common 32-bit integer functions.
 Most operations are available as built-in operators (e.g. `1 + 1`).
 
 ## Type `Int32`
@@ -10,40 +11,97 @@ type Int32 = Prim.Types.Int32
 
 32-bit signed integers.
 
+## Value `minimumValue`
+``` motoko no-repl
+let minimumValue : Int32
+```
+
+Minimum 32-bit integer value, `-2 ** 31`.
+
+## Value `maximumValue`
+``` motoko no-repl
+let maximumValue : Int32
+```
+
+Maximum 32-bit integer value, `+2 ** 31 - 1`.
+
 ## Value `toInt`
 ``` motoko no-repl
 let toInt : Int32 -> Int
 ```
 
-Conversion.
+Converts a 32-bit signed integer to a signed integer with infinite precision.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.toInt(123_456) // => 123_456 : Int
+```
 
 ## Value `fromInt`
 ``` motoko no-repl
 let fromInt : Int -> Int32
 ```
 
-Conversion. Traps on overflow/underflow.
+Converts a signed integer with infinite precision to a 32-bit signed integer.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.fromInt(123_456) // => +123_456 : Int32
+```
 
 ## Value `fromIntWrap`
 ``` motoko no-repl
 let fromIntWrap : Int -> Int32
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts a signed integer with infinite precision to a 32-bit signed integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.fromIntWrap(-123_456) // => -123_456 : Int
+```
 
 ## Value `fromNat32`
 ``` motoko no-repl
 let fromNat32 : Nat32 -> Int32
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts an unsigned 32-bit integer to a signed 32-bit integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.fromNat32(123_456) // => +123_456 : Int32
+```
 
 ## Value `toNat32`
 ``` motoko no-repl
 let toNat32 : Int32 -> Nat32
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts a signed 32-bit integer to an unsigned 32-bit integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.toNat32(-1) // => 4_294_967_295 : Nat32 // underflow
+```
 
 ## Function `toText`
 ``` motoko no-repl
@@ -51,13 +109,30 @@ func toText(x : Int32) : Text
 ```
 
 Returns the Text representation of `x`.
+Formats the integer in decimal representation without underscore separators for thousand figures.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.toText(-123456) // => "-123456"
+```
 
 ## Function `abs`
 ``` motoko no-repl
 func abs(x : Int32) : Int32
 ```
 
-Returns the absolute value of `x`. Traps when `x = -2^31`.
+Returns the absolute value of `x`.
+
+Traps when `x == -2 ** 31` (the minimum `Int32` value).
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.abs(-123456) // => +123_456
+```
 
 ## Function `min`
 ``` motoko no-repl
@@ -66,12 +141,26 @@ func min(x : Int32, y : Int32) : Int32
 
 Returns the minimum of `x` and `y`.
 
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.min(+2, -3) // => -3
+```
+
 ## Function `max`
 ``` motoko no-repl
 func max(x : Int32, y : Int32) : Int32
 ```
 
 Returns the maximum of `x` and `y`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.max(+2, -3) // => +2
+```
 
 ## Function `equal`
 ``` motoko no-repl
@@ -80,12 +169,26 @@ func equal(x : Int32, y : Int32) : Bool
 
 Returns `x == y`.
 
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.equal(123, 123) // => true
+```
+
 ## Function `notEqual`
 ``` motoko no-repl
 func notEqual(x : Int32, y : Int32) : Bool
 ```
 
 Returns `x != y`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.notEqual(123, 123) // => false
+```
 
 ## Function `less`
 ``` motoko no-repl
@@ -94,12 +197,26 @@ func less(x : Int32, y : Int32) : Bool
 
 Returns `x < y`.
 
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.less(123, 1234) // => true
+```
+
 ## Function `lessOrEqual`
 ``` motoko no-repl
 func lessOrEqual(x : Int32, y : Int32) : Bool
 ```
 
 Returns `x <= y`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.lessOrEqual(123, 1234) // => true
+```
 
 ## Function `greater`
 ``` motoko no-repl
@@ -108,12 +225,26 @@ func greater(x : Int32, y : Int32) : Bool
 
 Returns `x > y`.
 
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.greater(1234, 123) // => true
+```
+
 ## Function `greaterOrEqual`
 ``` motoko no-repl
 func greaterOrEqual(x : Int32, y : Int32) : Bool
 ```
 
 Returns `x >= y`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.greaterOrEqual(1234, 123) // => true
+```
 
 ## Function `compare`
 ``` motoko no-repl
@@ -122,140 +253,319 @@ func compare(x : Int32, y : Int32) : {#less; #equal; #greater}
 
 Returns the order of `x` and `y`.
 
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.compare(123, 1234) // => #less
+```
+
 ## Function `neg`
 ``` motoko no-repl
 func neg(x : Int32) : Int32
 ```
 
-Returns the negation of `x`, `-x`. Traps on overflow.
+Returns the negation of `x`, `-x`.
+
+Traps on overflow, i.e. for `neg(-2 ** 31)`.
+
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.neg(123) // => -123
+```
 
 ## Function `add`
 ``` motoko no-repl
 func add(x : Int32, y : Int32) : Int32
 ```
 
-Returns the sum of `x` and `y`, `x + y`. Traps on overflow.
+Returns the sum of `x` and `y`, `x + y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.add(1234, 123) // => +1_357
+```
 
 ## Function `sub`
 ``` motoko no-repl
 func sub(x : Int32, y : Int32) : Int32
 ```
 
-Returns the difference of `x` and `y`, `x - y`. Traps on underflow.
+Returns the difference of `x` and `y`, `x - y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.sub(1234, 123) // => +1_111
+```
 
 ## Function `mul`
 ``` motoko no-repl
 func mul(x : Int32, y : Int32) : Int32
 ```
 
-Returns the product of `x` and `y`, `x * y`. Traps on overflow.
+Returns the product of `x` and `y`, `x * y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.mul(123, 100) // => +12_300
+```
 
 ## Function `div`
 ``` motoko no-repl
 func div(x : Int32, y : Int32) : Int32
 ```
 
-Returns the division of `x by y`, `x / y`.
+Returns the signed integer division of `x` by `y`, `x / y`.
+Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.div(123, 10) // => +12
+```
 
 ## Function `rem`
 ``` motoko no-repl
 func rem(x : Int32, y : Int32) : Int32
 ```
 
-Returns the remainder of `x` divided by `y`, `x % y`.
+Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
+which is defined as `x - x / y * y`.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.rem(123, 10) // => +3
+```
 
 ## Function `pow`
 ``` motoko no-repl
 func pow(x : Int32, y : Int32) : Int32
 ```
 
-Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
+Returns `x` to the power of `y`, `x ** y`.
+
+Traps on overflow/underflow and when `y < 0 or y >= 32`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.pow(2, 10) // => +1_024
+```
 
 ## Function `bitnot`
 ``` motoko no-repl
-func bitnot(x : Int32, y : Int32) : Int32
+func bitnot(x : Int32) : Int32
 ```
 
 Returns the bitwise negation of `x`, `^x`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitnot(-256 /* 0xffff_ff00 */) // => +255 // 0xff
+```
 
 ## Function `bitand`
 ``` motoko no-repl
 func bitand(x : Int32, y : Int32) : Int32
 ```
 
-Returns the bitwise and of `x` and `y`, `x & y`.
+Returns the bitwise "and" of `x` and `y`, `x & y`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitand(0xffff, 0x00f0) // => +240 // 0xf0
+```
 
 ## Function `bitor`
 ``` motoko no-repl
 func bitor(x : Int32, y : Int32) : Int32
 ```
 
-Returns the bitwise or of `x` and `y`, `x \| y`.
+Returns the bitwise "or" of `x` and `y`, `x | y`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitor(0xffff, 0x00f0) // => +65_535 // 0xffff
+```
 
 ## Function `bitxor`
 ``` motoko no-repl
 func bitxor(x : Int32, y : Int32) : Int32
 ```
 
-Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+Returns the bitwise "exclusive or" of `x` and `y`, `x ^ y`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitxor(0xffff, 0x00f0) // => +65_295 // 0xff0f
+```
 
 ## Function `bitshiftLeft`
 ``` motoko no-repl
 func bitshiftLeft(x : Int32, y : Int32) : Int32
 ```
 
-Returns the bitwise shift left of `x` by `y`, `x << y`.
+Returns the bitwise left shift of `x` by `y`, `x << y`.
+The right bits of the shift filled with zeros.
+Left-overflowing bits, including the sign bit, are discarded.
+
+For `y >= 32`, the semantics is the same as for `bitshiftLeft(x, y % 32)`.
+For `y < 0`,  the semantics is the same as for `bitshiftLeft(x, y + y % 32)`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitshiftLeft(1, 8) // => +256 // 0x100 equivalent to `2 ** 8`.
+```
 
 ## Function `bitshiftRight`
 ``` motoko no-repl
 func bitshiftRight(x : Int32, y : Int32) : Int32
 ```
 
-Returns the bitwise shift right of `x` by `y`, `x >> y`.
+Returns the signed bitwise right shift of `x` by `y`, `x >> y`.
+The sign bit is retained and the left side is filled with the sign bit.
+Right-underflowing bits are discarded, i.e. not rotated to the left side.
+
+For `y >= 32`, the semantics is the same as for `bitshiftRight(x, y % 32)`.
+For `y < 0`,  the semantics is the same as for `bitshiftRight (x, y + y % 32)`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitshiftRight(1024, 8) // => +4 // equivalent to `1024 / (2 ** 8)`
+```
 
 ## Function `bitrotLeft`
 ``` motoko no-repl
 func bitrotLeft(x : Int32, y : Int32) : Int32
 ```
 
-Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+Returns the bitwise left rotatation of `x` by `y`, `x <<> y`.
+Each left-overflowing bit is inserted again on the right side.
+The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
+
+Changes the direction of rotation for negative `y`.
+For `y >= 32`, the semantics is the same as for `bitrotLeft(x, y % 32)`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitrotLeft(0x2000_0001, 4) // => +18 // 0x12.
+```
 
 ## Function `bitrotRight`
 ``` motoko no-repl
 func bitrotRight(x : Int32, y : Int32) : Int32
 ```
 
-Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+Returns the bitwise right rotation of `x` by `y`, `x <>> y`.
+Each right-underflowing bit is inserted again on the right side.
+The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
+
+Changes the direction of rotation for negative `y`.
+For `y >= 32`, the semantics is the same as for `bitrotRight(x, y % 32)`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitrotRight(0x0002_0001, 8) // => +16_777_728 // 0x0100_0200.
+```
 
 ## Function `bittest`
 ``` motoko no-repl
 func bittest(x : Int32, p : Nat) : Bool
 ```
 
-Returns the value of bit `p mod 16` in `x`, `(x & 2^(p mod 16)) == 2^(p mod 16)`.
+Returns the value of bit `p` in `x`, `x & 2**p == 2**p`.
+If `p >= 32`, the semantics is the same as for `bittest(x, p % 32)`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bittest(128, 7) // => true
+```
 
 ## Function `bitset`
 ``` motoko no-repl
 func bitset(x : Int32, p : Nat) : Int32
 ```
 
-Returns the value of setting bit `p mod 16` in `x` to `1`.
+Returns the value of setting bit `p` in `x` to `1`.
+If `p >= 32`, the semantics is the same as for `bitset(x, p % 32)`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitset(0, 7) // => +128
+```
 
 ## Function `bitclear`
 ``` motoko no-repl
 func bitclear(x : Int32, p : Nat) : Int32
 ```
 
-Returns the value of clearing bit `p mod 16` in `x` to `0`.
+Returns the value of clearing bit `p` in `x` to `0`.
+If `p >= 32`, the semantics is the same as for `bitclear(x, p % 32)`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitclear(-1, 7) // => -129
+```
 
 ## Function `bitflip`
 ``` motoko no-repl
 func bitflip(x : Int32, p : Nat) : Int32
 ```
 
-Returns the value of flipping bit `p mod 16` in `x`.
+Returns the value of flipping bit `p` in `x`.
+If `p >= 32`, the semantics is the same as for `bitclear(x, p % 32)`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitflip(255, 7) // => +127
+```
 
 ## Value `bitcountNonZero`
 ``` motoko no-repl
@@ -264,12 +574,26 @@ let bitcountNonZero : (x : Int32) -> Int32
 
 Returns the count of non-zero bits in `x`.
 
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitcountNonZero(0xffff) // => +16
+```
+
 ## Value `bitcountLeadingZero`
 ``` motoko no-repl
 let bitcountLeadingZero : (x : Int32) -> Int32
 ```
 
 Returns the count of leading zero bits in `x`.
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitcountLeadingZero(0x8000) // => +16
+```
 
 ## Value `bitcountTrailingZero`
 ``` motoko no-repl
@@ -278,19 +602,46 @@ let bitcountTrailingZero : (x : Int32) -> Int32
 
 Returns the count of trailing zero bits in `x`.
 
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.bitcountTrailingZero(0x0201_0000) // => +16
+```
+
 ## Function `addWrap`
 ``` motoko no-repl
 func addWrap(x : Int32, y : Int32) : Int32
 ```
 
-Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+Returns the sum of `x` and `y`, `x +% y`.
+
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.addWrap(2 ** 30, 2 ** 30) // => -2_147_483_648 // overflow
+```
 
 ## Function `subWrap`
 ``` motoko no-repl
 func subWrap(x : Int32, y : Int32) : Int32
 ```
 
-Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+Returns the difference of `x` and `y`, `x -% y`.
+
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.subWrap(-2 ** 31, 1) // => +2_147_483_647 // underflow
+```
 
 ## Function `mulWrap`
 ``` motoko no-repl
@@ -299,9 +650,30 @@ func mulWrap(x : Int32, y : Int32) : Int32
 
 Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
 
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.mulWrap(2 ** 16, 2 ** 16) // => 0 // overflow
+```
+
 ## Function `powWrap`
 ``` motoko no-repl
 func powWrap(x : Int32, y : Int32) : Int32
 ```
 
-Returns `x` to the power of `y`, `x **% y`. Wraps on overflow. Traps if `y < 0`.
+Returns `x` to the power of `y`, `x **% y`.
+
+Wraps on overflow/underflow.
+Traps if `y < 0 or y >= 32`.
+
+
+Example:
+```motoko
+import Int32 "mo:base/Int32";
+
+Int32.powWrap(2, 31) // => -2_147_483_648 // overflow
+```

--- a/doc/md/base/Int64.md
+++ b/doc/md/base/Int64.md
@@ -1,6 +1,7 @@
 # Int64
-64-bit signed integers with checked arithmetic
+64-bit signed integers with checked arithmetic.
 
+Common 64-bit integer functions.
 Most operations are available as built-in operators (e.g. `1 + 1`).
 
 ## Type `Int64`
@@ -10,40 +11,97 @@ type Int64 = Prim.Types.Int64
 
 64-bit signed integers.
 
+## Value `minimumValue`
+``` motoko no-repl
+let minimumValue : Int64
+```
+
+Minimum 64-bit integer value, `-2 ** 63`.
+
+## Value `maximumValue`
+``` motoko no-repl
+let maximumValue : Int64
+```
+
+Maximum 64-bit integer value, `+2 ** 63 - 1`.
+
 ## Value `toInt`
 ``` motoko no-repl
 let toInt : Int64 -> Int
 ```
 
-Conversion.
+Converts a 64-bit signed integer to a signed integer with infinite precision.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.toInt(123_456) // => 123_456 : Int
+```
 
 ## Value `fromInt`
 ``` motoko no-repl
 let fromInt : Int -> Int64
 ```
 
-Conversion. Traps on overflow/underflow.
+Converts a signed integer with infinite precision to a 64-bit signed integer.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.fromInt(123_456) // => +123_456 : Int64
+```
 
 ## Value `fromIntWrap`
 ``` motoko no-repl
 let fromIntWrap : Int -> Int64
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts a signed integer with infinite precision to a 64-bit signed integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.fromIntWrap(-123_456) // => -123_456 : Int64
+```
 
 ## Value `fromNat64`
 ``` motoko no-repl
 let fromNat64 : Nat64 -> Int64
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts an unsigned 64-bit integer to a signed 64-bit integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.fromNat64(123_456) // => +123_456 : Int64
+```
 
 ## Value `toNat64`
 ``` motoko no-repl
 let toNat64 : Int64 -> Nat64
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts a signed 64-bit integer to an unsigned 64-bit integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.toNat64(-1) // => 18_446_744_073_709_551_615 : Nat64 // underflow
+```
 
 ## Function `toText`
 ``` motoko no-repl
@@ -51,13 +109,30 @@ func toText(x : Int64) : Text
 ```
 
 Returns the Text representation of `x`.
+Formats the integer in decimal representation without underscore separators for thousand figures.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.toText(-123456) // => "-123456"
+```
 
 ## Function `abs`
 ``` motoko no-repl
 func abs(x : Int64) : Int64
 ```
 
-Returns the absolute value of `x`. Traps when `x = -2^63`.
+Returns the absolute value of `x`.
+
+Traps when `x == -2 ** 63` (the minimum `Int64` value).
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.abs(-123456) // => +123_456
+```
 
 ## Function `min`
 ``` motoko no-repl
@@ -66,12 +141,26 @@ func min(x : Int64, y : Int64) : Int64
 
 Returns the minimum of `x` and `y`.
 
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.min(+2, -3) // => -3
+```
+
 ## Function `max`
 ``` motoko no-repl
 func max(x : Int64, y : Int64) : Int64
 ```
 
 Returns the maximum of `x` and `y`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.max(+2, -3) // => +2
+```
 
 ## Function `equal`
 ``` motoko no-repl
@@ -80,12 +169,26 @@ func equal(x : Int64, y : Int64) : Bool
 
 Returns `x == y`.
 
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.equal(123, 123) // => true
+```
+
 ## Function `notEqual`
 ``` motoko no-repl
 func notEqual(x : Int64, y : Int64) : Bool
 ```
 
 Returns `x != y`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.notEqual(123, 123) // => false
+```
 
 ## Function `less`
 ``` motoko no-repl
@@ -94,12 +197,26 @@ func less(x : Int64, y : Int64) : Bool
 
 Returns `x < y`.
 
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.less(123, 1234) // => true
+```
+
 ## Function `lessOrEqual`
 ``` motoko no-repl
 func lessOrEqual(x : Int64, y : Int64) : Bool
 ```
 
 Returns `x <= y`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.lessOrEqual(123, 1234) // => true
+```
 
 ## Function `greater`
 ``` motoko no-repl
@@ -108,12 +225,26 @@ func greater(x : Int64, y : Int64) : Bool
 
 Returns `x > y`.
 
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.greater(1234, 123) // => true
+```
+
 ## Function `greaterOrEqual`
 ``` motoko no-repl
 func greaterOrEqual(x : Int64, y : Int64) : Bool
 ```
 
 Returns `x >= y`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.greaterOrEqual(1234, 123) // => true
+```
 
 ## Function `compare`
 ``` motoko no-repl
@@ -122,140 +253,319 @@ func compare(x : Int64, y : Int64) : {#less; #equal; #greater}
 
 Returns the order of `x` and `y`.
 
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.compare(123, 1234) // => #less
+```
+
 ## Function `neg`
 ``` motoko no-repl
 func neg(x : Int64) : Int64
 ```
 
-Returns the negation of `x`, `-x`. Traps on overflow.
+Returns the negation of `x`, `-x`.
+
+Traps on overflow, i.e. for `neg(-2 ** 63)`.
+
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.neg(123) // => -123
+```
 
 ## Function `add`
 ``` motoko no-repl
 func add(x : Int64, y : Int64) : Int64
 ```
 
-Returns the sum of `x` and `y`, `x + y`. Traps on overflow.
+Returns the sum of `x` and `y`, `x + y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.add(1234, 123) // => +1_357
+```
 
 ## Function `sub`
 ``` motoko no-repl
 func sub(x : Int64, y : Int64) : Int64
 ```
 
-Returns the difference of `x` and `y`, `x - y`. Traps on underflow.
+Returns the difference of `x` and `y`, `x - y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.sub(1234, 123) // => +1_111
+```
 
 ## Function `mul`
 ``` motoko no-repl
 func mul(x : Int64, y : Int64) : Int64
 ```
 
-Returns the product of `x` and `y`, `x * y`. Traps on overflow.
+Returns the product of `x` and `y`, `x * y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.mul(123, 100) // => +12_300
+```
 
 ## Function `div`
 ``` motoko no-repl
 func div(x : Int64, y : Int64) : Int64
 ```
 
-Returns the division of `x by y`, `x / y`.
+Returns the signed integer division of `x` by `y`, `x / y`.
+Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.div(123, 10) // => +12
+```
 
 ## Function `rem`
 ``` motoko no-repl
 func rem(x : Int64, y : Int64) : Int64
 ```
 
-Returns the remainder of `x` divided by `y`, `x % y`.
+Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
+which is defined as `x - x / y * y`.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.rem(123, 10) // => +3
+```
 
 ## Function `pow`
 ``` motoko no-repl
 func pow(x : Int64, y : Int64) : Int64
 ```
 
-Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
+Returns `x` to the power of `y`, `x ** y`.
+
+Traps on overflow/underflow and when `y < 0 or y >= 64`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.pow(2, 10) // => +1_024
+```
 
 ## Function `bitnot`
 ``` motoko no-repl
-func bitnot(x : Int64, y : Int64) : Int64
+func bitnot(x : Int64) : Int64
 ```
 
 Returns the bitwise negation of `x`, `^x`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitnot(-256 /* 0xffff_ffff_ffff_ff00 */) // => +255 // 0xff
+```
 
 ## Function `bitand`
 ``` motoko no-repl
 func bitand(x : Int64, y : Int64) : Int64
 ```
 
-Returns the bitwise and of `x` and `y`, `x & y`.
+Returns the bitwise "and" of `x` and `y`, `x & y`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitand(0xffff, 0x00f0) // => +240 // 0xf0
+```
 
 ## Function `bitor`
 ``` motoko no-repl
 func bitor(x : Int64, y : Int64) : Int64
 ```
 
-Returns the bitwise or of `x` and `y`, `x \| y`.
+Returns the bitwise "or" of `x` and `y`, `x | y`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitor(0xffff, 0x00f0) // => +65_535 // 0xffff
+```
 
 ## Function `bitxor`
 ``` motoko no-repl
 func bitxor(x : Int64, y : Int64) : Int64
 ```
 
-Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+Returns the bitwise "exclusive or" of `x` and `y`, `x ^ y`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitxor(0xffff, 0x00f0) // => +65_295 // 0xff0f
+```
 
 ## Function `bitshiftLeft`
 ``` motoko no-repl
 func bitshiftLeft(x : Int64, y : Int64) : Int64
 ```
 
-Returns the bitwise shift left of `x` by `y`, `x << y`.
+Returns the bitwise left shift of `x` by `y`, `x << y`.
+The right bits of the shift filled with zeros.
+Left-overflowing bits, including the sign bit, are discarded.
+
+For `y >= 64`, the semantics is the same as for `bitshiftLeft(x, y % 64)`.
+For `y < 0`,  the semantics is the same as for `bitshiftLeft(x, y + y % 64)`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitshiftLeft(1, 8) // => +256 // 0x100 equivalent to `2 ** 8`.
+```
 
 ## Function `bitshiftRight`
 ``` motoko no-repl
 func bitshiftRight(x : Int64, y : Int64) : Int64
 ```
 
-Returns the bitwise shift right of `x` by `y`, `x >> y`.
+Returns the signed bitwise right shift of `x` by `y`, `x >> y`.
+The sign bit is retained and the left side is filled with the sign bit.
+Right-underflowing bits are discarded, i.e. not rotated to the left side.
+
+For `y >= 64`, the semantics is the same as for `bitshiftRight(x, y % 64)`.
+For `y < 0`,  the semantics is the same as for `bitshiftRight (x, y + y % 64)`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitshiftRight(1024, 8) // => +4 // equivalent to `1024 / (2 ** 8)`
+```
 
 ## Function `bitrotLeft`
 ``` motoko no-repl
 func bitrotLeft(x : Int64, y : Int64) : Int64
 ```
 
-Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+Returns the bitwise left rotatation of `x` by `y`, `x <<> y`.
+Each left-overflowing bit is inserted again on the right side.
+The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
+
+Changes the direction of rotation for negative `y`.
+For `y >= 64`, the semantics is the same as for `bitrotLeft(x, y % 64)`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitrotLeft(0x2000_0000_0000_0001, 4) // => +18 // 0x12.
+```
 
 ## Function `bitrotRight`
 ``` motoko no-repl
 func bitrotRight(x : Int64, y : Int64) : Int64
 ```
 
-Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+Returns the bitwise right rotation of `x` by `y`, `x <>> y`.
+Each right-underflowing bit is inserted again on the right side.
+The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
+
+Changes the direction of rotation for negative `y`.
+For `y >= 64`, the semantics is the same as for `bitrotRight(x, y % 64)`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitrotRight(0x0002_0000_0000_0001, 48) // => +65538 // 0x1_0002.
+```
 
 ## Function `bittest`
 ``` motoko no-repl
 func bittest(x : Int64, p : Nat) : Bool
 ```
 
-Returns the value of bit `p mod 64` in `x`, `(x & 2^(p mod 64)) == 2^(p mod 64)`.
+Returns the value of bit `p` in `x`, `x & 2**p == 2**p`.
+If `p >= 64`, the semantics is the same as for `bittest(x, p % 64)`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bittest(128, 7) // => true
+```
 
 ## Function `bitset`
 ``` motoko no-repl
 func bitset(x : Int64, p : Nat) : Int64
 ```
 
-Returns the value of setting bit `p mod 64` in `x` to `1`.
+Returns the value of setting bit `p` in `x` to `1`.
+If `p >= 64`, the semantics is the same as for `bitset(x, p % 64)`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitset(0, 7) // => +128
+```
 
 ## Function `bitclear`
 ``` motoko no-repl
 func bitclear(x : Int64, p : Nat) : Int64
 ```
 
-Returns the value of clearing bit `p mod 64` in `x` to `0`.
+Returns the value of clearing bit `p` in `x` to `0`.
+If `p >= 64`, the semantics is the same as for `bitclear(x, p % 64)`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitclear(-1, 7) // => -129
+```
 
 ## Function `bitflip`
 ``` motoko no-repl
 func bitflip(x : Int64, p : Nat) : Int64
 ```
 
-Returns the value of flipping bit `p mod 64` in `x`.
+Returns the value of flipping bit `p` in `x`.
+If `p >= 64`, the semantics is the same as for `bitclear(x, p % 64)`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitflip(255, 7) // => +127
+```
 
 ## Value `bitcountNonZero`
 ``` motoko no-repl
@@ -264,12 +574,26 @@ let bitcountNonZero : (x : Int64) -> Int64
 
 Returns the count of non-zero bits in `x`.
 
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitcountNonZero(0xffff) // => +16
+```
+
 ## Value `bitcountLeadingZero`
 ``` motoko no-repl
 let bitcountLeadingZero : (x : Int64) -> Int64
 ```
 
 Returns the count of leading zero bits in `x`.
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitcountLeadingZero(0x8000_0000) // => +32
+```
 
 ## Value `bitcountTrailingZero`
 ``` motoko no-repl
@@ -278,19 +602,46 @@ let bitcountTrailingZero : (x : Int64) -> Int64
 
 Returns the count of trailing zero bits in `x`.
 
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.bitcountTrailingZero(0x0201_0000) // => +16
+```
+
 ## Function `addWrap`
 ``` motoko no-repl
 func addWrap(x : Int64, y : Int64) : Int64
 ```
 
-Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+Returns the sum of `x` and `y`, `x +% y`.
+
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.addWrap(2 ** 62, 2 ** 62) // => -9_223_372_036_854_775_808 // overflow
+```
 
 ## Function `subWrap`
 ``` motoko no-repl
 func subWrap(x : Int64, y : Int64) : Int64
 ```
 
-Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+Returns the difference of `x` and `y`, `x -% y`.
+
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.subWrap(-2 ** 63, 1) // => +9_223_372_036_854_775_807 // underflow
+```
 
 ## Function `mulWrap`
 ``` motoko no-repl
@@ -299,9 +650,30 @@ func mulWrap(x : Int64, y : Int64) : Int64
 
 Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
 
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.mulWrap(2 ** 32, 2 ** 32) // => 0 // overflow
+```
+
 ## Function `powWrap`
 ``` motoko no-repl
 func powWrap(x : Int64, y : Int64) : Int64
 ```
 
-Returns `x` to the power of `y`, `x **% y`. Wraps on overflow. Traps if `y < 0`.
+Returns `x` to the power of `y`, `x **% y`.
+
+Wraps on overflow/underflow.
+Traps if `y < 0 or y >= 64`.
+
+
+Example:
+```motoko
+import Int64 "mo:base/Int64";
+
+Int64.powWrap(2, 63) // => -9_223_372_036_854_775_808 // overflow
+```

--- a/doc/md/base/Int8.md
+++ b/doc/md/base/Int8.md
@@ -1,6 +1,7 @@
 # Int8
-8-bit signed integers with checked arithmetic
+8-bit signed integers with checked arithmetic.
 
+Common 8-bit integer functions.
 Most operations are available as built-in operators (e.g. `1 + 1`).
 
 ## Type `Int8`
@@ -10,40 +11,97 @@ type Int8 = Prim.Types.Int8
 
 8-bit signed integers.
 
+## Value `minimumValue`
+``` motoko no-repl
+let minimumValue : Int8
+```
+
+Minimum 8-bit integer value, `-2 ** 7`.
+
+## Value `maximumValue`
+``` motoko no-repl
+let maximumValue : Int8
+```
+
+Maximum 8-bit integer value, `+2 ** 7 - 1`.
+
 ## Value `toInt`
 ``` motoko no-repl
 let toInt : Int8 -> Int
 ```
 
-Conversion.
+Converts a 8-bit signed integer to a signed integer with infinite precision.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.toInt(123) // => 123 : Int
+```
 
 ## Value `fromInt`
 ``` motoko no-repl
 let fromInt : Int -> Int8
 ```
 
-Conversion. Traps on overflow/underflow.
+Converts a signed integer with infinite precision to a 8-bit signed integer.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.fromInt(123) // => +123 : Int8
+```
 
 ## Value `fromIntWrap`
 ``` motoko no-repl
 let fromIntWrap : Int -> Int8
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts a signed integer with infinite precision to a 8-bit signed integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.fromIntWrap(-123) // => -123 : Int
+```
 
 ## Value `fromNat8`
 ``` motoko no-repl
 let fromNat8 : Nat8 -> Int8
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts an unsigned 8-bit integer to a signed 8-bit integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.fromNat8(123) // => +123 : Int8
+```
 
 ## Value `toNat8`
 ``` motoko no-repl
 let toNat8 : Int8 -> Nat8
 ```
 
-Conversion. Wraps on overflow/underflow.
+Converts a signed 8-bit integer to an unsigned 8-bit integer.
+
+Wraps on overflow/underflow.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.toNat8(-1) // => 255 : Nat8 // underflow
+```
 
 ## Function `toText`
 ``` motoko no-repl
@@ -51,13 +109,30 @@ func toText(x : Int8) : Text
 ```
 
 Returns the Text representation of `x`.
+Formats the integer in decimal representation.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.toText(-123) // => "-123"
+```
 
 ## Function `abs`
 ``` motoko no-repl
 func abs(x : Int8) : Int8
 ```
 
-Returns the absolute value of `x`. Traps when `x = -2^7`.
+Returns the absolute value of `x`.
+
+Traps when `x == -2 ** 7` (the minimum `Int8` value).
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.abs(-123) // => +123
+```
 
 ## Function `min`
 ``` motoko no-repl
@@ -66,12 +141,26 @@ func min(x : Int8, y : Int8) : Int8
 
 Returns the minimum of `x` and `y`.
 
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.min(+2, -3) // => -3
+```
+
 ## Function `max`
 ``` motoko no-repl
 func max(x : Int8, y : Int8) : Int8
 ```
 
 Returns the maximum of `x` and `y`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.max(+2, -3) // => +2
+```
 
 ## Function `equal`
 ``` motoko no-repl
@@ -80,12 +169,26 @@ func equal(x : Int8, y : Int8) : Bool
 
 Returns `x == y`.
 
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.equal(123, 123) // => true
+```
+
 ## Function `notEqual`
 ``` motoko no-repl
 func notEqual(x : Int8, y : Int8) : Bool
 ```
 
 Returns `x != y`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.notEqual(123, 123) // => false
+```
 
 ## Function `less`
 ``` motoko no-repl
@@ -94,12 +197,26 @@ func less(x : Int8, y : Int8) : Bool
 
 Returns `x < y`.
 
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.less(123, 124) // => true
+```
+
 ## Function `lessOrEqual`
 ``` motoko no-repl
 func lessOrEqual(x : Int8, y : Int8) : Bool
 ```
 
 Returns `x <= y`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.lessOrEqual(123, 124) // => true
+```
 
 ## Function `greater`
 ``` motoko no-repl
@@ -108,12 +225,26 @@ func greater(x : Int8, y : Int8) : Bool
 
 Returns `x > y`.
 
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.greater(124, 123) // => true
+```
+
 ## Function `greaterOrEqual`
 ``` motoko no-repl
 func greaterOrEqual(x : Int8, y : Int8) : Bool
 ```
 
 Returns `x >= y`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.greaterOrEqual(124, 123) // => true
+```
 
 ## Function `compare`
 ``` motoko no-repl
@@ -122,140 +253,319 @@ func compare(x : Int8, y : Int8) : {#less; #equal; #greater}
 
 Returns the order of `x` and `y`.
 
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.compare(123, 124) // => #less
+```
+
 ## Function `neg`
 ``` motoko no-repl
 func neg(x : Int8) : Int8
 ```
 
-Returns the negation of `x`, `-x`. Traps on overflow.
+Returns the negation of `x`, `-x`.
+
+Traps on overflow, i.e. for `neg(-2 ** 7)`.
+
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.neg(123) // => -123
+```
 
 ## Function `add`
 ``` motoko no-repl
 func add(x : Int8, y : Int8) : Int8
 ```
 
-Returns the sum of `x` and `y`, `x + y`. Traps on overflow.
+Returns the sum of `x` and `y`, `x + y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.add(100, 23) // => +123
+```
 
 ## Function `sub`
 ``` motoko no-repl
 func sub(x : Int8, y : Int8) : Int8
 ```
 
-Returns the difference of `x` and `y`, `x - y`. Traps on underflow.
+Returns the difference of `x` and `y`, `x - y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.sub(123, 23) // => +100
+```
 
 ## Function `mul`
 ``` motoko no-repl
 func mul(x : Int8, y : Int8) : Int8
 ```
 
-Returns the product of `x` and `y`, `x * y`. Traps on overflow.
+Returns the product of `x` and `y`, `x * y`.
+
+Traps on overflow/underflow.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.mul(12, 10) // => +120
+```
 
 ## Function `div`
 ``` motoko no-repl
 func div(x : Int8, y : Int8) : Int8
 ```
 
-Returns the division of `x by y`, `x / y`.
+Returns the signed integer division of `x` by `y`, `x / y`.
+Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.div(123, 10) // => +12
+```
 
 ## Function `rem`
 ``` motoko no-repl
 func rem(x : Int8, y : Int8) : Int8
 ```
 
-Returns the remainder of `x` divided by `y`, `x % y`.
+Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
+which is defined as `x - x / y * y`.
+
 Traps when `y` is zero.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.rem(123, 10) // => +3
+```
 
 ## Function `pow`
 ``` motoko no-repl
 func pow(x : Int8, y : Int8) : Int8
 ```
 
-Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
+Returns `x` to the power of `y`, `x ** y`.
+
+Traps on overflow/underflow and when `y < 0 or y >= 8`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.pow(2, 6) // => +64
+```
 
 ## Function `bitnot`
 ``` motoko no-repl
-func bitnot(x : Int8, y : Int8) : Int8
+func bitnot(x : Int8) : Int8
 ```
 
 Returns the bitwise negation of `x`, `^x`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitnot(-16 /* 0xf0 */) // => +15 // 0x0f
+```
 
 ## Function `bitand`
 ``` motoko no-repl
 func bitand(x : Int8, y : Int8) : Int8
 ```
 
-Returns the bitwise and of `x` and `y`, `x & y`.
+Returns the bitwise "and" of `x` and `y`, `x & y`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitand(0x1f, 0x70) // => +16 // 0x10
+```
 
 ## Function `bitor`
 ``` motoko no-repl
 func bitor(x : Int8, y : Int8) : Int8
 ```
 
-Returns the bitwise or of `x` and `y`, `x \| y`.
+Returns the bitwise "or" of `x` and `y`, `x | y`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitor(0x0f, 0x70) // => +127 // 0x7f
+```
 
 ## Function `bitxor`
 ``` motoko no-repl
 func bitxor(x : Int8, y : Int8) : Int8
 ```
 
-Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+Returns the bitwise "exclusive or" of `x` and `y`, `x ^ y`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitxor(0x70, 0x7f) // => +15 // 0x0f
+```
 
 ## Function `bitshiftLeft`
 ``` motoko no-repl
 func bitshiftLeft(x : Int8, y : Int8) : Int8
 ```
 
-Returns the bitwise shift left of `x` by `y`, `x << y`.
+Returns the bitwise left shift of `x` by `y`, `x << y`.
+The right bits of the shift filled with zeros.
+Left-overflowing bits, including the sign bit, are discarded.
+
+For `y >= 8`, the semantics is the same as for `bitshiftLeft(x, y % 8)`.
+For `y < 0`,  the semantics is the same as for `bitshiftLeft(x, y + y % 8)`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitshiftLeft(1, 4) // => +16 // 0x10 equivalent to `2 ** 4`.
+```
 
 ## Function `bitshiftRight`
 ``` motoko no-repl
 func bitshiftRight(x : Int8, y : Int8) : Int8
 ```
 
-Returns the bitwise shift right of `x` by `y`, `x >> y`.
+Returns the signed bitwise right shift of `x` by `y`, `x >> y`.
+The sign bit is retained and the left side is filled with the sign bit.
+Right-underflowing bits are discarded, i.e. not rotated to the left side.
+
+For `y >= 8`, the semantics is the same as for `bitshiftRight(x, y % 8)`.
+For `y < 0`,  the semantics is the same as for `bitshiftRight (x, y + y % 8)`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitshiftRight(64, 4) // => +4 // equivalent to `64 / (2 ** 4)`
+```
 
 ## Function `bitrotLeft`
 ``` motoko no-repl
 func bitrotLeft(x : Int8, y : Int8) : Int8
 ```
 
-Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+Returns the bitwise left rotatation of `x` by `y`, `x <<> y`.
+Each left-overflowing bit is inserted again on the right side.
+The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
+
+Changes the direction of rotation for negative `y`.
+For `y >= 8`, the semantics is the same as for `bitrotLeft(x, y % 8)`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitrotLeft(0x11 /* 0b0001_0001 */, 2) // => +68 // 0b0100_0100 == 0x44.
+```
 
 ## Function `bitrotRight`
 ``` motoko no-repl
 func bitrotRight(x : Int8, y : Int8) : Int8
 ```
 
-Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+Returns the bitwise right rotation of `x` by `y`, `x <>> y`.
+Each right-underflowing bit is inserted again on the right side.
+The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
+
+Changes the direction of rotation for negative `y`.
+For `y >= 8`, the semantics is the same as for `bitrotRight(x, y % 8)`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitrotRight(0x11 /* 0b0001_0001 */, 1) // => -120 // 0b1000_1000 == 0x88.
+```
 
 ## Function `bittest`
 ``` motoko no-repl
 func bittest(x : Int8, p : Nat) : Bool
 ```
 
-Returns the value of bit `p mod 8` in `x`, `(x & 2^(p mod 8)) == 2^(p mod 8)`.
+Returns the value of bit `p` in `x`, `x & 2**p == 2**p`.
+If `p >= 8`, the semantics is the same as for `bittest(x, p % 8)`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bittest(64, 6) // => true
+```
 
 ## Function `bitset`
 ``` motoko no-repl
 func bitset(x : Int8, p : Nat) : Int8
 ```
 
-Returns the value of setting bit `p mod 8` in `x` to `1`.
+Returns the value of setting bit `p` in `x` to `1`.
+If `p >= 8`, the semantics is the same as for `bitset(x, p % 8)`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitset(0, 6) // => +64
+```
 
 ## Function `bitclear`
 ``` motoko no-repl
 func bitclear(x : Int8, p : Nat) : Int8
 ```
 
-Returns the value of clearing bit `p mod 8` in `x` to `0`.
+Returns the value of clearing bit `p` in `x` to `0`.
+If `p >= 8`, the semantics is the same as for `bitclear(x, p % 8)`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitclear(-1, 6) // => -65
+```
 
 ## Function `bitflip`
 ``` motoko no-repl
 func bitflip(x : Int8, p : Nat) : Int8
 ```
 
-Returns the value of flipping bit `p mod 8` in `x`.
+Returns the value of flipping bit `p` in `x`.
+If `p >= 8`, the semantics is the same as for `bitclear(x, p % 8)`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitflip(127, 6) // => +63
+```
 
 ## Value `bitcountNonZero`
 ``` motoko no-repl
@@ -264,12 +574,26 @@ let bitcountNonZero : (x : Int8) -> Int8
 
 Returns the count of non-zero bits in `x`.
 
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitcountNonZero(0x0f) // => +4
+```
+
 ## Value `bitcountLeadingZero`
 ``` motoko no-repl
 let bitcountLeadingZero : (x : Int8) -> Int8
 ```
 
 Returns the count of leading zero bits in `x`.
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitcountLeadingZero(0x08) // => +4
+```
 
 ## Value `bitcountTrailingZero`
 ``` motoko no-repl
@@ -278,19 +602,46 @@ let bitcountTrailingZero : (x : Int8) -> Int8
 
 Returns the count of trailing zero bits in `x`.
 
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.bitcountTrailingZero(0x10) // => +4
+```
+
 ## Function `addWrap`
 ``` motoko no-repl
 func addWrap(x : Int8, y : Int8) : Int8
 ```
 
-Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+Returns the sum of `x` and `y`, `x +% y`.
+
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.addWrap(2 ** 6, 2 ** 6) // => -128 // overflow
+```
 
 ## Function `subWrap`
 ``` motoko no-repl
 func subWrap(x : Int8, y : Int8) : Int8
 ```
 
-Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+Returns the difference of `x` and `y`, `x -% y`.
+
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.subWrap(-2 ** 7, 1) // => +127 // underflow
+```
 
 ## Function `mulWrap`
 ``` motoko no-repl
@@ -299,9 +650,30 @@ func mulWrap(x : Int8, y : Int8) : Int8
 
 Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
 
+Wraps on overflow/underflow.
+
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.mulWrap(2 ** 4, 2 ** 4) // => 0 // overflow
+```
+
 ## Function `powWrap`
 ``` motoko no-repl
 func powWrap(x : Int8, y : Int8) : Int8
 ```
 
-Returns `x` to the power of `y`, `x **% y`. Wraps on overflow. Traps if `y < 0`.
+Returns `x` to the power of `y`, `x **% y`.
+
+Wraps on overflow/underflow.
+Traps if `y < 0 or y >= 8`.
+
+
+Example:
+```motoko
+import Int8 "mo:base/Int8";
+
+Int8.powWrap(2, 7) // => -128 // overflow
+```

--- a/doc/md/base/Iter.md
+++ b/doc/md/base/Iter.md
@@ -20,7 +20,11 @@ for (x in i) {
 }
 ```
 
-## `class range`
+## Class `range`
+
+``` motoko no-repl
+class range(x : Nat, y : Int)
+```
 
 Creates an iterator that produces all `Nat`s from `x` to `y` including
 both of the bounds.
@@ -39,7 +43,11 @@ func next() : ?Nat
 ```
 
 
-## `class revRange`
+## Class `revRange`
+
+``` motoko no-repl
+class revRange(x : Int, y : Int)
+```
 
 Like `range` but produces the values in the opposite
 order.

--- a/doc/md/base/List.md
+++ b/doc/md/base/List.md
@@ -214,9 +214,6 @@ func equal<T>(l1 : List<T>, l2 : List<T>, eq : (T, T) -> Bool) : Bool
 
 Compare two lists for equality as specified by the given relation `eq` on the elements.
 
-The function `isEq(l1, l2)` is equivalent to `lessThanEq(l1, l2) && lessThanEq(l2, l1)`,
-but the former is more efficient.
-
 ## Function `tabulate`
 ``` motoko no-repl
 func tabulate<T>(n : Nat, f : Nat -> T) : List<T>

--- a/doc/md/base/Nat16.md
+++ b/doc/md/base/Nat16.md
@@ -147,7 +147,7 @@ Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
 
 ## Function `bitnot`
 ``` motoko no-repl
-func bitnot(x : Nat16, y : Nat16) : Nat16
+func bitnot(x : Nat16) : Nat16
 ```
 
 Returns the bitwise negation of `x`, `^x`.

--- a/doc/md/base/Nat32.md
+++ b/doc/md/base/Nat32.md
@@ -147,7 +147,7 @@ Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
 
 ## Function `bitnot`
 ``` motoko no-repl
-func bitnot(x : Nat32, y : Nat32) : Nat32
+func bitnot(x : Nat32) : Nat32
 ```
 
 Returns the bitwise negation of `x`, `^x`.

--- a/doc/md/base/Nat64.md
+++ b/doc/md/base/Nat64.md
@@ -147,7 +147,7 @@ Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
 
 ## Function `bitnot`
 ``` motoko no-repl
-func bitnot(x : Nat64, y : Nat64) : Nat64
+func bitnot(x : Nat64) : Nat64
 ```
 
 Returns the bitwise negation of `x`, `^x`.

--- a/doc/md/base/Nat8.md
+++ b/doc/md/base/Nat8.md
@@ -147,7 +147,7 @@ Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
 
 ## Function `bitnot`
 ``` motoko no-repl
-func bitnot(x : Nat8, y : Nat8) : Nat8
+func bitnot(x : Nat8) : Nat8
 ```
 
 Returns the bitwise negation of `x`, `^x`.

--- a/doc/md/base/RBTree.md
+++ b/doc/md/base/RBTree.md
@@ -1,105 +1,363 @@
 # RBTree
-Red-Black Trees
+Key-value map implemented as a red-black tree (RBTree) with nodes storing key-value pairs.
+
+A red-black tree is a balanced binary search tree ordered by the keys.
+
+The tree data structure internally colors each of its nodes either red or black,
+and uses this information to balance the tree during the modifying operations.
+
+Creation:
+Instantiate class `RBTree<K, V>` that provides a map from keys of type `K` to values of type `V`.
+
+Example:
+```motoko
+import RBTree "mo:base/RBTree";
+import Nat "mo:base/Nat";
+import Debug "mo:base/Debug";
+
+let tree = RBTree.RBTree<Nat, Text>(Nat.compare); // Create a new red-black tree mapping Nat to Text
+tree.put(1, "one");
+tree.put(2, "two");
+tree.put(3, "tree");
+for (entry in tree.entries()) {
+  Debug.print("Entry key=" # debug_show(entry.0) # " value=\"" # entry.1 #"\"");
+}
+```
+
+Performance:
+* Runtime: `O(log(n))` worst case cost per insertion, removal, and retrieval operation.
+* Space: `O(n)` for storing the entire tree.
+`n` denotes the number of key-value entries (i.e. nodes) stored in the tree.
+
+Note:
+* Tree operations, such as retrieval, insertion, and removal create `O(log(n))` temporary objects that become garbage.
 
 ## Type `Color`
 ``` motoko no-repl
 type Color = {#R; #B}
 ```
 
-Node color: red or black.
+Node color: Either red (`#R`) or black (`#B`).
 
 ## Type `Tree`
 ``` motoko no-repl
-type Tree<X, Y> = {#node : (Color, Tree<X, Y>, (X, ?Y), Tree<X, Y>); #leaf}
+type Tree<K, V> = {#node : (Color, Tree<K, V>, (K, ?V), Tree<K, V>); #leaf}
 ```
 
-Ordered, (red-black) tree of entries.
+Red-black tree of nodes with key-value entries, ordered by the keys.
+The keys have the generic type `K` and the values the generic type `V`.
+Leaves are considered implicitly black.
 
-## `class RBTree<X, Y>`
+## Class `RBTree<K, V>`
 
-Create an order map from an order function for its keys.
+``` motoko no-repl
+class RBTree<K, V>(compare : (K, K) -> O.Order)
+```
+
+A map from keys of type `K` to values of type `V` implemented as a red-black tree.
+The entries of key-value pairs are ordered by `compare` function applied to the keys.
+
+The class enables imperative usage in object-oriented-style.
+However, internally, the class uses a functional implementation.
+
+The `compare` function should implement a consistent total order among all possible values of `K` and
+for efficiency, only involves `O(1)` runtime costs without space allocation.
+
+Example:
+```motoko name=initialize
+import RBTree "mo:base/RBTree";
+import Nat "mo:base/Nat";
+
+let tree = RBTree.RBTree<Nat, Text>(Nat.compare); // Create a map of `Nat` to `Text` using the `Nat.compare` order
+```
+
+Costs of instantiation (only empty tree):
+Runtime: `O(1)`.
+Space: `O(1)`.
 
 ### Function `share`
 ``` motoko no-repl
-func share() : Tree<X, Y>
+func share() : Tree<K, V>
 ```
 
-Tree as sharable data.
+Return a snapshot of the internal functional tree representation as sharable data.
+The returned tree representation is not affected by subsequent changes of the `RBTree` instance.
 
-Get non-OO, purely-functional representation:
-for drawing, pretty-printing and non-OO contexts
-(e.g., async args and results):
+
+Example:
+```motoko include=initialize
+
+tree.put(1, "one");
+let treeSnapshot = tree.share();
+tree.put(2, "second");
+RBTree.size(treeSnapshot) // => 1 (Only the first insertion is part of the snapshot.)
+```
+
+Useful for storing the tree as a stable variable, determining its size, pretty-printing, and sharing it across async function calls,
+i.e. passing it in async arguments or async results.
+
+Runtime: `O(1)`.
+Space: `O(1)`.
 
 
 ### Function `get`
 ``` motoko no-repl
-func get(x : X) : ?Y
+func get(key : K) : ?V
 ```
 
-Get the value associated with a given key.
+Retrieve the value associated with a given key, if present. Returns `null`, if the key is absent.
+The key is searched according to the `compare` function defined on the class instantiation.
+
+Example:
+```motoko include=initialize
+
+tree.put(1, "one");
+tree.put(2, "two");
+
+tree.get(1) // => ?"one"
+```
+
+Runtime: `O(log(n))`.
+Space: `O(1)` retained memory plus garbage, see the note below.
+where `n` denotes the number of key-value entries stored in the tree and
+assuming that the `compare` function implements an `O(1)` comparison.
+
+Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
 
 
 ### Function `replace`
 ``` motoko no-repl
-func replace(x : X, y : Y) : ?Y
+func replace(key : K, value : V) : ?V
 ```
 
-Replace the value associated with a given key.
+Replace the value associated with a given key, if the key is present.
+Otherwise, if the key does not yet exist, insert the key-value entry.
+
+Returns the previous value of the key, if the key already existed.
+Otherwise, `null`, if the key did not yet exist before.
+
+Example:
+```motoko include=initialize
+import Iter "mo:base/Iter";
+
+tree.put(1, "old one");
+tree.put(2, "two");
+
+ignore tree.replace(1, "new one");
+Iter.toArray(tree.entries()) // => [(1, "new one"), (2, "two")]
+```
+
+Runtime: `O(log(n))`.
+Space: `O(1)` retained memory plus garbage, see the note below.
+where `n` denotes the number of key-value entries stored in the tree and
+assuming that the `compare` function implements an `O(1)` comparison.
+
+Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
 
 
 ### Function `put`
 ``` motoko no-repl
-func put(x : X, y : Y)
+func put(key : K, value : V)
 ```
 
-Put an entry: A value associated with a given key.
+Insert a key-value entry in the tree. If the key already exists, it overwrites the associated value.
+
+Example:
+```motoko include=initialize
+import Iter "mo:base/Iter";
+
+tree.put(1, "one");
+tree.put(2, "two");
+tree.put(3, "three");
+Iter.toArray(tree.entries()) // now contains three entries
+```
+
+Runtime: `O(log(n))`.
+Space: `O(1)` retained memory plus garbage, see the note below.
+where `n` denotes the number of key-value entries stored in the tree and
+assuming that the `compare` function implements an `O(1)` comparison.
+
+Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
 
 
 ### Function `delete`
 ``` motoko no-repl
-func delete(x : X)
+func delete(key : K)
 ```
 
-Delete the entry associated with a given key.
+Delete the entry associated with a given key, if the key exists.
+No effect if the key is absent. Same as `remove(key)` except that it
+does not have a return value.
+
+Example:
+```motoko include=initialize
+import Iter "mo:base/Iter";
+
+tree.put(1, "one");
+tree.put(2, "two");
+
+tree.delete(1);
+Iter.toArray(tree.entries()) // => [(2, "two")].
+```
+
+Runtime: `O(log(n))`.
+Space: `O(1)` retained memory plus garbage, see the note below.
+where `n` denotes the number of key-value entries stored in the tree and
+assuming that the `compare` function implements an `O(1)` comparison.
+
+Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
 
 
 ### Function `remove`
 ``` motoko no-repl
-func remove(x : X) : ?Y
+func remove(key : K) : ?V
 ```
 
-Remove the entry associated with a given key.
+Remove the entry associated with a given key, if the key exists, and return the associated value.
+Returns `null` without any other effect if the key is absent.
+
+Example:
+```motoko include=initialize
+import Iter "mo:base/Iter";
+
+tree.put(1, "one");
+tree.put(2, "two");
+
+ignore tree.remove(1);
+Iter.toArray(tree.entries()) // => [(2, "two")].
+```
+
+Runtime: `O(log(n))`.
+Space: `O(1)` retained memory plus garbage, see the note below.
+where `n` denotes the number of key-value entries stored in the tree and
+assuming that the `compare` function implements an `O(1)` comparison.
+
+Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
 
 
 ### Function `entries`
 ``` motoko no-repl
-func entries() : I.Iter<(X, Y)>
+func entries() : I.Iter<(K, V)>
 ```
 
 An iterator for the key-value entries of the map, in ascending key order.
+The iterator takes a snapshot view of the tree and is not affected by concurrent modifications.
 
-iterator is persistent, like the tree itself
+Example:
+```motoko include=initialize
+import Debug "mo:base/Debug";
+
+tree.put(1, "one");
+tree.put(2, "two");
+tree.put(3, "two");
+
+for (entry in tree.entries()) {
+  Debug.print("Entry key=" # debug_show(entry.0) # " value=\"" # entry.1 #"\"");
+}
+
+// Entry key=1 value="one"
+// Entry key=2 value="two"
+// Entry key=3 value="three"
+```
+
+Cost of iteration over all elements:
+Runtime: `O(n)`.
+Space: `O(log(n))` retained memory plus garbage, see the note below.
+where `n` denotes the number of key-value entries stored in the tree.
+
+Note: Full tree iteration creates `O(n)` temporary objects that will be collected as garbage.
 
 
 ### Function `entriesRev`
 ``` motoko no-repl
-func entriesRev() : I.Iter<(X, Y)>
+func entriesRev() : I.Iter<(K, V)>
 ```
 
 An iterator for the key-value entries of the map, in descending key order.
+The iterator takes a snapshot view of the tree and is not affected by concurrent modifications.
 
-iterator is persistent, like the tree itself
+Example:
+```motoko include=initialize
+import Debug "mo:base/Debug";
+
+let tree = RBTree.RBTree<Nat, Text>(Nat.compare);
+tree.put(1, "one");
+tree.put(2, "two");
+tree.put(3, "two");
+
+for (entry in tree.entriesRev()) {
+  Debug.print("Entry key=" # debug_show(entry.0) # " value=\"" # entry.1 #"\"");
+}
+
+// Entry key=3 value="three"
+// Entry key=2 value="two"
+// Entry key=1 value="one"
+```
+
+Cost of iteration over all elements:
+Runtime: `O(n)`.
+Space: `O(log(n))` retained memory plus garbage, see the note below.
+where `n` denotes the number of key-value entries stored in the tree.
+
+Note: Full tree iteration creates `O(n)` temporary objects that will be collected as garbage.
 
 ## Function `iter`
 ``` motoko no-repl
-func iter<X, Y>(t : Tree<X, Y>, dir : {#fwd; #bwd}) : I.Iter<(X, Y)>
+func iter<X, Y>(tree : Tree<X, Y>, direction : {#fwd; #bwd}) : I.Iter<(X, Y)>
 ```
 
-An iterator for the entries of the map, in ascending (`#fwd`) or descending (`#bwd`) order.
+Get an iterator for the entries of the `tree`, in ascending (`#fwd`) or descending (`#bwd`) order as specified by `direction`.
+The iterator takes a snapshot view of the tree and is not affected by concurrent modifications.
+
+Example:
+```motoko
+import RBTree "mo:base/RBTree";
+import Nat "mo:base/Nat";
+import Debug "mo:base/Debug";
+
+let tree = RBTree.RBTree<Nat, Text>(Nat.compare);
+tree.put(1, "one");
+tree.put(2, "two");
+tree.put(3, "two");
+
+for (entry in RBTree.iter(tree.share(), #bwd)) { // backward iteration
+  Debug.print("Entry key=" # debug_show(entry.0) # " value=\"" # entry.1 #"\"");
+}
+
+// Entry key=3 value="three"
+// Entry key=2 value="two"
+// Entry key=1 value="one"
+```
+
+Cost of iteration over all elements:
+Runtime: `O(n)`.
+Space: `O(log(n))` retained memory plus garbage, see the note below.
+where `n` denotes the number of key-value entries stored in the tree.
+
+Note: Full tree iteration creates `O(n)` temporary objects that will be collected as garbage.
 
 ## Function `size`
 ``` motoko no-repl
 func size<X, Y>(t : Tree<X, Y>) : Nat
 ```
 
-The size of the tree as the number of key-value entries.
+Determine the size of the tree as the number of key-value entries.
+
+Example:
+```motoko
+import RBTree "mo:base/RBTree";
+import Nat "mo:base/Nat";
+
+let tree = RBTree.RBTree<Nat, Text>(Nat.compare);
+tree.put(1, "one");
+tree.put(2, "two");
+tree.put(3, "three");
+
+RBTree.size(tree.share()) // 3 entries
+```
+
+Runtime: `O(log(n))`.
+Space: `O(1)` retained memory plus garbage, see the note below.
+where `n` denotes the number of key-value entries stored in the tree.
+
+Note: Creates `O(log(n))` temporary objects that will be collected as garbage.

--- a/doc/md/base/Random.md
+++ b/doc/md/base/Random.md
@@ -22,7 +22,28 @@ These are provided for performance (and convenience) reasons, and need
 special care when used. Similar caveats apply for user-defined (pseudo)
 random number generators.
 
-## `class Finite`
+Usage:
+```motoko no-repl
+import Random "mo:base/Random";
+```
+
+## Value `blob`
+``` motoko no-repl
+let blob : shared () -> async Blob
+```
+
+Obtains a full blob (32 bytes) worth of fresh entropy.
+
+Example:
+```motoko no-repl
+let random = Random.Finite(await Random.blob());
+```
+
+## Class `Finite`
+
+``` motoko no-repl
+class Finite(entropy : Blob)
+```
 
 Drawing from a finite supply of entropy, `Finite` provides
 methods to obtain random values. When the entropy is used up,
@@ -31,6 +52,16 @@ stated for each method. The uniformity of outcomes is
 guaranteed only when the supplied entropy is originally obtained
 by the `blob()` call, and is never reused.
 
+Example:
+```motoko no-repl
+import Random "mo:base/Random";
+
+let random = Random.Finite(await Random.blob());
+
+let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
+let seedRandom = Random.Finite(seed);
+```
+
 ### Function `byte`
 ``` motoko no-repl
 func byte() : ?Nat8
@@ -38,6 +69,13 @@ func byte() : ?Nat8
 
 Uniformly distributes outcomes in the numeric range [0 .. 255].
 Consumes 1 byte of entropy.
+
+Example:
+```motoko no-repl
+let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
+let random = Random.Finite(seed);
+random.byte() // => ?20
+```
 
 
 ### Function `coin`
@@ -48,6 +86,13 @@ func coin() : ?Bool
 Simulates a coin toss. Both outcomes have equal probability.
 Consumes 1 bit of entropy (amortised).
 
+Example:
+```motoko no-repl
+let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
+let random = Random.Finite(seed);
+random.coin() // => ?false
+```
+
 
 ### Function `range`
 ``` motoko no-repl
@@ -57,6 +102,13 @@ func range(p : Nat8) : ?Nat
 Uniformly distributes outcomes in the numeric range [0 .. 2^p - 1].
 Consumes ⌈p/8⌉ bytes of entropy.
 
+Example:
+```motoko no-repl
+let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
+let random = Random.Finite(seed);
+random.range(32) // => ?348746249
+```
+
 
 ### Function `binomial`
 ``` motoko no-repl
@@ -64,7 +116,14 @@ func binomial(n : Nat8) : ?Nat8
 ```
 
 Counts the number of heads in `n` fair coin tosses.
-Consumes ⌈p/8⌉ bytes of entropy.
+Consumes ⌈n/8⌉ bytes of entropy.
+
+Example:
+```motoko no-repl
+let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
+let random = Random.Finite(seed);
+random.binomial(5) // => ?1
+```
 
 ## Function `byteFrom`
 ``` motoko no-repl
@@ -74,6 +133,12 @@ func byteFrom(seed : Blob) : Nat8
 Distributes outcomes in the numeric range [0 .. 255].
 Seed blob must contain at least a byte.
 
+Example:
+```motoko no-repl
+let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
+Random.byteFrom(seed) // => 20
+```
+
 ## Function `coinFrom`
 ``` motoko no-repl
 func coinFrom(seed : Blob) : Bool
@@ -82,12 +147,11 @@ func coinFrom(seed : Blob) : Bool
 Simulates a coin toss.
 Seed blob must contain at least a byte.
 
-## Value `blob`
-``` motoko no-repl
-let blob : shared () -> async Blob
+Example:
+```motoko no-repl
+let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
+Random.coinFrom(seed) // => false
 ```
-
-Obtains a full blob (32 bytes) worth of fresh entropy.
 
 ## Function `rangeFrom`
 ``` motoko no-repl
@@ -97,6 +161,12 @@ func rangeFrom(p : Nat8, seed : Blob) : Nat
 Distributes outcomes in the numeric range [0 .. 2^p - 1].
 Seed blob must contain at least ((p+7) / 8) bytes.
 
+Example:
+```motoko no-repl
+let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
+Random.rangeFrom(32, seed) // => 348746249
+```
+
 ## Function `binomialFrom`
 ``` motoko no-repl
 func binomialFrom(n : Nat8, seed : Blob) : Nat8
@@ -104,3 +174,9 @@ func binomialFrom(n : Nat8, seed : Blob) : Nat8
 
 Counts the number of heads in `n` coin tosses.
 Seed blob must contain at least ((n+7) / 8) bytes.
+
+Example:
+```motoko no-repl
+let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
+Random.binomialFrom(5, seed) // => 1
+```

--- a/doc/md/base/Stack.md
+++ b/doc/md/base/Stack.md
@@ -1,11 +1,23 @@
 # Stack
-Stack collection (LIFO discipline).
+Class `Stack<X>` provides a Minimal LIFO stack of elements of type `X`.
 
-Minimal LIFO (last in first out) implementation, as a class.
 See library `Deque` for mixed LIFO/FIFO behavior.
 
+Example:
+```motoko name=initialize
+import Stack "mo:base/Stack";
 
-## `class Stack<T>`
+let stack = Stack.Stack<Nat>(); // create a stack
+```
+Runtime: O(1)
+
+Space: O(1)
+
+## Class `Stack<T>`
+
+``` motoko no-repl
+class Stack<T>()
+```
 
 
 ### Function `push`
@@ -15,13 +27,34 @@ func push(x : T)
 
 Push an element on the top of the stack.
 
+Example:
+```motoko include=initialize
+stack.push(1);
+stack.push(2);
+stack.push(3);
+stack.peek(); // examine the top most element
+```
+
+Runtime: O(1)
+
+Space: O(1)
+
 
 ### Function `isEmpty`
 ``` motoko no-repl
 func isEmpty() : Bool
 ```
 
-True when the stack is empty.
+True when the stack is empty and false otherwise.
+
+Example:
+```motoko include=initialize
+stack.isEmpty();
+```
+
+Runtime: O(1)
+
+Space: O(1)
 
 
 ### Function `peek`
@@ -29,7 +62,19 @@ True when the stack is empty.
 func peek() : ?T
 ```
 
-Return and retain the top element, or return null.
+Return (without removing) the top element, or return null if the stack is empty.
+
+Example:
+```motoko include=initialize
+stack.push(1);
+stack.push(2);
+stack.push(3);
+stack.peek();
+```
+
+Runtime: O(1)
+
+Space: O(1)
 
 
 ### Function `pop`
@@ -37,4 +82,15 @@ Return and retain the top element, or return null.
 func pop() : ?T
 ```
 
-Remove and return the top element, or return null.
+Remove and return the top element, or return null if the stack is empty.
+
+Example:
+```motoko include=initialize
+stack.push(1);
+ignore stack.pop();
+stack.isEmpty();
+```
+
+Runtime: O(1)
+
+Space: O(1)

--- a/doc/md/base/Timer.md
+++ b/doc/md/base/Timer.md
@@ -1,0 +1,68 @@
+# Timer
+Timers for one-off or periodic tasks.
+
+Note: If `moc` is invoked with `-no-timer`, the importing will fail.
+Note: The resolution of the timers is in the order of the block rate,
+      so durations should be chosen well above that. For frequent
+      canister wake-ups the heatbeat mechanism should be considered.
+
+## Type `Duration`
+``` motoko no-repl
+type Duration = {#seconds : Nat; #nanoseconds : Nat}
+```
+
+
+## Type `TimerId`
+``` motoko no-repl
+type TimerId = Nat
+```
+
+
+## Function `setTimer`
+``` motoko no-repl
+func setTimer(d : Duration, job : () -> async ()) : TimerId
+```
+
+Installs a one-off timer that upon expiration after given duration `d`
+executes the future `job()`.
+
+```motoko no-repl
+let now = Time.now();
+let thirtyMinutes = 1_000_000_000 * 60 * 30;
+func alarmUser() : async () {
+  // ...
+};
+appt.reminder = setTimer(#nanoseconds (Int.abs(appt.when - now - thirtyMinutes)), alarmUser);
+```
+
+## Function `recurringTimer`
+``` motoko no-repl
+func recurringTimer(d : Duration, job : () -> async ()) : TimerId
+```
+
+Installs a recurring timer that upon expiration after given duration `d`
+executes the future `job()` and reinserts itself for another expiration.
+
+Note: A duration of 0 will only expire once.
+
+```motoko no-repl
+func checkAndWaterPlants() : async () {
+  // ...
+};
+let daily = recurringTimer(#seconds (24 * 60 * 60), checkAndWaterPlants);
+```
+
+## Value `cancelTimer`
+``` motoko no-repl
+let cancelTimer : TimerId -> ()
+```
+
+Cancels a still active timer with `(id : TimerId)`. For expired timers
+and not recognised `id`s nothing happens.
+
+```motoko no-repl
+func deleteAppt(appt : Appointment) {
+  cancelTimer (appt.reminder);
+  // ...
+};
+```

--- a/doc/md/base/Trie.md
+++ b/doc/md/base/Trie.md
@@ -6,7 +6,7 @@ independent of operation history (unlike other popular search trees).
 
 The representation we use here comes from Section 6 of ["Incremental computation via function caching", Pugh & Teitelbaum](https://dl.acm.org/citation.cfm?id=75305).
 
-## User's overview
+## <a name="overview"></a>User's overview
 
 This module provides an applicative (functional) hash map.
 Notably, each `put` produces a **new trie _and value being replaced, if any_**.
@@ -17,27 +17,90 @@ object-oriented) hash map should consider `TrieMap` or `HashMap` instead.
 The basic `Trie` operations consist of:
 - `put` - put a key-value into the trie, producing a new version.
 - `get` - get a key's value from the trie, or `null` if none.
+- `remove` - remove a key's value from the trie
 - `iter` - visit every key-value in the trie.
 
-The `put` and `get` operations work over `Key` records,
+The `put`, `get` and `remove` operations work over `Key` records,
 which group the hash of the key with its non-hash key value.
 
+Example:
 ```motoko
 import Trie "mo:base/Trie";
 import Text "mo:base/Text";
 
+// we do this to have shorter type names and thus
+// better readibility
 type Trie<K, V> = Trie.Trie<K, V>;
 type Key<K> = Trie.Key<K>;
 
-func key(t: Text) : Key<Text> { { key = t; hash = Text.hash t } };
+// we have to provide `put`, `get` and `remove` with
+// a record of type `Key<K> = { hash : Hash.Hash; key : K }`;
+// thus we define the following function that takes a value of type `K`
+// (in this case `Text`) and returns a `Key<K>` record.
+func key(t: Text) : Key<Text> { { hash = Text.hash t; key = t } };
 
+// we start off by creating an empty `Trie`
 let t0 : Trie<Text, Nat> = Trie.empty();
+
+// `put` requires 4 arguments:
+// - the trie we want to insert the value into,
+// - the key of the value we want to insert (note that we use the `key` function defined above),
+// - a function that checks for equality of keys, and
+// - the value we want to insert.
+//
+// When inserting a value, `put` returns a tuple of type `(Trie<K, V>, ?V)`.
+// to get the new trie that contains the value,  we use the `0` projection
+// and assign it to `t1` and `t2` respectively.
 let t1 : Trie<Text, Nat> = Trie.put(t0, key "hello", Text.equal, 42).0;
 let t2 : Trie<Text, Nat> = Trie.put(t1, key "world", Text.equal, 24).0;
-let n : ?Nat = Trie.put(t1, key "hello", Text.equal, 0).1;
-assert (n == ?42);
-```
 
+// If for a given key there already was a value in the trie, `put` returns
+// that previous value as the second element of the tuple.
+// in our case we have already inserted the value 42 for the key "hello", so
+// `put` returns 42 as the second element of the tuple.
+let (t3, n) : (Trie<Text, Nat>, ?Nat) = Trie.put(
+  t2,
+  key "hello",
+  Text.equal,
+  0,
+);
+assert (n == ?42);
+
+// `get` requires 3 arguments:
+// - the trie we want to get the value from
+// - the key of the value we want to get (note that we use the `key` function defined above)
+// - a function that checks for equality of keys
+//
+// If the given key is nonexistent in the trie, `get` returns `null`.
+var value = Trie.get(t3, key "hello", Text.equal); // Returns `?42`
+assert(value == ?0);
+value := Trie.get(t3, key "universe", Text.equal); // Returns `null`
+assert(value == null);
+
+// `remove` requires 3 arguments:
+// - the trie we want to remove the value from,
+// - the key of the value we want to remove (note that we use the `key` function defined above), and
+// - a function that checks for equality of keys.
+//
+// In the case of keys of type `Text`, we can use `Text.equal`
+// to check for equality of keys. Function `remove` returns a tuple of type `(Trie<K, V>, ?V)`.
+// where the second element of the tuple is the value that was removed, or `null` if
+// there was no value for the given key.
+let removedValue : ?Nat = Trie.remove(
+  t3,
+  key "hello",
+  Text.equal,
+).1;
+assert (removedValue == ?0);
+
+// To iterate over the Trie, we use the `iter` function that takes a trie
+// of type `Trie<K,V>` and returns an iterator of type `Iter<(K,V)>`:
+var sum : Nat = 0;
+for (kv in Trie.iter(t3)) {
+  sum += kv.1;
+};
+assert(sum == 24);
+```
 
 ## Type `Trie`
 ``` motoko no-repl
@@ -73,6 +136,9 @@ type AssocList<K, V> = AssocList.AssocList<K, V>
 type Key<K> = { hash : Hash.Hash; key : K }
 ```
 
+A `Key` for the trie has an associated hash value
+- `hash` permits fast inequality checks, and permits collisions, while
+- `key` permits precise equality checks, but is only used on values with equal hashes.
 
 ## Function `equalKey`
 ``` motoko no-repl
@@ -102,22 +168,51 @@ type Trie3D<K1, K2, K3, V> = Trie<K1, Trie2D<K2, K3, V>>
 ```
 
 A 3D trie maps dimension-1 keys to another
-layer of 2D tries, each keyed on the dimension-2 and dimension-3 keys.
+Composition of 2D tries, each keyed on the dimension-2 and dimension-3 keys.
 
 ## Function `empty`
 ``` motoko no-repl
 func empty<K, V>() : Trie<K, V>
 ```
 
-An empty trie.
+An empty trie. This is usually the starting point for building a trie.
+
+Example:
+```motoko name=initialize
+import { print } "mo:base/Debug";
+import Trie "mo:base/Trie";
+import Text "mo:base/Text";
+
+// we do this to have shorter type names and thus
+// better readibility
+type Trie<K, V> = Trie.Trie<K, V>;
+type Key<K> = Trie.Key<K>;
+
+// We have to provide `put`, `get` and `remove` with
+// a function of return type `Key<K> = { hash : Hash.Hash; key : K }`
+func key(t: Text) : Key<Text> { { hash = Text.hash t; key = t } };
+// We start off by creating an empty `Trie`
+var trie : Trie<Text, Nat> = Trie.empty();
+```
 
 ## Function `size`
 ``` motoko no-repl
 func size<K, V>(t : Trie<K, V>) : Nat
 ```
 
- Get the number of key-value pairs in the trie, in constant time.
-Get size in O(1) time.
+Get the size in O(1) time.
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+var size = Trie.size(trie); // Returns 0, as `trie` is empty
+assert(size == 0);
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+size := Trie.size(trie); // Returns 1, as we just added a new entry
+assert(size == 1);
+```
 
 ## Function `branch`
 ``` motoko no-repl
@@ -165,21 +260,55 @@ Replace the given key's value option with the given one, returning the previous 
 func put<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool, v : V) : (Trie<K, V>, ?V)
 ```
 
-Put the given key's value in the trie; return the new trie, and the previous value associated with the key, if any
+Put the given key's value in the trie; return the new trie, and the previous value associated with the key, if any.
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+let previousValue = Trie.put(trie, key "hello", Text.equal, 33).1; // Returns ?42
+assert(previousValue == ?42);
+```
 
 ## Function `get`
 ``` motoko no-repl
 func get<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool) : ?V
 ```
 
-Get the value of the given key in the trie, or return null if nonexistent
+Get the value of the given key in the trie, or return null if nonexistent.
+
+For a more detailed overview of how to use a Trie,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+var value = Trie.get(trie, key "hello", Text.equal); // Returns `?42`
+assert(value == ?42);
+value := Trie.get(trie, key "world", Text.equal); // Returns `null`
+assert(value == null);
+```
 
 ## Function `find`
 ``` motoko no-repl
 func find<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool) : ?V
 ```
 
-Find the given key's value in the trie, or return null if nonexistent
+Find the given key's value in the trie, or return `null` if nonexistent
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+var value = Trie.find(trie, key "hello", Text.equal); // Returns `?42`
+assert(value == ?42);
+value := Trie.find(trie, key "world", Text.equal); // Returns `null`
+assert(value == null);
+```
 
 ## Function `merge`
 ``` motoko no-repl
@@ -193,23 +322,75 @@ note: the `disj` operation generalizes this `merge`
 operation in various ways, and does not (in general) lose
 information; this operation is a simpler, special case.
 
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 42).0;
+// trie2 is a copy of trie
+var trie2 = Trie.clone(trie);
+// trie2 has a different value for "hello"
+trie2 := Trie.put(trie2, key "hello", Text.equal, 33).0;
+// mergedTrie has the value 42 for "hello", as the left trie is preferred
+// in the case of a collision
+var mergedTrie = Trie.merge(trie, trie2, Text.equal);
+var value = Trie.get(mergedTrie, key "hello", Text.equal);
+assert(value == ?42);
+```
+
 ## Function `mergeDisjoint`
 ``` motoko no-repl
 func mergeDisjoint<K, V>(tl : Trie<K, V>, tr : Trie<K, V>, k_eq : (K, K) -> Bool) : Trie<K, V>
 ```
 
-Merge tries like `merge`, except signals a
-dynamic error if there are collisions in common keys between the
+<a name="mergedisjoint"></a>
+
+Merge tries like `merge`, but traps if there are collisions in common keys between the
 left and right inputs.
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 42).0;
+// trie2 is a copy of trie
+var trie2 = Trie.clone(trie);
+// trie2 has a different value for "hello"
+trie2 := Trie.put(trie2, key "hello", Text.equal, 33).0;
+// `mergeDisjoint` signals a dynamic errror
+// in the case of a collision
+var mergedTrie = Trie.mergeDisjoint(trie, trie2, Text.equal);
+```
 
 ## Function `diff`
 ``` motoko no-repl
 func diff<K, V, W>(tl : Trie<K, V>, tr : Trie<K, W>, k_eq : (K, K) -> Bool) : Trie<K, V>
 ```
 
-Difference of tries. The output consists are pairs of
+Difference of tries. The output consists of pairs of
 the left trie whose keys are not present in the right trie; the
 values of the right trie are irrelevant.
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 42).0;
+// trie2 is a copy of trie
+var trie2 = Trie.clone(trie);
+// trie2 now has an additional key
+trie2 := Trie.put(trie2, key "ciao", Text.equal, 33).0;
+// `diff` returns a trie with the key "ciao",
+// as this key is not present in `trie`
+// (note that we pass `trie2` as the left trie)
+Trie.diff(trie2, trie, Text.equal);
+```
 
 ## Function `disj`
 ``` motoko no-repl
@@ -277,9 +458,29 @@ these input keys.
 func iter<K, V>(t : Trie<K, V>) : I.Iter<(K, V)>
 ```
 
-Returns an `Iter` over the key-value entries of the trie.
+Returns an iterator of type `Iter` over the key-value entries of the trie.
 
 Each iterator gets a _persistent view_ of the mapping, independent of concurrent updates to the iterated map.
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+// create an Iterator over key-value pairs of trie
+let iter = Trie.iter(trie);
+// add another key-value pair to `trie`.
+// because we created our iterator before
+// this update, it will not contain this new key-value pair
+trie := Trie.put(trie, key "ciao", Text.equal, 3).0;
+var sum : Nat = 0;
+for ((k,v) in iter) {
+  sum += v;
+};
+assert(sum == 74);
+```
 
 ## Value `Build`
 ``` motoko no-repl
@@ -312,6 +513,22 @@ func fold<K, V, X>(t : Trie<K, V>, f : (K, V, X) -> X, x : X) : X
 Fold over the key-value pairs of the trie, using an accumulator.
 The key-value pairs have no reliable or meaningful ordering.
 
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+trie := Trie.put(trie, key "ciao", Text.equal, 3).0;
+// create an accumulator, in our case the sum of all values
+func calculateSum(k : Text, v : Nat, acc : Nat) : Nat = acc + v;
+// Fold over the trie using the accumulator.
+// Note that 0 is the initial value of the accumulator.
+let sum = Trie.fold(trie, calculateSum, 0);
+assert(sum == 77);
+```
+
 ## Function `some`
 ``` motoko no-repl
 func some<K, V>(t : Trie<K, V>, f : (K, V) -> Bool) : Bool
@@ -319,12 +536,58 @@ func some<K, V>(t : Trie<K, V>, f : (K, V) -> Bool) : Bool
 
 Test whether a given key-value pair is present, or not.
 
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+trie := Trie.put(trie, key "ciao", Text.equal, 3).0;
+// `some` takes a function that returns a Boolean indicating whether
+// the key-value pair is present or not
+var isPresent = Trie.some(
+  trie,
+  func(k : Text, v : Nat) : Bool = k == "bye" and v == 32,
+);
+assert(isPresent == true);
+isPresent := Trie.some(
+  trie,
+  func(k : Text, v : Nat) : Bool = k == "hello" and v == 32,
+);
+assert(isPresent == false);
+```
+
 ## Function `all`
 ``` motoko no-repl
 func all<K, V>(t : Trie<K, V>, f : (K, V) -> Bool) : Bool
 ```
 
 Test whether all key-value pairs have a given property.
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+trie := Trie.put(trie, key "ciao", Text.equal, 10).0;
+// `all` takes a function that returns a boolean indicating whether
+// the key-value pairs all have a given property, in our case that
+// all values are greater than 9
+var hasProperty = Trie.all(
+  trie,
+  func(k : Text, v : Nat) : Bool = v > 9,
+);
+assert(hasProperty == true);
+// now we check if all values are greater than 100
+hasProperty := Trie.all(
+  trie,
+  func(k : Text, v : Nat) : Bool = v > 100,
+);
+assert(hasProperty == false);
+```
 
 ## Function `nth`
 ``` motoko no-repl
@@ -336,12 +599,53 @@ Project the nth key-value pair from the trie.
 Note: This position is not meaningful; it's only here so that we
 can inject tries into arrays using functions like `Array.tabulate`.
 
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+import Array "mo:base/Array";
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+trie := Trie.put(trie, key "ciao", Text.equal, 10).0;
+// `tabulate` takes a size parameter, so we check the size of
+// the trie first
+let size = Trie.size(trie);
+// Now we can create an array of the same size passing `nth` as
+// the generator used to fill the array.
+// Note that `toArray` is a convenience function that does the
+// same thing without you having to check whether the tuple is
+// `null` or not, which we're not doing in this example
+let array = Array.tabulate<?(Key<Text>, Nat)>(
+  size,
+  func n = Trie.nth(trie, n)
+);
+```
+
 ## Function `toArray`
 ``` motoko no-repl
 func toArray<K, V, W>(t : Trie<K, V>, f : (K, V) -> W) : [W]
 ```
 
 Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+trie := Trie.put(trie, key "ciao", Text.equal, 10).0;
+// `toArray` takes a function that takes a key-value tuple
+// and returns a value of the type you want to use to fill
+// the array.
+// In our case we just return the value
+let array = Trie.toArray<Text, Nat, Nat>(
+  trie,
+  func (k, v) = v
+);
+```
 
 ## Function `isEmpty`
 ``` motoko no-repl
@@ -359,12 +663,48 @@ func filter<K, V>(t : Trie<K, V>, f : (K, V) -> Bool) : Trie<K, V>
 
 Filter the key-value pairs by a given predicate.
 
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+trie := Trie.put(trie, key "ciao", Text.equal, 10).0;
+// `filter` takes a function that takes a key-value tuple
+// and returns true if the key-value pair should be included.
+// In our case those are pairs with a value greater than 20
+let filteredTrie = Trie.filter<Text, Nat>(
+  trie,
+  func (k, v) = v > 20
+);
+assert (Trie.all<Text, Nat>(filteredTrie, func(k, v) = v > 20) == true);
+```
+
 ## Function `mapFilter`
 ``` motoko no-repl
 func mapFilter<K, V, W>(t : Trie<K, V>, f : (K, V) -> ?W) : Trie<K, W>
 ```
 
 Map and filter the key-value pairs by a given predicate.
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+trie := Trie.put(trie, key "ciao", Text.equal, 10).0;
+// `mapFilter` takes a function that takes a key-value tuple
+// and returns a possibly-distinct value if the key-value pair should be included.
+// In our case, we filter for values greater than 20 and map them to their square.
+let filteredTrie = Trie.mapFilter<Text, Nat, Nat>(
+  trie,
+  func (k, v) = if (v > 20) return ?(v**2) else return null
+);
+assert (Trie.all<Text, Nat>(filteredTrie, func(k, v) = v > 60) == true);
+```
 
 ## Function `equalStructure`
 ``` motoko no-repl
@@ -388,12 +728,57 @@ Replace the given key's value in the trie,
 and only if successful, do the success continuation,
 otherwise, return the failure value
 
+For a more detailed overview of how to use a Trie,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+trie := Trie.put(trie, key "ciao", Text.equal, 10).0;
+// `replaceThen` takes the same arguments as `replace` but also a success continuation
+// and a failure connection that are called in the respective scenarios.
+// if the replace fails, that is the key is not present in the trie, the failure continuation is called.
+// if the replace succeeds, that is the key is present in the trie, the success continuation is called.
+// in this example we are simply returning the Text values `success` and `fail` respectively.
+var continuation = Trie.replaceThen<Text, Nat, Text>(
+  trie,
+  key "hello",
+  Text.equal,
+  12,
+  func (t, v) = "success",
+  func () = "fail"
+);
+assert (continuation == "success");
+continuation := Trie.replaceThen<Text, Nat, Text>(
+  trie,
+  key "shalom",
+  Text.equal,
+  12,
+  func (t, v) = "success",
+  func () = "fail"
+);
+assert (continuation == "fail");
+```
+
 ## Function `putFresh`
 ``` motoko no-repl
 func putFresh<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool, v : V) : Trie<K, V>
 ```
 
 Put the given key's value in the trie; return the new trie; assert that no prior value is associated with the key
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+// note that compared to `put`, `putFresh` does not return a tuple
+trie := Trie.putFresh(trie, key "hello", Text.equal, 42);
+trie := Trie.putFresh(trie, key "bye", Text.equal, 32);
+// this will fail as "hello" is already present in the trie
+trie := Trie.putFresh(trie, key "hello", Text.equal, 10);
+```
 
 ## Function `put2D`
 ``` motoko no-repl
@@ -415,6 +800,18 @@ func remove<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool) : (Trie<K, 
 ```
 
 Remove the given key's value in the trie; return the new trie
+
+For a more detailed overview of how to use a `Trie`,
+see the [User's Overview](#overview).
+
+Example:
+```motoko include=initialize
+trie := Trie.put(trie, key "hello", Text.equal, 42).0;
+trie := Trie.put(trie, key "bye", Text.equal, 32).0;
+// remove the value associated with "hello"
+trie := Trie.remove(trie, key "hello", Text.equal).0;
+assert (Trie.get(trie, key "hello", Text.equal) == null);
+```
 
 ## Function `removeThen`
 ``` motoko no-repl

--- a/doc/md/base/TrieMap.md
+++ b/doc/md/base/TrieMap.md
@@ -19,7 +19,11 @@ import Iter "mo:base/Iter";
 let map = TrieMap.TrieMap<Nat, Nat>(Nat.equal, Hash.hash)
 ```
 
-## `class TrieMap<K, V>`
+## Class `TrieMap<K, V>`
+
+``` motoko no-repl
+class TrieMap<K, V>(isEq : (K, K) -> Bool, hashOf : K -> Hash.Hash)
+```
 
 
 ### Function `size`

--- a/doc/md/base/TrieSet.md
+++ b/doc/md/base/TrieSet.md
@@ -51,6 +51,20 @@ func size<T>(s : Set<T>) : Nat
 
 The number of set elements, set's cardinality.
 
+## Function `isEmpty`
+``` motoko no-repl
+func isEmpty<T>(s : Set<T>) : Bool
+```
+
+Test if `s` is the empty set.
+
+## Function `isSubset`
+``` motoko no-repl
+func isSubset<T>(s1 : Set<T>, s2 : Set<T>, eq : (T, T) -> Bool) : Bool
+```
+
+Test if `s1` is a subset of `s2`.
+
 ## Function `mem`
 ``` motoko no-repl
 func mem<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Bool

--- a/doc/md/base/index.md
+++ b/doc/md/base/index.md
@@ -8,21 +8,21 @@
 * [CertifiedData](CertifiedData.md) Certified data.
 * [Char](Char.md) Characters
 * [Debug](Debug.md) Utility functions for debugging.
-* [Deque](Deque.md) Functions for persistent, double-ended queues.
+* [Deque](Deque.md) Double-ended queue (deque) of a generic element type `T`.
 * [Error](Error.md) Error values and inspection.
-* [ExperimentalCycles](ExperimentalCycles.md) Managing cycles
+* [ExperimentalCycles](ExperimentalCycles.md) Managing cycles within actors on the Internet Computer (IC).
 * [ExperimentalInternetComputer](ExperimentalInternetComputer.md) Low-level interface to the Internet Computer.
 * [ExperimentalStableMemory](ExperimentalStableMemory.md) Byte-level access to (virtual) _stable memory_.
-* [Float](Float.md) 64-bit Floating-point numbers
-* [Func](Func.md) Functions on functions
+* [Float](Float.md) Double precision (64-bit) floating-point numbers in IEEE 754 representation.
+* [Func](Func.md) Functions on functions, creating functions from simpler inputs.
 * [Hash](Hash.md) Hash values
-* [HashMap](HashMap.md) Mutable hash map (aka Hashtable)
+* [HashMap](HashMap.md) Class `HashMap<K, V>` provides a hashmap from keys of type `K` to values of type `V`.
 * [Heap](Heap.md) Priority Queue
-* [Int](Int.md) Integer numbers
-* [Int16](Int16.md) 16-bit signed integers with checked arithmetic
-* [Int32](Int32.md) 32-bit signed integers with checked arithmetic
-* [Int64](Int64.md) 64-bit signed integers with checked arithmetic
-* [Int8](Int8.md) 8-bit signed integers with checked arithmetic
+* [Int](Int.md) Signed integer numbers with infinite precision (also called big integers).
+* [Int16](Int16.md) 16-bit signed integers with checked arithmetic.
+* [Int32](Int32.md) 32-bit signed integers with checked arithmetic.
+* [Int64](Int64.md) 64-bit signed integers with checked arithmetic.
+* [Int8](Int8.md) 8-bit signed integers with checked arithmetic.
 * [Iter](Iter.md) Iterators
 * [IterType](IterType.md) The Iterator type
 * [List](List.md) Purely-functional, singly-linked lists.
@@ -36,12 +36,13 @@
 * [Order](Order.md) Order
 * [Prelude](Prelude.md) General utilities
 * [Principal](Principal.md) IC principals (user and canister smart contract IDs)
-* [RBTree](RBTree.md) Red-Black Trees
+* [RBTree](RBTree.md) Key-value map implemented as a red-black tree (RBTree) with nodes storing key-value pairs.
 * [Random](Random.md) A module for obtaining randomness on the Internet Computer (IC).
 * [Result](Result.md) Error handling with the Result type.
-* [Stack](Stack.md) Stack collection (LIFO discipline).
-* [Text](Text.md) Text values
+* [Stack](Stack.md) Class `Stack<X>` provides a Minimal LIFO stack of elements of type `X`.
+* [Text](Text.md) Utility functions for `Text` values.
 * [Time](Time.md) System time
+* [Timer](Timer.md) Timers for one-off or periodic tasks.
 * [Trie](Trie.md) Functional key-value hash maps.
 * [TrieMap](TrieMap.md) Class `TrieMap<K, V>` provides a map from keys of type `K` to values of type `V`.
 * [TrieSet](TrieSet.md) Functional set

--- a/src/docs/plain.ml
+++ b/src/docs/plain.ml
@@ -240,11 +240,18 @@ let rec declaration_header :
       end_block buf;
       doc_comment ()
   | Class class_doc ->
-      title buf lvl "`";
+      title buf lvl "";
       plain_of_obj_sort buf class_doc.sort;
+      bprintf buf "Class `%s" class_doc.name;
+      plain_of_typ_binders buf plain_render_functions class_doc.type_args;
+      bprintf buf "`\n";
+      begin_block buf;
       bprintf buf "class %s" class_doc.name;
       plain_of_typ_binders buf plain_render_functions class_doc.type_args;
-      bprintf buf "`\n\n";
+      bprintf buf "(";
+      sep_by buf ", " (function_arg buf) class_doc.constructor;
+      bprintf buf ")";
+      end_block buf;
       doc_comment ();
       sep_by buf "\n" (plain_of_doc buf (lvl + 1)) class_doc.fields
   | Unknown u ->


### PR DESCRIPTION
Resolves #3721 by adjusting the output of class members to use the same format as functions, types, and values. 

Since there's a lot of noise in this PR from other base library changes, here's an example of the new output: [`Random.Finite()`](https://github.com/dfinity/motoko/pull/3722/files#diff-0e47a97d3a5d33f1c8aa4ec08b3d79551388f614fc34d0ca958bf19eee0bc5ccR42-R46)