### PR TITLE
chore: make timer tests more deterministic

### DIFF
--- a/test/run-drun/ok/timer-cancel.drun-run.ok
+++ b/test/run-drun/ok/timer-cancel.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
 debug.print: CANCELLING!
-debug.print: {counter = 4}
+debug.print: {attempts = 200; counter = 4}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/timer-cancel.drun-run.ok
+++ b/test/run-drun/ok/timer-cancel.drun-run.ok
@@ -1,8 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: TICK!
-debug.print: TICK!
-debug.print: TICK!
 debug.print: CANCELLING!
 debug.print: {counter = 4}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/timer-cancel.ic-ref-run.ok
+++ b/test/run-drun/ok/timer-cancel.ic-ref-run.ok
@@ -4,5 +4,5 @@
 <= replied: ()
 => update go()
 debug.print: CANCELLING!
-debug.print: {counter = 4}
+debug.print: {attempts = 200; counter = 4}
 <= replied: ()

--- a/test/run-drun/ok/timer-cancel.ic-ref-run.ok
+++ b/test/run-drun/ok/timer-cancel.ic-ref-run.ok
@@ -3,9 +3,6 @@
 => update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0...
 <= replied: ()
 => update go()
-debug.print: TICK!
-debug.print: TICK!
-debug.print: TICK!
 debug.print: CANCELLING!
 debug.print: {counter = 4}
 <= replied: ()

--- a/test/run-drun/ok/timer-initial.drun-run.ok
+++ b/test/run-drun/ok/timer-initial.drun-run.ok
@@ -1,5 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
-debug.print: INITIAL!
 ingress Completed: Reply: 0x4449444c0000
 debug.print: {count = 1}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/timer-initial.ic-ref-run.ok
+++ b/test/run-drun/ok/timer-initial.ic-ref-run.ok
@@ -3,6 +3,5 @@
 => update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0...
 <= replied: ()
 => update go()
-debug.print: INITIAL!
 debug.print: {count = 1}
 <= replied: ()

--- a/test/run-drun/timer-cancel.mo
+++ b/test/run-drun/timer-cancel.mo
@@ -37,7 +37,7 @@ actor {
        if (attempts >= 200)
          counter += 1;
      };
-     debugPrint(debug_show {counter});
+     debugPrint(debug_show {attempts; counter});
   };
 };
 

--- a/test/run-drun/timer-cancel.mo
+++ b/test/run-drun/timer-cancel.mo
@@ -7,7 +7,6 @@ actor {
   var t : Nat = 0;
 
   private func remind() : async () {
-    debugPrint("TICK!");
     counter += 1;
   };
 

--- a/test/run-drun/timer-initial.mo
+++ b/test/run-drun/timer-initial.mo
@@ -7,7 +7,6 @@ actor {
   system func timer(setGlobalTimer : Nat64 -> ()) : async () {
       count += 1;
       setGlobalTimer 0; // FIXME: this shouldn't be necessary for recent `drun`, but we might run an outdated version...
-      debugPrint "INITIAL!";
   };
 
   let raw_rand = (actor "aaaaa-aa" : actor { raw_rand : () -> async Blob }).raw_rand;


### PR DESCRIPTION
This removes the textual outputs and relies on checking the globals instead.