### PR TITLE
Exclude updating nix hash for dependabot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 
     - name: Calculate performance delta
-      if: runner.os == 'Linux' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && github.event_name == 'pull_request'
       run: |
         from="$(git merge-base origin/${{ github.base_ref }} HEAD)"
         to="${{ github.event.pull_request.head.sha }}"
@@ -50,14 +50,14 @@ jobs:
           --argstr to "$to"
 
     - name: Read performance delta
-      if: runner.os == 'Linux' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && github.event_name == 'pull_request'
       id: perf
       uses: juliangruber/read-file-action@v1.1.5
       with:
         path: ./perf-delta.txt
 
     - name: Find performance comment
-      if: runner.os == 'Linux' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && github.event_name == 'pull_request'
       uses: peter-evans/find-comment@v2.0.1
       id: fc
       with:
@@ -68,7 +68,7 @@ jobs:
     # Forks can't add comments so this job does not run on forks, see
     # motoko#2864.
     - name: Create or update performance comment
-      if: runner.os == 'Linux' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: peter-evans/create-or-update-comment@v2.1.0
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   examine-author:
+    if: github.actor != "kentosugama"
     runs-on: ubuntu-latest
     steps:
     - name: View PR author

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -8,13 +8,8 @@ on:
       - '**'
 
 jobs:
-  examine-author:
-    if: github.actor !=  'kentosugama'
-    runs-on: ubuntu-latest
-    steps:
-    - name: View PR author
-      run: echo "This PR is opened by ${{ github.actor }} ."
   update-hash:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -8,11 +8,11 @@ on:
       - '**'
 
 jobs:
-  examine-author: 
+  examine-author:
     runs-on: ubuntu-latest
     steps:
     - name: View PR author
-      run: echo "This PR is opened by ${{ github.event.pull_request.user.login }} ."
+      run: echo "This PR is opened by ${{ github.actor }} ."
   update-hash:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   examine-author:
-    if: github.actor != 'kentosugama'
+    if: github.actor !=  'kentosugama'
     runs-on: ubuntu-latest
     steps:
     - name: View PR author

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   examine-author:
-    if: github.actor != "kentosugama"
+    if: github.actor != 'kentosugama'
     runs-on: ubuntu-latest
     steps:
     - name: View PR author

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -8,6 +8,11 @@ on:
       - '**'
 
 jobs:
+  examine-author: 
+    runs-on: ubuntu-latest
+    steps:
+    - name: View PR author
+      run: echo "This PR is opened by ${{ github.event.pull_request.user.login }} ."
   update-hash:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Restrict _dependabot_ from running on actions that need access token. The reason is that PRs initiated by dependabot don't have access to the `NIV_UPDATER_TOKEN` and thus cannot modify the repository, causing every build to fail twice:
- in the `update-hash` workflow
- in the performance diffing step of the `build` workflow when changing a PR comment.

This PR suppresses those mutations and as such the automatisms can bring the PR to completion.

For reference, a [recent failed CI run's log](https://github.com/dfinity/motoko/actions/runs/4025099722/jobs/6918617978).