### PR TITLE
chore: bump `upload-release-action`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
     - run: nix-build --max-jobs 1 --arg officialRelease true release-files.nix
 
     - name: Upload Release Assets
-      uses: svenstaro/upload-release-action@74f6bde645a3f5f70c0311ede61fb790fd79441a
+      uses: svenstaro/upload-release-action@72f6bf584affe60a3dda8f3983bc80f207768868
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}


### PR DESCRIPTION
This should fix the upload difficulties we had for a few days.

When there is an official release I'll bump again.