### PR TITLE
chore: stop `mergify` from looping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
     - run: nix-build --max-jobs 1 --arg officialRelease true release-files.nix
 
     - name: Upload Release Assets
-      uses: svenstaro/upload-release-action@72f6bf584affe60a3dda8f3983bc80f207768868
+      uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -60,6 +60,7 @@ pull_request_rules:
         message: A change to `Changelog.md`? I can handle that!
   - name: Auto-approve dependabot PR
     conditions:
+      - open
       - files=doc/docusaurus/package-lock.json
       - "#files=1"
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -60,6 +60,7 @@ pull_request_rules:
         message: A change to `Changelog.md`? I can handle that!
   - name: Auto-approve dependabot PR
     conditions:
+      - -merged
       - -closed
       - files=doc/docusaurus/package-lock.json
       - "#files=1"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -60,7 +60,7 @@ pull_request_rules:
         message: A change to `Changelog.md`? I can handle that!
   - name: Auto-approve dependabot PR
     conditions:
-      - open
+      - -closed
       - files=doc/docusaurus/package-lock.json
       - "#files=1"
     actions:


### PR DESCRIPTION
For some strange reason #3762 exhibits a looping behaviour adding and removing the merge label. Stop it.

Fun fact: in #3559 the bot has tried >14000 times.