### PR TITLE
bugfix: follow on PR to #3758 (optimization and refactoring)

### DIFF
--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -1117,5 +1117,3 @@ let import_unit (u : S.comp_unit) : import_declaration =
       letD (var (id_of_full_path f) mod_typ) mod_exp ]
   | I.ProgU ds ->
     raise (Invalid_argument "Desugar: Cannot import program")
-
-

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -939,92 +939,31 @@ let import_compiled_class (lib : S.comp_unit) wasm : import_declaration =
   let _, _, t_actor = T.as_async (T.normalize t_async) in
   let cs' = T.open_binds tbs in
   let c', _ = T.as_con (List.hd cs') in
-  let available = fresh_var "available" T.nat in
-  let accepted = fresh_var "accepted" T.nat in
-  let cycles = var "@cycles" (T.Mut (T.nat)) in
+  let install_actor_helper = var "@install_actor_helper"
+    (T.Func (T.Local, T.Returns, [T.scope_bind],
+      [T.install_arg_typ; T.blob; T.blob],
+      [T.Async(T.Cmp, T.Var (T.default_scope_var, 0), T.principal)]))
+  in
+  let wasm_blob = fresh_var "wasm_blob" T.blob in
   let install_arg =
     fresh_var "install_arg" T.install_arg_typ  in
   let installBody =
     let vs = fresh_vars "param" ts1' in
     let principal = fresh_var "principal" T.principal in
-    let principal1 = fresh_var "principal1" T.principal in
-    let actor1 = fresh_var "actor1" T.(obj Actor []) in
-    let actor2 = fresh_var "actor2" T.(obj Actor []) in
-    let mode_typ = T.(sum [
-      ("install", unit);
-      ("reinstall", unit);
-      ("upgrade",  unit) ])
-    in
-    let record_typ = T.(obj Object [
-      ("mode", mode_typ);
-      ("canister_id", principal);
-      ("wasm_module", blob);
-      ("arg", blob)])
-    in
-    let ic00_install_code = var "@ic00_install_code"
-      T.(Func (Local, Returns, [],
-          [],
-          [Func (Shared Write, Promises, [scope_bind],
-            [record_typ],
-            [])]))
-    in
-    let ic00_create_canister = var "@ic00_create_canister"
-      T.(Func (Local, Returns, [],
-          [],
-          [Func (Shared Write, Promises, [scope_bind],
-            [canister_settings_typ],
-            [obj Object ["canister_id", principal]])]))
-    in
-    let modeprincipal =
-      fresh_var "modeprincipal" T.(Tup [mode_typ; principal])
-    in
-    let record =
-      fresh_var "record" record_typ in
-    let settings =
-      fresh_var "settings" T.canister_settings_typ
-    in
     funcE id T.Local T.Returns
     [typ_arg c T.Scope T.scope_bound]
     (List.map arg_of_var vs)
     ts2'
-    (asyncE T.Fut (* TBR *) (* make this T.Cmp *)
+    (asyncE T.Fut
       (typ_arg c' T.Scope T.scope_bound)
-      (blockE
-        [ letD modeprincipal
-            (switch_variantE (varE install_arg) [
-               ("new", varP settings,
-                tupE [
-                  tagE "install" (unitE());
-                  blockE
-                    [ (* pass on cycles *)
-                      letD available (primE Ir.SystemCyclesAvailablePrim []);
-                      letD accepted (primE Ir.SystemCyclesAcceptPrim [varE available]);
-                      expD (assignE cycles (varE accepted)) ]
-                      (dotE
-                         (awaitE T.Fut
-                           (callE (callE (varE ic00_create_canister) [] (unitE()))
-                              cs' (varE settings)))
-                         "canister_id" T.principal)]);
-               ("install", varP principal1,
-                tupE [tagE "install" (unitE());
-                      varE principal1]);
-               ("reinstall", varP actor1,
-                tupE [tagE "reinstall" (unitE());
-                      primE (Ir.CastPrim (T.(obj Actor []), T.principal)) [varE actor1]]);
-               ("upgrade", varP actor2,
-                tupE [tagE "upgrade" (unitE());
-                      primE (Ir.CastPrim (T.(obj Actor []), T.principal)) [varE actor2]])]
-               (T.(Tup [mode_typ; principal])));
-          letD principal (projE (varE modeprincipal) 1);
-          letD record (recordE [
-            ("mode", projE (varE modeprincipal) 0);
-            ("canister_id", varE principal);
-            ("wasm_module", blobE wasm);
-            ("arg", primE (Ir.SerializePrim ts1') [seqE (List.map varE vs)])
-          ]);
-          expD (awaitE T.Fut (callE (callE (varE ic00_install_code) [] (unitE()) ) cs' (varE record)))
-        ]
-        (primE (Ir.CastPrim (T.principal, t_actor)) [varE principal]))
+      (letE principal
+         (awaitE T.Cmp
+           (callE (varE install_actor_helper) cs'
+              (tupE [
+                 varE install_arg;
+                 varE wasm_blob;
+                 primE (Ir.SerializePrim ts1') [seqE (List.map varE vs)]])))
+         (primE (Ir.CastPrim (T.principal, t_actor)) [varE principal]))
       (List.hd cs))
   in
   let install =
@@ -1034,35 +973,28 @@ let import_compiled_class (lib : S.comp_unit) wasm : import_declaration =
       [installBody.note.Note.typ]
     installBody
   in
-  let install_var = fresh_var "install" install.note.Note.typ in
-  (* eta-expansion of
-     `install { new = { setting = null} }: ts1 -> async class_typ`, i.e.
-     `func vs = async await (install { new = { setting = null} } vs`
-     This must be pure to allow dead-coding of unused classes, hence the eta-expansion
-   *)
   let install_new =
     let vs = fresh_vars "param" ts1' in
+    let principal = fresh_var "principal" T.principal in
     funcE id T.Local T.Returns
       [typ_arg c T.Scope T.scope_bound]
       (List.map arg_of_var vs)
       ts2'
-      (asyncE
-         T.Fut
-         (typ_arg c' T.Scope T.scope_bound)
-         (blockE [
-           (* pass on cycles *)
-           letD available (primE Ir.SystemCyclesAvailablePrim []);
-           letD accepted (primE Ir.SystemCyclesAcceptPrim [varE available]);
-           expD (assignE cycles (varE accepted)) ]
-           (awaitE T.Fut
-             (callE (callE (varE install_var) [] (tagE "new" (recordE ["settings", nullE()])))
-               cs'
-               (seqE (List.map varE vs)))))
-         (List.hd cs))
+      (asyncE T.Fut
+        (typ_arg c' T.Scope T.scope_bound)
+        (letE principal
+           (awaitE T.Cmp
+              (callE (varE install_actor_helper) cs'
+                 (tupE [
+                   tagE "new" (recordE ["settings", nullE()]);
+                   varE wasm_blob;
+                   primE (Ir.SerializePrim ts1') [seqE (List.map varE vs)]])))
+        (primE (Ir.CastPrim (T.principal, t_actor)) [varE principal]))
+      (List.hd cs))
   in
-  let mod_exp = actor_class_mod_exp id class_typ (varE install_var) install_new in
+  let mod_exp = actor_class_mod_exp id class_typ install install_new in
   let mod_typ = mod_exp.note.Note.typ in
-  [ letD install_var install;
+  [ letD wasm_blob (blobE wasm);
     letD (var (id_of_full_path f) mod_typ) mod_exp ]
 
 let import_prelude prelude : import_declaration =

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -397,23 +397,6 @@ let @ic00 = actor "aaaaa-aa" :
     } -> async ()
  };
 
-// TBD
-func @ic00_create_canister() : shared {
-      settings : ?@ManagementCanister.canister_settings
-    } -> async { canister_id : Principal } {
-  @ic00.create_canister
-};
-
-// TBD
-func @ic00_install_code() : shared {
-    mode : { #install; #reinstall; #upgrade };
-    canister_id : Principal;
-    wasm_module : @ManagementCanister.wasm_module;
-    arg : Blob;
-  } -> async () {
-  @ic00.install_code
-};
-
 func @install_actor_helper(
     install_arg: {
       #new : { settings : ?@ManagementCanister.canister_settings } ;
@@ -457,19 +440,19 @@ func @install_actor_helper(
 // without paying the extra self-remote-call-cost
 // TODO: This helper is now only used by Prim.createActor and could be removed, except
 // that Prim.createActor was mentioned on the forum and might be in use. (#3420)
-func @create_actor_helper(wasm_module_ : Blob, arg_ : Blob) : async Principal = async {
+func @create_actor_helper(wasm_module : Blob, arg : Blob) : async Principal = async {
   let available = (prim "cyclesAvailable" : () -> Nat) ();
   let accepted = (prim "cyclesAccept" : Nat -> Nat) (available);
   @cycles += accepted;
-  let { canister_id = canister_id_ } =
+  let { canister_id } =
     await @ic00.create_canister({settings = null});
   await @ic00.install_code({
     mode = #install;
-    canister_id = canister_id_;
-    wasm_module = wasm_module_;
-    arg = arg_;
+    canister_id;
+    wasm_module;
+    arg;
   });
-  return canister_id_;
+  return canister_id;
 };
 
 // raw calls

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -397,12 +397,14 @@ let @ic00 = actor "aaaaa-aa" :
     } -> async ()
  };
 
+// TBD
 func @ic00_create_canister() : shared {
       settings : ?@ManagementCanister.canister_settings
     } -> async { canister_id : Principal } {
   @ic00.create_canister
 };
 
+// TBD
 func @ic00_install_code() : shared {
     mode : { #install; #reinstall; #upgrade };
     canister_id : Principal;
@@ -430,23 +432,20 @@ func @install_actor_helper(
         @cycles += accepted;
         let { canister_id } =
           await @ic00.create_canister(settings);
-        (#install,
-          canister_id)
+        (#install, canister_id)
       };
       case (#install principal1) {
         (#install, principal1)
       };
       case (#reinstall actor1) {
-        (#reinstall,
-          (prim "cast" : (actor {}) -> Principal) actor1)
+        (#reinstall, (prim "cast" : (actor {}) -> Principal) actor1)
       };
       case (#upgrade actor2) {
-        (#upgrade,
-          (prim "cast" : (actor {}) -> Principal) actor2)
+        (#upgrade, (prim "cast" : (actor {}) -> Principal) actor2)
       }
     };
   await @ic00.install_code({
-    mode = #install;
+    mode;
     canister_id;
     wasm_module;
     arg

--- a/test/fail/ok/illegal-await.tc.ok
+++ b/test/fail/ok/illegal-await.tc.ok
@@ -24,14 +24,14 @@ illegal-await.mo:24.11: info, start of scope $anon-async-24.11 mentioned in erro
 illegal-await.mo:26.5: info, end of scope $anon-async-24.11 mentioned in error at illegal-await.mo:25.7-25.14
 illegal-await.mo:22.10: info, start of scope $anon-async-22.10 mentioned in error at illegal-await.mo:25.7-25.14
 illegal-await.mo:27.3: info, end of scope $anon-async-22.10 mentioned in error at illegal-await.mo:25.7-25.14
-illegal-await.mo:35.11-35.12: type error [M0087], ill-scoped await: expected async type from current scope $Rec, found async type from other scope $__17
+illegal-await.mo:35.11-35.12: type error [M0087], ill-scoped await: expected async type from current scope $Rec, found async type from other scope $__13
   scope $Rec is illegal-await.mo:33.44-40.2
-  scope $__17 is illegal-await.mo:33.1-40.2
+  scope $__13 is illegal-await.mo:33.1-40.2
 illegal-await.mo:33.44: info, start of scope $Rec mentioned in error at illegal-await.mo:35.5-35.12
 illegal-await.mo:40.1: info, end of scope $Rec mentioned in error at illegal-await.mo:35.5-35.12
-illegal-await.mo:33.1: info, start of scope $__17 mentioned in error at illegal-await.mo:35.5-35.12
-illegal-await.mo:40.1: info, end of scope $__17 mentioned in error at illegal-await.mo:35.5-35.12
+illegal-await.mo:33.1: info, start of scope $__13 mentioned in error at illegal-await.mo:35.5-35.12
+illegal-await.mo:40.1: info, end of scope $__13 mentioned in error at illegal-await.mo:35.5-35.12
 illegal-await.mo:38.20-38.21: type error [M0096], expression of type
-  async<$__17> ()
+  async<$__13> ()
 cannot produce expected type
   async<$Rec> ()

--- a/test/fail/ok/illegal-await.tc.ok
+++ b/test/fail/ok/illegal-await.tc.ok
@@ -24,14 +24,14 @@ illegal-await.mo:24.11: info, start of scope $anon-async-24.11 mentioned in erro
 illegal-await.mo:26.5: info, end of scope $anon-async-24.11 mentioned in error at illegal-await.mo:25.7-25.14
 illegal-await.mo:22.10: info, start of scope $anon-async-22.10 mentioned in error at illegal-await.mo:25.7-25.14
 illegal-await.mo:27.3: info, end of scope $anon-async-22.10 mentioned in error at illegal-await.mo:25.7-25.14
-illegal-await.mo:35.11-35.12: type error [M0087], ill-scoped await: expected async type from current scope $Rec, found async type from other scope $__16
+illegal-await.mo:35.11-35.12: type error [M0087], ill-scoped await: expected async type from current scope $Rec, found async type from other scope $__17
   scope $Rec is illegal-await.mo:33.44-40.2
-  scope $__16 is illegal-await.mo:33.1-40.2
+  scope $__17 is illegal-await.mo:33.1-40.2
 illegal-await.mo:33.44: info, start of scope $Rec mentioned in error at illegal-await.mo:35.5-35.12
 illegal-await.mo:40.1: info, end of scope $Rec mentioned in error at illegal-await.mo:35.5-35.12
-illegal-await.mo:33.1: info, start of scope $__16 mentioned in error at illegal-await.mo:35.5-35.12
-illegal-await.mo:40.1: info, end of scope $__16 mentioned in error at illegal-await.mo:35.5-35.12
+illegal-await.mo:33.1: info, start of scope $__17 mentioned in error at illegal-await.mo:35.5-35.12
+illegal-await.mo:40.1: info, end of scope $__17 mentioned in error at illegal-await.mo:35.5-35.12
 illegal-await.mo:38.20-38.21: type error [M0096], expression of type
-  async<$__16> ()
+  async<$__17> ()
 cannot produce expected type
   async<$Rec> ()


### PR DESCRIPTION
optimizes #3758, exploiting async*/await* to remove a redundant yield on (default) class construction.
Also refactors code to be more understandable, now to we can abstract the installation code into helper in internals.mo, rather than generating lots of unreadable IR.
