### PR TITLE
chore: bump GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Read performance delta
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && github.event_name == 'pull_request'
       id: perf
-      uses: juliangruber/read-file-action@v1.1.5
+      uses: juliangruber/read-file-action@v1
       with:
         path: ./perf-delta.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
       run: nix-build -A report-site -o report-site
     - name: Resolve symlinks
       run: cp -rL report-site report-site-copy
-    - name: Push report to gitub pages
+    - name: Push report to GitHub pages
       uses: JamesIves/github-pages-deploy-action@v4.2.5
       with:
         branch: gh-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Find performance comment
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && github.event_name == 'pull_request'
-      uses: peter-evans/find-comment@v2.0.1
+      uses: peter-evans/find-comment@v2
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -66,7 +66,7 @@ jobs:
     # motoko#2864.
     - name: Create or update performance comment
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-      uses: peter-evans/create-or-update-comment@v2.1.0
+      uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Resolve symlinks
       run: cp -rL report-site report-site-copy
     - name: Push report to GitHub pages
-      uses: JamesIves/github-pages-deploy-action@v4.2.5
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         folder: report-site-copy


### PR DESCRIPTION
This eliminates the `build` action's warning on the Ubuntu builders.