### PR TITLE
chore: make `timer.mo` deterministic

### DIFF
--- a/test/run-drun/timer.mo
+++ b/test/run-drun/timer.mo
@@ -17,7 +17,7 @@ actor {
      var attempts = 0;
 
      let id1 = setTimer(1 * second, false, func () : async () { count += 1; debugPrint "YEP!" });
-     let id2 = setTimer(2 * second, true, func () : async () { count += 1; debugPrint "DIM!" });
+     let id2 = setTimer(2 * (second - second / 10), true, func () : async () { count += 1; debugPrint "DIM!" });
      let id3 = setTimer(3 * second, false, func () : async () {
          count += 1;
          debugPrint "ROOK!";


### PR DESCRIPTION
The updated schedule is
| seconds | reaction |
|----|-----|
| 1,0 | YEP! |
| 1,8  | DIM! |
| 3,0 | ROOK! |
| 3,6 | DIM! |
| 4,0 | BATT! |
| 5,0 | BATT! |
| 6,0 | BATT! |

whereas before the schedule was ambiguous
| seconds | reaction |
|----|-----|
| 1,0 | YEP! |
| 2,0  | DIM! |
| 3,0 | ROOK! |
| **4,0** | DIM! |
| **4,0** | BATT! |
| 5,0 | BATT! |
| 6,0 | BATT! |
