### PR TITLE
fix: stack overflow in UTF-8 encode/decode for moc.js

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -423,7 +423,7 @@ module E = struct
 
   let export_global env name =
     add_export env (nr {
-      name = Wasm.Utf8.decode name;
+      name = Lib.Utf8.decode name;
       edesc = nr (GlobalExport (nr (get_global env name)))
     })
 
@@ -480,8 +480,8 @@ module E = struct
       raise (CodegenError "Add all imports before all functions!");
 
     let i = {
-      module_name = Wasm.Utf8.decode modname;
-      item_name = Wasm.Utf8.decode funcname;
+      module_name = Lib.Utf8.decode modname;
+      item_name = Lib.Utf8.decode funcname;
       idesc = nr (FuncImport (nr (func_type env (FuncType (arg_tys, ret_tys)))))
     } in
     let fi = reg env.func_imports (nr i) in
@@ -1132,7 +1132,7 @@ module Heap = struct
     )) in
 
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "get_heap_base";
+      name = Lib.Utf8.decode "get_heap_base";
       edesc = nr (FuncExport (nr get_heap_base_fn))
     })
 
@@ -3932,7 +3932,7 @@ module IC = struct
           end);
 
       E.add_export env (nr {
-        name = Wasm.Utf8.decode "print_ptr";
+        name = Lib.Utf8.decode "print_ptr";
         edesc = nr (FuncExport (nr (E.built_in env "print_ptr")))
       })
 
@@ -3976,7 +3976,7 @@ module IC = struct
   let default_exports env =
     (* these exports seem to be wanted by the hypervisor/v8 *)
     E.add_export env (nr {
-      name = Wasm.Utf8.decode (
+      name = Lib.Utf8.decode (
         match E.mode env with
         | Flags.WASIMode -> "memory"
         | _  -> "mem"
@@ -3984,7 +3984,7 @@ module IC = struct
       edesc = nr (MemoryExport (nr 0l))
     });
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "table";
+      name = Lib.Utf8.decode "table";
       edesc = nr (TableExport (nr 0l))
     })
 
@@ -4000,7 +4000,7 @@ module IC = struct
     ) in
     let fi = E.add_fun env "canister_init" empty_f in
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "canister_init";
+      name = Lib.Utf8.decode "canister_init";
       edesc = nr (FuncExport (nr fi))
       })
 
@@ -4016,7 +4016,7 @@ module IC = struct
         GC.record_mutator_instructions env (* future: GC.collect_garbage env *)))
     in
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "canister_heartbeat";
+      name = Lib.Utf8.decode "canister_heartbeat";
       edesc = nr (FuncExport (nr fi))
     })
 
@@ -4033,7 +4033,7 @@ module IC = struct
         GC.record_mutator_instructions env (* future: GC.collect_garbage env *)))
     in
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "canister_global_timer";
+      name = Lib.Utf8.decode "canister_global_timer";
       edesc = nr (FuncExport (nr fi))
     })
 
@@ -4046,7 +4046,7 @@ module IC = struct
         (* no need to GC !*)))
     in
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "canister_inspect_message";
+      name = Lib.Utf8.decode "canister_inspect_message";
       edesc = nr (FuncExport (nr fi))
     })
 
@@ -4058,7 +4058,7 @@ module IC = struct
       Lifecycle.trans env Lifecycle.Idle
     )) in
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "_start";
+      name = Lib.Utf8.decode "_start";
       edesc = nr (FuncExport (nr fi))
       })
 
@@ -4088,12 +4088,12 @@ module IC = struct
     )) in
 
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "canister_pre_upgrade";
+      name = Lib.Utf8.decode "canister_pre_upgrade";
       edesc = nr (FuncExport (nr pre_upgrade_fi))
     });
 
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "canister_post_upgrade";
+      name = Lib.Utf8.decode "canister_post_upgrade";
       edesc = nr (FuncExport (nr post_upgrade_fi))
     })
 
@@ -4708,7 +4708,7 @@ module RTS_Exports = struct
       )
     ) in
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "bigint_trap";
+      name = Lib.Utf8.decode "bigint_trap";
       edesc = nr (FuncExport (nr bigint_trap_fi))
     });
 
@@ -4720,7 +4720,7 @@ module RTS_Exports = struct
       )
     ) in
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "rts_trap";
+      name = Lib.Utf8.decode "rts_trap";
       edesc = nr (FuncExport (nr rts_trap_fi))
     });
 
@@ -4734,7 +4734,7 @@ module RTS_Exports = struct
           )
       else E.reuse_import env "ic0" "stable64_write" in
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "stable64_write_moc";
+      name = Lib.Utf8.decode "stable64_write_moc";
       edesc = nr (FuncExport (nr stable64_write_moc_fi))
     })
 
@@ -6826,7 +6826,7 @@ module GCRoots = struct
     )) in
 
     E.add_export env (nr {
-      name = Wasm.Utf8.decode "get_static_roots";
+      name = Lib.Utf8.decode "get_static_roots";
       edesc = nr (FuncExport (nr get_static_roots))
     })
 
@@ -7664,7 +7664,7 @@ module FuncDec = struct
 
       let fi = E.built_in env name in
       E.add_export env (nr {
-        name = Wasm.Utf8.decode ("canister_update " ^ name);
+        name = Lib.Utf8.decode ("canister_update " ^ name);
         edesc = nr (FuncExport (nr fi))
       })
     | _ -> ()
@@ -10167,7 +10167,7 @@ and export_actor_field env  ae (f : Ir.field) =
     | _ -> assert false in
 
   E.add_export env (nr {
-    name = Wasm.Utf8.decode (match E.mode env with
+    name = Lib.Utf8.decode (match E.mode env with
       | Flags.ICMode | Flags.RefMode ->
         Mo_types.Type.(
         match normalize f.note with

--- a/src/exes/dune
+++ b/src/exes/dune
@@ -25,7 +25,7 @@
 (executable
  (name didc)
  (modules didc)
- (libraries idllib source_id)
+ (libraries lib idllib source_id)
  (instrumentation (backend bisect_ppx --bisect-silent yes))
 )
 (executable

--- a/src/idllib/lexer.mll
+++ b/src/idllib/lexer.mll
@@ -1,6 +1,6 @@
 {
 open Parser
-module Utf8 = Wasm.Utf8
+module Utf8 = Lib.Utf8
 
 let convert_pos pos =
   { Source.file = pos.Lexing.pos_fname;

--- a/src/idllib/parser.mly
+++ b/src/idllib/parser.mly
@@ -80,8 +80,8 @@ seplist(X, SEP) :
 
 %inline text :
  | s=TEXT
-   { try ignore (Wasm.Utf8.decode s); s
-     with Wasm.Utf8.Utf8 -> raise (ParseError (at $sloc, "Invalid UTF-8"))
+   { try ignore (Lib.Utf8.decode s); s
+     with Lib.Utf8.Utf8 -> raise (ParseError (at $sloc, "Invalid UTF-8"))
    }
 
 %inline id :

--- a/src/ir_interpreter/interpret_ir.ml
+++ b/src/ir_interpreter/interpret_ir.ml
@@ -415,9 +415,9 @@ and interpret_exp_mut env exp (k : V.value V.cont) =
         k v1
       | DecodeUtf8, [v1] ->
         let s = V.as_blob v1 in
-        begin match Wasm.Utf8.decode s with
+        begin match Lib.Utf8.decode s with
           | _ -> k (V.Opt (V.Text s))
-          | exception Wasm.Utf8.Utf8 -> k V.Null
+          | exception Lib.Utf8.Utf8 -> k V.Null
         end
       | EncodeUtf8, [v1] ->
         k (V.Blob (V.as_text v1))

--- a/src/js/dune
+++ b/src/js/dune
@@ -25,7 +25,7 @@
  (name didc_js)
  (modes js)
  (modules didc_js)
- (libraries idllib lang_utils)
+ (libraries lib idllib lang_utils)
  (preprocess (pps js_of_ocaml-ppx))
 )
 

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name lib)
- (libraries bigarray checkseum)
+ (libraries bigarray checkseum wasm)
  (inline_tests)
  (preprocess (pps ppx_inline_test))
   (instrumentation (backend bisect_ppx --bisect-silent yes))

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -711,7 +711,7 @@ struct
   let%test "Base32.decode 000000000000" = Base32.decode "AAAAAAAA" = Ok "\x00\x00\x00\x00\x00"
   let%test "Base32.decode DEADBEEF" = Base32.decode "32W353Y" = Ok "\xDE\xAD\xBE\xEF"
 
-  let%test "Utf8.decode prim emoji" = Utf8.encode (Utf8.decode "mo:⛔") = "mo:⛔"
+  let%test "Utf8.decode/encode prim emoji" = Utf8.encode (Utf8.decode "mo:⛔") = "mo:⛔"
 
   let%test "Utf8.is_valid agrees with Utf8.decode for single-byte strings" =
     let rec loop f i =

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -309,20 +309,11 @@ struct
       | n::ns when n < 0x80 ->
         encode' (n::acc) ns
       | n::ns when n < 0x800 ->
-        let b1 = 0xc0 lor (n lsr 6) in
-        let b2 = con n in
-        encode' (b1::b2::acc) ns
+        encode' (0xc0 lor (n lsr 6) :: con n :: acc) ns
       | n::ns when n < 0x10000 ->
-        let b1 = 0xe0 lor (n lsr 12) in
-        let b2 = con (n lsr 6) in
-        let b3 = con n in
-        encode' (b1::b2::b3::acc) ns
+        encode' (0xe0 lor (n lsr 12) :: con (n lsr 6) :: con n :: acc) ns
       | n::ns when n < 0x110000 ->
-        let b1 = 0xf0 lor (n lsr 18) in
-        let b2 = con (n lsr 12) in
-        let b3 = con (n lsr 6) in
-        let b4 = con n in
-        encode' (b1::b2::b3::b4::acc) ns
+        encode' (0xf0 lor (n lsr 18) :: con (n lsr 12) :: con (n lsr 6) :: con n :: acc) ns
       | _ ->
         raise Utf8
 end

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -266,7 +266,7 @@ struct
     | _ ->
       raise Utf8 *)
     and decode' acc = function
-      | [] -> acc
+      | [] -> List.rev acc
       | b1::bs when b1 < 0x80 ->
         decode' (code 0x0 b1 :: acc) bs
       | b1::bs when b1 < 0xc2 -> raise Utf8

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -266,7 +266,7 @@ struct
     | _ ->
       raise Utf8 *)
     and decode' acc = function
-      | [] -> List.rev acc
+      | [] -> acc
       | b1::bs when b1 < 0x80 ->
         decode' (code 0x0 b1 :: acc) bs
       | b1::bs when b1 < 0xc2 -> raise Utf8
@@ -711,7 +711,7 @@ struct
   let%test "Base32.decode 000000000000" = Base32.decode "AAAAAAAA" = Ok "\x00\x00\x00\x00\x00"
   let%test "Base32.decode DEADBEEF" = Base32.decode "32W353Y" = Ok "\xDE\xAD\xBE\xEF"
 
-  let%test "Utf8.decode prim emoji" = Utf8.decode "mo:⛔" = Wasm.Utf8.decode "mo:⛔"
+  let%test "Utf8.decode prim emoji" = Utf8.encode (Utf8.decode "mo:⛔") = "mo:⛔"
 
   let%test "Utf8.is_valid agrees with Utf8.decode for single-byte strings" =
     let rec loop f i =

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -279,8 +279,8 @@ struct
       | _ -> raise Utf8
   
   let con n = 0x80 lor (n land 0x3f)
-  let rec encode ns = String.implode (List.map Char.chr (encode' ns))
-  and encode' = function
+  let rec encode ns = String.implode (List.map Char.chr (encode' [] ns))
+  (* and encode' = function
     | [] -> []
     | n::ns when n < 0 ->
       raise Utf8
@@ -294,19 +294,19 @@ struct
       0xf0 lor (n lsr 18) :: con (n lsr 12) :: con (n lsr 6) :: con n
       :: encode' ns
     | _ ->
-      raise Utf8
-    (* and encode' acc = function
+      raise Utf8 *)
+    and encode' acc = function
       | [] -> List.rev acc
       | n::ns when n < 0 -> raise Utf8
       | n::ns when n < 0x80 ->
         encode' (n :: acc) ns
       | n::ns when n < 0x800 ->
-        encode' (0xc0 lor (n lsr 6) :: con n :: acc) ns
+        encode' (con n :: 0xc0 lor (n lsr 6) :: acc) ns
       | n::ns when n < 0x10000 ->
-        encode' (0xe0 lor (n lsr 12) :: con (n lsr 6) :: con n :: acc) ns
+        encode' (con n :: con (n lsr 6) :: 0xe0 lor (n lsr 12) :: acc) ns
       | n::ns when n < 0x110000 ->
-        encode' (0xf0 lor (n lsr 18) :: con (n lsr 12) :: con (n lsr 6) :: con n :: acc) ns
-      | _ -> raise Utf8 *)
+        encode' (con n :: con (n lsr 6) :: con (n lsr 12) :: 0xf0 lor (n lsr 18) :: acc) ns
+      | _ -> raise Utf8
 end
 
 module List =

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -279,8 +279,8 @@ struct
       | _ -> raise Utf8
   
   let con n = 0x80 lor (n land 0x3f)
-  let rec encode ns = String.implode (List.map Char.chr (encode' [] ns))
-  (* and encode' = function
+  let rec encode ns = String.implode (List.map Char.chr (encode' ns))
+  and encode' = function
     | [] -> []
     | n::ns when n < 0 ->
       raise Utf8
@@ -294,8 +294,8 @@ struct
       0xf0 lor (n lsr 18) :: con (n lsr 12) :: con (n lsr 6) :: con n
       :: encode' ns
     | _ ->
-      raise Utf8 *)
-    and encode' acc = function
+      raise Utf8
+    (* and encode' acc = function
       | [] -> List.rev acc
       | n::ns when n < 0 -> raise Utf8
       | n::ns when n < 0x80 ->
@@ -306,7 +306,7 @@ struct
         encode' (0xe0 lor (n lsr 12) :: con (n lsr 6) :: con n :: acc) ns
       | n::ns when n < 0x110000 ->
         encode' (0xf0 lor (n lsr 18) :: con (n lsr 12) :: con (n lsr 6) :: con n :: acc) ns
-      | _ -> raise Utf8
+      | _ -> raise Utf8 *)
 end
 
 module List =

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -230,19 +230,19 @@ struct
   type t = int list
   exception Utf8 = Wasm.Utf8.Utf8
 
-  let rec is_valid s = is_valid' [] (List.map Char.code (String.explode s))
-  and is_valid' acc = function
+  let rec is_valid s = is_valid' (List.map Char.code (String.explode s))
+  and is_valid' = function
     | [] -> true
     | b1::bs when b1 < 0x80 ->
-      is_valid' acc bs
+      is_valid' bs
     | b1::bs when b1 < 0xc2 ->
       false
     | b1::b2::bs when b1 < 0xe0 ->
-      (b2 land 0xc0 = 0x80) && is_valid' acc bs
+      (b2 land 0xc0 = 0x80) && is_valid' bs
     | b1::b2::b3::bs when b1 < 0xf0 ->
-      (b2 land 0xc0 = 0x80) && (b3 land 0xc0 = 0x80) && is_valid' acc bs
+      (b2 land 0xc0 = 0x80) && (b3 land 0xc0 = 0x80) && is_valid' bs
     | b1::b2::b3::b4::bs when b1 < 0xf8 ->
-      (b2 land 0xc0 = 0x80) && (b3 land 0xc0 = 0x80) && (b4 land 0xc0 = 0x80) && is_valid' acc bs
+      (b2 land 0xc0 = 0x80) && (b3 land 0xc0 = 0x80) && (b4 land 0xc0 = 0x80) && is_valid' bs
     | _ ->
       false
   

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -235,7 +235,7 @@ struct
     | [] -> true
     | b1::bs when b1 < 0x80 ->
       is_valid' bs
-    | b1::bs when b1 < 0xc2 -> false
+    | b1::bs when b1 < 0xc0 -> false
     | b1::b2::bs when b1 < 0xe0 ->
       (b2 land 0xc0 = 0x80) && is_valid' bs
     | b1::b2::b3::bs when b1 < 0xf0 ->
@@ -254,7 +254,7 @@ struct
     | [] -> List.rev acc
     | b1::bs when b1 < 0x80 ->
       decode' (code 0x0 b1 :: acc) bs
-    | b1::bs when b1 < 0xc2 -> raise Utf8
+    | b1::bs when b1 < 0xc0 -> raise Utf8
     | b1::b2::bs when b1 < 0xe0 ->
       decode' (code 0x80 ((b1 land 0x1f) lsl 6 + con b2) :: acc) bs
     | b1::b2::b3::bs when b1 < 0xf0 ->

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -235,16 +235,14 @@ struct
     | [] -> true
     | b1::bs when b1 < 0x80 ->
       is_valid' bs
-    | b1::bs when b1 < 0xc2 ->
-      false
+    | b1::bs when b1 < 0xc2 -> false
     | b1::b2::bs when b1 < 0xe0 ->
       (b2 land 0xc0 = 0x80) && is_valid' bs
     | b1::b2::b3::bs when b1 < 0xf0 ->
       (b2 land 0xc0 = 0x80) && (b3 land 0xc0 = 0x80) && is_valid' bs
     | b1::b2::b3::b4::bs when b1 < 0xf8 ->
       (b2 land 0xc0 = 0x80) && (b3 land 0xc0 = 0x80) && (b4 land 0xc0 = 0x80) && is_valid' bs
-    | _ ->
-      false
+    | _ -> false
   
   let con b = if b land 0xc0 = 0x80 then b land 0x3f else raise Utf8
   let code min n =
@@ -271,8 +269,7 @@ struct
       | [] -> List.rev acc
       | b1::bs when b1 < 0x80 ->
         decode' (code 0x0 b1 :: acc) bs
-      | b1::bs when b1 < 0xc0 ->
-        raise Utf8
+      | b1::bs when b1 < 0xc0 -> raise Utf8
       | b1::b2::bs when b1 < 0xe0 ->
         let c = code 0x80 ((b1 land 0x1f) lsl 6 + con b2) in
         decode' (c :: acc) bs
@@ -282,8 +279,7 @@ struct
       | b1::b2::b3::b4::bs when b1 < 0xf8 ->
         let c = code 0x10000 ((b1 land 0x07) lsl 18 + con b2 lsl 12 + con b3 lsl 6 + con b4) in
         decode' (c :: acc) bs
-      | _ ->
-        raise Utf8
+      | _ -> raise Utf8
   
   let con n = 0x80 lor (n land 0x3f)
   let rec encode ns = String.implode (List.map Char.chr (encode' [] ns))
@@ -314,8 +310,7 @@ struct
         encode' (0xe0 lor (n lsr 12) :: con (n lsr 6) :: con n :: acc) ns
       | n::ns when n < 0x110000 ->
         encode' (0xf0 lor (n lsr 18) :: con (n lsr 12) :: con (n lsr 6) :: con n :: acc) ns
-      | _ ->
-        raise Utf8
+      | _ -> raise Utf8
 end
 
 module List =

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -296,7 +296,7 @@ struct
     | _ ->
       raise Utf8 *)
     and encode' acc = function
-      | [] -> List.rev acc
+      | [] -> acc
       | n::ns when n < 0 -> raise Utf8
       | n::ns when n < 0x80 ->
         encode' (n :: acc) ns

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -225,6 +225,91 @@ struct
     Buffer.contents buf
 end
 
+module Utf8 =
+struct
+  type t = int list
+  exception Utf8 = Wasm.Utf8.Utf8
+  let con n = 0x80 lor (n land 0x3f)
+  let rec encode ns = String.implode (List.map Char.chr (encode' [] ns))
+  (* and encode' = function
+    | [] -> []
+    | n::ns when n < 0 ->
+      raise Utf8
+    | n::ns when n < 0x80 ->
+      n :: encode' ns
+    | n::ns when n < 0x800 ->
+      0xc0 lor (n lsr 6) :: con n :: encode' ns
+    | n::ns when n < 0x10000 ->
+      0xe0 lor (n lsr 12) :: con (n lsr 6) :: con n :: encode' ns
+    | n::ns when n < 0x110000 ->
+      0xf0 lor (n lsr 18) :: con (n lsr 12) :: con (n lsr 6) :: con n
+      :: encode' ns
+    | _ ->
+      raise Utf8 *)
+    and encode' acc = function
+      | [] -> List.rev acc
+      | n::ns when n < 0 ->
+        raise Utf8
+      | n::ns when n < 0x80 ->
+        encode' (n::acc) ns
+      | n::ns when n < 0x800 ->
+        let b1 = 0xc0 lor (n lsr 6) in
+        let b2 = con n in
+        encode' (b1::b2::acc) ns
+      | n::ns when n < 0x10000 ->
+        let b1 = 0xe0 lor (n lsr 12) in
+        let b2 = con (n lsr 6) in
+        let b3 = con n in
+        encode' (b1::b2::b3::acc) ns
+      | n::ns when n < 0x110000 ->
+        let b1 = 0xf0 lor (n lsr 18) in
+        let b2 = con (n lsr 12) in
+        let b3 = con (n lsr 6) in
+        let b4 = con n in
+        encode' (b1::b2::b3::b4::acc) ns
+      | _ ->
+        raise Utf8
+
+  let con b = if b land 0xc0 = 0x80 then b land 0x3f else raise Utf8
+  let code min n =
+    if n < min || (0xd800 <= n && n < 0xe000) || n >= 0x110000 then raise Utf8
+    else n
+
+  let rec decode s = decode' [] (List.map Char.code (String.explode s))
+  (* and decode' = function
+    | [] -> []
+    | b1::bs when b1 < 0x80 ->
+      code 0x0 b1 :: decode' bs
+    | b1::bs when b1 < 0xc0 ->
+      raise Utf8
+    | b1::b2::bs when b1 < 0xe0 ->
+      code 0x80 ((b1 land 0x1f) lsl 6 + con b2) :: decode' bs
+    | b1::b2::b3::bs when b1 < 0xf0 ->
+      code 0x800 ((b1 land 0x0f) lsl 12 + con b2 lsl 6 + con b3) :: decode' bs
+    | b1::b2::b3::b4::bs when b1 < 0xf8 ->
+      code 0x10000 ((b1 land 0x07) lsl 18 + con b2 lsl 12 + con b3 lsl 6 + con b4)
+      :: decode' bs
+    | _ ->
+      raise Utf8 *)
+    and decode' acc = function
+      | [] -> List.rev acc
+      | b1::bs when b1 < 0x80 ->
+        decode' (code 0x0 b1 :: acc) bs
+      | b1::bs when b1 < 0xc0 ->
+        raise Utf8
+      | b1::b2::bs when b1 < 0xe0 ->
+        let c = code 0x80 ((b1 land 0x1f) lsl 6 + con b2) in
+        decode' (c :: acc) bs
+      | b1::b2::b3::bs when b1 < 0xf0 ->
+        let c = code 0x800 ((b1 land 0x0f) lsl 12 + con b2 lsl 6 + con b3) in
+        decode' (c :: acc) bs
+      | b1::b2::b3::b4::bs when b1 < 0xf8 ->
+        let c = code 0x10000 ((b1 land 0x07) lsl 18 + con b2 lsl 12 + con b3 lsl 6 + con b4) in
+        decode' (c :: acc) bs
+      | _ ->
+        raise Utf8
+end
+
 module List =
 struct
   let equal p xs ys =

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -296,7 +296,7 @@ struct
     | _ ->
       raise Utf8 *)
     and encode' acc = function
-      | [] -> acc
+      | [] -> List.rev acc
       | n::ns when n < 0 -> raise Utf8
       | n::ns when n < 0x80 ->
         encode' (n :: acc) ns
@@ -711,7 +711,8 @@ struct
   let%test "Base32.decode 000000000000" = Base32.decode "AAAAAAAA" = Ok "\x00\x00\x00\x00\x00"
   let%test "Base32.decode DEADBEEF" = Base32.decode "32W353Y" = Ok "\xDE\xAD\xBE\xEF"
 
-  let%test "Utf8.decode/encode prim emoji" = Utf8.encode (Utf8.decode "mo:⛔") = "mo:⛔"
+  let%test "Utf8.decode prim emoji" = Wasm.Utf8.encode (Utf8.decode "mo:⛔") = "mo:⛔"
+  let%test "Utf8.encode prim emoji" = Utf8.encode (Wasm.Utf8.decode "mo:⛔") = "mo:⛔"
 
   let%test "Utf8.is_valid agrees with Utf8.decode for single-byte strings" =
     let rec loop f i =

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -187,6 +187,7 @@ module Utf8 :
 sig
   type t = int list
   exception Utf8
+  val is_valid : string -> bool
   val decode : string -> t (* raises Utf8 *)
   val encode : t -> string (* raises Utf8 *)
 end

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -183,6 +183,14 @@ sig
   val encode : string -> string
 end
 
+module Utf8 :
+sig
+  type t = int list
+  exception Utf8
+  val decode : string -> t (* raises Utf8 *)
+  val encode : t -> string (* raises Utf8 *)
+end
+
 module FilePath :
 sig
   (**

--- a/src/mo_frontend/source_lexer.mll
+++ b/src/mo_frontend/source_lexer.mll
@@ -61,7 +61,7 @@ let char lexbuf s =
     | [n] -> n
     | [] -> error lexbuf "empty character literal"
     | _ -> error lexbuf "overlong character literal"
-  with Wasm.Utf8.Utf8 ->
+  with Lib.Utf8.Utf8 ->
     error lexbuf "invalid utf8 in character literal"
 }
 

--- a/src/mo_frontend/source_lexer.mll
+++ b/src/mo_frontend/source_lexer.mll
@@ -2,7 +2,7 @@
 open Mo_def.Trivia
 open Source_token
 open Lexer_lib
-module Utf8 = Wasm.Utf8
+module Utf8 = Lib.Utf8
 
 let region lexbuf =
   let left = convert_pos (Lexing.lexeme_start_p lexbuf) in

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -818,8 +818,8 @@ let check_int64 env = check_lit_val env T.Int64 Numerics.Int_64.of_string
 let check_float env = check_lit_val env T.Float Numerics.Float.of_string
 
 let check_text env at s =
-  (try ignore (Wasm.Utf8.decode s)
-   with Wasm.Utf8.Utf8 -> local_error env at "M0049" "string literal \"%s\": is not valid utf8" (String.escaped s));
+  (try ignore (Lib.Utf8.decode s)
+   with Lib.Utf8.Utf8 -> local_error env at "M0049" "string literal \"%s\": is not valid utf8" (String.escaped s));
   s
 
 

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -818,10 +818,9 @@ let check_int64 env = check_lit_val env T.Int64 Numerics.Int_64.of_string
 let check_float env = check_lit_val env T.Float Numerics.Float.of_string
 
 let check_text env at s =
-  (try ignore (Lib.Utf8.decode s)
-   with Lib.Utf8.Utf8 -> local_error env at "M0049" "string literal \"%s\": is not valid utf8" (String.escaped s));
+  if not (Lib.Utf8.is_valid s) then
+    local_error env at "M0049" "string literal \"%s\": is not valid utf8" (String.escaped s);
   s
-
 
 let infer_lit env lit at : T.prim =
   match !lit with

--- a/src/mo_interpreter/interpret.ml
+++ b/src/mo_interpreter/interpret.ml
@@ -350,7 +350,7 @@ let text_chars t at =
   V.local_func 0 1 (fun c v k ->
     V.as_unit v;
     let i = ref 0 in
-    let s = Wasm.Utf8.decode t in
+    let s = Lib.Utf8.decode t in
     let next =
       V.local_func 0 1 (fun c v k' ->
         if !i = List.length s
@@ -363,7 +363,7 @@ let text_chars t at =
 let text_len t at =
   V.local_func 0 1 (fun c v k ->
     V.as_unit v;
-    k (V.Int (Numerics.Nat.of_int (List.length (Wasm.Utf8.decode t))))
+    k (V.Int (Numerics.Nat.of_int (List.length (Lib.Utf8.decode t))))
   )
 
 (* Expressions *)

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -200,7 +200,7 @@ let prim trap =
 
   | "conv_Char_Text" -> fun _ v k -> let str = match as_char v with
                                           | c when c <= 0o177 -> String.make 1 (Char.chr c)
-                                          | code -> Wasm.Utf8.encode [code]
+                                          | code -> Lib.Utf8.encode [code]
                                in k (Text str)
   | "print" -> fun _ v k -> Printf.printf "%s\n%!" (as_text v); k unit
   | "trap" -> fun _ v k -> trap.trap ("explicit trap: " ^ (as_text v))
@@ -240,7 +240,7 @@ let prim trap =
     | Seq.Cons (v, vs) -> i := vs; k v
     end
   | "text_len" -> fun _ v k ->
-    k (Int (Nat.of_int (List.length (Wasm.Utf8.decode (Value.as_text v)))))
+    k (Int (Nat.of_int (List.length (Lib.Utf8.decode (Value.as_text v)))))
   | "text_compare" -> fun _ v k ->
     (match Value.as_tup v with
      | [a; b] -> k (Int8 (Int_8.of_int
@@ -248,7 +248,7 @@ let prim trap =
                              if a = b then 0 else if a < b then -1 else 1)))
      | _ -> assert false)
   | "text_iter" -> fun _ v k ->
-    let s = Wasm.Utf8.decode (Value.as_text v) in
+    let s = Lib.Utf8.decode (Value.as_text v) in
     let i = Seq.map (fun c -> Char c) (List.to_seq s) in
     k (Iter (ref i))
   | "Array.init" -> fun _ v k ->
@@ -345,9 +345,9 @@ let prim trap =
   | "decodeUtf8" ->
       fun _ v k ->
         let s = as_blob v in
-        begin match Wasm.Utf8.decode s with
+        begin match Lib.Utf8.decode s with
           | _ -> k (Opt (Text s))
-          | exception Wasm.Utf8.Utf8 -> k Null
+          | exception Lib.Utf8.Utf8 -> k Null
         end
 
   | "encodeUtf8" ->

--- a/src/mo_values/show.ml
+++ b/src/mo_values/show.ml
@@ -52,7 +52,7 @@ let rec show_val t v =
   | T.(Prim Float), Value.Float i -> Numerics.Float.to_string i
   | T.(Prim Text), Value.Text s -> "\"" ^ s ^ "\""
   | T.(Prim Blob), Value.Blob s -> "\"" ^ Value.Blob.escape s ^ "\""
-  | T.(Prim Char), Value.Char c -> "\'" ^ Wasm.Utf8.encode [c] ^ "\'"
+  | T.(Prim Char), Value.Char c -> "\'" ^ Lib.Utf8.encode [c] ^ "\'"
   | T.(Prim Principal), Value.Blob s -> Ic.Url.encode_principal s
   | T.(Prim Null), Value.Null -> "null"
   | T.Opt _, Value.Null -> "null"

--- a/src/mo_values/value.ml
+++ b/src/mo_values/value.ml
@@ -194,7 +194,7 @@ let rec pp_val_nullary d ppf = function
   | Nat64 n -> pr ppf (Nat64.to_pretty_string n)
   | Float f -> pr ppf (Float.to_pretty_string f)
   | Char c ->  pr ppf (string_of_string '\'' [c] '\'')
-  | Text t -> pr ppf (string_of_string '\"' (Wasm.Utf8.decode t) '\"')
+  | Text t -> pr ppf (string_of_string '\"' (Lib.Utf8.decode t) '\"')
   | Blob b -> pr ppf ("\"" ^ Blob.escape b ^ "\"")
   | Tup vs ->
     fprintf ppf "@[<1>(%a%s)@]"

--- a/src/wasm-exts/customModuleDecode.ml
+++ b/src/wasm-exts/customModuleDecode.ml
@@ -23,7 +23,7 @@ module F32 = Wasm.F32
 module F64 = Wasm.F64
 module I32_convert = Wasm.I32_convert
 module I64_convert = Wasm.I64_convert
-module Utf8 = Wasm.Utf8
+module Utf8 = Lib.Utf8
 open CustomModule
 
 (* Decoding stream *)

--- a/src/wasm-exts/customModuleEncode.ml
+++ b/src/wasm-exts/customModuleEncode.ml
@@ -315,7 +315,7 @@ let encode (em : extended_module) =
 
     let bool b = vu1 (if b then 1 else 0)
     let string bs = len (String.length bs); put_string s bs
-    let name n = string (Wasm.Utf8.encode n)
+    let name n = string (Lib.Utf8.encode n)
     let list f xs = List.iter f xs
     let opt f xo = Option.iter f xo
     let vec_by l f xs = l (List.length xs); list f xs
@@ -842,7 +842,7 @@ let encode (em : extended_module) =
       section 0 (vec string) labels (labels <> [])
 
     let utf8 bs =
-      ignore (Wasm.Utf8.decode bs);  (* assert well-formedness *)
+      ignore (Lib.Utf8.decode bs);  (* assert well-formedness *)
       put_string s bs
 
     let motoko_sections motoko =

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -33,122 +33,134 @@ moc.Motoko.saveFile(
     };
   }`
 );
+moc.Motoko.saveFile('text.mo', `let s = "${'.'.repeat(10000)}"; s.size()`); // #3822
 
-assert.equal(moc.Motoko.readFile("empty.mo"), "");
-assert.equal(moc.Motoko.readFile("ok.mo"), "1");
+try {
+  assert.equal(moc.Motoko.readFile("empty.mo"), "");
+  assert.equal(moc.Motoko.readFile("ok.mo"), "1");
 
-// Compile the empty module in wasi and ic mode
-const empty_wasm_plain = moc.Motoko.compileWasm("wasi", "empty.mo");
-const empty_wasm_ic = moc.Motoko.compileWasm("ic", "empty.mo");
+  // Compile the empty module in wasi and ic mode
+  const empty_wasm_plain = moc.Motoko.compileWasm("wasi", "empty.mo");
+  const empty_wasm_ic = moc.Motoko.compileWasm("ic", "empty.mo");
 
-// For the plain module...
-// Check that the code looks like a WebAssembly binary
-assert.equal(typeof empty_wasm_plain, "object");
-assert.deepEqual(
-  empty_wasm_plain.code.wasm.subarray(0, 4),
-  new Uint8Array([0, 97, 115, 109])
-);
-assert.deepEqual(
-  empty_wasm_plain.code.wasm.subarray(4, 8),
-  new Uint8Array([1, 0, 0, 0])
-);
-assert.equal(typeof empty_wasm_plain.diagnostics, "object");
-assert.equal(empty_wasm_plain.diagnostics.length, 0);
+  // For the plain module...
+  // Check that the code looks like a WebAssembly binary
+  assert.equal(typeof empty_wasm_plain, "object");
+  assert.deepEqual(
+    empty_wasm_plain.code.wasm.subarray(0, 4),
+    new Uint8Array([0, 97, 115, 109])
+  );
+  assert.deepEqual(
+    empty_wasm_plain.code.wasm.subarray(4, 8),
+    new Uint8Array([1, 0, 0, 0])
+  );
+  assert.equal(typeof empty_wasm_plain.diagnostics, "object");
+  assert.equal(empty_wasm_plain.diagnostics.length, 0);
 
-// Check that the WebAssembly binary can be loaded
-WebAssembly.compile(empty_wasm_plain.code.wasm);
+  // Check that the WebAssembly binary can be loaded
+  WebAssembly.compile(empty_wasm_plain.code.wasm);
 
-// Now again for the ic module
-assert.equal(typeof empty_wasm_ic, "object");
-assert.deepEqual(
-  empty_wasm_plain.code.wasm.subarray(0, 4),
-  new Uint8Array([0, 97, 115, 109])
-);
-assert.deepEqual(
-  empty_wasm_plain.code.wasm.subarray(4, 8),
-  new Uint8Array([1, 0, 0, 0])
-);
-assert.equal(typeof empty_wasm_ic.diagnostics, "object");
-assert.equal(empty_wasm_ic.diagnostics.length, 0);
+  // Now again for the ic module
+  assert.equal(typeof empty_wasm_ic, "object");
+  assert.deepEqual(
+    empty_wasm_plain.code.wasm.subarray(0, 4),
+    new Uint8Array([0, 97, 115, 109])
+  );
+  assert.deepEqual(
+    empty_wasm_plain.code.wasm.subarray(4, 8),
+    new Uint8Array([1, 0, 0, 0])
+  );
+  assert.equal(typeof empty_wasm_ic.diagnostics, "object");
+  assert.equal(empty_wasm_ic.diagnostics.length, 0);
 
-WebAssembly.compile(empty_wasm_ic.code.wasm);
+  WebAssembly.compile(empty_wasm_ic.code.wasm);
 
-// The plain and the ic module should not be the same
-assert.notEqual(empty_wasm_plain.code.wasm, empty_wasm_ic.code.wasm);
+  // The plain and the ic module should not be the same
+  assert.notEqual(empty_wasm_plain.code.wasm, empty_wasm_ic.code.wasm);
 
-moc.Motoko.removeFile("empty.mo");
-assert.throws(() => {
-  moc.Motoko.compileWasm("ic", "empty.mo");
-}, /No such file or directory/);
+  moc.Motoko.removeFile("empty.mo");
+  assert.throws(() => {
+    moc.Motoko.compileWasm("ic", "empty.mo");
+  }, /No such file or directory/);
 
-// Check if error messages are correctly returned
-const bad_result = moc.Motoko.compileWasm("ic", "bad.mo");
-// Uncomment to see what to paste below
-// console.log(JSON.stringify(bad_result, null, 2));
-assert.deepStrictEqual(bad_result, {
-  diagnostics: [
-    {
-      range: {
-        start: {
-          line: 0,
-          character: 2,
+  // Check if error messages are correctly returned
+  const bad_result = moc.Motoko.compileWasm("ic", "bad.mo");
+  // Uncomment to see what to paste below
+  // console.log(JSON.stringify(bad_result, null, 2));
+  assert.deepStrictEqual(bad_result, {
+    diagnostics: [
+      {
+        range: {
+          start: {
+            line: 0,
+            character: 2,
+          },
+          end: {
+            line: 0,
+            character: 2,
+          },
         },
-        end: {
-          line: 0,
-          character: 2,
-        },
+        severity: 1,
+        source: "bad.mo",
+        message:
+          "unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>",
       },
-      severity: 1,
-      source: "bad.mo",
-      message:
-        "unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>",
-    },
-  ],
-  code: null,
-});
+    ],
+    code: null,
+  });
 
-// Check the check command (should print errors, but have no code)
-assert.deepStrictEqual(moc.Motoko.check("ok.mo"), {
-  diagnostics: [],
-  code: null,
-});
+  // Check the check command (should print errors, but have no code)
+  assert.deepStrictEqual(moc.Motoko.check("ok.mo"), {
+    diagnostics: [],
+    code: null,
+  });
 
-assert.deepStrictEqual(moc.Motoko.check("bad.mo"), {
-  diagnostics: [
-    {
-      range: {
-        start: {
-          line: 0,
-          character: 2,
+  assert.deepStrictEqual(moc.Motoko.check("bad.mo"), {
+    diagnostics: [
+      {
+        range: {
+          start: {
+            line: 0,
+            character: 2,
+          },
+          end: {
+            line: 0,
+            character: 2,
+          },
         },
-        end: {
-          line: 0,
-          character: 2,
-        },
+        severity: 1,
+        source: "bad.mo",
+        message:
+          "unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>",
       },
-      severity: 1,
-      source: "bad.mo",
-      message:
-        "unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>",
-    },
-  ],
-  code: null,
-});
+    ],
+    code: null,
+  });
 
-const astString = JSON.stringify(
-  moc.Motoko.parseMotoko(moc.Motoko.readFile("ast.mo"))
-);
+  const astString = JSON.stringify(
+    moc.Motoko.parseMotoko(moc.Motoko.readFile("ast.mo"))
+  );
 
-// Check doc comments
-assert.match(astString, /"name":"\*","args":\["Module"/);
-assert.match(astString, /"name":"\*","args":\["Variable"/);
-assert.match(astString, /"name":"\*","args":\["Type"/);
-assert.match(astString, /"name":"\*","args":\["Function"/);
-assert.match(astString, /"name":"\*","args":\["Sub-module"/);
-assert.match(astString, /"name":"\*","args":\["Class"/);
+  // Check doc comments
+  assert.match(astString, /"name":"\*","args":\["Module"/);
+  assert.match(astString, /"name":"\*","args":\["Variable"/);
+  assert.match(astString, /"name":"\*","args":\["Type"/);
+  assert.match(astString, /"name":"\*","args":\["Function"/);
+  assert.match(astString, /"name":"\*","args":\["Sub-module"/);
+  assert.match(astString, /"name":"\*","args":\["Class"/);
 
-// // Check Wasm reproducibility
-// assert.deepStrictEqual(
-//   moc.Motoko.compileWasm("ic", "actor.mo").code.wasm,
-//   moc.Motoko.compileWasm("ic", "actor.mo").code.wasm
-// );
+  // // Check Wasm reproducibility
+  // assert.deepStrictEqual(
+  //   moc.Motoko.compileWasm("ic", "actor.mo").code.wasm,
+  //   moc.Motoko.compileWasm("ic", "actor.mo").code.wasm
+  // );
+
+  // Check that long text literals type-check without error
+  assert.deepStrictEqual(moc.Motoko.check("text.mo"), {
+    code: null,
+    diagnostics: []
+  });
+}
+catch (err) {
+  assert.fail(err);
+}

--- a/test/test-moc_interpreter.js
+++ b/test/test-moc_interpreter.js
@@ -11,45 +11,59 @@ moc.Motoko.saveFile('ok.mo', '1');
 moc.Motoko.saveFile('warn.mo', '2 - 1');
 moc.Motoko.saveFile('bad.mo', '1+');
 moc.Motoko.saveFile('limit.mo', 'var i = 0; while (i < 10000) { i += 1 }; i');
+moc.Motoko.saveFile('text.mo', `let s = "${'.'.repeat(10000)}"; s.size()`); // #3822
 
-assert.deepStrictEqual(moc.Motoko.run([], 'ok.mo'), {
-  result: {
-    error: null,
-  },
-  stderr: '',
-  stdout: '1 : Nat\n'
-});
+try {
+  assert.deepStrictEqual(moc.Motoko.run([], 'ok.mo'), {
+    result: {
+      error: null,
+    },
+    stderr: '',
+    stdout: '1 : Nat\n'
+  });
 
-assert.deepStrictEqual(moc.Motoko.run([], 'warn.mo'), {
-  result: {
-    error: null,
-  },
-  stderr: 'warn.mo:1.1-1.6: warning [M0155], operator may trap for inferred type\n  Nat\n',
-  stdout: '1 : Nat\n',
-});
+  assert.deepStrictEqual(moc.Motoko.run([], 'warn.mo'), {
+    result: {
+      error: null,
+    },
+    stderr: 'warn.mo:1.1-1.6: warning [M0155], operator may trap for inferred type\n  Nat\n',
+    stdout: '1 : Nat\n',
+  });
 
-assert.deepStrictEqual(moc.Motoko.run([], 'bad.mo'), {
-  result: {
-    error: {},
-  },
-  stderr: 'bad.mo:1.3: syntax error [M0001], unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>\n',
-  stdout: '',
-});
+  assert.deepStrictEqual(moc.Motoko.run([], 'bad.mo'), {
+    result: {
+      error: {},
+    },
+    stderr: 'bad.mo:1.3: syntax error [M0001], unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>\n',
+    stdout: '',
+  });
 
-assert.deepStrictEqual(moc.Motoko.run([], 'limit.mo'), {
-  result: {
-    error: null,
-  },
-  stderr: '',
-  stdout: '10_000 : Nat\n'
-});
+  assert.deepStrictEqual(moc.Motoko.run([], 'limit.mo'), {
+    result: {
+      error: null,
+    },
+    stderr: '',
+    stdout: '10_000 : Nat\n'
+  });
 
-moc.Motoko.setRunStepLimit(5000);
+  moc.Motoko.setRunStepLimit(5000);
 
-assert.deepStrictEqual(moc.Motoko.run([], 'limit.mo'), {
-  result: {
-    error: {},
-  },
-  stderr: 'cancelled: interpreter reached step limit\n',
-  stdout: ''
-});
+  assert.deepStrictEqual(moc.Motoko.run([], 'limit.mo'), {
+    result: {
+      error: {},
+    },
+    stderr: 'cancelled: interpreter reached step limit\n',
+    stdout: ''
+  });
+
+  // assert.deepStrictEqual(moc.Motoko.run([], 'text.mo'), {
+  //   result: {
+  //     error: null,
+  //   },
+  //   stderr: '',
+  //   stdout: `10_000 : Nat\n`
+  // });
+}
+catch (err) {
+  assert.fail(err);
+}

--- a/test/test-moc_interpreter.js
+++ b/test/test-moc_interpreter.js
@@ -56,13 +56,13 @@ try {
     stdout: ''
   });
 
-  // assert.deepStrictEqual(moc.Motoko.run([], 'text.mo'), {
-  //   result: {
-  //     error: null,
-  //   },
-  //   stderr: '',
-  //   stdout: `10_000 : Nat\n`
-  // });
+  assert.deepStrictEqual(moc.Motoko.run([], 'text.mo'), {
+    result: {
+      error: null,
+    },
+    stderr: '',
+    stdout: `10_000 : Nat\n`
+  });
 }
 catch (err) {
   assert.fail(err);


### PR DESCRIPTION
This PR makes the following changes:

- Adds `Lib.Utf8` with tail-recursive implementations for `encode` and `decode` ([based on `Wasm.Utf8`](https://github.com/WebAssembly/spec/blob/main/interpreter/binary/utf8.ml))
- Implements a new `is_valid` function in the `Lib.Utf8` module
- Replaces all existing usages of `Wasm.Utf8` with `Lib.Utf8`
- Adds relevant unit tests for the moc.js type checker and interpreter

TODO:
- [x] Include tests for `is_valid`
- [x] Debug tail-recursive `encode`

The original (non-tail-recursive) implementations remain in this PR for convenience during the code review. I'll remove these before merging. 

Fixes #3822.