### PR TITLE
chore(js): replace `uglify-js` with `terser`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -535,7 +535,7 @@ rec {
           nixpkgs.ocamlPackages.js_of_ocaml
           nixpkgs.ocamlPackages.js_of_ocaml-ppx
           nixpkgs.nodejs-16_x
-          nixpkgs.nodePackages.uglify-js
+          nixpkgs.nodePackages.terser
         ];
         buildPhase = ''
           patchShebangs .
@@ -543,7 +543,7 @@ rec {
           ./rts/gen.sh ${rts}/rts/
           '' + ''
           make DUNE_OPTS="--profile=release" ${n}.js
-          uglifyjs ${n}.js -o ${n}.min.js -c -m
+          terser ${n}.js -o ${n}.min.js -c -m
         '';
         installPhase = ''
           mkdir -p $out


### PR DESCRIPTION
This PR swaps [uglify-js](https://www.npmjs.com/package/uglify-js) with [terser](https://www.npmjs.com/package/terser), a better-maintained JS minifier with more configuration options. By itself, this change has a negligible effect on minified file size, although we could potentially make further improvements by targeting newer JS output versions. 