### PR TITLE
Backend: Avoid pointless bounds checking array access

### DIFF
--- a/test/run/ok/array-bounds.wasm-run.ok
+++ b/test/run/ok/array-bounds.wasm-run.ok
@@ -5,7 +5,8 @@ Caused by:
     0: failed to invoke command default
     1: wasm trap: unreachable
        wasm backtrace:
-         0: Array.idx_bigint
-         1: init
-         2: _start
+         0: Array.idx
+         1: Array.idx_bigint
+         2: init
+         3: _start
        

--- a/test/run/ok/array-bounds.wasm-run.ok
+++ b/test/run/ok/array-bounds.wasm-run.ok
@@ -5,8 +5,7 @@ Caused by:
     0: failed to invoke command default
     1: wasm trap: unreachable
        wasm backtrace:
-         0: Array.idx
-         1: Array.idx_bigint
-         2: init
-         3: _start
+         0: Array.idx_bigint
+         1: init
+         2: _start
        


### PR DESCRIPTION
this has been in the back of my mind for a while: Originally, I intentionally used safe array access almost everywhere in the backend, even in places where the bounds should always be fine, so that bugs can be reported more efficiently. It seems that people have not found bugs related to that code, so we can drop the bounds check in compiler-generated loops over arrays (mostly in serialization/deserialization).

Turns out all array accesses that need to be bounds-checked go via the bignum index function anyways, so I moved the bounds check there.