### PR TITLE
perf: identify const variants

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10321,8 +10321,8 @@ and compile_const_exp env pre_ae exp : Const.t * (E.t -> VarEnv.t -> unit) =
     Const.(t_of_v (Array cs)),
     (fun env ae -> List.iter (fun fill -> fill env ae) fills)
   | PrimE (TagPrim i, [e]) ->
-    let (object_ct, fill) = compile_const_exp env pre_ae e in
-    Const.(t_of_v (Tag (i, object_ct))),
+    let (arg_ct, fill) = compile_const_exp env pre_ae e in
+    Const.(t_of_v (Tag (i, arg_ct))),
     fill
 
   | _ -> assert false

--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -867,6 +867,8 @@ let rec check_exp env (exp:Ir.exp) : unit =
       check e1.note.Note.const "constant DotPrim on non-constant subexpression"
     | PrimE (ProjPrim _, [e1]) ->
       check e1.note.Note.const "constant ProjPrim on non-constant subexpression"
+    | PrimE (TagPrim _, [e1]) ->
+      check e1.note.Note.const "constant variant with non-constant payload"
     | BlockE (ds, e) ->
       List.iter (fun d -> match d.it with
         | VarD _ | RefD _ -> check false "VarD/RefD in constant BlockE"

--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -868,7 +868,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
     | PrimE (ProjPrim _, [e1]) ->
       check e1.note.Note.const "constant ProjPrim on non-constant subexpression"
     | PrimE (TagPrim _, [e1]) ->
-      check e1.note.Note.const "constant variant with non-constant payload"
+      check e1.note.Note.const "constant TagPrim with non-constant subexpression"
     | BlockE (ds, e) ->
       List.iter (fun d -> match d.it with
         | VarD _ | RefD _ -> check false "VarD/RefD in constant BlockE"

--- a/src/ir_passes/const.ml
+++ b/src/ir_passes/const.ml
@@ -124,9 +124,7 @@ let rec exp lvl (env : env) e : Lbool.t =
     | PrimE (TupPrim, es)
     | PrimE (ArrayPrim (Const, _), es) ->
       all (List.map (fun e -> exp lvl env e) es)
-    | PrimE (DotPrim _, [e1])
-    | PrimE (ProjPrim _, [e1])
-    | PrimE (TagPrim _, [e1]) ->
+    | PrimE (DotPrim _, [e1] | ProjPrim _, [e1] | TagPrim _, [e1]) ->
       exp lvl env e1
     | LitE _ ->
       surely_true

--- a/src/ir_passes/const.ml
+++ b/src/ir_passes/const.ml
@@ -125,7 +125,8 @@ let rec exp lvl (env : env) e : Lbool.t =
     | PrimE (ArrayPrim (Const, _), es) ->
       all (List.map (fun e -> exp lvl env e) es)
     | PrimE (DotPrim _, [e1])
-    | PrimE (ProjPrim _, [e1]) ->
+    | PrimE (ProjPrim _, [e1])
+    | PrimE (TagPrim _, [e1]) ->
       exp lvl env e1
     | LitE _ ->
       surely_true


### PR DESCRIPTION
Variants with constant payloads should be constant and end up in the static heap. This will speed up all tree-like data structures that have unit-payload leaves (not to speak of allocation wins!). See https://github.com/dfinity/motoko-base/issues/543 for motivation.

For below program
``` Motoko
import P = "mo:⛔️";

type Tree = { #leaf; #node : (Tree, Tree) };

func leaf() : (Tree, (Nat, Nat)) = (#leaf, (5, 42));

P.debugPrint(debug_show leaf());
```
the function `leaf()` now looks like
``` wasm
  (func $leaf (type 5) (param $clos i32)
    i32.const 2097267
    i32.const 2097279
    global.set 18
    global.set 17)
```
looks as expected. It also runs happily
```
$ wasmtime tree.wasm 
(#leaf, (5, 42))
```