### PR TITLE
chore: remove FIXME from `timer-initial.mo` test

### DIFF
--- a/test/run-drun/timer-initial.mo
+++ b/test/run-drun/timer-initial.mo
@@ -5,22 +5,21 @@ actor {
   var count = 0;
 
   system func timer(setGlobalTimer : Nat64 -> ()) : async () {
-      count += 1;
-      setGlobalTimer 0; // FIXME: this shouldn't be necessary for recent `drun`, but we might run an outdated version...
+    count += 1;
   };
 
   let raw_rand = (actor "aaaaa-aa" : actor { raw_rand : () -> async Blob }).raw_rand;
   public shared func go() : async () {
-     var attempts = 0;
+    var attempts = 0;
 
-     while (count < 1) {
-       ignore await raw_rand(); // yield to scheduler
-       attempts += 1;
-       if (attempts >= 200 and count == 0)
-         throw error("he's dead Jim");
-     };
-     debugPrint(debug_show {count});
-  };
+    while (count < 1) {
+      ignore await raw_rand(); // yield to scheduler
+      attempts += 1;
+      if (attempts >= 200 and count == 0)
+        throw error("he's dead Jim");
+    };
+    debugPrint(debug_show {count});
+  }
 }
 
 //SKIP run


### PR DESCRIPTION
Looks like we have a conforming `drun` now.