### PR TITLE
bugfix: check `@nextExpiration` after the changes are committed

### DIFF
--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -519,15 +519,8 @@ func @timer_helper() : async () {
   func Array_init<T>(len : Nat,  x : T) : [var T] {
     (prim "Array.init" : <T>(Nat, T) -> [var T])<T>(len, x)
   };
+
   let now = (prim "time" : () -> Nat64)();
-  let exp = @nextExpiration @timers;
-  let prev = (prim "global_timer_set" : Nat64 -> Nat64) exp;
-
-  // debug { assert prev == 0 };
-
-  if (exp == 0) {
-    return
-  };
 
   var gathered = 0;
   let thunks = Array_init<?(() -> async ())>(10, null); // we want max 10
@@ -564,6 +557,10 @@ func @timer_helper() : async () {
   };
 
   gatherExpired(@timers);
+
+  let exp = @nextExpiration @timers;
+  let prev = (prim "global_timer_set" : Nat64 -> Nat64) exp;
+  if (exp == 0) @timers := null;
 
   for (k in thunks.keys()) {
     ignore switch (thunks[k]) { case (?thunk) ?thunk(); case _ null };

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -559,7 +559,7 @@ func @timer_helper() : async () {
   gatherExpired(@timers);
 
   let exp = @nextExpiration @timers;
-  let prev = (prim "global_timer_set" : Nat64 -> Nat64) exp;
+  ignore (prim "global_timer_set" : Nat64 -> Nat64) exp;
   if (exp == 0) @timers := null;
 
   for (k in thunks.keys()) {

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -562,8 +562,11 @@ func @timer_helper() : async () {
   ignore (prim "global_timer_set" : Nat64 -> Nat64) exp;
   if (exp == 0) @timers := null;
 
-  for (k in thunks.keys()) {
-    ignore switch (thunks[k]) { case (?thunk) ?thunk(); case _ null };
+  for (o in thunks.vals()) {
+     switch o { 
+       case (?thunk) { ignore thunk() };
+       case _ { } 
+    };
   }
 };
 

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -563,10 +563,10 @@ func @timer_helper() : async () {
   if (exp == 0) @timers := null;
 
   for (o in thunks.vals()) {
-     switch o {
-       case (?thunk) { ignore thunk() };
-       case _ { }
-    };
+    switch o {
+      case (?thunk) { ignore thunk() };
+      case _ { }
+    }
   }
 };
 

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -563,9 +563,9 @@ func @timer_helper() : async () {
   if (exp == 0) @timers := null;
 
   for (o in thunks.vals()) {
-     switch o { 
+     switch o {
        case (?thunk) { ignore thunk() };
-       case _ { } 
+       case _ { }
     };
   }
 };


### PR DESCRIPTION
There was a slightly buggy behaviour with setting the global timer from `@timer_helper`. We observed that for each one-off timer set there were two expirations happening. The reason is that we were computing the next expiration before the current batch of expired timers were expunged. This re-added the same time as before, and thus caused the second (in-vain) wakeup.

The fix is of course to compute the next global expiration _after_ the already expired nodes were expunged.