### PR TITLE
compile-time match literals and options

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10220,7 +10220,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
   let const_exp_helper =
     lazy begin
         let[@warning "-8"] LetD (p, e) = dec.it in
-        const_exp_matches_pat env p e
+        const_exp_matches_pat env pre_ae p e
       end in
   (*let is_compile_time_matchable () =
     let lazy const_exp_matches = const_exp_helper in
@@ -10403,9 +10403,9 @@ and compile_const_decs env pre_ae decs : (VarEnv.t -> VarEnv.t) * (E.t -> VarEnv
         (fun env ae -> fill1 env ae; fill2 env ae) in
   go pre_ae decs
 
-and const_exp_matches_pat env pat exp : bool option =
+and const_exp_matches_pat env ae pat exp : bool option =
   assert exp.note.Note.const;
-  let c, _ = compile_const_exp env VarEnv.empty_ae exp in
+  let c, _ = compile_const_exp env ae exp in
   (try ignore (destruct_const_pat VarEnv.empty_ae pat c); Some true with Invalid_argument _ -> Some false)
 
 and destruct_const_pat ae pat const : VarEnv.t = match pat.it with

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10230,13 +10230,11 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
   (* A special case for constant expressions *)
   | LetD (p, e) when e.note.Note.const ->
     (* constant expression matching with patterns is fully decidable *)
-    let is_compile_time_bottom =
-      not (const_exp_matches_pat env pre_ae p e) in
-    if is_compile_time_bottom then (* refuted *)
-      (pre_ae, G.nop, (fun _ -> PatCode.patternFailTrap env), unmodified)
-    else (* not refuted *)
+    if const_exp_matches_pat env pre_ae p e then (* not refuted *)
       let extend, fill = compile_const_dec env pre_ae dec in
       G.(extend pre_ae, nop, (fun ae -> fill env ae; nop), unmodified)
+    else (* refuted *)
+      (pre_ae, G.nop, (fun _ -> PatCode.patternFailTrap env), unmodified)
 
   | LetD (p, e) ->
     let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how p in

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10391,13 +10391,8 @@ and compile_const_decs env pre_ae decs : (VarEnv.t -> VarEnv.t) * (E.t -> VarEnv
 
 and const_exp_matches_pat env pat exp : bool option =
   assert exp.note.Note.const;
-  match exp.it with
-  | _ when Ir_utils.is_irrefutable pat -> Some true
-  | LitE _
-  | PrimE (TagPrim _, _) ->
-     let c, _ = compile_const_exp env VarEnv.empty_ae exp in
-     (try ignore (destruct_const_pat env VarEnv.empty_ae pat c); Some true with Invalid_argument _ -> Some false)
-  | _ -> None
+  let c, _ = compile_const_exp env VarEnv.empty_ae exp in
+  (try ignore (destruct_const_pat VarEnv.empty_ae pat c); Some true with Invalid_argument _ -> Some false)
 
 and destruct_const_pat env ae pat const : VarEnv.t = match pat.it with
   | WildP -> ae

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -8189,16 +8189,15 @@ let const_lit_of_lit : Ir.lit -> Const.lit = function
   | BlobLit t     -> Const.Blob t
   | FloatLit f    -> Const.Float64 f
 
-let const_of_lit _env lit =
+let const_of_lit lit =
   Const.t_of_v (Const.Lit (const_lit_of_lit lit))
 
-let compile_lit env lit =
-  SR.Const (const_of_lit env lit), G.nop
+let compile_lit lit =
+  SR.Const (const_of_lit lit), G.nop
 
 let compile_lit_as env sr_out lit =
-  let sr_in, code = compile_lit env lit in
+  let sr_in, code = compile_lit lit in
   code ^^ StackRep.adjust env sr_in sr_out
-
 
 (* helper, traps with message *)
 let then_arithmetic_overflow env =
@@ -9831,7 +9830,7 @@ and compile_exp_with_hint (env : E.t) ae sr_hint exp =
     compile_exp_as env ae sr e2 ^^
     store_code
   | LitE l ->
-    compile_lit env l
+    compile_lit l
   | IfE (scrut, e1, e2) ->
     let code_scrut = compile_exp_as_test env ae scrut in
     let sr1, code1 = compile_exp_with_hint env ae sr_hint e1 in

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -7165,10 +7165,12 @@ module StackRep = struct
     | Const.Tag (i, c) ->
       let ptr = materialize_const_t env c in
       Variant.vanilla_lit env i ptr
+    | Const.Lit l -> materialize_lit env l
     | Const.Opt c ->
       let ptr = materialize_const_t env c in
-      Opt.vanilla_lit env ptr
-    | Const.Lit l -> materialize_lit env l
+      match c with
+      | (_, Const.(Opt _ | Lit Null)) -> Opt.vanilla_lit env ptr
+      | _ -> ptr (* not option shaped, we can short-circuit *)
 
   let adjust env (sr_in : t) sr_out =
     if eq sr_in sr_out

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10231,8 +10231,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
   | LetD (p, e) when e.note.Note.const ->
     (* constant expression matching with patterns is fully decidable *)
     let is_compile_time_bottom =
-      let const_exp_matches = const_exp_matches_pat env pre_ae p e in
-      not (Option.get const_exp_matches) in
+      not (const_exp_matches_pat env pre_ae p e) in
     if is_compile_time_bottom then (* refuted *)
       (pre_ae, G.nop, (fun _ -> PatCode.patternFailTrap env), unmodified)
     else (* not refuted *)
@@ -10394,10 +10393,10 @@ and compile_const_decs env pre_ae decs : (VarEnv.t -> VarEnv.t) * (E.t -> VarEnv
         (fun env ae -> fill1 env ae; fill2 env ae) in
   go pre_ae decs
 
-and const_exp_matches_pat env ae pat exp : bool option =
+and const_exp_matches_pat env ae pat exp : bool =
   assert exp.note.Note.const;
   let c, _ = compile_const_exp env ae exp in
-  (try ignore (destruct_const_pat VarEnv.empty_ae pat c); Some true with Invalid_argument _ -> Some false)
+  (try ignore (destruct_const_pat VarEnv.empty_ae pat c); true with Invalid_argument _ -> false)
 
 and destruct_const_pat ae pat const : VarEnv.t = match pat.it with
   | WildP -> ae

--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -867,6 +867,8 @@ let rec check_exp env (exp:Ir.exp) : unit =
       check e1.note.Note.const "constant DotPrim on non-constant subexpression"
     | PrimE (ProjPrim _, [e1]) ->
       check e1.note.Note.const "constant ProjPrim on non-constant subexpression"
+    | PrimE (OptPrim, [e1]) ->
+      check e1.note.Note.const "constant OptPrim with non-constant subexpression"
     | PrimE (TagPrim _, [e1]) ->
       check e1.note.Note.const "constant TagPrim with non-constant subexpression"
     | BlockE (ds, e) ->

--- a/src/ir_passes/const.ml
+++ b/src/ir_passes/const.ml
@@ -124,7 +124,7 @@ let rec exp lvl (env : env) e : Lbool.t =
     | PrimE (TupPrim, es)
     | PrimE (ArrayPrim (Const, _), es) ->
       all (List.map (fun e -> exp lvl env e) es)
-    | PrimE (DotPrim _, [e1] | ProjPrim _, [e1] | TagPrim _, [e1]) ->
+    | PrimE (DotPrim _, [e1] | ProjPrim _, [e1] | OptPrim, [e1] | TagPrim _, [e1]) ->
       exp lvl env e1
     | LitE _ ->
       surely_true

--- a/test/run/ok/refuted-const-float.run.ok
+++ b/test/run/ok/refuted-const-float.run.ok
@@ -1,0 +1,1 @@
+refuted-const-float.mo:2.5-2.9: execution error, value 3.140_000_000_000_000_1 does not match pattern

--- a/test/run/ok/refuted-const-float.run.ret.ok
+++ b/test/run/ok/refuted-const-float.run.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/run/ok/refuted-const-float.tc.ok
+++ b/test/run/ok/refuted-const-float.tc.ok
@@ -1,0 +1,4 @@
+refuted-const-float.mo:2.5-2.9: warning [M0145], this pattern of type
+  Float
+does not cover value
+  _

--- a/test/run/ok/refuted-const-float.wasm-run.ok
+++ b/test/run/ok/refuted-const-float.wasm-run.ok
@@ -1,0 +1,10 @@
+pattern failed
+Error: failed to run main module `_out/refuted-const-float.wasm`
+
+Caused by:
+    0: failed to invoke command default
+    1: wasm trap: unreachable
+       wasm backtrace:
+         0: init
+         1: _start
+       

--- a/test/run/ok/refuted-const-float.wasm-run.ret.ok
+++ b/test/run/ok/refuted-const-float.wasm-run.ret.ok
@@ -1,0 +1,1 @@
+Return code 134

--- a/test/run/ok/refuted-const-option-null.run.ok
+++ b/test/run/ok/refuted-const-option-null.run.ok
@@ -1,0 +1,1 @@
+refuted-const-option-null.mo:2.5-2.7: execution error, value null does not match pattern

--- a/test/run/ok/refuted-const-option-null.run.ret.ok
+++ b/test/run/ok/refuted-const-option-null.run.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/run/ok/refuted-const-option-null.tc.ok
+++ b/test/run/ok/refuted-const-option-null.tc.ok
@@ -1,0 +1,4 @@
+refuted-const-option-null.mo:2.5-2.7: warning [M0145], this pattern of type
+  Null
+does not cover value
+  null

--- a/test/run/ok/refuted-const-option-null.wasm-run.ok
+++ b/test/run/ok/refuted-const-option-null.wasm-run.ok
@@ -1,0 +1,10 @@
+pattern failed
+Error: failed to run main module `_out/refuted-const-option-null.wasm`
+
+Caused by:
+    0: failed to invoke command default
+    1: wasm trap: unreachable
+       wasm backtrace:
+         0: init
+         1: _start
+       

--- a/test/run/ok/refuted-const-option-null.wasm-run.ret.ok
+++ b/test/run/ok/refuted-const-option-null.wasm-run.ret.ok
@@ -1,0 +1,1 @@
+Return code 134

--- a/test/run/ok/refuted-const-option.run.ok
+++ b/test/run/ok/refuted-const-option.run.ok
@@ -1,0 +1,1 @@
+refuted-const-option.mo:2.5-2.9: execution error, value ?42 does not match pattern

--- a/test/run/ok/refuted-const-option.run.ret.ok
+++ b/test/run/ok/refuted-const-option.run.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/run/ok/refuted-const-option.tc.ok
+++ b/test/run/ok/refuted-const-option.tc.ok
@@ -1,0 +1,4 @@
+refuted-const-option.mo:2.5-2.9: warning [M0145], this pattern of type
+  ?Nat
+does not cover value
+  ?(_)

--- a/test/run/ok/refuted-const-option.wasm-run.ok
+++ b/test/run/ok/refuted-const-option.wasm-run.ok
@@ -1,0 +1,10 @@
+pattern failed
+Error: failed to run main module `_out/refuted-const-option.wasm`
+
+Caused by:
+    0: failed to invoke command default
+    1: wasm trap: unreachable
+       wasm backtrace:
+         0: init
+         1: _start
+       

--- a/test/run/ok/refuted-const-option.wasm-run.ret.ok
+++ b/test/run/ok/refuted-const-option.wasm-run.ret.ok
@@ -1,0 +1,1 @@
+Return code 134

--- a/test/run/refuted-const-float.mo
+++ b/test/run/refuted-const-float.mo
@@ -1,0 +1,5 @@
+// a failing pattern match that can be compiled to a trap
+let 0.67 = 3.14;
+
+//SKIP run-low
+//SKIP run-ir

--- a/test/run/refuted-const-float.mo
+++ b/test/run/refuted-const-float.mo
@@ -1,5 +1,11 @@
 // a failing pattern match that can be compiled to a trap
 let 0.67 = 3.14;
 
+// CHECK: (func $init (type
+// CHECK: call $blob_of_principal
+// CHECK: i32.const 14
+// CHECK-NEXT: call $print_ptr
+// CHECK-NEXT: unreachable)
+
 //SKIP run-low
 //SKIP run-ir

--- a/test/run/refuted-const-option-null.mo
+++ b/test/run/refuted-const-option-null.mo
@@ -1,0 +1,5 @@
+// a failing pattern match that can be compiled to a trap
+let ?b = null;
+
+//SKIP run-low
+//SKIP run-ir

--- a/test/run/refuted-const-option-null.mo
+++ b/test/run/refuted-const-option-null.mo
@@ -1,5 +1,11 @@
 // a failing pattern match that can be compiled to a trap
 let ?b = null;
 
+// CHECK: (func $init (type
+// CHECK: call $blob_of_principal
+// CHECK: i32.const 14
+// CHECK-NEXT: call $print_ptr
+// CHECK-NEXT: unreachable)
+
 //SKIP run-low
 //SKIP run-ir

--- a/test/run/refuted-const-option.mo
+++ b/test/run/refuted-const-option.mo
@@ -1,0 +1,5 @@
+// a failing pattern match that can be compiled to a trap
+let null = ?42;
+
+//SKIP run-low
+//SKIP run-ir

--- a/test/run/refuted-const-option.mo
+++ b/test/run/refuted-const-option.mo
@@ -1,5 +1,11 @@
 // a failing pattern match that can be compiled to a trap
 let null = ?42;
 
+// CHECK: (func $init (type
+// CHECK: call $blob_of_principal
+// CHECK: i32.const 14
+// CHECK-NEXT: call $print_ptr
+// CHECK-NEXT: unreachable)
+
 //SKIP run-low
 //SKIP run-ir

--- a/test/run/refuted-const-variant.mo
+++ b/test/run/refuted-const-variant.mo
@@ -1,5 +1,11 @@
 // a failing pattern match that can be compiled to a trap
 let (#const b) = #bummer;
 
+// CHECK: (func $init (type
+// CHECK: call $blob_of_principal
+// CHECK: i32.const 14
+// CHECK-NEXT: call $print_ptr
+// CHECK-NEXT: unreachable)
+
 //SKIP run-low
 //SKIP run-ir


### PR DESCRIPTION
This PR makes constant expressions fully matchable. We now also cover
- `LitP` and
- `OptP`

in the matching machinery. Thus there is no need to differentiate if the pattern is irrefutable.

Simplifies the logic quite a bit (as it should!)

-----------
TODO
- [x] tests for const `Opt` and `Lit`
- [x] bottoming cases too
- [x] check that `Opt` shortcutting works as intended — already in `iter-no-alloc.mo` for kernel present and `aardvark.mo` for kernel missing.