### PR TITLE
feat(mo-doc): nested modules

### DIFF
--- a/doc/md/base/Trie.md
+++ b/doc/md/base/Trie.md
@@ -496,9 +496,10 @@ for ((k,v) in iter) {
 assert(sum == 74);
 ```
 
-## Value `Build`
+## Module `Build`
+
 ``` motoko no-repl
-let Build
+module Build
 ```
 
 Represent the construction of tries as data.
@@ -518,6 +519,67 @@ sequence.  It is only as balanced as the tries from which we generate
 these build ASTs.  They have no intrinsic balance properties of their
 own.
 
+
+### Type `Build`
+``` motoko no-repl
+type Build<K, V> = {#skip; #put : (K, ?Hash.Hash, V); #seq : { size : Nat; left : Build<K, V>; right : Build<K, V> }}
+```
+
+The build of a trie, as an AST for a simple DSL.
+
+
+### Function `size`
+``` motoko no-repl
+func size<K, V>(tb : Build<K, V>) : Nat
+```
+
+Size of the build, measured in `#put` operations
+
+
+### Function `seq`
+``` motoko no-repl
+func seq<K, V>(l : Build<K, V>, r : Build<K, V>) : Build<K, V>
+```
+
+Build sequence of two sub-builds
+
+
+### Function `prod`
+``` motoko no-repl
+func prod<K1, V1, K2, V2, K3, V3>(tl : Trie<K1, V1>, tr : Trie<K2, V2>, op : (K1, V1, K2, V2) -> ?(K3, V3), k3_eq : (K3, K3) -> Bool) : Build<K3, V3>
+```
+
+Like [`prod`](#prod), except do not actually do the put calls, just
+record them, as a (binary tree) data structure, isomorphic to the
+recursion of this function (which is balanced, in expectation).
+
+
+### Function `nth`
+``` motoko no-repl
+func nth<K, V>(tb : Build<K, V>, i : Nat) : ?(K, ?Hash.Hash, V)
+```
+
+Project the nth key-value pair from the trie build.
+
+This position is meaningful only when the build contains multiple uses of one or more keys, otherwise it is not.
+
+
+### Function `projectInner`
+``` motoko no-repl
+func projectInner<K1, K2, V>(t : Trie<K1, Build<K2, V>>) : Build<K2, V>
+```
+
+Like [`mergeDisjoint`](#mergedisjoint), except that it avoids the
+work of actually merging any tries; rather, just record the work for
+latter (if ever).
+
+
+### Function `toArray`
+``` motoko no-repl
+func toArray<K, V, W>(tb : Build<K, V>, f : (K, V) -> W) : [W]
+```
+
+Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
 
 ## Function `fold`
 ``` motoko no-repl

--- a/doc/md/base/Trie.md
+++ b/doc/md/base/Trie.md
@@ -496,7 +496,7 @@ for ((k,v) in iter) {
 assert(sum == 74);
 ```
 
-## Moduleaa `Build`
+## Module `Build`
 
 ``` motoko no-repl
 module Build

--- a/doc/md/base/Trie.md
+++ b/doc/md/base/Trie.md
@@ -496,7 +496,7 @@ for ((k,v) in iter) {
 assert(sum == 74);
 ```
 
-## Module `Build`
+## Moduleaa `Build`
 
 ``` motoko no-repl
 module Build

--- a/nix/drun.nix
+++ b/nix/drun.nix
@@ -15,7 +15,7 @@ pkgs:
       # installed. You will normally not be bothered to perform
       # the command therein manually.
 
-      cargoSha256 = "";
+      cargoSha256 = "sha256-YHLGj2pK9WvGxRW+T2sUUvA6UhNv+sc0m1NlR18sJAc=";
 
       patchPhase = ''
       cd ../drun-vendor.tar.gz

--- a/nix/drun.nix
+++ b/nix/drun.nix
@@ -15,7 +15,7 @@ pkgs:
       # installed. You will normally not be bothered to perform
       # the command therein manually.
 
-      cargoSha256 = "sha256-YHLGj2pK9WvGxRW+T2sUUvA6UhNv+sc0m1NlR18sJAc=";
+      cargoSha256 = "";
 
       patchPhase = ''
       cd ../drun-vendor.tar.gz

--- a/src/docs/adoc.ml
+++ b/src/docs/adoc.ml
@@ -147,12 +147,12 @@ let rec adoc_of_declaration :
       doc_comment ();
       bprintf buf "\n\n";
       List.iter (adoc_of_doc buf env) class_doc.fields
-  | Module module_doc ->
-      header module_doc.name;
-      signature (fun _ -> bprintf buf "module %s" module_doc.name);
+  | Object obj_doc ->
+      header obj_doc.name;
+      signature (fun _ -> bprintf buf "%s" obj_doc.name);
       doc_comment ();
       bprintf buf "\n\n";
-      List.iter (adoc_of_doc buf env) module_doc.fields
+      List.iter (adoc_of_doc buf env) obj_doc.fields
   | Unknown unknown ->
       signature (fun _ -> bprintf buf "Unknown %s" unknown);
       doc_comment ()

--- a/src/docs/adoc.ml
+++ b/src/docs/adoc.ml
@@ -147,6 +147,12 @@ let rec adoc_of_declaration :
       doc_comment ();
       bprintf buf "\n\n";
       List.iter (adoc_of_doc buf env) class_doc.fields
+  | Module module_doc ->
+      header module_doc.name;
+      signature (fun _ -> bprintf buf "module %s" module_doc.name);
+      doc_comment ();
+      bprintf buf "\n\n";
+      List.iter (adoc_of_doc buf env) module_doc.fields
   | Unknown unknown ->
       signature (fun _ -> bprintf buf "Unknown %s" unknown);
       doc_comment ()

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -138,7 +138,7 @@ struct
           _;
         } -> (
         match rhs with
-        | Source.{ it = Syntax.ObjE (sort, fields); _ } ->
+        | Source.{ it = Syntax.ObjBlockE (sort, fields); _ } ->
             let mk_field_xref xref = mk_xref (Xref.XClass (name, xref)) in
             Some
               ( mk_xref (Xref.XType name),

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -12,7 +12,7 @@ and declaration_doc =
   | Value of value_doc
   | Type of type_doc
   | Class of class_doc
-  | Module of module_doc
+  | Object of object_doc
   | Unknown of string
 
 and function_doc = {
@@ -50,7 +50,7 @@ and class_doc = {
   sort : Syntax.obj_sort;
 }
 
-and module_doc = { name : string; fields : doc list }
+and object_doc = { name : string; fields : doc list; sort : Syntax.obj_sort }
 
 let un_prog prog =
   let comp_unit = Mo_def.CompUnit.comp_unit_of_prog true prog in
@@ -142,11 +142,12 @@ struct
             let mk_field_xref xref = mk_xref (Xref.XClass (name, xref)) in
             Some
               ( mk_xref (Xref.XType name),
-                Module
+                Object
                   {
                     name;
                     fields =
                       List.filter_map (extract_dec_field mk_field_xref) fields;
+                    sort;
                   } )
         | _ -> Some (mk_xref (Xref.XValue name), extract_let_doc rhs name))
     | Source.{ it = Syntax.TypD (name, ty_args, typ); _ } ->

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -12,6 +12,7 @@ and declaration_doc =
   | Value of value_doc
   | Type of type_doc
   | Class of class_doc
+  | Module of module_doc
   | Unknown of string
 
 and function_doc = {
@@ -48,6 +49,8 @@ and class_doc = {
   fields : doc list;
   sort : Syntax.obj_sort;
 }
+
+and module_doc = { name : string; fields : doc list }
 
 let un_prog prog =
   let comp_unit = Mo_def.CompUnit.comp_unit_of_prog true prog in
@@ -133,8 +136,19 @@ struct
         {
           it = Syntax.LetD ({ it = Syntax.VarP { it = name; _ }; _ }, rhs, _);
           _;
-        } ->
-        Some (mk_xref (Xref.XValue name), extract_let_doc rhs name)
+        } -> (
+        match rhs with
+        | Source.{ it = Syntax.ObjE (sort, fields); _ } ->
+            let mk_field_xref xref = mk_xref (Xref.XClass (name, xref)) in
+            Some
+              ( mk_xref (Xref.XType name),
+                Module
+                  {
+                    name;
+                    fields =
+                      List.filter_map (extract_dec_field mk_field_xref) fields;
+                  } )
+        | _ -> Some (mk_xref (Xref.XValue name), extract_let_doc rhs name))
     | Source.{ it = Syntax.TypD (name, ty_args, typ); _ } ->
         let doc_typ =
           match typ.it with

--- a/src/docs/html.ml
+++ b/src/docs/html.ml
@@ -16,6 +16,7 @@ let space : t = string "\u{00A0}"
 let cls_span : string -> string -> t = fun cls s -> span ~cls (string s)
 let fn_name : string -> t = cls_span "fnname"
 let class_name : string -> t = cls_span "classname"
+let module_name : string -> t = cls_span "modulename"
 let keyword : string -> t = cls_span "keyword"
 let parameter : string -> t = cls_span "parameter"
 let html_type : string -> t = cls_span "type"
@@ -265,6 +266,10 @@ let rec html_of_declaration : env -> Xref.t -> Extract.declaration_doc -> t =
         ++ br'
         ++ string ")")
       ++ list (List.map (html_of_doc env) class_doc.fields)
+  | Module module_doc ->
+      h4 ~cls:"module-declaration" ~id
+        (keyword "module " ++ module_name module_doc.name)
+      ++ list (List.map (html_of_doc env) module_doc.fields)
   | Type type_doc -> html_of_type_doc env type_doc xref
   | Value value_doc ->
       h4 ~cls:"value-declaration" ~id
@@ -304,6 +309,8 @@ let html_of_docs : render_input -> Cow.Html.t =
         li (a ~href:(Uri.of_string ("#type." ^ typ.name)) (string typ.name))
     | Extract.Class cls ->
         li (a ~href:(Uri.of_string ("#type." ^ cls.name)) (string cls.name))
+    | Extract.Module mdl ->
+        li (a ~href:(Uri.of_string ("#type." ^ mdl.name)) (string mdl.name))
     | Extract.Value val' ->
         li (a ~href:(Uri.of_string ("#" ^ val'.name)) (string val'.name))
     | Extract.Unknown typ -> empty

--- a/src/docs/html.ml
+++ b/src/docs/html.ml
@@ -266,10 +266,10 @@ let rec html_of_declaration : env -> Xref.t -> Extract.declaration_doc -> t =
         ++ br'
         ++ string ")")
       ++ list (List.map (html_of_doc env) class_doc.fields)
-  | Module module_doc ->
-      h4 ~cls:"module-declaration" ~id
-        (keyword "module " ++ module_name module_doc.name)
-      ++ list (List.map (html_of_doc env) module_doc.fields)
+  | Object obj_doc ->
+      h4 ~cls:"object-declaration" ~id
+        (html_of_obj_sort obj_doc.sort ++ module_name obj_doc.name)
+      ++ list (List.map (html_of_doc env) obj_doc.fields)
   | Type type_doc -> html_of_type_doc env type_doc xref
   | Value value_doc ->
       h4 ~cls:"value-declaration" ~id
@@ -309,8 +309,8 @@ let html_of_docs : render_input -> Cow.Html.t =
         li (a ~href:(Uri.of_string ("#type." ^ typ.name)) (string typ.name))
     | Extract.Class cls ->
         li (a ~href:(Uri.of_string ("#type." ^ cls.name)) (string cls.name))
-    | Extract.Module mdl ->
-        li (a ~href:(Uri.of_string ("#type." ^ mdl.name)) (string mdl.name))
+    | Extract.Object obj ->
+        li (a ~href:(Uri.of_string ("#type." ^ obj.name)) (string obj.name))
     | Extract.Value val' ->
         li (a ~href:(Uri.of_string ("#" ^ val'.name)) (string val'.name))
     | Extract.Unknown typ -> empty

--- a/src/docs/html.ml
+++ b/src/docs/html.ml
@@ -16,7 +16,7 @@ let space : t = string "\u{00A0}"
 let cls_span : string -> string -> t = fun cls s -> span ~cls (string s)
 let fn_name : string -> t = cls_span "fnname"
 let class_name : string -> t = cls_span "classname"
-let module_name : string -> t = cls_span "modulename"
+let object_name : string -> t = cls_span "objectname"
 let keyword : string -> t = cls_span "keyword"
 let parameter : string -> t = cls_span "parameter"
 let html_type : string -> t = cls_span "type"
@@ -268,7 +268,7 @@ let rec html_of_declaration : env -> Xref.t -> Extract.declaration_doc -> t =
       ++ list (List.map (html_of_doc env) class_doc.fields)
   | Object obj_doc ->
       h4 ~cls:"object-declaration" ~id
-        (html_of_obj_sort obj_doc.sort ++ module_name obj_doc.name)
+        (html_of_obj_sort obj_doc.sort ++ object_name obj_doc.name)
       ++ list (List.map (html_of_doc env) obj_doc.fields)
   | Type type_doc -> html_of_type_doc env type_doc xref
   | Value value_doc ->

--- a/src/docs/plain.ml
+++ b/src/docs/plain.ml
@@ -256,7 +256,6 @@ let rec declaration_header :
       sep_by buf "\n" (plain_of_doc buf (lvl + 1)) class_doc.fields
   | Module module_doc ->
       title buf lvl "";
-      plain_of_obj_sort buf module_doc.sort;
       bprintf buf "Module `%s" module_doc.name;
       bprintf buf "`\n";
       begin_block buf;

--- a/src/docs/plain.ml
+++ b/src/docs/plain.ml
@@ -77,8 +77,18 @@ let plain_of_func_sort : Buffer.t -> Syntax.func_sort -> unit =
     | Shared Query -> bprintf buf "shared query "
     | Shared Write -> bprintf buf "shared ")
 
+let plain_of_obj_sort_title : Buffer.t -> Syntax.obj_sort -> unit =
+ fun buf sort ->
+  Buffer.add_string buf
+    Mo_types.Type.(
+      match sort.it with
+      | Object -> "Object "
+      | Actor -> "Actor "
+      | Module -> "Module "
+      | Memory -> "Memory ")
+
 let plain_of_obj_sort : Buffer.t -> Syntax.obj_sort -> unit =
-  fun buf sort ->
+ fun buf sort ->
   Buffer.add_string buf
     Mo_types.Type.(
       match sort.it with
@@ -241,7 +251,9 @@ let rec declaration_header :
       doc_comment ()
   | Class class_doc ->
       title buf lvl "";
-      plain_of_obj_sort buf class_doc.sort;
+      (match class_doc.sort.it with
+      | Type.Object -> ()
+      | _ -> plain_of_obj_sort_title buf class_doc.sort);
       bprintf buf "Class `%s" class_doc.name;
       plain_of_typ_binders buf plain_render_functions class_doc.type_args;
       bprintf buf "`\n";
@@ -256,7 +268,7 @@ let rec declaration_header :
       sep_by buf "\n" (plain_of_doc buf (lvl + 1)) class_doc.fields
   | Object obj_doc ->
       title buf lvl "";
-      plain_of_obj_sort buf obj_doc.sort;
+      plain_of_obj_sort_title buf obj_doc.sort;
       bprintf buf "`%s`\n" obj_doc.name;
       begin_block buf;
       plain_of_obj_sort buf obj_doc.sort;

--- a/src/docs/plain.ml
+++ b/src/docs/plain.ml
@@ -254,6 +254,16 @@ let rec declaration_header :
       end_block buf;
       doc_comment ();
       sep_by buf "\n" (plain_of_doc buf (lvl + 1)) class_doc.fields
+  | Module module_doc ->
+      title buf lvl "";
+      plain_of_obj_sort buf module_doc.sort;
+      bprintf buf "Module `%s" module_doc.name;
+      bprintf buf "`\n";
+      begin_block buf;
+      bprintf buf "module %s" module_doc.name;
+      end_block buf;
+      doc_comment ();
+      sep_by buf "\n" (plain_of_doc buf (lvl + 1)) module_doc.fields
   | Unknown u ->
       title buf lvl (Printf.sprintf "Unknown %s" u);
       doc_comment ()

--- a/src/docs/plain.ml
+++ b/src/docs/plain.ml
@@ -78,7 +78,7 @@ let plain_of_func_sort : Buffer.t -> Syntax.func_sort -> unit =
     | Shared Write -> bprintf buf "shared ")
 
 let plain_of_obj_sort : Buffer.t -> Syntax.obj_sort -> unit =
- fun buf sort ->
+  fun buf sort ->
   Buffer.add_string buf
     Mo_types.Type.(
       match sort.it with
@@ -254,15 +254,16 @@ let rec declaration_header :
       end_block buf;
       doc_comment ();
       sep_by buf "\n" (plain_of_doc buf (lvl + 1)) class_doc.fields
-  | Module module_doc ->
+  | Object obj_doc ->
       title buf lvl "";
-      bprintf buf "Module `%s" module_doc.name;
-      bprintf buf "`\n";
+      plain_of_obj_sort buf obj_doc.sort;
+      bprintf buf "`%s`\n" obj_doc.name;
       begin_block buf;
-      bprintf buf "module %s" module_doc.name;
+      plain_of_obj_sort buf obj_doc.sort;
+      bprintf buf "%s" obj_doc.name;
       end_block buf;
       doc_comment ();
-      sep_by buf "\n" (plain_of_doc buf (lvl + 1)) module_doc.fields
+      sep_by buf "\n" (plain_of_doc buf (lvl + 1)) obj_doc.fields
   | Unknown u ->
       title buf lvl (Printf.sprintf "Unknown %s" u);
       doc_comment ()


### PR DESCRIPTION
Renders nested modules in the HTML, ADoc, and Markdown output formats. 

Fixes #1727.
