### PR TITLE
Apply `*.drun` tests to all GCs

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -444,7 +444,7 @@ do
         fi
 
         flags_var_name="FLAGS_${runner//-/_}"
-        run $mo_base.$runner.comp moc ${!flags_var_name} --hide-warnings -c $mo_file -o $out/$base/$mo_base.$runner.wasm
+        run $mo_base.$runner.comp moc $EXTRA_MOC_ARGS ${!flags_var_name} --hide-warnings -c $mo_file -o $out/$base/$mo_base.$runner.wasm
       done
 
       # mangle drun script


### PR DESCRIPTION
Currently, the `*.drun` test cases (upgrades etc.) are only applied to the copying GC.
I would be good to also test the other GCs for these test cases.
