### PR TITLE
chore: specify `nix` version on CI by pinning v2.13.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       if: startsWith(github.ref, 'refs/heads/')
       with:
@@ -75,6 +77,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       with:
         name: ic-hs-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         # fetch PR commit, not predicted merge commit
         ref: ${{ github.event.pull_request.head.sha }}
     - uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
 
     # We are using the ic-hs-test cachix cache that is also used by
     # dfinity/ic-hs. This is partly laziness (on need to set up a separate
@@ -83,6 +85,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       with:
         name: ic-hs-test

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -18,6 +18,8 @@ jobs:
         token: ${{ secrets.NIV_UPDATER_TOKEN }}
     - uses: cachix/install-nix-action@v20
       with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+      with:
         nix_path: nixpkgs=channel:nixos-22.11
     - uses: cachix/cachix-action@v12
       with:


### PR DESCRIPTION
solution by @crusso

Recent bump of `nix` to 2.15 broke our CI. Pinning 2.13.3, so that we can restore our manoeuvrability. It remains to be evaluated if it is only us or the general public that is affected.

See also #3932.