### PR TITLE
chore: fix `update-hash`

### DIFF
--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -19,8 +19,7 @@ jobs:
     - uses: cachix/install-nix-action@v20
       with:
         install_url: https://releases.nixos.org/nix/nix-2.13.3/install
-      # with:
-      #   nix_path: nixpkgs=channel:nixos-22.11
+        nix_path: nixpkgs=channel:nixos-22.11
     - uses: cachix/cachix-action@v12
       with:
         name: ic-hs-test

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -19,8 +19,8 @@ jobs:
     - uses: cachix/install-nix-action@v20
       with:
         install_url: https://releases.nixos.org/nix/nix-2.13.3/install
-      with:
-        nix_path: nixpkgs=channel:nixos-22.11
+      # with:
+      #   nix_path: nixpkgs=channel:nixos-22.11
     - uses: cachix/cachix-action@v12
       with:
         name: ic-hs-test


### PR DESCRIPTION
standardise the way we get `nix`

This is a follow-up to #3933, as that broke this action due to invalid YAML.