### PR TITLE
chore: bump `rustc` stable to v1.69

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -120,9 +120,9 @@ let
           };
         })
 
-        # Rust 1.66.1
+        # Rust 1.69
         (self: super: let
-          rust-channel = self.moz_overlay.rustChannelOf { date = "2023-01-10"; channel = "stable"; };
+          rust-channel = self.moz_overlay.rustChannelOf { date = "2023-04-20"; channel = "stable"; };
         in {
           rustPlatform_moz_stable = self.makeRustPlatform {
             rustc = rust-channel.rust;

--- a/nix/drun.nix
+++ b/nix/drun.nix
@@ -15,7 +15,7 @@ pkgs:
       # installed. You will normally not be bothered to perform
       # the command therein manually.
 
-      cargoSha256 = "sha256-WkIe1mFxPWkxgzG94FJ9XIyh8J9WSZ5kK4yaVw39lUA=";
+      cargoSha256 = "sha256-Fm4OgEWKMksxR0N5AcC137lPbhDSODrq1lBpQiPaMEw=";
 
       patchPhase = ''
         # for some reason ic-btc-validation tries to reach out

--- a/nix/drun.nix
+++ b/nix/drun.nix
@@ -18,6 +18,18 @@ pkgs:
       cargoSha256 = "sha256-Fm4OgEWKMksxR0N5AcC137lPbhDSODrq1lBpQiPaMEw=";
 
       patchPhase = ''
+
+        # `cargo remove` (below) doesn't tolerate legacy spelling
+        # `default_features`, so fix it
+        substituteInPlace rs/embedders/Cargo.toml \
+          --replace "default_features" "default-features"
+
+        substituteInPlace rs/rosetta-api/Cargo.toml \
+          --replace "default_features" "default-features"
+
+        substituteInPlace rs/rosetta-api/ledger_canister_blocks_synchronizer/Cargo.toml \
+          --replace "default_features" "default-features"
+
         # for some reason ic-btc-validation tries to reach out
         # into the web, so simply remove it
         cargo remove --package ic-btc-adapter ic-btc-validation
@@ -25,6 +37,7 @@ pkgs:
         substituteInPlace .cargo/config.toml \
           --replace "linker = \"clang\"" "linker = \"$CLANG_PATH\"" \
           --replace "\"-C\", \"link-arg=-fuse-ld=/usr/bin/mold\"" ""
+
 
         cd ../drun-vendor.tar.gz
         patch librocksdb-sys/build.rs << EOF

--- a/nix/drun.nix
+++ b/nix/drun.nix
@@ -19,25 +19,9 @@ pkgs:
 
       patchPhase = ''
 
-        # `cargo remove` (below) doesn't tolerate legacy spelling
-        # `default_features`, so fix it
-        substituteInPlace rs/embedders/Cargo.toml \
-          --replace "default_features" "default-features"
-
-        substituteInPlace rs/rosetta-api/Cargo.toml \
-          --replace "default_features" "default-features"
-
-        substituteInPlace rs/rosetta-api/ledger_canister_blocks_synchronizer/Cargo.toml \
-          --replace "default_features" "default-features"
-
-        # for some reason ic-btc-validation tries to reach out
-        # into the web, so simply remove it
-        cargo remove --package ic-btc-adapter ic-btc-validation
-
         substituteInPlace .cargo/config.toml \
           --replace "linker = \"clang\"" "linker = \"$CLANG_PATH\"" \
           --replace "\"-C\", \"link-arg=-fuse-ld=/usr/bin/mold\"" ""
-
 
         cd ../drun-vendor.tar.gz
         patch librocksdb-sys/build.rs << EOF


### PR DESCRIPTION
`cargo remove` is not needed anymore!

---------
This is moot now

Minor problem with `wasmtime` not adhering to convention:
> error: Use of `default_features` in `wasmtime` is unsupported, please switch to `default-features`