### PR TITLE
chore: show failed tests only once

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -557,7 +557,7 @@ done
 if [ ${#failures[@]} -gt 0  ]
 then
   echo "Some tests failed:"
-  echo "${failures[@]}"
+  tr ' ' '\n' <<< "${failures[@]}" | uniq | xargs echo
   exit 1
 else
   $ECHO "All tests passed."


### PR DESCRIPTION
Before:
```
Some tests failed:
recombine.mo recombine.mo recombine.mo recombine.mo recombine.mo recombine.mo recombine.mo recombine.mo
```
after:
```
Some tests failed:
recombine.mo
```