### PR TITLE
perf: improve codegen for `?_` and `#variant _` (and also `()`)

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10082,12 +10082,10 @@ and compile_lit_pat env l =
     todo_trap env "compile_lit_pat" (Arrange_ir.lit l)
 
 and fill_pat env ae pat : patternCode =
-  let irrefutable_nonbinding p =
-    Ir_utils.is_irrefutable p && Freevars.(M.is_empty (pat p)) in
   PatCode.with_region pat.at @@
   match pat.it with
   | WildP -> CannotFail (G.i Drop)
-  | OptP p when irrefutable_nonbinding p ->
+  | OptP p when Ir_utils.is_irrefutable_nonbinding p ->
       CanFail (fun fail_code ->
         Opt.is_some env ^^
         G.if0 G.nop fail_code)
@@ -10104,7 +10102,7 @@ and fill_pat env ae pat : patternCode =
           )
           fail_code
       )
-  | TagP (l, p) when irrefutable_nonbinding p ->
+  | TagP (l, p) when Ir_utils.is_irrefutable_nonbinding p ->
       CanFail (fun fail_code ->
         Variant.test_is env l ^^
         G.if0 G.nop fail_code)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -9934,8 +9934,8 @@ and compile_exp_with_hint (env : E.t) ae sr_hint exp =
     compile_exp_vanilla env ae exp_r ^^ set_r ^^
 
     FuncDec.ic_self_call env ts
-      (IC.get_self_reference env ^^
-       IC.actor_public_field env (IC.async_method_name))
+      IC.(get_self_reference env ^^
+          actor_public_field env async_method_name)
       get_future
       get_k
       get_r
@@ -10083,7 +10083,7 @@ and compile_lit_pat env l =
 
 and fill_pat env ae pat : patternCode =
   let irrefutable_nonbinding p =
-    Ir_utils.is_irrefutable pat && Freevars.(M.is_empty (pat p)) in
+    Ir_utils.is_irrefutable p && Freevars.(M.is_empty (pat p)) in
   PatCode.with_region pat.at @@
   match pat.it with
   | WildP -> CannotFail (G.i Drop)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10085,6 +10085,11 @@ and fill_pat env ae pat : patternCode =
   PatCode.with_region pat.at @@
   match pat.it with
   | WildP -> CannotFail (G.i Drop)
+  | OptP { it = WildP; _ } ->
+      CanFail (fun fail_code ->
+        Opt.is_some env ^^
+        G.if0 G.nop fail_code
+      )
   | OptP p ->
       let (set_x, get_x) = new_local env "opt_scrut" in
       CanFail (fun fail_code ->
@@ -10097,6 +10102,11 @@ and fill_pat env ae pat : patternCode =
             with_fail fail_code (fill_pat env ae p)
           )
           fail_code
+      )
+  | TagP (l, { it = WildP; _ }) ->
+      CanFail (fun fail_code ->
+        Variant.test_is env l ^^
+        G.if0 G.nop fail_code
       )
   | TagP (l, p) ->
       let (set_x, get_x) = new_local env "tag_scrut" in

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10082,10 +10082,12 @@ and compile_lit_pat env l =
     todo_trap env "compile_lit_pat" (Arrange_ir.lit l)
 
 and fill_pat env ae pat : patternCode =
+  let irrefutable_nonbinding p =
+    Ir_utils.is_irrefutable pat && Freevars.(M.is_empty (pat p)) in
   PatCode.with_region pat.at @@
   match pat.it with
   | WildP -> CannotFail (G.i Drop)
-  | OptP { it = (WildP | TupP []); _ } ->
+  | OptP p when irrefutable_nonbinding p ->
       CanFail (fun fail_code ->
         Opt.is_some env ^^
         G.if0 G.nop fail_code)
@@ -10102,7 +10104,7 @@ and fill_pat env ae pat : patternCode =
           )
           fail_code
       )
-  | TagP (l, { it = (WildP | TupP []); _ }) ->
+  | TagP (l, p) when irrefutable_nonbinding p ->
       CanFail (fun fail_code ->
         Variant.test_is env l ^^
         G.if0 G.nop fail_code)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10085,7 +10085,7 @@ and fill_pat env ae pat : patternCode =
   PatCode.with_region pat.at @@
   match pat.it with
   | WildP -> CannotFail (G.i Drop)
-  | OptP { it = WildP; _ } ->
+  | OptP { it = (WildP | TupP []); _ } ->
       CanFail (fun fail_code ->
         Opt.is_some env ^^
         G.if0 G.nop fail_code)
@@ -10102,7 +10102,7 @@ and fill_pat env ae pat : patternCode =
           )
           fail_code
       )
-  | TagP (l, { it = WildP; _ }) ->
+  | TagP (l, { it = (WildP | TupP []); _ }) ->
       CanFail (fun fail_code ->
         Variant.test_is env l ^^
         G.if0 G.nop fail_code)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10088,8 +10088,7 @@ and fill_pat env ae pat : patternCode =
   | OptP { it = WildP; _ } ->
       CanFail (fun fail_code ->
         Opt.is_some env ^^
-        G.if0 G.nop fail_code
-      )
+        G.if0 G.nop fail_code)
   | OptP p ->
       let (set_x, get_x) = new_local env "opt_scrut" in
       CanFail (fun fail_code ->
@@ -10106,8 +10105,7 @@ and fill_pat env ae pat : patternCode =
   | TagP (l, { it = WildP; _ }) ->
       CanFail (fun fail_code ->
         Variant.test_is env l ^^
-        G.if0 G.nop fail_code
-      )
+        G.if0 G.nop fail_code)
   | TagP (l, p) ->
       let (set_x, get_x) = new_local env "tag_scrut" in
       CanFail (fun fail_code ->

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10084,7 +10084,8 @@ and compile_lit_pat env l =
 and fill_pat env ae pat : patternCode =
   PatCode.with_region pat.at @@
   match pat.it with
-  | WildP -> CannotFail (G.i Drop)
+  | _ when Ir_utils.is_irrefutable_nonbinding pat -> CannotFail (G.i Drop)
+  | WildP -> assert false (* matched above *)
   | OptP p when Ir_utils.is_irrefutable_nonbinding p ->
       CanFail (fun fail_code ->
         Opt.is_some env ^^

--- a/src/ir_def/ir_utils.ml
+++ b/src/ir_def/ir_utils.ml
@@ -6,3 +6,6 @@ let rec is_irrefutable p = match p.it with
   | AltP (pat1, _) -> is_irrefutable pat1
   | WildP | VarP _ -> true
   | TagP _ | LitP _ | OptP _ -> false
+
+let is_irrefutable_nonbinding p =
+  is_irrefutable p && Freevars.(M.is_empty (pat p))


### PR DESCRIPTION
Applies a shortcut when the inner pattern is a `WildP`. I also cover `()`, the prototypical non-binding irrefutable pattern.

Generally we now don't even make an attempt to enter into matching irrefutable patterns below options or tags when there are no bindings to fill.

This removes the unnecessary locals holding the scrutinees, since we don't have to project out for bindings or further pattern matching.

Normally the _push/drop_ peephole optimisation would _almost_ clean this up, but the local `tee` still remains.

Spotted in #3955.

Further optimisation could be to also allow:
- [x] _irrefutable_ patterns with `Freevars.(M.is_empty (pat p))` (e.g. `#foo ((), _)`) — see c06a0c9af
- when the scrutinee is _singleton-typed_ with no bindings in the pattern (but that might be less interesting).