### PR TITLE
perf: `If`-related peephole rules

### DIFF
--- a/test/run/empty-if.mo
+++ b/test/run/empty-if.mo
@@ -1,0 +1,16 @@
+var a = 'N';
+
+func foo() = if (a == 'Y') {} else {};
+func barX() = if (a == 'Y') {} else {};
+
+barX();
+foo();
+
+// CHECK: func $foo
+// CHECK: i32.eq
+// CHECK-NEXT: drop
+// CHECK: func $barX
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low

--- a/test/run/issue1356.mo
+++ b/test/run/issue1356.mo
@@ -37,13 +37,13 @@ func matchInt(n : Int) : Bool =
 func match8(n : Nat8) : Bool = switch n { case 42 true; case _ false };
 // CHECK-LABEL: (func $match8
 // CHECK:        i32.const 704643072
-// CHECK-NEXT:   i32.eq
+// CHECK-NEXT:   i32.ne
 // N.B.: 704643072 == 0x2a000000 == 42 << 24
 
 func match16(n : Nat16) : Bool = switch n { case 42 true; case _ false };
 // CHECK-LABEL: (func $match16
 // CHECK:        i32.const 2752512
-// CHECK-NEXT:   i32.eq
+// CHECK-NEXT:   i32.ne
 // N.B.: 2752512 == 0x002a0000 == 42 << 16
 
 // NB: reverse order, so that things appear in order


### PR DESCRIPTION
- `If` blocks with empty legs just `Drop`
- `If` blocks with empty `then` after comparison can invert the comparison and swap legs

The latter is not removing instructions, but cleans up the `.wat`, making it more idiomatic (and if we are lucky it saves cycles too).
``` diff wasm
     local.get $buf
     i32.load offset=4
     local.get $buf
     i32.load
-    i32.eq
+    i32.ne
     if  ;; label = @1
-    else
       i32.const 2098196
       i32.const 30
       call 31
       unreachable
     end
```
The former is needed so that we don't loop on the latter.

TODO:
- [x] needs test for the empty legs case — see b0b669e5d