### PR TITLE
ci: add an artifact job

### DIFF
--- a/.github/workflows/comment-artifact-link.yml
+++ b/.github/workflows/comment-artifact-link.yml
@@ -1,0 +1,63 @@
+name: Comment artifact link
+on:
+  workflow_run:
+    # This job only runs from the main branch. You won't see any change until it's merged to main.
+    # To test this job, you can temporarily change it to `pull_request` and hardcode the run_id and pr_number
+    workflows: ['build']
+    types: [completed]
+jobs:
+  pr_comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          # This snippet is public-domain, taken from
+          # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
+          script: |
+            async function upsertComment(owner, repo, issue_number, purpose, body) {
+              const {data: comments} = await github.rest.issues.listComments(
+                {owner, repo, issue_number});
+
+              const marker = `<!-- bot: ${purpose} -->`;
+              body = marker + "\n" + body;
+
+              const existing = comments.filter((c) => c.body.includes(marker));
+              if (existing.length > 0) {
+                const last = existing[existing.length - 1];
+                core.info(`Updating comment ${last.id}`);
+                await github.rest.issues.updateComment({
+                  owner, repo,
+                  body,
+                  comment_id: last.id,
+                });
+              } else {
+                core.info(`Creating a comment in issue / PR #${issue_number}`);
+                await github.rest.issues.createComment({issue_number, body, owner, repo});
+              }
+            }
+
+            const {owner, repo} = context.repo;
+            const run_id = ${{github.event.workflow_run.id}};
+
+            const pull_requests = ${{ toJSON(github.event.workflow_run.pull_requests) }};
+            if (!pull_requests.length) {
+              return core.error("This workflow doesn't match any pull requests!");
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
+            if (!artifacts.length) {
+              return core.error(`No artifacts found`);
+            }
+            let body = `Download the artifacts for this pull request:\n`;
+            for (const art of artifacts) {
+              body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+            }
+
+            core.info("Review thread message body:", body);
+
+            for (const pr of pull_requests) {
+              await upsertComment(owner, repo, pr.number,
+                "nightly-link", body);
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
     - uses: actions/github-script@v6
       with:
         script: |
-          console.log(${{github.event.pull_request.labels}});
+          console.log(${{ toJson(github.event.pull_request.labels.*.name) }});
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
       with:
@@ -119,11 +119,14 @@ jobs:
       with:
         name: ic-hs-test
     - name: nix-build
-      run: nix-build --arg officialRelease true -A moc
+      run: |
+        nix-build --arg officialRelease true -A moc
+        ls -al
+        ls -al result/
     - name: upload artifacts
       uses: actions/upload-artifact@v3
       with:
         name: moc
-        path: result
+        path: result/*
         retention-days: 5
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,6 @@ jobs:
       with:
         script: |
           console.log(github.event.pull_request.labels);
-          console.log(github.event.pull_request.labels.*.name);
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
     - uses: actions/github-script@v6
       with:
         script: |
-          console.log(github.event.pull_request.labels);
+          console.log(${{github.event.pull_request.labels}});
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
         single-commit: true
 
   artifacts:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'build_artifacts')
     needs: tests
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
@@ -123,10 +123,13 @@ jobs:
         nix-build --arg officialRelease true -A moc
         ls -al
         ls -al result/
+    # upload-artifact doesn't work for symlink dir
+    # https://github.com/actions/upload-artifact/issues/92
+    - run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
     - name: upload artifacts
       uses: actions/upload-artifact@v3
       with:
         name: moc
-        path: result/*
+        path: ${{ env.UPLOAD_PATH }}
         retention-days: 5
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,10 +107,6 @@ jobs:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v6
-      with:
-        script: |
-          console.log(${{ toJson(github.event.pull_request.labels.*.name) }});
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
       with:
@@ -121,8 +117,6 @@ jobs:
     - name: nix-build
       run: |
         nix-build --arg officialRelease true -A moc
-        ls -al
-        ls -al result/
     # upload-artifact doesn't work for symlink dir
     # https://github.com/actions/upload-artifact/issues/92
     - run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,3 +100,26 @@ jobs:
         branch: gh-pages
         folder: report-site-copy
         single-commit: true
+
+  artifacts:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'build_artifacts')
+    needs: tests
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+    - uses: cachix/cachix-action@v12
+      with:
+        name: ic-hs-test
+    - name: nix-build
+      run: nix-build --arg officialRelease true -A moc
+    - name: upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: moc
+        path: result
+        retention-days: 5
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,11 +102,16 @@ jobs:
         single-commit: true
 
   artifacts:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'build_artifacts')
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: tests
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          console.log(github.event.pull_request.labels);
+          console.log(github.event.pull_request.labels.*.name);
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
       with:


### PR DESCRIPTION
When "build_artifacts" label is applied, CI builds the `moc` binary and uploads to artifact.

- [x] generate a nightly.link to download the artifact.