### PR TITLE
feat: add blob get and slice prim functions

### DIFF
--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -285,6 +285,23 @@ let prim trap =
     k (Blob (String.of_seq (Seq.map (fun v ->
       Char.chr (Nat8.to_int (Value.as_nat8 !(Value.as_mut v)))
     ) (Array.to_seq (Value.as_array v)))))
+  (* returns a single nat8 at the given index *)
+  | "blobGet" -> fun _ v k ->
+    (match Value.as_tup v with
+    | [a; b] -> let (a, b) = (Value.as_blob a, Int.to_int (as_int b)) in
+      if b < 0 || b >= String.length a (* check bounds *)
+      then trap.trap "blob index out of bounds"
+      else k (Nat8 (Nat8.of_int (Char.code (String.get a b))))
+    | _ -> assert false)
+  (* returns a new blob that contains a subset [from,to) of the given blob *)
+  (* in the future negative values could be used to offset from the end, nat :< int *)
+  | "blobSlice" -> fun _ v k ->
+    (match Value.as_tup v with
+    | [a; b; c] -> let (a, b, c) = (Value.as_blob a, Int.to_int (as_int b), Int.to_int (as_int c)) in
+      if c < b || b < 0 || b > String.length a (* check bounds, b <= c *)
+      then trap.trap "blob index out of bounds"
+      else k (Blob (String.sub a b (c - b)))
+    | _ -> assert false)
 
   | "cast" -> fun _ v k -> k v
 

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -235,6 +235,13 @@ func blobToArrayMut(b : Blob) : [var Nat8] = (prim "blobToArrayMut" : (Blob) -> 
 func arrayToBlob(a : [Nat8]) : Blob = (prim "arrayToBlob" : [Nat8] -> Blob) a;
 func arrayMutToBlob(a : [var Nat8]) : Blob = (prim "arrayMutToBlob" : [var Nat8] -> Blob) a;
 
+// Gets the byte at the given offset in the blob.
+// The offset must be less than the length of the blob.
+func blobGet(b : Blob, offset : Nat) : Nat8 = (prim "blobGet" : (Blob, Nat) -> Nat8) (b, offset);
+
+// Creates and returns a new blob which contains the bytes of the given blob `from` the given offset (inclusive) `to` the given offset (exclusive).
+// The offsets must be less than the length of the blob.
+func blobSlice(b : Blob, from : Nat, to : Nat) : Blob = (prim "blobSlice" : (Blob, Nat, Nat) -> Blob) (b, from, to);
 
 // Error codes
 type ErrorCode = {

--- a/test/run/blobs.mo
+++ b/test/run/blobs.mo
@@ -39,3 +39,15 @@ switch(i1.next()) {
   case null {};
 };
 };
+
+assert (Prim.blobGet("\00\01\02", 0) == (0:Nat8));
+assert (Prim.blobGet("\00\01\02", 1) == (1:Nat8));
+assert (Prim.blobGet("\00\01\02", 2) == (2:Nat8));
+
+assert (Prim.blobSlice("\00\01\02", 0, 0) == ("":Blob));
+assert (Prim.blobSlice("\00\01\02", 0, 1) == ("\00":Blob));
+assert (Prim.blobSlice("\00\01\02", 0, 2) == ("\00\01":Blob));
+assert (Prim.blobSlice("\00\01\02", 0, 3) == ("\00\01\02":Blob));
+assert (Prim.blobSlice("\00\01\02", 1, 1) == ("":Blob));
+assert (Prim.blobSlice("\00\01\02", 1, 3) == ("\01\02":Blob));
+assert (Prim.blobSlice("\00\01\02", 2, 3) == ("\02":Blob));


### PR DESCRIPTION
Hi 👋🏼

Here is my first attempt to start contributing to Motoko, and writing OCaml.

This PR adds two new primitives to the Prim library: `blobGet` and `blobSlice`. These primitives allow for (more) efficient byte manipulation with a blob.

This is my first time writing OCaml, so there may be room for improvement in the implementation. However, I have tested these functions and they work as intended.

---

The `blobGet` function takes a blob `b` and an offset `offset` as arguments and returns the byte at that offset in the blob.

The `blobSlice` function creates a new blob from a portion of an existing blob. It takes a blob `b`, a starting offset `from`, and an ending offset `to` as arguments. The new blob will contain the bytes of the original blob from the from offset (inclusive) to the to offset (exclusive).

---

I welcome any feedback on the implementation and look forward to improving my OCaml skills 🐫. 