### PR TITLE
updates to Motoko mentions of the SDK and DFX

### DIFF
--- a/design/DFX-Interface.md
+++ b/design/DFX-Interface.md
@@ -1,8 +1,8 @@
 Stable CLI for dfx
 ==================
 
-An important way of using the Motoko compiler is via the the `dfx` tool,
-provided by the DFINITY SDK, which provides project and package management
+An important way of using the Motoko compiler is via the the `dfx` command,
+provided by the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install), which provides project and package management
 support.
 
 This document describes the interface that `moc` and related tools provide to
@@ -14,7 +14,7 @@ This document describes the interface that `moc` and related tools provide to
    this document.)
 
 This interface includes:
- * nix derivations imported by SDK
+ * nix derivations imported by the IC SDK
  * binaries executed
  * command line arguments and environment variables passed to these binaries
  * where these binaries read files and

--- a/doc/md/about-this-guide.md
+++ b/doc/md/about-this-guide.md
@@ -4,11 +4,11 @@
 
 The *Motoko Programming Language Guide* introduces key features of the general-purpose Motoko programming language and provides examples and reference information to help you learn the nuances of the language and the practical implications of how to apply it.
 
-The Motoko programming language is optimized for developing programs that run on the Internet Computer blockchain network and to work with the DFINITY Canister Software Development Kit (SDK). You could, in principle, also write programs using Motoko for more traditional platforms and to run in other contexts, though support for this is currently best-effort and incomplete. This guide attempts to strike a balance between highlighting features that are uniquely suited to running on the Internet Computer and features that are generally-applicable or well-suited for programs running on all targets.
+The Motoko programming language is optimized for developing programs that run on the Internet Computer blockchain network and to work with the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install). You could, in principle, also write programs using Motoko for more traditional platforms and to run in other contexts, though support for this is currently best-effort and incomplete. This guide attempts to strike a balance between highlighting features that are uniquely suited to running on the Internet Computer and features that are generally-applicable or well-suited for programs running on all targets.
 
 ## Intended audience
 
-This guide provides reference information and examples for programmers who want to explore or plan to use the Motoko programming language. Most of the information in this guide is applicable independent of whether you are developing programs to run on the Internet Computer or working with the DFINITY Canister SDK.
+This guide provides reference information and examples for programmers who want to explore or plan to use the Motoko programming language. Most of the information in this guide is applicable independent of whether you are developing programs to run on the Internet Computer or working with the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install).
 
 The guide assumes you are familiar with basic programming principles and terminology and have at least some experience writing programs in a high-level programming language such as C++ or Rust, or have practical experience working with a scripting language such as JavaScript or TypeScript. In addition, Motoko incorporates some aspects of functional programming, so you might find some knowledge of functional programming design principles helpful in learning to use Motoko.
 
@@ -66,7 +66,7 @@ The following principles represent the secondary values of the engineering organ
 
 2.  Performance, so that Motoko provides reasonably fast operation initially and continues to improves as the language evolves.
 
-3.  Readiness, so the Motoko comes with "batteries included" in the form of libraries and examples and out-of-the-box integration with the DFINITY Canister SDK.
+3.  Readiness, so the Motoko comes with "batteries included" in the form of libraries and examples and out-of-the-box integration with the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install).
 
 ### Non-goals
 

--- a/doc/md/compiler-ref.md
+++ b/doc/md/compiler-ref.md
@@ -1,6 +1,6 @@
 # Compiler reference
 
-The Motoko compiler (`moc`) is the primary tool for compiling Motoko programs into executable WebAssembly (Wasm) modules. The compiler runs in the background when you build projects using the DFINITY Canister SDK. If you invoke the compiler directly on the command-line, you can press CTRL-C to exit.
+The Motoko compiler (`moc`) is the primary tool for compiling Motoko programs into executable WebAssembly (Wasm) modules. The compiler runs in the background when you build projects using the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install). If you invoke the compiler directly on the command-line, you can press CTRL-C to exit.
 
 This section provides compiler command-line reference information.
 

--- a/doc/md/language-manual.md
+++ b/doc/md/language-manual.md
@@ -1194,7 +1194,7 @@ In detail, if `<url>` is of the form:
 
 The case sensitivity of file references depends on the host operating system so it is recommended not to distinguish resources by filename casing alone.
 
-(Remark: when building multi-canister projects with the DFINITY Canister SDK, Motoko programs can typically import canisters by alias (e.g. `import C "canister:counter"`), without specifying low-level canister ids (e.g. `import C "ic:lg264-qjkae"`). The SDK tooling takes care of supplying the appropriate command-line arguments to the Motoko compiler.)
+(Remark: when building multi-canister projects with the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install), Motoko programs can typically import canisters by alias (e.g. `import C "canister:counter"`), without specifying low-level canister ids (e.g. `import C "ic:lg264-qjkae"`). The SDK tooling takes care of supplying the appropriate command-line arguments to the Motoko compiler.)
 
 (Remark: sensible choices for `<pat>` are identifiers, such as `Array`, or object patterns like `{ cons; nil = empty }`, which allow selective importing of individual fields, under original or other names.)
 

--- a/doc/md/motoko.md
+++ b/doc/md/motoko.md
@@ -2,7 +2,7 @@
 
 :::tip
 
-The Motoko programming language continues to evolve with each release of the DFINITY Canister SDK and with ongoing updates to the Motoko compiler. Check back regularly to try new features and see what’s changed.
+The Motoko programming language continues to evolve with each release of the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install) and with ongoing updates to the Motoko compiler. Check back regularly to try new features and see what’s changed.
 
 :::
 
@@ -88,6 +88,6 @@ For scenarios that can’t be solved using stable variables alone, Motoko provid
 
 Motoko provides many other developer productivity features, including subtyping, arbitrary precision arithmetic and garbage collection.
 
-Motoko is not, and is not intended to be, the only language for implementing canister smart contracts. If it doesn’t suit your needs, there is a canister development kit (CDK) for the Rust programming language. Our goal is to enable any language (with a compiler that targets WebAssembly) to be able to produce canister smart contracts that run on the Internet Computer and interoperate with other, perhaps foreign, canister smart contracts through language neutral Candid interfaces.
+Motoko is not, and is not intended to be, the only language for implementing canister smart contracts. If it doesn’t suit your needs, there is a canister development kit [(CDK) for the Rust programming language](https://github.com/dfinity/cdk-rs). Our goal is to enable any language (with a compiler that targets WebAssembly) to be able to produce canister smart contracts that run on the Internet Computer and interoperate with other, perhaps foreign, canister smart contracts through language neutral Candid interfaces.
 
 Its tailored design means Motoko should be the easiest and safest language for coding on the Internet Computer, at least for the forseeable future.


### PR DESCRIPTION
Updates to the Motoko docs so it shows the correct naming for IC SDK