### PR TITLE
Releasing 0.9.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Motoko compiler changelog
 
+## 0.9.1 (2023-05-15)
+
+* motoko (`moc`)
+
+  * Added implementation for `ic0.is_controller` as a primitive (#3935).
+
+  * Added ability to enable the new incremental GC in the Motoko Playground (#3976).
+
 ## 0.9.0 (2023-05-12)
 
 * motoko (`moc`)


### PR DESCRIPTION
**WARNING**: This release had to deactivate the `ic-ref` testing until https://dfinity.atlassian.net/browse/VER-2322 restores binary artefact caching on Linux via `cachix`. As this release won't be pushed towards `dfx` for some time, this was deemed acceptable. (Also there are no codegen changes in the pipeline.)

Primary reason for this release is to facilitate using the incremental collector in the Motoko Playground.