### PR TITLE
feat: include error categories and codes in `moc.js` diagnostics

### DIFF
--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -23,6 +23,8 @@ let diagnostics_of_msg (msg : Diag.message) =
     val source = Js.string msg.at.left.file
     val severity = match msg.sev with Diag.Error -> 1 | (Diag.Warning | Diag.Info) -> 2
     val range = range_of_region msg.at
+    val code = Js.string msg.code
+    val category = Js.string msg.cat
     val message = Js.string msg.text
   end)
 

--- a/src/lang_utils/error_codes/M0003.md
+++ b/src/lang_utils/error_codes/M0003.md
@@ -6,7 +6,8 @@ Erroneous code example (file is called `Self.mo`):
 
 ```motoko
 import S "./Self"; // import error, file Self.mo must not depend on itself
-module { }
+
+module { ... }
 ```
 
 If you encounter this error you should probably remove the offending import.

--- a/src/lang_utils/error_codes/M0149.md
+++ b/src/lang_utils/error_codes/M0149.md
@@ -1,6 +1,6 @@
 # M0149
 
-This error means that you supplied a immutable record field (declared without `var`), where a mutable record field (specified with `var`), was expected.
+This error means that you supplied an immutable record field (declared without `var`), where a mutable record field (specified with `var`), was expected.
 
 Erroneous code example:
 

--- a/src/lang_utils/error_codes/M0155.md
+++ b/src/lang_utils/error_codes/M0155.md
@@ -27,23 +27,23 @@ func f(n : Nat) {
 If the intended type was `Int`, however, you can either annotate it as such:
 
 ```
-  func f(n : Nat) {
-    let m : Int = 2 * (n - 1);
-  };
+func f(n : Nat) {
+  let m : Int = 2 * (n - 1);
+};
 ```
 
 Or you can insert a sign operator `+`, which also forces the expression to be of type `Int`:
 
 ```
-  func f(n : Nat) {
-    let m = 2 * (+n - 1);
-  };
+func f(n : Nat) {
+  let m = 2 * (+n - 1);
+};
 ```
 
 This latter possibility is particularly convenient in the case of comparisons, because it is always okay to perform them at type `Int`:
 
 ```
-  func g(n : Nat) {
-    if (+n - 1 < 10) { return };
-  };
+func g(n : Nat) {
+  if (+n - 1 < 10) { return };
+};
 ```

--- a/src/lang_utils/error_codes/M0155.md
+++ b/src/lang_utils/error_codes/M0155.md
@@ -1,4 +1,5 @@
 # M0155
+
 This warning indicates that the type of a subtraction operation had to be deduced from its operands and was inferred to be `Nat`.
 That implies that it traps when the result is negative, which may be unintentional.
 

--- a/src/lang_utils/error_codes/M0156.md
+++ b/src/lang_utils/error_codes/M0156.md
@@ -7,13 +7,13 @@ Motoko rejects type definitions that are expansive, in the sense that unfolding 
 For example, the type definition:
 
 ```motoko
-type List<T> = ?(T, List<T>),
+type List<T> = ?(T, List<T>);
 ```
 
 that recursively instantiates `List` at the same parameter `T`, is non-expansive and accepted, but the similar looking definition:
 
 ```motoko
-type Seq<T> = ?(T, Seq<[T]>),
+type Seq<T> = ?(T, Seq<[T]>);
 ```
 
 that recursively instantiates `Seq` with a larger type, `[T]`, containing `T`, is *expansive* and rejected.

--- a/src/lang_utils/error_codes/M0158.md
+++ b/src/lang_utils/error_codes/M0158.md
@@ -11,7 +11,7 @@ public class () {};
 If you encounter this error, you should probably name the class or make it private.
 
 ```motoko
-public class C () {};
+public class C() {};
 ```
 
 Public fields must be named since they determine the interface of the enclosing object.

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -33,7 +33,7 @@ moc.Motoko.saveFile(
     };
   }`
 );
-moc.Motoko.saveFile('text.mo', `let s = "${'⛔|'.repeat(10000)}"; s.size()`); // #3822
+moc.Motoko.saveFile("text.mo", `let s = "${"⛔|".repeat(10000)}"; s.size()`); // #3822
 
 try {
   assert.equal(moc.Motoko.readFile("empty.mo"), "");
@@ -102,6 +102,8 @@ try {
         },
         severity: 1,
         source: "bad.mo",
+        code: "M0001",
+        category: "syntax",
         message:
           "unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>",
       },
@@ -130,6 +132,8 @@ try {
         },
         severity: 1,
         source: "bad.mo",
+        category: "syntax",
+        code: "M0001",
         message:
           "unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>",
       },
@@ -158,9 +162,8 @@ try {
   // Check that long text literals type-check without error
   assert.deepStrictEqual(moc.Motoko.check("text.mo"), {
     code: null,
-    diagnostics: []
+    diagnostics: [],
   });
-}
-catch (err) {
+} catch (err) {
   assert.fail(err);
 }


### PR DESCRIPTION
- Sends more diagnostic information through `moc.js`
- Fixes various typos and formatting inconsistencies in the error code explanation files