### PR TITLE
chore: change binary release artefact names

### DIFF
--- a/release-files.nix
+++ b/release-files.nix
@@ -31,10 +31,13 @@ let
   release =
     nixpkgs.runCommandNoCC "motoko-release-${releaseVersion}" {} ''
       mkdir $out
-      cp ${as_tarball "x86_64-linux" (with linux; [ mo-ide mo-doc moc ])} $out/motoko-linux64-${releaseVersion}.tar.gz
-      cp ${as_tarball "x86_64-darwin" (with darwin; [ mo-ide mo-doc moc ])} $out/motoko-macos-${releaseVersion}.tar.gz
       cp ${as_tarball "x86_64-linux" (with linux; [ mo-ide mo-doc moc ])} $out/motoko-Linux-x86_64-${releaseVersion}.tar.gz
       cp ${as_tarball "x86_64-darwin" (with darwin; [ mo-ide mo-doc moc ])} $out/motoko-Darwin-x86_64-${releaseVersion}.tar.gz
+
+      # create legacy names too
+      ln $out/motoko-Linux-x86_64-${releaseVersion}.tar.gz $out/motoko-linux64-${releaseVersion}.tar.gz
+      ln $out/motoko-Darwin-x86_64-${releaseVersion}.tar.gz $out/motoko-macos-${releaseVersion}.tar.gz
+
       cp ${as_js "moc" linux.js.moc} $out/moc-${releaseVersion}.js
       cp ${as_js "moc-interpreter" linux.js.moc_interpreter} $out/moc-interpreter-${releaseVersion}.js
       tar --exclude=.github -C ${nixpkgs.sources.motoko-base} -czvf $out/motoko-base-library.tar.gz .

--- a/release-files.nix
+++ b/release-files.nix
@@ -31,6 +31,8 @@ let
   release =
     nixpkgs.runCommandNoCC "motoko-release-${releaseVersion}" {} ''
       mkdir $out
+      cp ${as_tarball "x86_64-linux" (with linux; [ mo-ide mo-doc moc ])} $out/motoko-linux64-${releaseVersion}.tar.gz
+      cp ${as_tarball "x86_64-darwin" (with darwin; [ mo-ide mo-doc moc ])} $out/motoko-macos-${releaseVersion}.tar.gz
       cp ${as_tarball "x86_64-linux" (with linux; [ mo-ide mo-doc moc ])} $out/motoko-Linux-x86_64-${releaseVersion}.tar.gz
       cp ${as_tarball "x86_64-darwin" (with darwin; [ mo-ide mo-doc moc ])} $out/motoko-Darwin-x86_64-${releaseVersion}.tar.gz
       cp ${as_js "moc" linux.js.moc} $out/moc-${releaseVersion}.js

--- a/release-files.nix
+++ b/release-files.nix
@@ -31,8 +31,8 @@ let
   release =
     nixpkgs.runCommandNoCC "motoko-release-${releaseVersion}" {} ''
       mkdir $out
-      cp ${as_tarball "x86_64-linux" (with linux; [ mo-ide mo-doc moc ])} $out/motoko-linux64-${releaseVersion}.tar.gz
-      cp ${as_tarball "x86_64-darwin" (with darwin; [ mo-ide mo-doc moc ])} $out/motoko-macos-${releaseVersion}.tar.gz
+      cp ${as_tarball "x86_64-linux" (with linux; [ mo-ide mo-doc moc ])} $out/motoko-Linux-x86_64-${releaseVersion}.tar.gz
+      cp ${as_tarball "x86_64-darwin" (with darwin; [ mo-ide mo-doc moc ])} $out/motoko-Darwin-x86_64-${releaseVersion}.tar.gz
       cp ${as_js "moc" linux.js.moc} $out/moc-${releaseVersion}.js
       cp ${as_js "moc-interpreter" linux.js.moc_interpreter} $out/moc-interpreter-${releaseVersion}.js
       tar --exclude=.github -C ${nixpkgs.sources.motoko-base} -czvf $out/motoko-base-library.tar.gz .


### PR DESCRIPTION
Here is a suggested PR to update the name of the release so they follow `$(uname -s)-$(uname -m)` convention. This would make it easier to fetch the releases from container build files like `Dockerfile`.

Hence: 
-  x86 Linux becomes `Linux-x86_64`
-  x86 Mac becomes `Darwin-x86_64`

In the future this would allow for: 
- M1/M2 Mac to become `Darwin-arm64`
- arm64 Linux to become `Linux-arm64`

Which would not have been possible under the current naming scheme which does not differentiate for the different macOS architecture (understandable as from my understanding there are no releases for M1/2 macOS yet).

_Note_: the legacy naming is still available. This will be discontinued when all downstream consumers have updated their procedures.