### PR TITLE
bugfix: fix bug in grammar for `async*` expressions

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -191,7 +191,7 @@
     <exp_bin> <binassign> <exp>
     'return' <exp>?
     'async' <exp_nest>
-    'async*' <block>
+    'async*' <exp_nest>
     'await' <exp_nest>
     'await*' <exp_nest>
     'assert' <exp_nest>

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -655,7 +655,7 @@ exp_un(B) :
     { RetE(e) @? at $sloc }
   | ASYNC e=exp_nest
     { AsyncE(Type.Fut, scope_bind (anon_id "async" (at $sloc)) (at $sloc), e) @? at $sloc }
-  | ASYNCSTAR e=block
+  | ASYNCSTAR e=exp_nest
     { AsyncE(Type.Cmp, scope_bind (anon_id "async*" (at $sloc)) (at $sloc), e) @? at $sloc }
   | AWAIT e=exp_nest
     { AwaitE(Type.Fut, e) @? at $sloc }


### PR DESCRIPTION
We currently allow
```
async ()
```
but not
```
async* ()
```
and just 
```
async* { ... }
```

Looks like a cut-n-paste error. Let's see if it passes CI.