### PR TITLE
chore: reinstate the `ic-ref-run` test

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -499,7 +499,7 @@ rec {
   in fix_names ({
       run        = test_subdir "run"        [ moc ] ;
       run-dbg    = snty_subdir "run"        [ moc ] ;
-      # ic-ref-run = test_subdir "run-drun"   [ moc ic-ref-run ];
+      ic-ref-run = test_subdir "run-drun"   [ moc ic-ref-run ];
       drun       = test_subdir "run-drun"   [ moc nixpkgs.drun ];
       drun-dbg   = snty_subdir "run-drun"   [ moc nixpkgs.drun ];
       drun-compacting-gc = snty_compacting_gc_subdir "run-drun" [ moc nixpkgs.drun ] ;

--- a/test/run-drun/ok/upgrades.ic-ref-run.ok
+++ b/test/run-drun/ok/upgrades.ic-ref-run.ok
@@ -49,11 +49,11 @@ debug.print: init'ed 3
 <= replied: ()
 => update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0...
 debug.print: init'ed 4
+debug.print: timer endpoint in 4
 <= replied: ()
 => query check(6)
 <= replied: ()
 => update inc()
-debug.print: timer endpoint in 4
 <= replied: ()
 => query check(7)
 <= replied: ()


### PR DESCRIPTION
which has been deactivated in #3935 due to missing `ic0.is_controller` interface. (It was missing because we couldn't import the `ic-hs` changes.)

The change in the test case is due to https://github.com/dfinity/ic-hs/pull/179.