### PR TITLE
feat: primitive for `ic0.canister_version`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * Added implementation for `ic0.canister_version` as a primitive (#4027).
+
 ## 0.9.1 (2023-05-15)
 
 * motoko (`moc`)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -4293,6 +4293,7 @@ module IC = struct
       E.add_func_import env "ic0" "canister_self_copy" (i32s 3) [];
       E.add_func_import env "ic0" "canister_self_size" [] [I32Type];
       E.add_func_import env "ic0" "canister_status" [] [I32Type];
+      E.add_func_import env "ic0" "canister_version" [] [I64Type];
       E.add_func_import env "ic0" "is_controller" (i32s 2) [I32Type];
       E.add_func_import env "ic0" "debug_print" (i32s 2) [];
       E.add_func_import env "ic0" "msg_arg_data_copy" (i32s 3) [];
@@ -4397,12 +4398,16 @@ module IC = struct
       })
 
 
-  let performance_counter env =
+  let ic_system_call call env =
     match E.mode env with
     | Flags.(ICMode | RefMode) ->
-      system_call env "performance_counter"
+      system_call env call
     | _ ->
-      E.trap_with env "cannot get performance counter when running locally"
+      E.trap_with env Printf.(sprintf "cannot get %s when running locally" call)
+
+  let performance_counter = ic_system_call "performance_counter"
+  let is_controller = ic_system_call "is_controller"
+  let canister_version = ic_system_call "canister_version"
 
   let print_ptr_len env = G.i (Call (nr (E.built_in env "print_ptr")))
 
@@ -9894,7 +9899,11 @@ and compile_prim_invocation (env : E.t) ae p es at =
     Blob.payload_ptr_unskewed env ^^
     get_principal ^^
     Blob.len env ^^
-    IC.system_call env "is_controller"
+    IC.is_controller env
+
+  | OtherPrim "canister_version", [] ->
+    SR.UnboxedWord64,
+    IC.canister_version env
 
   | OtherPrim "crc32Hash", [e] ->
     SR.UnboxedWord32,

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -362,4 +362,7 @@ let prim trap =
   | "is_controller" ->
       fun _ v k -> k (Bool false)
 
+  | "canister_version" ->
+      fun _ v k -> as_unit v; k (Nat64 (Numerics.Nat64.of_int 42))
+
   | s -> trap.trap ("Value.prim: " ^ s)

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -270,6 +270,7 @@ func principalOfBlob(act : Blob) : Principal = (prim "cast" : Blob -> Principal)
 
 func principalOfActor(act : actor {}) : Principal = (prim "cast" : (actor {}) -> Principal) act;
 func isController(p : Principal) : Bool = (prim "is_controller" : Principal -> Bool) p;
+func canisterVersion() : Nat64 = (prim "canister_version" : () -> Nat64) ();
 
 // Untyped dynamic actor creation from blobs
 let createActor : (wasm : Blob, argument : Blob) -> async Principal = @create_actor_helper;

--- a/test/run-drun/empty-actor.mo
+++ b/test/run-drun/empty-actor.mo
@@ -7,11 +7,11 @@ actor {};
 // CHECK-NEXT:    call $trans_state
 // CHECK-NEXT:    call $init
 // CHECK-NEXT:    i32.const 0
-// CHECK-NEXT:    call 31
+// CHECK-NEXT:    call 32
 // CHECK-NEXT:    global.set 4
 // CHECK-NEXT:    call ${{copying_gc|compacting_gc|generational_gc|incremental_gc}}
 // CHECK-NEXT:    i32.const 0
-// CHECK-NEXT:    call 31
+// CHECK-NEXT:    call 32
 // CHECK-NEXT:    global.get 4
 // CHECK-NEXT:    i64.sub
 // CHECK-NEXT:    global.set 5

--- a/test/run-drun/ok/upgrades.drun.ok
+++ b/test/run-drun/ok/upgrades.drun.ok
@@ -2,6 +2,7 @@ ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a000000000000000001
 debug.print: init'ed
 ingress Completed: Reply: 0x4449444c0000
 debug.print: init'ed 0
+debug.print: initial version: 2
 ingress Completed: Reply: 0x4449444c0000
 debug.print: a
 Ok: Reply: 0x4449444c0000
@@ -10,6 +11,7 @@ debug.print: aa
 Ok: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 debug.print: init'ed 1
+debug.print: current version: 5
 ingress Completed: Reply: 0x4449444c0000
 debug.print: 3
 debug.print: aaa

--- a/test/run-drun/ok/upgrades.ic-ref-run.ok
+++ b/test/run-drun/ok/upgrades.ic-ref-run.ok
@@ -5,6 +5,7 @@ debug.print: init'ed
 <= replied: ()
 => update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0...
 debug.print: init'ed 0
+debug.print: initial version: 2
 <= replied: ()
 => query check(1)
 debug.print: a
@@ -18,6 +19,7 @@ debug.print: aa
 <= replied: ()
 => update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0...
 debug.print: init'ed 1
+debug.print: current version: 3
 <= replied: ()
 => query check(3)
 debug.print: 3

--- a/test/run-drun/upgrades/upgrade0.mo
+++ b/test/run-drun/upgrades/upgrade0.mo
@@ -1,6 +1,7 @@
 import Prim "mo:⛔";
 actor {
   Prim.debugPrint ("init'ed 0");
+  Prim.debugPrint ("initial version: " # debug_show Prim.canisterVersion());
   stable var c = "a";
   public func inc() { c #= "a"; };
   public query func check(n : Int) : async () {
@@ -8,4 +9,3 @@ actor {
     assert (c.size() == n);
   };
 }
-

--- a/test/run-drun/upgrades/upgrade1.mo
+++ b/test/run-drun/upgrades/upgrade1.mo
@@ -1,6 +1,7 @@
 import Prim "mo:⛔";
 actor {
   Prim.debugPrint ("init'ed 1");
+  Prim.debugPrint ("current version: " # debug_show Prim.canisterVersion());
   stable let c = "a";
   stable var i : Nat = c.size();
   public func inc() { i += 1; };
@@ -12,4 +13,3 @@ actor {
     assert (c.size() <= i);
   };
 }
-


### PR DESCRIPTION
This PR adds support for the canister versioning feature of the IC, establishing the `canisterVersion` primitive.
A follow-up PR will amend the `create_canister` and `install_code` management canister calls (which we use to manage actor classes) with this information.
Retrieving the version history of canisters will be implemented from the `motoko-base` library.

- [x] tests added