### PR TITLE
chore: perform scheduled builds of `drun` in a sparse artefact environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,9 @@ jobs:
 
     - name: "pre-build `drun`"
       if: startsWith(github.head_ref, 'gabor/pre-warm')
-      run: nix-build --max-jobs 1 -A tidbits.drun
+      run: |
+        nix-build --max-jobs 1 -A tidbits.drun
+        nix-store --gc --print-live
 
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
 
     - run: nix-env -iA nix-build-uncached -f nix/
 
-    - name: "pre-puild `drun`"
-      if: ${{ github.ref == 'refs/heads/gabor/pre-warm' }}
+    - name: "pre-build `drun`"
+      if: startsWith(github.ref, 'refs/heads/gabor/')
       run: nix-build --max-jobs 1 -A tidbits.drun
 
     - name: "nix-build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     - run: echo '${{ github.ref }}' '${{ github.head_ref }}'
 
     - name: "pre-build `drun`"
-      if: startsWith(github.head_ref, 'gabor/pre-warm')
+      if: startsWith(github.head_ref, 'update/ic-')
       run: nix-build --max-jobs 1 -A tidbits.drun
 
     - name: "nix-build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
 
     - run: nix-env -iA nix-build-uncached -f nix/
 
-    - run: echo '${{ github.ref }}'
+    - run: echo '${{ github.ref }}' ${{ github.head_ref }}'
 
     - name: "pre-build `drun`"
-      if: startsWith(github.ref, 'refs/heads/')
+      if: startsWith(github.ref, 'refs/pull/4043')
       run: echo '${{ github.ref }}'; nix-build --max-jobs 1 -A tidbits.drun
 
     - name: "nix-build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     - run: nix-env -iA nix-build-uncached -f nix/
 
     - name: "pre-build `drun`"
-      if: startsWith(github.head_ref, 'gabor/pre-warm')
+      if: startsWith(github.head_ref, 'update/ic-')
       run: |
         nix-build --max-jobs 1 -A tidbits.drun
         nix-store --gc --print-roots | grep /motoko/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,6 @@ on:
   pull_request: {}
 jobs:
 
-  warmup:
-    if: github.ref == 'refs/heads/gabor/pre-warm'
-    runs-on: ubuntu-latest
-    steps:
-      - run: nix-build --max-jobs 1 -A tidbits.drun
-
   tests:
     strategy:
       matrix:
@@ -41,9 +35,11 @@ jobs:
 
     - run: nix-env -iA nix-build-uncached -f nix/
 
-    - name: "nix-build"
-      needs: warmup
+    - name: "pre-puild `drun`"
+      if: ${{ github.ref == 'refs/heads/gabor/pre-warm' }}
+      run: nix-build --max-jobs 1 -A tidbits.drun
 
+    - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 
     - name: Calculate performance delta

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: "pre-build `drun`"
       if: startsWith(github.ref, 'refs/heads/')
-      run: nix-build --max-jobs 1 -A tidbits.drun
+      run: echo '${{ github.ref }}'; nix-build --max-jobs 1 -A tidbits.drun
 
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     - run: nix-env -iA nix-build-uncached -f nix/
 
     - name: "pre-build `drun`"
-      if: startsWith(github.ref, 'refs/heads/gabor/')
+      if: startsWith(github.ref, 'refs/heads/')
       run: nix-build --max-jobs 1 -A tidbits.drun
 
     - name: "nix-build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ jobs:
 
   warmup:
     if: github.ref == 'refs/heads/gabor/pre-warm'
-    run: nix-build --max-jobs 1 -A tidbits.drun
+    steps:
+      - run: nix-build --max-jobs 1 -A tidbits.drun
 
   tests:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
 jobs:
 
   warmup:
+    if: github.ref == 'refs/heads/gabor/pre-warm'
     run: nix-build --max-jobs 1 -A tidbits.drun
 
   tests:
@@ -40,7 +41,6 @@ jobs:
 
     - name: "nix-build"
       needs: warmup
-        if: github.ref == 'refs/heads/gabor/pre-warm'
 
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
      branches: [ master ]
   pull_request: {}
 jobs:
+
+  warmup:
+    run: nix-build --max-jobs 1 -A tidbits.drun
+
   tests:
     strategy:
       matrix:
@@ -35,6 +39,9 @@ jobs:
     - run: nix-env -iA nix-build-uncached -f nix/
 
     - name: "nix-build"
+      needs: warmup
+        if: github.ref == 'refs/heads/gabor/pre-warm'
+
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 
     - name: Calculate performance delta

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     - run: nix-env -iA nix-build-uncached -f nix/
 
     - name: "pre-build `drun`"
-      if: startsWith(github.head_ref, 'update/ic-')
+      if: startsWith(github.head_ref, 'gabor/pre-warm')
       run: nix-build --max-jobs 1 -A tidbits.drun
 
     - name: "nix-build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
      branches: [ master ]
   pull_request: {}
 jobs:
-
   tests:
     strategy:
       matrix:
@@ -34,8 +33,6 @@ jobs:
     - run: cachix watch-store ic-hs-test &
 
     - run: nix-env -iA nix-build-uncached -f nix/
-
-    - run: echo '${{ github.ref }}' '${{ github.head_ref }}'
 
     - name: "pre-build `drun`"
       if: startsWith(github.head_ref, 'update/ic-')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
 
   warmup:
     if: github.ref == 'refs/heads/gabor/pre-warm'
+    runs-on: ubuntu-latest
     steps:
       - run: nix-build --max-jobs 1 -A tidbits.drun
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,11 @@ jobs:
 
     - run: nix-env -iA nix-build-uncached -f nix/
 
-    - run: echo '${{ github.ref }}' ${{ github.head_ref }}'
+    - run: echo '${{ github.ref }}' '${{ github.head_ref }}'
 
     - name: "pre-build `drun`"
-      if: startsWith(github.ref, 'refs/pull/4043')
-      run: echo '${{ github.ref }}'; nix-build --max-jobs 1 -A tidbits.drun
+      if: startsWith(github.head_ref, 'gabor/pre-warm')
+      run: nix-build --max-jobs 1 -A tidbits.drun
 
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: "pre-build `drun`"
       if: startsWith(github.head_ref, 'update/ic-')
       run: |
-        nix-build --max-jobs 1 -A tidbits.drun
+        nix-build --max-jobs 1 -A drun
         nix-store --gc --print-roots | grep /motoko/
 
     - name: "nix-build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       if: startsWith(github.head_ref, 'gabor/pre-warm')
       run: |
         nix-build --max-jobs 1 -A tidbits.drun
-        nix-store --gc --print-live
+        nix-store --gc --print-roots
 
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       if: startsWith(github.head_ref, 'gabor/pre-warm')
       run: |
         nix-build --max-jobs 1 -A tidbits.drun
-        nix-store --gc --print-roots
+        nix-store --gc --print-roots | grep /motoko/
 
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
 
     - run: nix-env -iA nix-build-uncached -f nix/
 
+    - run: echo '${{ github.ref }}'
+
     - name: "pre-build `drun`"
       if: startsWith(github.ref, 'refs/heads/')
       run: echo '${{ github.ref }}'; nix-build --max-jobs 1 -A tidbits.drun

--- a/default.nix
+++ b/default.nix
@@ -570,7 +570,7 @@ rec {
       recurseForDerivations = true;
     };
 
-  inherit (nixpkgs) wabt wasmtime wasm;
+  inherit (nixpkgs) drun wabt wasmtime wasm;
 
   filecheck = nixpkgs.runCommandNoCC "FileCheck" {} ''
     mkdir -p $out/bin
@@ -773,10 +773,6 @@ rec {
   viperServer = nixpkgs.fetchurl {
     url = https://github.com/viperproject/viperserver/releases/download/v.22.11-release/viperserver.jar;
     sha256 = "sha256-debC8ZpbIjgpEeISCISU0EVySJvf+WsUkUaLuJ526wA=";
-  };
-
-  tidbits = with nixpkgs; {
-    drun = drun;
   };
 
   shell = nixpkgs.mkShell {

--- a/default.nix
+++ b/default.nix
@@ -775,6 +775,10 @@ rec {
     sha256 = "sha256-debC8ZpbIjgpEeISCISU0EVySJvf+WsUkUaLuJ526wA=";
   };
 
+  tidbits = with nixpkgs; {
+    drun = drun;
+  };
+
   shell = nixpkgs.mkShell {
     name = "motoko-shell";
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -27,10 +27,10 @@
         "homepage": "",
         "owner": "dfinity",
         "repo": "ic",
-        "rev": "6df4f4d17da00861c3182c91e99081286bf21483",
-        "sha256": "0glxidx5d7hwnij96cl255x099rlnd7zslgfhxadi9ygs4d9jb58",
+        "rev": "ace6fcf0047ecc2a6a7bc3105b807e00ce5f7e7c",
+        "sha256": "1dnn2i8kxdyzmsqh9a3vca0yjn0nygwlfha5q4c3p7343aghdagb",
         "type": "tarball",
-        "url": "https://github.com/dfinity/ic/archive/6df4f4d17da00861c3182c91e99081286bf21483.tar.gz",
+        "url": "https://github.com/dfinity/ic/archive/ace6fcf0047ecc2a6a7bc3105b807e00ce5f7e7c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ic-hs": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -27,10 +27,10 @@
         "homepage": "",
         "owner": "dfinity",
         "repo": "ic",
-        "rev": "ace6fcf0047ecc2a6a7bc3105b807e00ce5f7e7c",
-        "sha256": "1dnn2i8kxdyzmsqh9a3vca0yjn0nygwlfha5q4c3p7343aghdagb",
+        "rev": "6df4f4d17da00861c3182c91e99081286bf21483",
+        "sha256": "0glxidx5d7hwnij96cl255x099rlnd7zslgfhxadi9ygs4d9jb58",
         "type": "tarball",
-        "url": "https://github.com/dfinity/ic/archive/ace6fcf0047ecc2a6a7bc3105b807e00ce5f7e7c.tar.gz",
+        "url": "https://github.com/dfinity/ic/archive/6df4f4d17da00861c3182c91e99081286bf21483.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ic-hs": {


### PR DESCRIPTION
Recently imports of `drun` tend to fail building, because the storage is very constrained on Linux builders, and `nix` preloads all necessary binary artefacts for the whole build process. This meant that when the `drun` build started there were already `OCaml` and `ghc` as well as many instances of `llvm`, `clang` and `rustc` present.

This PR detects when `drun` is about to be built, does it in a frugal way, and also cleans up after itself.

If this method turns out to be effective in the middle term, we can adopt it for `rustc` and other bigger chunks too.