### PR TITLE
chore: remove unnecessary `ppx` dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -83,8 +83,6 @@ let commonBuildInputs = pkgs:
     pkgs.ocamlPackages.ppxlib
     pkgs.ocamlPackages.ppx_blob
     pkgs.ocamlPackages.ppx_inline_test
-    pkgs.ocamlPackages.ocaml-migrate-parsetree
-    pkgs.ocamlPackages.ppx_tools_versioned
     pkgs.ocamlPackages.bisect_ppx
     pkgs.ocamlPackages.uucp
     pkgs.obelisk


### PR DESCRIPTION
Does anybody know why these were needed in first place?

Anyway, if they are now needed for CI, we can remove them, right?