### PR TITLE
experiment: simplify regions 

### DIFF
--- a/rts/motoko-rts/src/region.rs
+++ b/rts/motoko-rts/src/region.rs
@@ -444,7 +444,7 @@ pub(crate) unsafe fn region_migration_from_v1_into_v2<M: Memory>(mem: &mut M) {
     // - copy the head block of data from temp blob into new "final block" (logically still first) for region 0.
     // - initialize the meta data for the region system in vacated initial block.
 
-    use crate::ic0_stable::nicer::{size, grow, read, write};
+    use crate::ic0_stable::nicer::{grow, read, size, write};
 
     let header_len = meta_data::size::BLOCK_IN_BYTES as u32;
 

--- a/test/bench/ok/heap-32.drun-run-opt.ok
+++ b/test/bench/ok/heap-32.drun-run-opt.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +30_261_252, 620_394_274)
-debug.print: (50_070, +32_992_212, 671_304_501)
+debug.print: (50_227, +30_261_252, 620_394_313)
+debug.print: (50_070, +32_992_212, 671_304_514)
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/heap-32.drun-run.ok
+++ b/test/bench/ok/heap-32.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +30_261_252, 667_797_438)
-debug.print: (50_070, +32_992_212, 720_521_385)
+debug.print: (50_227, +30_261_252, 667_797_513)
+debug.print: (50_070, +32_992_212, 720_521_410)
 ingress Completed: Reply: 0x4449444c0000


### PR DESCRIPTION
Builds on #3768 
Simplifies regions code by using compiler/StableMem as underlying page allocator, avoiding error-prone duplication of state.

See follow-up PR #4145 that also avoids communication --max-stable-pages to the rts.
