### PR TITLE
experiment: refactor enforcement of --max-stable-pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,11 +103,13 @@ jobs:
         folder: report-site-copy
         single-commit: true
 
-  artifacts-ubuntu:
+  artifacts:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'build_artifacts')
     needs: tests
     concurrency: ci-${{ github.ref }}
-    runs-on: ubuntu-latest
+    strategy:
+      os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v22
@@ -123,31 +125,6 @@ jobs:
     - name: upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: moc-ubuntu
+        name: moc-${{ matrix.os }}
         path: ${{ env.UPLOAD_PATH }}
         retention-days: 5
-
-  artifacts-macos:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'build_artifacts')
-    needs: tests
-    concurrency: ci-${{ github.ref }}
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
-    - uses: cachix/cachix-action@v12
-      with:
-        name: ic-hs-test
-    - name: nix-build
-      run: |
-        nix-build --arg officialRelease true -A moc
-    # upload-artifact doesn't work for symlink dir
-    # https://github.com/actions/upload-artifact/issues/92
-    - run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
-    - name: upload artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: moc-macos
-        path: ${{ env.UPLOAD_PATH }}
-        retention-days: 5
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,8 @@ jobs:
     needs: tests
     concurrency: ci-${{ github.ref }}
     strategy:
-      os: [ ubuntu-latest, macos-latest ]
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/rts/motoko-rts/src/ic0_stable.rs
+++ b/rts/motoko-rts/src/ic0_stable.rs
@@ -2,7 +2,7 @@ extern "C" {
     pub fn stable64_write_moc(offset: u64, src: u64, size: u64);
     pub fn stable64_read_moc(dst: u64, offset: u64, size: u64);
     pub fn stable64_size_moc() -> u64;
-    pub fn stable64_grow_moc(additional_pages: u64) -> i64;
+    pub fn stable64_grow_moc(additional_pages: u64) -> u64;
 }
 
 // to do -- rename this module something better.
@@ -14,7 +14,7 @@ pub mod nicer {
         unsafe { stable64_size_moc() }
     }
 
-    pub fn grow(pages: u64) -> i64 {
+    pub fn grow(pages: u64) -> u64 {
         // SAFETY: This is safe because of the ic0 api guarantees.
         unsafe { stable64_grow_moc(pages) }
     }

--- a/rts/motoko-rts/src/region.rs
+++ b/rts/motoko-rts/src/region.rs
@@ -536,11 +536,10 @@ pub unsafe fn region_size<M: Memory>(_mem: &mut M, r: Value) -> u64 {
 }
 
 #[ic_mem_fn]
-pub unsafe fn region_grow<M: Memory>(mem: &mut M, r: Value, new_pages: u64, max_pages: u64) -> u64 {
+pub unsafe fn region_grow<M: Memory>(mem: &mut M, r: Value, new_pages: u64) -> u64 {
     use meta_data::size::{required_pages, PAGES_IN_BLOCK};
     let r = r.as_region();
     let new_pages_ = new_pages as u32;
-    let max_pages_ = max_pages as u32;
     let old_page_count = (*r).page_count;
     let old_block_count = (old_page_count + (PAGES_IN_BLOCK - 1)) / PAGES_IN_BLOCK;
     let new_block_count = (old_page_count + new_pages_ + (PAGES_IN_BLOCK - 1)) / PAGES_IN_BLOCK;
@@ -551,11 +550,6 @@ pub unsafe fn region_grow<M: Memory>(mem: &mut M, r: Value, new_pages: u64, max_
     let old_total_blocks = {
         let c = meta_data::total_allocated_blocks::get();
         let c_ = c + inc_block_count as u64;
-        let max_blocks = (max_pages_ + (PAGES_IN_BLOCK - 1)) / PAGES_IN_BLOCK;
-        if c_ > max_blocks.into() {
-            // Signals an error.
-            return 0xFFFF_FFFF_FFFF_FFFF;
-        };
         meta_data::total_allocated_blocks::set(c_);
         c
     };
@@ -567,7 +561,10 @@ pub unsafe fn region_grow<M: Memory>(mem: &mut M, r: Value, new_pages: u64, max_
         let need = required_pages();
         if have < need {
             let diff = need - have;
-            crate::ic0_stable::nicer::grow(diff);
+            if crate::ic0_stable::nicer::grow(diff) == 0xFFFF_FFFF_FFFF_FFFF {
+                meta_data::total_allocated_blocks::set(old_total_blocks); // revert block allocation
+                return 0xFFFF_FFFF_FFFF_FFFF; // Propagate error
+            }
         }
     }
 

--- a/rts/motoko-rts/src/region.rs
+++ b/rts/motoko-rts/src/region.rs
@@ -444,7 +444,7 @@ pub(crate) unsafe fn region_migration_from_v1_into_v2<M: Memory>(mem: &mut M) {
     // - copy the head block of data from temp blob into new "final block" (logically still first) for region 0.
     // - initialize the meta data for the region system in vacated initial block.
 
-    use crate::ic0_stable::nicer::{size, grow, read, write};
+    use crate::ic0_stable::nicer::{grow, read, size, write};
 
     let header_len = meta_data::size::BLOCK_IN_BYTES as u32;
 

--- a/rts/motoko-rts/src/region0.rs
+++ b/rts/motoko-rts/src/region0.rs
@@ -36,9 +36,9 @@ pub unsafe fn region0_size<M: Memory>(mem: &mut M) -> u64 {
 }
 
 #[ic_mem_fn]
-pub unsafe fn region0_grow<M: Memory>(mem: &mut M, new_pages: u64, max_pages: u64) -> u64 {
+pub unsafe fn region0_grow<M: Memory>(mem: &mut M, new_pages: u64) -> u64 {
     assert_ne!(REGION_0, NO_REGION);
-    region_grow(mem, REGION_0, new_pages, max_pages)
+    region_grow(mem, REGION_0, new_pages)
 }
 
 // -- Region0 load operations.

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1001,7 +1001,7 @@ module RTS = struct
     E.add_func_import env "rts" "region_new" [] [I32Type];
     E.add_func_import env "rts" "region_id" [I32Type] [I32Type];
     E.add_func_import env "rts" "region_size" [I32Type] [I64Type];
-    E.add_func_import env "rts" "region_grow" [I32Type; I64Type; I64Type] [I64Type];
+    E.add_func_import env "rts" "region_grow" [I32Type; I64Type] [I64Type];
     E.add_func_import env "rts" "region_load_blob" [I32Type; I64Type; I32Type] [I32Type];
     E.add_func_import env "rts" "region_store_blob" [I32Type; I64Type; I32Type] [];
     E.add_func_import env "rts" "region_load_word8" [I32Type; I64Type] [I32Type];
@@ -1016,7 +1016,7 @@ module RTS = struct
     E.add_func_import env "rts" "region_store_float64" [I32Type; I64Type; F64Type] [];
     E.add_func_import env "rts" "region0_size" [] [I64Type];
     E.add_func_import env "rts" "region0_get" [] [I32Type];
-    E.add_func_import env "rts" "region0_grow" [I64Type; I64Type] [I64Type];
+    E.add_func_import env "rts" "region0_grow" [I64Type] [I64Type];
     E.add_func_import env "rts" "region0_load_blob" [I64Type; I32Type] [I32Type];
     E.add_func_import env "rts" "region0_store_blob" [I64Type; I32Type] [];
     E.add_func_import env "rts" "region0_load_word8" [I64Type] [I32Type];
@@ -3901,7 +3901,6 @@ module Region0 = struct
 
   let get_mem_size env = E.call_import env "rts" "region0_size"  
   let logical_grow env =
-    compile_const_64 (Int64.of_int (!Flags.max_stable_pages)) ^^
     E.call_import env "rts" "region0_grow"
 
   let load_blob env = E.call_import env "rts" "region0_load_blob"
@@ -3984,7 +3983,6 @@ module Region = struct
   let size env =
     E.call_import env "rts" "region_size"
   let grow env =
-    compile_const_64 (Int64.of_int (!Flags.max_stable_pages)) ^^
     E.call_import env "rts" "region_grow"
   let load_blob env = E.call_import env "rts" "region_load_blob"
   let store_blob env = E.call_import env "rts" "region_store_blob"

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3899,7 +3899,7 @@ module Region0 = struct
    *)
   let get env = E.call_import env "rts" "region0_get"
 
-  let get_mem_size env = E.call_import env "rts" "region0_size"  
+  let get_mem_size env = E.call_import env "rts" "region0_size"
   let logical_grow env =
     E.call_import env "rts" "region0_grow"
 

--- a/test/run-drun/ok/region0-stable-mem-grow-fail.drun-run.ok
+++ b/test/run-drun/ok/region0-stable-mem-grow-fail.drun-run.ok
@@ -1,3 +1,2 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
-debug.print: 0
-ingress Err: IC0502: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped: stable memory out of bounds
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/region0-stable-mem-custom-max.mo
+++ b/test/run-drun/region0-stable-mem-custom-max.mo
@@ -3,7 +3,7 @@ import P "mo:⛔";
 import StableMemory "stable-mem/StableMemory";
 
 actor {
-  let max : Nat64 = 65536 - 128; // -128 to account for stable_regions metadata block
+  let max : Nat64 = 16384 - 128; // -128 to account for stable_regions metadata block
   public func testGrow() : async () {
     assert 0  == StableMemory.grow(max - 1);
     assert (max - 1) == StableMemory.grow(1);

--- a/test/run-drun/region0-stable-mem-custom-max.mo
+++ b/test/run-drun/region0-stable-mem-custom-max.mo
@@ -3,7 +3,7 @@ import P "mo:⛔";
 import StableMemory "stable-mem/StableMemory";
 
 actor {
-  let max : Nat64 = 16384;
+  let max : Nat64 = 65536 - 128; // -128 to account for stable_regions metadata block
   public func testGrow() : async () {
     assert 0  == StableMemory.grow(max - 1);
     assert (max - 1) == StableMemory.grow(1);

--- a/test/run-drun/region0-stable-mem-max.mo
+++ b/test/run-drun/region0-stable-mem-max.mo
@@ -5,7 +5,10 @@ import StableMemory "stable-mem/StableMemory";
 actor {
   let max : Nat64 = 65536;
   public func testGrow() : async () {
-    assert 0  == StableMemory.grow(max - 1);
+  
+    let o = StableMemory.grow(max - 1); P.debugPrint(debug_show(o)); assert (o == 0);
+
+
     assert (max - 1) == StableMemory.grow(1);
     assert max == StableMemory.size();
     assert max == StableMemory.grow(0);

--- a/test/run-drun/region0-stable-mem-max.mo
+++ b/test/run-drun/region0-stable-mem-max.mo
@@ -3,12 +3,9 @@ import P "mo:⛔";
 import StableMemory "stable-mem/StableMemory";
 
 actor {
-  let max : Nat64 = 65536;
+  let max : Nat64 = 65536 - 128; // -128 to account for stable_regions metadata block
   public func testGrow() : async () {
-  
-    let o = StableMemory.grow(max - 1); P.debugPrint(debug_show(o)); assert (o == 0);
-
-
+    assert 0 == StableMemory.grow(max - 1);
     assert (max - 1) == StableMemory.grow(1);
     assert max == StableMemory.size();
     assert max == StableMemory.grow(0);


### PR DESCRIPTION
builds on #4143 (which builds on #3768)

--max-stable-pages is enforced in one place only, the low-level page allocator StableMem.

It now bounds the physical stable pages occupied by the user code, leaving the rest as reserve for stable variables.

This means some tests need to know if they are running with --stable-regions or not because the overheads are different.
