### PR TITLE
experiment: repro for bug in region.grow

### DIFF
--- a/test/run-drun/ok/region0-stable-mem-grow-fail.drun-run.ok
+++ b/test/run-drun/ok/region0-stable-mem-grow-fail.drun-run.ok
@@ -1,0 +1,3 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+debug.print: 0
+ingress Err: IC0502: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped: stable memory out of bounds

--- a/test/run-drun/ok/stable-mem-grow-fail.drun-run.ok
+++ b/test/run-drun/ok/stable-mem-grow-fail.drun-run.ok
@@ -1,0 +1,2 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/region0-stable-mem-grow-fail.mo
+++ b/test/run-drun/region0-stable-mem-grow-fail.mo
@@ -1,0 +1,21 @@
+//MOC-FLAG --stable-regions --max-stable-pages 16777216
+import P "mo:⛔";
+import StableMemory "stable-mem/StableMemory";
+
+// tests that allocation failure is reported when the replica fails to allocate
+// (even when --max-stable-pages not exceeded)
+actor {
+  assert (167777216 > 128*65536);
+  let m = StableMemory.grow(128*65536); //128 GB, should fail!
+  if (m != 0xFFFF_FFFF_FFFF_FFFF) {
+    // force IC stable memory out of bounds error
+    P.debugPrint(debug_show m);
+    ignore StableMemory.loadNat8(128*65536-1);
+  }
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+// too slow on ic-ref-run:
+//SKIP comp-ref

--- a/test/run-drun/stable-mem-grow-fail.mo
+++ b/test/run-drun/stable-mem-grow-fail.mo
@@ -1,0 +1,21 @@
+//MOC-FLAG --max-stable-pages 16777216
+import P "mo:⛔";
+import StableMemory "stable-mem/StableMemory";
+
+// tests that allocation failure is reported when the replica fails to allocate
+// (even when --max-stable-pages not exceeded)
+actor {
+  assert (167777216 > 128*65536);
+  let m = StableMemory.grow(128*65536); //128 GB, should fail!
+  if (m != 0xFFFF_FFFF_FFFF_FFFF) {
+    // force IC stable memory out of bounds error
+    P.debugPrint(debug_show m);
+    ignore StableMemory.loadNat8(128*65536-1);
+  }
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+// too slow on ic-ref-run:
+//SKIP comp-ref


### PR DESCRIPTION
@luc-blaeser mentioned seeing  unexpected "stable memory out of bounds" failures.

I think the bug is due to region_grow only checking the page allocation against the logical maximum determented --max-stable-pages, which may be set higher than what is currently available on the replica. In particular, the region_grow implementation fails to check whether the call to ic0.grow actually succeeds and pretends it has, which then let's you read/write unallocated pages.

This test reproduces the error. 

It's actually fixed in https://github.com/dfinity/motoko/pull/4145