### PR TITLE
bug: missing overflow check in regions.grow

### DIFF
--- a/test/run-drun/ok/region0-overflow.drun-run.ok
+++ b/test/run-drun/ok/region0-overflow.drun-run.ok
@@ -1,0 +1,5 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: RTS error: region access out of bounds.
+debug.print: IC0502: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped: stable memory out of bounds
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/region0-overflow.tc.ok
+++ b/test/run-drun/ok/region0-overflow.tc.ok
@@ -1,0 +1,4 @@
+region0-overflow.mo:13.9-13.10: warning [M0145], this pattern of type
+  Nat64
+does not cover value
+  1 or 2 or _

--- a/test/run-drun/region0-overflow.mo
+++ b/test/run-drun/region0-overflow.mo
@@ -1,0 +1,49 @@
+//MOC-FLAG --stable-regions
+import P "mo:⛔";
+import StableMemory "stable-mem/StableMemory";
+
+// test for correct out-of-bounds detection.
+// Both ok() and bad() should fail for the same reason (but don't)
+// ok() reports RTS error: region access out of bounds, caught by RTS
+// bad() reports: "stable memory out of bounds", not caught by RTS but by IC
+
+// I think one could exploit this bound check failure to break isolation between regions...
+
+actor {
+    let 0 = StableMemory.grow(1);
+
+    public func ok() : async Blob {
+        StableMemory.loadBlob(0xFFFF_FFFF_FFFF_FFFF, 0);
+    };
+
+    public func bad() : async Blob {
+        StableMemory.loadBlob(0xFFFF_FFFF_FFFF_FFFF, 2);
+    };
+
+    public func go() : async () {
+
+     let b1 =
+       try await ok()
+       catch e {
+         P.debugPrint(P.errorMessage e);
+       };
+
+     let b2 =
+       try await bad()
+       catch e {
+         P.debugPrint(P.errorMessage e);
+       }
+
+    }
+
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+// too slow on ic-ref-run:
+//SKIP comp-ref
+
+//CALL ingress go "DIDL\x00\x00"
+
+


### PR DESCRIPTION
A repro exposing the missing overflow check that we discussed (offset+len-1 can overflow).