### PR TITLE
Incremental GC: Adjust Total Allocation Statistics

### DIFF
--- a/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
+++ b/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
@@ -557,7 +557,7 @@ impl PartitionedHeap {
             if partition.to_be_evacuated() {
                 debug_assert!(partition.index != self.allocation_index);
                 debug_assert!(partition.dynamic_size >= marked_size);
-                self.reclaimed += (partition.dynamic_size - marked_size) as u64;
+                self.reclaimed += partition.dynamic_size as u64;
             }
             if partition.to_be_evacuated() || partition.temporary {
                 self.precomputed_heap_size -= partition.dynamic_size;

--- a/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
+++ b/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
@@ -354,6 +354,7 @@ pub struct PartitionedHeap {
     bitmap_allocation_pointer: usize, // Free pointer for allocating the next mark bitmap.
     gc_running: bool, // Create bitmaps for partitions when allocated during active GC.
     precomputed_heap_size: usize, // Occupied heap size, excluding the dynamic heap in the allocation partition.
+    evacuated_size: usize, // Size of all evacuated objects during a GC run. Serves for accurate total allocation statistics.
 }
 
 /// Optimization: Avoiding `Option` or `LazyCell`.
@@ -367,6 +368,7 @@ pub const UNINITIALIZED_HEAP: PartitionedHeap = PartitionedHeap {
     bitmap_allocation_pointer: 0,
     gc_running: false,
     precomputed_heap_size: 0,
+    evacuated_size: 0,
 };
 
 impl PartitionedHeap {
@@ -403,6 +405,7 @@ impl PartitionedHeap {
             bitmap_allocation_pointer: 0,
             gc_running: false,
             precomputed_heap_size: heap_base,
+            evacuated_size: 0,
         }
     }
 
@@ -526,6 +529,7 @@ impl PartitionedHeap {
                 evacuation_space -= partition.marked_size();
                 partition.evacuate = true;
                 self.evacuating = true;
+                debug_assert_eq!(self.evacuated_size, 0);
             }
         }
     }
@@ -557,7 +561,7 @@ impl PartitionedHeap {
             if partition.to_be_evacuated() {
                 debug_assert!(partition.index != self.allocation_index);
                 debug_assert!(partition.dynamic_size >= marked_size);
-                self.reclaimed += partition.dynamic_size as u64;
+                self.reclaimed += (partition.dynamic_size - marked_size) as u64;
             }
             if partition.to_be_evacuated() || partition.temporary {
                 self.precomputed_heap_size -= partition.dynamic_size;
@@ -566,6 +570,7 @@ impl PartitionedHeap {
             }
         }
         self.evacuating = false;
+        self.evacuated_size = 0;
         self.bitmap_allocation_pointer = 0;
         debug_assert!(self.gc_running);
         self.gc_running = false;
@@ -629,6 +634,16 @@ impl PartitionedHeap {
 
     pub fn reclaimed_size(&self) -> Bytes<u64> {
         Bytes(self.reclaimed)
+    }
+
+    pub fn increase_evacuated_size(&mut self, size: Words<u32>) {
+        self.evacuated_size += size.to_bytes().as_usize();
+    }
+
+    pub fn total_allocated_size(&self) -> Bytes<u64> {
+        debug_assert!(self.evacuated_size <= self.occupied_size().as_usize());
+        let heap_size_without_evacuations = self.occupied_size().as_usize() - self.evacuated_size;
+        Bytes(heap_size_without_evacuations as u64) + self.reclaimed_size()
     }
 
     pub unsafe fn allocate<M: Memory>(&mut self, mem: &mut M, words: Words<u32>) -> Value {

--- a/rts/motoko-rts/src/gc/incremental/phases/evacuation_increment.rs
+++ b/rts/motoko-rts/src/gc/incremental/phases/evacuation_increment.rs
@@ -79,6 +79,7 @@ impl<'a, M: Memory + 'a> EvacuationIncrement<'a, M> {
         debug_assert!(!original.is_forwarded());
         let size = block_size(original as usize);
         let new_address = self.mem.alloc_words(size);
+        self.heap.increase_evacuated_size(size);
         let copy = new_address.get_ptr() as *mut Obj;
         memcpy_words(copy as usize, original as usize, size);
         (*copy).forward = new_address;
@@ -88,7 +89,6 @@ impl<'a, M: Memory + 'a> EvacuationIncrement<'a, M> {
         // Marking is necessary to ensure field updates in the copy.
         let unmarked_before = self.heap.mark_object(copy);
         debug_assert!(unmarked_before);
-
         // Determined by measurements in comparison to the mark and update phases.
         const TIME_FRACTION_PER_WORD: f64 = 2.7;
         self.time

--- a/rts/motoko-rts/src/memory/ic/partitioned_memory.rs
+++ b/rts/motoko-rts/src/memory/ic/partitioned_memory.rs
@@ -8,7 +8,7 @@ unsafe extern "C" fn get_reclaimed() -> Bytes<u64> {
 
 #[no_mangle]
 pub unsafe extern "C" fn get_total_allocations() -> Bytes<u64> {
-    Bytes(u64::from(get_heap_size().as_u32())) + get_reclaimed()
+    crate::gc::incremental::get_partitioned_heap().total_allocated_size()
 }
 
 #[no_mangle]


### PR DESCRIPTION
# Incremental GC: Adjust Total Allocation Statistics

This is a minor, mostly cosmetic fix for the incremental GC: The total allocation statistics (`rts_total_allocation()`) was not monotonously growing but temporarily growing and shrinking while a GC run involved multiple increments. The reason was that the evacuation space were incorrectly counted as new allocations.

Before this PR (example of `cancan` GC benchmark case):

![image](https://github.com/dfinity/motoko/assets/112870813/35d0f8f4-e909-4a1b-86e7-2757468f3b56)

**Fix**: The temporary copying space for evacuations is no longer considered in the total allocation metric.

With this PR (example of `cancan` GC benchmark case):

![image](https://github.com/dfinity/motoko/assets/112870813/4808b517-c63b-4761-b168-45a5262b403d)


