### PR TITLE
chore: revert drun-wrapper extra batches to 1 for perf measurement

### DIFF
--- a/test/drun-wrapper.sh
+++ b/test/drun-wrapper.sh
@@ -27,7 +27,7 @@ export LANG=C.UTF-8
 # it doesn't work reliably and slows down the test significantly.
 # so until DFN-1269 fixes this properly, let's just not run
 # affected tests on drun (only ic-ref-run).
-EXTRA_BATCHES=128
+EXTRA_BATCHES=1
 
 # on darwin, I have seen
 #   thread 'MR Batch Processor' has overflowed its stack


### PR DESCRIPTION
The regions PR #3768 bumped up drun-wrapper extra batches from 1 to 128, affecting the perf of perf/dao due to a longer running heartbeat. This restores the extra batches back to 1.

