### PR TITLE
fix: title case of doc/md/motoko.md

### DIFF
--- a/doc/md/motoko.md
+++ b/doc/md/motoko.md
@@ -1,4 +1,4 @@
-# Motoko Programming Language
+# Motoko programming language
 
 :::tip
 


### PR DESCRIPTION
Change to align this page's title with the rest of the content