### PR TITLE
chore: modify CI to free linux disk-space before tests action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,23 +27,23 @@ jobs:
         name: ic-hs-test
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-    - name: clean unncessary files to save space
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-          docker rmi `docker images -q`
-          sudo rm -rf /usr/share/dotnet /etc/mysql /etc/php /etc/sudo apt/sources.list.d
-          sudo apt -y autoremove --purge
-          sudo apt -y autoclean
-          sudo apt clean
-          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-          df -h
-
       # Free up disk space on Ubuntu
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       if: matrix.os == 'ubuntu-latest'
       with:
-        # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
+
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
         tool-cache: false
         large-packages: true
         swap-storage: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,6 @@ jobs:
         large-packages: true
         docker-images: true
         swap-storage: true
-        large-packages: true
-        swap-storage: true
 
     # until https://github.com/cachix/cachix-action/issues/86 is fixed:
     - run: cachix watch-store ic-hs-test &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
 
       # Free up disk space on Ubuntu
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      if: matrix.os == 'ubuntu-latest'
+      uses: insightsengineering/disk-space-reclaimer@v1
+      if: startsWith(matrix.os, 'ubuntu-')
       with:
         # this might remove tools that are actually needed,
         # if set to "true" but frees about 6 GB

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,27 @@ jobs:
         name: ic-hs-test
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
+    - name: clean unncessary files to save space
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+          docker rmi `docker images -q`
+          sudo rm -rf /usr/share/dotnet /etc/mysql /etc/php /etc/sudo apt/sources.list.d
+          sudo apt -y autoremove --purge
+          sudo apt -y autoclean
+          sudo apt clean
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df -h
+
+      # Free up disk space on Ubuntu
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      if: matrix.os == 'ubuntu-latest'
+      with:
+        # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
+        tool-cache: false
+        large-packages: true
+        swap-storage: true
+
     # until https://github.com/cachix/cachix-action/issues/86 is fixed:
     - run: cachix watch-store ic-hs-test &
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1,4 +1,5 @@
 (*
+
 This module is the backend of the Motoko compiler. It takes a program in
 the intermediate representation (ir.ml), and produces a WebAssembly module,
 with Internet Computer extensions (customModule.ml). An important helper module is
@@ -8,6 +9,7 @@ instruction lists, as it takes care of (1) source locations and (2) labels.
 This file is split up in a number of modules, purely for namespacing and
 grouping. Every module has a high-level prose comment explaining the concept;
 this keeps documentation close to the code (a lesson learned from Simon PJ).
+
 *)
 
 open Ir_def

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1,5 +1,4 @@
 (*
-
 This module is the backend of the Motoko compiler. It takes a program in
 the intermediate representation (ir.ml), and produces a WebAssembly module,
 with Internet Computer extensions (customModule.ml). An important helper module is

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -9,7 +9,6 @@ instruction lists, as it takes care of (1) source locations and (2) labels.
 This file is split up in a number of modules, purely for namespacing and
 grouping. Every module has a high-level prose comment explaining the concept;
 this keeps documentation close to the code (a lesson learned from Simon PJ).
-
 *)
 
 open Ir_def


### PR DESCRIPTION
My linux CI jobs have been failing due to lack of disk space.

I stumbled across this suggestion on the web

https://saturncloud.io/blog/github-action-ecr-optimizing-disk-space/#handling-or-maximizing-github-runner-out-of-disk-space-error

and it seems to help.

Maybe it's enough to just use the GH action https://github.com/jlumbroso/free-disk-space.

Ok, just this gives us back an extra 28GB of disk space. Hopefully that can keep us going for  a while more.
