### PR TITLE
Update docs to remove links to deleted page

### DIFF
--- a/doc/md/about-this-guide.md
+++ b/doc/md/about-this-guide.md
@@ -52,7 +52,7 @@ For transparency into the principles that guide the engineering effort, the engi
 
 The following guiding principles represent the core values of the engineering organization in prioritized order:
 
-1.  Seamless integration with the [Internet Computer blockchain network](../../concepts/what-is-IC.md#what-is-the-internet-computer) to ensure that Motoko provides full language support for the actor-based model, asynchronous messaging, data persistence, interface description language interoperability, and other features.
+1.  Seamless integration with the Internet Computer blockchain network to ensure that Motoko provides full language support for the actor-based model, asynchronous messaging, data persistence, interface description language interoperability, and other features.
 
 2.  Ergonomics to ensure that Motoko embraces familiarity, simplicity, clarity, explicitness, and other human factors.
 

--- a/doc/md/motoko-introduction.md
+++ b/doc/md/motoko-introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Motoko is a modern, general-purpose programming language you can use specifically to author [Internet Computer](../../concepts/what-is-IC.md) canister smart contracts. Although aimed squarely at the Internet Computer, its design is general enough to support future compilation to other targets.
+Motoko is a modern, general-purpose programming language you can use specifically to author Internet Computer canister smart contracts. Although aimed squarely at the Internet Computer, its design is general enough to support future compilation to other targets.
 
 ## Approachability
 
@@ -12,11 +12,11 @@ Motoko permits modern programming idioms, including special programming abstract
 
 Specifically, Motoko programs are *type sound* since Motoko includes a practical, modern type system that checks each one before it executes. The Motoko type system statically checks that each Motoko program will execute safely, without dynamic type errors, on all possible inputs. Consequently, entire classes of common programming pitfalls that are common in other languages, and web programming languages in particular, are ruled out. This includes null reference errors, mis-matched argument or result types, missing field errors and many others.
 
-To execute, Motoko statically compiles to [WebAssembly](about-this-guide.md#webassembly), a portable binary format that abstracts cleanly over modern computer hardware, and thus permits its execution broadly on the Internet, and the [Internet Computer](../../concepts/what-is-IC.md).
+To execute, Motoko statically compiles to [WebAssembly](about-this-guide.md#webassembly), a portable binary format that abstracts cleanly over modern computer hardware, and thus permits its execution broadly on the Internet, and the Internet Computer.
 
 ## Each canister smart contract as an *actor*
 
-Motoko provides an **actor-based** programming model to developers to express *services*, including those of canister smart contracts on the [Internet Computer](../../concepts/what-is-IC.md).
+Motoko provides an **actor-based** programming model to developers to express *services*, including those of canister smart contracts on the Internet Computer.
 
 An actor is similar to an object, but is special in that its state is completely isolated, and all its interactions with the world are by *asynchronous* messaging.
 


### PR DESCRIPTION
This PR removes links to the page `/concepts/what-is-IC` in the Motoko docs, since this page has been deleted. 