### PR TITLE
fix: don't coalesce tag with underscore

### DIFF
--- a/src/mo_frontend/coverage.ml
+++ b/src/mo_frontend/coverage.ml
@@ -140,9 +140,8 @@ let rec string_of_desc t = function
     "?(" ^ string_of_desc t' desc ^ ")"
   | Tag (desc, l) ->
     let t' = T.lookup_val_field l (T.as_variant_sub l t) in
-    let sep = function "_" -> " _" | s -> s in
     if T.sub t' T.unit then "#" ^ l
-    else if T.is_tup t' then "#" ^ l ^ sep (string_of_desc t' desc)
+    else if T.is_tup t' then "#" ^ l ^ " " ^ string_of_desc t' desc
     else "#" ^ l ^ "(" ^ string_of_desc t' desc ^ ")"
   | NotTag ls ->
     let tfs = T.as_variant (T.promote t) in

--- a/src/mo_frontend/coverage.ml
+++ b/src/mo_frontend/coverage.ml
@@ -142,7 +142,7 @@ let rec string_of_desc t = function
     let t' = T.lookup_val_field l (T.as_variant_sub l t) in
     let sep = function "_" -> " _" | s -> s in
     if T.sub t' T.unit then "#" ^ l
-    else if T.is_tup t' then "#" ^ l ^ sep (string_of_desc t') desc
+    else if T.is_tup t' then "#" ^ l ^ sep (string_of_desc t' desc)
     else "#" ^ l ^ "(" ^ string_of_desc t' desc ^ ")"
   | NotTag ls ->
     let tfs = T.as_variant (T.promote t) in

--- a/src/mo_frontend/coverage.ml
+++ b/src/mo_frontend/coverage.ml
@@ -140,8 +140,9 @@ let rec string_of_desc t = function
     "?(" ^ string_of_desc t' desc ^ ")"
   | Tag (desc, l) ->
     let t' = T.lookup_val_field l (T.as_variant_sub l t) in
+    let sep = function "_" -> " _" | s -> s in
     if T.sub t' T.unit then "#" ^ l
-    else if T.is_tup t' then "#" ^ l ^ string_of_desc t' desc
+    else if T.is_tup t' then "#" ^ l ^ sep (string_of_desc t') desc
     else "#" ^ l ^ "(" ^ string_of_desc t' desc ^ ")"
   | NotTag ls ->
     let tfs = T.as_variant (T.promote t) in


### PR DESCRIPTION
... in the coverage warnings.

Repro:
``` Motoko
type A = { #a : { f : Int; g : Text }; #b : (Char, Char); #c : ?Nat; #d : Nat };

var a : A = #d 42;
switch a {case (#d 1) ()};
```
Gives
> stdin:13.1-13.26: warning [M0145], this switch of type
>   {#a : {f : Int; g : Text}; #b : (Char, Char); #c : ?Nat; #d : Nat}
> does not cover value
>   #d(0 or 2 or _) or
>   #a(_) or **#b_** or #c(_)
