### PR TITLE
feat: add doc comments to Candid interfaces generated via `--idl` flag

### DIFF
--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -255,9 +255,11 @@ let process_files files : unit =
       end;
 
     if !idl then begin
+      let open Idllib in
       let did_file = Filename.remove_extension !out_file ^ ".did" in
       let oc = open_out did_file in
-      let idl_code = Idllib.Arrange_idl.string_of_prog idl_prog in
+      let module WithComments = Arrange_idl.Make(struct let trivia = Some idl_prog.Source.note.Syntax.trivia end) in
+      let idl_code = WithComments.string_of_prog idl_prog in
       output_string oc idl_code; close_out oc
     end;
 


### PR DESCRIPTION
This PR includes doc comments from #4178 in the Candid files generated by dfx using the `--idl` compiler flag. 

Unblocks @tiagoicp's developer grant. 