### PR TITLE
bugfix: fix Region.storeNat32/loadNat32 and Region.storeInt32/loadInt32 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * bugfix: fix broken implementations of `Region.loadNat32`, `Region.storeNat32`, `Region.loadInt32`, `Region.storeInt32` (#4335).
+    Values previously stored with the broken 32-bit operations must be loaded with care.
+    If bit 0 is clear, the original value can be obtained by an arithmetic shift right by 1 bit.
+    If bit 0 is set, the value cannot be trusted and should be ignored
+    (it encodes some transient address of a boxed value).
+
 ## 0.10.2 (2023-11-12)
 
 * motoko (`moc`)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10871,7 +10871,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
     Region.store_word16 env
 
   | OtherPrim ("regionLoadNat32" | "regionLoadInt32"), [e0; e1] ->
-    SR.Vanilla,
+    SR.UnboxedWord32,
     compile_exp_as env ae SR.Vanilla e0 ^^
     compile_exp_as env ae SR.UnboxedWord64 e1 ^^
     Region.load_word32 env
@@ -10880,7 +10880,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
     SR.unit,
     compile_exp_as env ae SR.Vanilla e0 ^^
     compile_exp_as env ae SR.UnboxedWord64 e1 ^^
-    compile_exp_as env ae SR.Vanilla e2 ^^
+    compile_exp_as env ae SR.UnboxedWord32 e2 ^^
     Region.store_word32 env
 
   | OtherPrim ("regionLoadNat64" | "regionLoadInt64"), [e0; e1] ->

--- a/test/run-drun/ok/region-nat32-bug.drun-run.ok
+++ b/test/run-drun/ok/region-nat32-bug.drun-run.ok
@@ -1,0 +1,3 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+debug.print: {bytes = "\02\00\00\00"; i = 1; i32 = 1; i64 = 2}
+ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: assertion failed at region-nat32-bug.mo:14.8-14.21

--- a/test/run-drun/ok/region-nat32-bug.drun-run.ok
+++ b/test/run-drun/ok/region-nat32-bug.drun-run.ok
@@ -1,3 +1,2 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
-debug.print: {bytes = "\02\00\00\00"; i = 1; i32 = 1; i64 = 2}
-ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: assertion failed at region-nat32-bug.mo:14.8-14.21
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/region-nat32-bug.tc.ok
+++ b/test/run-drun/ok/region-nat32-bug.tc.ok
@@ -1,0 +1,4 @@
+region-nat32-bug.mo:5.5-5.6: warning [M0145], this pattern of type
+  Nat64
+does not cover value
+  1 or 2 or _

--- a/test/run-drun/region-nat32-bug.mo
+++ b/test/run-drun/region-nat32-bug.mo
@@ -1,0 +1,21 @@
+import Prim "mo:⛔";
+import Region "stable-region/Region";
+
+let r = Region.new();
+let 0 = Region.grow(r, 1);
+
+var i : Nat32 = 0;
+while(i <= 0xFFFF_FFFF) {
+     Region.storeNat32(r, 0, i);
+     let i32 = Region.loadNat32(r, 0);
+     let i64 = Region.loadNat64(r, 0);
+     if (i32 != i or Prim.nat64ToNat32(i64) != i) {
+       Prim.debugPrint(debug_show({i;i64;i32;bytes=Region.loadBlob(r,0,4)}));
+       assert(false);
+     };
+     i += 1;
+   };
+
+//SKIP run-low
+//SKIP run
+//SKIP run-ir

--- a/test/run-drun/region-nat32-bug.mo
+++ b/test/run-drun/region-nat32-bug.mo
@@ -5,7 +5,7 @@ let r = Region.new();
 let 0 = Region.grow(r, 1);
 
 var i : Nat32 = 0;
-while(i <= 0xFFFF_FFFF) {
+while(i < 0xFFFF_FF00) {
      Region.storeNat32(r, 0, i);
      let i32 = Region.loadNat32(r, 0);
      let i64 = Region.loadNat64(r, 0);
@@ -13,7 +13,7 @@ while(i <= 0xFFFF_FFFF) {
        Prim.debugPrint(debug_show({i;i64;i32;bytes=Region.loadBlob(r,0,4)}));
        assert(false);
      };
-     i += 1;
+     i += 256;
    };
 
 //SKIP run-low

--- a/test/run-drun/region-nat32-bug.mo
+++ b/test/run-drun/region-nat32-bug.mo
@@ -4,8 +4,9 @@ import Region "stable-region/Region";
 let r = Region.new();
 let 0 = Region.grow(r, 1);
 
-var i : Nat32 = 0;
-while(i < 0xFFFF_FF00) {
+do {
+  var i : Nat32 = 0;
+  while(i < 0xFFFF) {
      Region.storeNat32(r, 0, i);
      let i32 = Region.loadNat32(r, 0);
      let i64 = Region.loadNat64(r, 0);
@@ -13,8 +14,23 @@ while(i < 0xFFFF_FF00) {
        Prim.debugPrint(debug_show({i;i64;i32;bytes=Region.loadBlob(r,0,4)}));
        assert(false);
      };
-     i += 256;
+     i += 1;
    };
+};
+
+do {
+  var i : Nat32 = 0xFFFF_FFFF;
+  while(i > 0xFFFF_0000) {
+     Region.storeNat32(r, 0, i);
+     let i32 = Region.loadNat32(r, 0);
+     let i64 = Region.loadNat64(r, 0);
+     if (i32 != i or Prim.nat64ToNat32(i64) != i) {
+       Prim.debugPrint(debug_show({i;i64;i32;bytes=Region.loadBlob(r,0,4)}));
+       assert(false);
+     };
+     i -= 1;
+   };
+}
 
 //SKIP run-low
 //SKIP run


### PR DESCRIPTION

bugfix: fix broken implementations of `Region.loadNat32`, `Region.storeNat32`, `Region.loadInt32`, `Region.storeInt32` (#4335). The operations were writing the 32-bit vanilla representation of the Motoko values, not the decoded values. 

Values previously stored with the broken 32-bit operations must be loaded with care.
If bit 0 is clear, the original value can be obtained by an arithmetic shift right by 1 bit.
If bit 0 is set, the value cannot be trusted and should be ignored (it encodes some transient address of a boxed value).



