### PR TITLE
extending `ObjBlockE` with optional conformity

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -295,7 +295,7 @@
 <dec_nonvar> ::= 
     'let' <pat> '=' <exp>
     'type' <id> ('<' <list(<typ_bind>, ',')> '>')? '=' <typ>
-    <obj_sort> <id>? '='? <obj_body>
+    <obj_sort> <id>? <annot_opt_eq>? <obj_body>
     <shared_pat_opt> 'func' <id>? ('<' <list(<typ_bind>, ',')> '>')? <pat_plain> (':' <typ>)? <func_body>
     <shared_pat_opt> <obj_sort>? 'class' <id>? ('<' <list(<typ_bind>, ',')> '>')? <pat_plain> (':' <typ>)? <class_body>
 

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -138,7 +138,7 @@ struct
           _;
         } -> (
         match rhs with
-        | Source.{ it = Syntax.ObjBlockE (sort, fields); _ } ->
+        | Source.{ it = Syntax.ObjBlockE (sort, _, fields); _ } ->
             let mk_field_xref xref = mk_xref (Xref.XClass (name, xref)) in
             Some
               ( mk_xref (Xref.XType name),

--- a/src/docs/namespace.ml
+++ b/src/docs/namespace.ml
@@ -32,7 +32,7 @@ let from_module =
         | Syntax.ExpD _ -> acc
         | Syntax.LetD
             ( { it = Syntax.VarP id; _ },
-              { it = Syntax.ObjBlockE (_, decs); _ },
+              { it = Syntax.ObjBlockE (_, _, decs); _ },
               _ ) ->
             let mk_nested x = mk_xref (Xref.XNested (id.it, x)) in
             {

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -195,4 +195,5 @@ let error_codes : (string * string option) list =
     "M0189", None; (* Different set of bindings in pattern alternatives *)
     "M0190", None; (* Types inconsistent for alternative pattern variables, losing information *)
     "M0191", None; (* Code requires Wasm features ... to execute *)
+    "M0192", None; (* Object/Actor/Module body type mismatch *)
   ]

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -90,7 +90,7 @@ and exp' at note = function
       (breakE "!" (nullE()))
       (* case ? v : *)
       (varP v) (varE v) ty).it
-  | S.ObjBlockE (s, dfs) ->
+  | S.ObjBlockE (s, _t, dfs) ->
     obj_block at s None dfs note.Note.typ
   | S.ObjE (bs, efs) ->
     obj note.Note.typ efs bs

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -69,7 +69,7 @@ module Make (Cfg : Config) = struct
     | FromCandidE e       -> "FromCandidE" $$ [exp e]
     | TupE es             -> "TupE"      $$ exps es
     | ProjE (e, i)        -> "ProjE"     $$ [exp e; Atom (string_of_int i)]
-    | ObjBlockE (s, dfs)  -> "ObjBlockE" $$ [obj_sort s] @ List.map dec_field dfs
+    | ObjBlockE (s, t, dfs) -> "ObjBlockE" $$ [obj_sort s; match t with None -> Atom "_" | Some t -> typ t] @ List.map dec_field dfs
     | ObjE ([], efs)      -> "ObjE"      $$ List.map exp_field efs
     | ObjE (bases, efs)   -> "ObjE"      $$ exps bases @ [Atom "with"] @ List.map exp_field efs
     | DotE (e, x)         -> "DotE"      $$ [exp e; id x]

--- a/src/mo_def/compUnit.ml
+++ b/src/mo_def/compUnit.ml
@@ -8,13 +8,13 @@ open Syntax
 let is_actor_def e =
   let open Source in
   match e.it with
-  | AwaitE (Type.Fut, { it = AsyncE (Type.Fut, _, {it = ObjBlockE ({ it = Type.Actor; _}, _fields); _ }) ; _  }) -> true
+  | AwaitE (Type.Fut, { it = AsyncE (Type.Fut, _, {it = ObjBlockE ({ it = Type.Actor; _}, _t, _fields); _ }) ; _  }) -> true
   | _ -> false
 
 let as_actor_def e =
   let open Source in
   match e.it with
-  | AwaitE (Type.Fut, { it = AsyncE (Type.Fut, _, {it = ObjBlockE ({ it = Type.Actor; _}, fields); note; at }) ; _  }) ->
+  | AwaitE (Type.Fut, { it = AsyncE (Type.Fut, _, {it = ObjBlockE ({ it = Type.Actor; _}, _t, fields); note; at }) ; _  }) ->
     fields, note, at
   | _ -> assert false
 
@@ -35,7 +35,7 @@ let comp_unit_of_prog as_lib (prog : prog) : comp_unit =
       go (i :: imports) ds'
 
     (* terminal expressions *)
-    | [{it = ExpD ({it = ObjBlockE ({it = Type.Module; _}, fields); _} as e); _}] when as_lib ->
+    | [{it = ExpD ({it = ObjBlockE ({it = Type.Module; _}, _t, fields); _} as e); _}] when as_lib ->
       finish imports { it = ModuleU (None, fields); note = e.note; at = e.at }
     | [{it = ExpD e; _} ] when is_actor_def e ->
       let fields, note, at = as_actor_def e in
@@ -44,7 +44,7 @@ let comp_unit_of_prog as_lib (prog : prog) : comp_unit =
       assert (List.length tbs > 0);
       finish imports { it = ActorClassU (sp, tid, tbs, p, typ_ann, self_id, fields); note = d.note; at = d.at }
     (* let-bound terminal expressions *)
-    | [{it = LetD ({it = VarP i1; _}, ({it = ObjBlockE ({it = Type.Module; _}, fields); _} as e), _); _}] when as_lib ->
+    | [{it = LetD ({it = VarP i1; _}, ({it = ObjBlockE ({it = Type.Module; _}, _t, fields); _} as e), _); _}] when as_lib ->
       finish imports { it = ModuleU (Some i1, fields); note = e.note; at = e.at }
     | [{it = LetD ({it = VarP i1; _}, e, _); _}] when is_actor_def e ->
       let fields, note, at = as_actor_def e in
@@ -68,14 +68,14 @@ let obj_decs obj_sort at note id_opt fields =
   match id_opt with
   | None -> [
     { it = ExpD {
-        it = ObjBlockE ( { it = obj_sort; at; note = () }, fields);
+        it = ObjBlockE ( { it = obj_sort; at; note = () }, None, fields);
         at;
         note };
       at; note }]
   | Some id -> [
     { it = LetD (
         { it = VarP id; at; note = note.note_typ },
-        { it = ObjBlockE ({ it = obj_sort; at; note = () }, fields);
+        { it = ObjBlockE ({ it = obj_sort; at; note = () }, None, fields);
           at; note; },
         None);
       at; note

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -162,7 +162,7 @@ and exp' =
   | OptE of exp                                (* option injection *)
   | DoOptE of exp                              (* option monad *)
   | BangE of exp                               (* scoped option projection *)
-  | ObjBlockE of obj_sort * dec_field list     (* object block *)
+  | ObjBlockE of obj_sort * typ option * dec_field list  (* object block *)
   | ObjE of exp list * exp_field list          (* record literal/extension *)
   | TagE of id * exp                           (* variant *)
   | DotE of exp * id                           (* object projection *)

--- a/src/mo_frontend/definedness.ml
+++ b/src/mo_frontend/definedness.ml
@@ -101,7 +101,7 @@ let rec exp msgs e : f = match e.it with
   | FromCandidE e       -> exp msgs e
   | TupE es             -> exps msgs es
   | ProjE (e, i)        -> exp msgs e
-  | ObjBlockE (s, dfs)       ->
+  | ObjBlockE (s, _, dfs) ->
     (* For actors, this may be too permissive; to be revised when we work on actors again *)
     group msgs (dec_fields msgs dfs)
   | ObjE (bases, efs)   -> exps msgs bases ++ exp_fields msgs efs

--- a/src/mo_frontend/effect.ml
+++ b/src/mo_frontend/effect.ml
@@ -99,7 +99,7 @@ let rec infer_effect_exp (exp:Syntax.exp) : T.eff =
     map_max_effs effect_exp exps
   | BlockE decs ->
     map_max_effs effect_dec decs
-  | ObjBlockE (sort, dfs) ->
+  | ObjBlockE (sort, _, dfs) ->
     infer_effect_dec_fields dfs
   | ObjE (bases, efs) ->
     let bases = map_max_effs effect_exp bases in

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -108,7 +108,7 @@ let is_sugared_func_or_module dec = match dec.it with
   | LetD({it = VarP _; _} as pat, exp, None) ->
     dec.at = pat.at && pat.at = exp.at &&
     (match exp.it with
-    | ObjBlockE (sort, _) ->
+    | ObjBlockE (sort, _, _) ->
       sort.it = Type.Module
     | FuncE _ ->
       true
@@ -189,13 +189,13 @@ let share_dec_field (df : dec_field) =
       }
     else df
 
-and objblock s dec_fields =
+and objblock s ty dec_fields =
   List.iter (fun df ->
     match df.it.vis.it, df.it.dec.it with
     | Public _, ClassD (_, id, _, _, _, _, _, _) when is_anon_id id ->
       syntax_error df.it.dec.at "M0158" "a public class cannot be anonymous, please provide a name"
     | _ -> ()) dec_fields;
-  ObjBlockE(s, dec_fields)
+  ObjBlockE(s, ty, dec_fields)
 
 %}
 
@@ -865,9 +865,9 @@ dec_nonvar :
           AwaitE
             (Type.Fut,
              AsyncE(Type.Fut, scope_bind (anon_id "async" (at $sloc)) (at $sloc),
-                    annot_exp (objblock s (List.map share_dec_field efs) @? at $sloc) t)
+                    objblock s t (List.map share_dec_field efs) @? at $sloc)
              @? at $sloc) @? at $sloc
-        else annot_exp (objblock s efs @? at $sloc) t
+        else objblock s t efs @? at $sloc
       in
       let_or_exp named x e.it e.at }
   | sp=shared_pat_opt FUNC xf=id_opt

--- a/src/mo_frontend/static.ml
+++ b/src/mo_frontend/static.ml
@@ -44,7 +44,7 @@ let rec exp m e = match e.it with
       | Const ->  List.iter (exp m) es
       | Var -> err m e.at
     end
-  | ObjBlockE (_, dfs) -> dec_fields m dfs
+  | ObjBlockE (_, _, dfs) -> dec_fields m dfs
   | ObjE (bases, efs) -> List.iter (exp m) bases; exp_fields m efs
 
   (* Variable access. Dangerous, due to loops. *)

--- a/src/mo_frontend/traversals.ml
+++ b/src/mo_frontend/traversals.ml
@@ -54,8 +54,8 @@ let rec over_exp (f : exp -> exp) (exp : exp) : exp = match exp.it with
      f { exp with it = ArrayE (x, List.map (over_exp f) exps) }
   | BlockE ds ->
      f { exp with it = BlockE (List.map (over_dec f) ds) }
-  | ObjBlockE (x, dfs) ->
-     f { exp with it = ObjBlockE (x, List.map (over_dec_field f) dfs) }
+  | ObjBlockE (x, t, dfs) ->
+     f { exp with it = ObjBlockE (x, t, List.map (over_dec_field f) dfs) }
   | ObjE (bases, efs) ->
      f { exp with it = ObjE (List.map (over_exp f) bases, List.map (over_exp_field f) efs) }
   | IfE (exp1, exp2, exp3) ->

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1151,9 +1151,8 @@ and infer_exp'' env exp : T.typ =
       else env
     in
     let t = infer_obj env' obj_sort.it dec_fields exp.at in
-    begin match typ_opt, obj_sort.it with
-      | Some { it = AsyncT (T.Fut, _, typ); at; _ }, T.Actor
-      | Some ({ at; _ } as typ), T.(Module | Object) ->
+    begin match typ_opt with
+      | Some typ ->
         let t' = check_typ env' typ in
         if not (T.sub t t') then
           local_error env obj_sort.at "M0134"(*FIXME*)

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1155,7 +1155,7 @@ and infer_exp'' env exp : T.typ =
       | Some typ ->
         let t' = check_typ env' typ in
         if not (T.sub t t') then
-          local_error env obj_sort.at "M0192"
+          local_error env exp.at "M0192"
             "body of type%a\ndoes not match expected type%a"
             display_typ_expand t
             display_typ_expand t'

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1151,8 +1151,8 @@ and infer_exp'' env exp : T.typ =
       else env
     in
     let t = infer_obj env' obj_sort.it dec_fields exp.at in
-    begin match typ_opt with
-      | Some typ ->
+    begin match env.pre, typ_opt with
+      | false, Some typ ->
         let t' = check_typ env' typ in
         if not (T.sub t t') then
           local_error env exp.at "M0192"

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1155,7 +1155,7 @@ and infer_exp'' env exp : T.typ =
       | Some typ ->
         let t' = check_typ env' typ in
         if not (T.sub t t') then
-          local_error env obj_sort.at "M0134"(*FIXME*)
+          local_error env obj_sort.at "M0192"
             "body of type%a\ndoes not match expected type%a"
             display_typ_expand t
             display_typ_expand t'
@@ -2445,7 +2445,7 @@ and infer_dec env dec : T.typ =
             display_typ_expand t'
             display_typ_expand t''
       | Some typ, T.Actor ->
-         local_error env dec.at "M0135"(*FIXME*) "actor class has non-async return type"
+         local_error env dec.at "M0135"(*FIXME: repeated?*) "actor class has non-async return type"
       | _, T.Memory -> assert false
     end;
     T.normalize t

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2524,8 +2524,8 @@ and gather_dec env scope dec : Scope.t =
   (* TODO: generalize beyond let <id> = <obje> *)
   | LetD (
       {it = VarP id; _},
-      ({it = ObjBlockE (obj_sort, _, dec_fields); at; _} |
-       {it = AwaitE (_,{ it = AsyncE (_, _, {it = ObjBlockE ({ it = Type.Actor; _} as obj_sort, _, dec_fields); at; _}) ; _  }); _ }),
+      ( {it = ObjBlockE (obj_sort, _, dec_fields); at; _}
+      | {it = AwaitE (_,{ it = AsyncE (_, _, {it = ObjBlockE ({ it = Type.Actor; _} as obj_sort, _, dec_fields); at; _}) ; _  }); _ }),
        _
     ) ->
     let decs = List.map (fun df -> df.it.dec) dec_fields in
@@ -2607,8 +2607,8 @@ and infer_dec_typdecs env dec : Scope.t =
   (* TODO: generalize beyond let <id> = <obje> *)
   | LetD (
       {it = VarP id; _},
-      ( {it = ObjBlockE (obj_sort, _t, dec_fields); at; _} |
-        {it = AwaitE (_, { it = AsyncE (_, _, {it = ObjBlockE ({ it = Type.Actor; _} as obj_sort, _t, dec_fields); at; _}) ; _  }); _ }),
+      ( {it = ObjBlockE (obj_sort, _t, dec_fields); at; _}
+      | {it = AwaitE (_, { it = AsyncE (_, _, {it = ObjBlockE ({ it = Type.Actor; _} as obj_sort, _t, dec_fields); at; _}) ; _  }); _ }),
         _
     ) ->
     let decs = List.map (fun {it = {vis; dec; _}; _} -> dec) dec_fields in
@@ -2689,8 +2689,8 @@ and infer_dec_valdecs env dec : Scope.t =
   (* TODO: generalize beyond let <id> = <obje> *)
   | LetD (
       {it = VarP id; _} as pat,
-      ( {it = ObjBlockE (obj_sort, _t, dec_fields); at; _} |
-        {it = AwaitE (_, { it = AsyncE (_, _, {it = ObjBlockE ({ it = Type.Actor; _} as obj_sort, _t, dec_fields); at; _}) ; _ }); _ }),
+      ( {it = ObjBlockE (obj_sort, _t, dec_fields); at; _}
+      | {it = AwaitE (_, { it = AsyncE (_, _, {it = ObjBlockE ({ it = Type.Actor; _} as obj_sort, _t, dec_fields); at; _}) ; _ }); _ }),
         _
     ) ->
     let decs = List.map (fun df -> df.it.dec) dec_fields in

--- a/src/mo_interpreter/interpret.ml
+++ b/src/mo_interpreter/interpret.ml
@@ -482,7 +482,7 @@ and interpret_exp_mut env exp (k : V.value V.cont) =
       | _ -> assert false)
   | ProjE (exp1, n) ->
     interpret_exp env exp1 (fun v1 -> k (List.nth (V.as_tup v1) n))
-  | ObjBlockE (obj_sort, dec_fields) ->
+  | ObjBlockE (obj_sort, _, dec_fields) ->
     interpret_obj env obj_sort.it dec_fields k
   | ObjE (exp_bases, exp_fields) ->
     let fields fld_env = interpret_exp_fields env exp_fields fld_env (fun env -> k (V.Obj env)) in

--- a/test/fail/ok/issue-4323.tc.ok
+++ b/test/fail/ok/issue-4323.tc.ok
@@ -1,4 +1,4 @@
-issue-4323.mo:4.1-4.6: type error [M0192], body of type
+issue-4323.mo:4.1-6.2: type error [M0192], body of type
   actor {}
 does not match expected type
   Main = actor {beep : shared () -> async ()}

--- a/test/fail/ok/issue-4323.tc.ok
+++ b/test/fail/ok/issue-4323.tc.ok
@@ -1,4 +1,4 @@
-issue-4323.mo:4.1-6.2: type error [M0096], expression of type
+issue-4323.mo:4.1-4.6: type error [M0134], body of type
   actor {}
-cannot produce expected type
-  actor {beep : shared () -> async ()}
+does not match expected type
+  Main = actor {beep : shared () -> async ()}

--- a/test/fail/ok/issue-4323.tc.ok
+++ b/test/fail/ok/issue-4323.tc.ok
@@ -1,4 +1,4 @@
-issue-4323.mo:4.1-4.6: type error [M0134], body of type
+issue-4323.mo:4.1-4.6: type error [M0192], body of type
   actor {}
 does not match expected type
   Main = actor {beep : shared () -> async ()}


### PR DESCRIPTION
Use the same procedure as with `ClassD`, viz. adding an optional type to `ObjBlockE` and checking for it after inferring the body's type.