### PR TITLE
chore: remove the `FIXME` for duplicated `M0135`

### DIFF
--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -196,4 +196,5 @@ let error_codes : (string * string option) list =
     "M0190", None; (* Types inconsistent for alternative pattern variables, losing information *)
     "M0191", None; (* Code requires Wasm features ... to execute *)
     "M0192", None; (* Object/Actor/Module body type mismatch *)
+    "M0193", None; (* Can't declare actor class to have `async*` result *)
   ]

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2445,7 +2445,7 @@ and infer_dec env dec : T.typ =
             display_typ_expand t'
             display_typ_expand t''
       | Some typ, T.Actor ->
-         local_error env dec.at "M0135"(*FIXME: repeated?*) "actor class has non-async return type"
+         local_error env dec.at "M0193" "actor class has non-async return type"
       | _, T.Memory -> assert false
     end;
     T.normalize t

--- a/test/fail/actor-class-star.mo
+++ b/test/fail/actor-class-star.mo
@@ -1,0 +1,1 @@
+actor class C() : async* actor {} = {}

--- a/test/fail/ok/actor-class-star.tc.ok
+++ b/test/fail/ok/actor-class-star.tc.ok
@@ -1,0 +1,1 @@
+actor-class-star.mo:1.1-1.39: type error [M0193], actor class has non-async return type

--- a/test/fail/ok/actor-class-star.tc.ret.ok
+++ b/test/fail/ok/actor-class-star.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1


### PR DESCRIPTION
Since the parser already ensures that the return type of actor classes is `AsyncT`, the only way how this can be triggered is by having `T.Cmp`.