### PR TITLE
fix: wrong new_pages calculation in StableMultiLog

### DIFF
--- a/doc/md/examples/StableMultiLog.mo
+++ b/doc/md/examples/StableMultiLog.mo
@@ -20,7 +20,7 @@ actor StableLog {
   func regionEnsureSizeBytes(r : Region, new_byte_count : Nat64) {
     let pages = Region.size(r);
     if (new_byte_count > pages << 16) {
-      let new_pages = pages - ((new_byte_count + ((1 << 16) - 1)) / (1 << 16));
+      let new_pages = ((new_byte_count + ((1 << 16) - 1)) / (1 << 16)) - pages;
       assert Region.grow(r, new_pages) == pages
     }
   };


### PR DESCRIPTION
Fix the wrong calculation on the new pages needed to grow stable memory in the StableMultiLog example used in our documentation. 