### PR TITLE
chore: update contact email

### DIFF
--- a/rts/cargo-vendor-tools/Cargo.toml
+++ b/rts/cargo-vendor-tools/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-vendor-tools"
 version = "0.1.0"
-authors = ["dfinity <sdk@dfinity.org>"]
+authors = ["dfinity <team-motoko@dfinity.org>"]
 edition = "2018"
 
 [[bin]]

--- a/rts/motoko-rts-macros/Cargo.toml
+++ b/rts/motoko-rts-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "motoko-rts-macros"
 version = "0.1.0"
-authors = ["dfinity <sdk@dfinity.org>"]
+authors = ["dfinity <team-motoko@dfinity.org>"]
 edition = "2018"
 
 [lib]

--- a/rts/motoko-rts-tests/Cargo.toml
+++ b/rts/motoko-rts-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "motoko-rts-tests"
 version = "0.1.0"
-authors = ["dfinity <sdk@dfinity.org"]
+authors = ["dfinity <team-motoko@dfinity.org"]
 edition = "2018"
 
 [features]

--- a/rts/motoko-rts/Cargo.toml
+++ b/rts/motoko-rts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "motoko-rts"
 version = "0.1.0"
-authors = ["dfinity <sdk@dfinity.org>"]
+authors = ["dfinity <team-motoko@dfinity.org>"]
 edition = "2018"
 
 # For rlib use native/Cargo.toml

--- a/rts/motoko-rts/native/Cargo.toml
+++ b/rts/motoko-rts/native/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "motoko-rts"
 version = "0.1.0"
-authors = ["dfinity <sdk@dfinity.org>"]
+authors = ["dfinity <team-motoko@dfinity.org>"]
 edition = "2018"
 
 [lib]

--- a/test/lsp-int/lsp-int.cabal
+++ b/test/lsp-int/lsp-int.cabal
@@ -5,7 +5,7 @@ version:             0
 synopsis:            Integration tests for the language server
 -- description:
 author:              dfinity
-maintainer:          sdk@dfinity.org
+maintainer:          team-motoko@dfinity.org
 -- copyright:
 category:            Testing
 extra-source-files:  CHANGELOG.md

--- a/test/random/qc-motoko.cabal
+++ b/test/random/qc-motoko.cabal
@@ -5,7 +5,7 @@ version:             1
 synopsis:            generate randomised tests for Motoko
 -- description:
 author:              dfinity
-maintainer:          sdk@dfinity.org
+maintainer:          team-motoko@dfinity.org
 -- copyright:
 category:            Testing
 extra-source-files:  CHANGELOG.md


### PR DESCRIPTION
Replaces `sdk@dfinity.org` with the recently introduced `team-motoko@dfinity.org`.