### PR TITLE
Exempt top-level actor class identifier from unused detection

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2529,6 +2529,8 @@ and infer_dec env dec : T.typ =
       let cs, tbs, te, ce = check_typ_binds env typ_binds in
       let env' = adjoin_typs env te ce in
       let in_actor = obj_sort.it = T.Actor in
+      (* Top-level actor class identifier is implicitly public and thus considered used. *)
+      if env.in_prog && in_actor then use_identifier env id.it;
       let t_pat, ve =
         infer_pat_exhaustive (if in_actor then error else warn) env' pat
       in

--- a/test/run-drun/ok/standalone-actor-class.drun-run.ok
+++ b/test/run-drun/ok/standalone-actor-class.drun-run.ok
@@ -1,0 +1,2 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/standalone-actor-class.mo
+++ b/test/run-drun/standalone-actor-class.mo
@@ -1,0 +1,3 @@
+actor class TestActorClass() {
+    public func test() : async () {};
+};


### PR DESCRIPTION
A possible fix for https://github.com/dfinity/motoko/issues/4448.

The unnecessary warning appears because the files are analyzed separately in VSCode. When compiled, e.g. with `dfx`, the actor class would not be reported unused if it is instantiated in the main program or a used module.