### PR TITLE
feat: use static type information for value pretty-printing logic

### DIFF
--- a/src/ir_interpreter/interpret_ir.ml
+++ b/src/ir_interpreter/interpret_ir.ml
@@ -80,7 +80,7 @@ let trace fmt =
     Printf.printf "%s%s\n%!" (String.make (2 * !trace_depth) ' ') s
   ) fmt
 
-let string_of_val env = V.string_of_val env.flags.print_depth
+let string_of_val env = V.string_of_val env.flags.print_depth None
 let string_of_def flags = V.string_of_def flags.print_depth
 let string_of_arg env = function
   | V.Tup _ as v -> string_of_val env v
@@ -643,7 +643,7 @@ and match_args at args v : val_env =
   | _ ->
     let vs = V.as_tup v in
     if (List.length vs <> List.length args) then
-      failwith (Printf.sprintf "%s %s" (Source.string_of_region at) (V.string_of_val 0 v));
+      failwith (Printf.sprintf "%s %s" (Source.string_of_region at) (V.string_of_val 0 None v));
     List.fold_left V.Env.adjoin V.Env.empty (List.map2 match_arg args vs)
 
 (* Patterns *)

--- a/src/mo_frontend/coverage.ml
+++ b/src/mo_frontend/coverage.ml
@@ -126,7 +126,7 @@ let rec expand_nottag tfs n ls : desc list =
 (* TODO: pretty print *)
 let rec string_of_desc t = function
   | Any -> "_"
-  | Val v -> V.string_of_val 100 v
+  | Val v -> V.string_of_val 100 (Some t) v
   | NotVal vs -> string_of_descs t (expand_notval (T.promote t) 0 vs)
   | Tup descs ->
     let ts = T.as_tup_sub (List.length descs) t in

--- a/src/mo_values/show.ml
+++ b/src/mo_values/show.ml
@@ -83,7 +83,7 @@ let rec show_val t v =
     end
   | _ ->
     Format.eprintf "@[show_val: %a : %a@.@]"
-      (Value.pp_val 2) v
+      (Value.pp_val 2) (t, v)
       T.pp_typ t;
     assert false
 

--- a/src/mo_values/value.mli
+++ b/src/mo_values/value.mli
@@ -116,5 +116,5 @@ val compare : value -> value -> int
 val pp_val : int -> Format.formatter -> (Type.typ * value) -> unit
 val pp_def : int -> Format.formatter -> def -> unit
 
-val string_of_val : int -> Type.typ -> value -> string
+val string_of_val : int -> Type.typ option -> value -> string
 val string_of_def : int -> def -> string

--- a/src/mo_values/value.mli
+++ b/src/mo_values/value.mli
@@ -113,8 +113,8 @@ val compare : value -> value -> int
 
 (* Pretty Printing *)
 
-val pp_val : int -> Format.formatter -> value -> unit
+val pp_val : int -> Format.formatter -> (Type.typ * value) -> unit
 val pp_def : int -> Format.formatter -> def -> unit
 
-val string_of_val : int -> value -> string
+val string_of_val : int -> Type.typ -> value -> string
 val string_of_def : int -> def -> string

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -62,7 +62,7 @@ let print_scope senv scope dve =
 
 let print_val _senv v t =
   Format.printf "@[<hv 2>%a :@ %a@]@."
-    (Value.pp_val !Flags.print_depth) v
+    (Value.pp_val !Flags.print_depth) (t, v)
     Type.pp_typ t
 
 
@@ -594,7 +594,7 @@ let run_stdin_from_file files file : Value.value option =
   let denv' = interpret_libs denv libs in
   let* (v, dscope) = interpret_prog denv' prog in
   Format.printf "@[<hv 2>%a :@ %a@]@."
-    (Value.pp_val 10) v
+    print_val senv v t
     Type.pp_typ t;
   Some v
 

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -593,9 +593,7 @@ let run_stdin_from_file files file : Value.value option =
     Diag.flush_messages (load_decl (parse_file Source.no_region file) senv) in
   let denv' = interpret_libs denv libs in
   let* (v, dscope) = interpret_prog denv' prog in
-  Format.printf "@[<hv 2>%a :@ %a@]@."
-    print_val senv v t
-    Type.pp_typ t;
+  print_val senv v t;
   Some v
 
 let run_files_and_stdin files =

--- a/src/profiler/counters.ml
+++ b/src/profiler/counters.ml
@@ -60,7 +60,7 @@ let dump (c:t) (ve: Value.value Value.Env.t) =
       Printf.printf "{\n" ;
       Value.Env.iter (fun fn fv ->
           Printf.printf " %s = %s;\n"
-            fn (Value.string_of_val 0 fv)
+            fn (Value.string_of_val 0 None fv)
         )
         ve ;
       Printf.printf "}\n"
@@ -112,7 +112,7 @@ let dump (c:t) (ve: Value.value Value.Env.t) =
         (fun var (line, flds) ->
           match Value.Env.find_opt var ve with
             None   -> (Printf.sprintf "%s, #err" line, (var :: flds))
-          | Some v -> (Printf.sprintf "%s, %s" line (Value.string_of_val 0 v), var :: flds)
+          | Some v -> (Printf.sprintf "%s, %s" line (Value.string_of_val 0 None v), var :: flds)
         ) !ProfilerFlags.profile_field_names ("", [])
     in
     Printf.fprintf file "# column: source region\n" ;

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -147,6 +147,13 @@ const astString = JSON.stringify(
   Motoko.parseMotoko(Motoko.readFile("ast.mo"))
 );
 
+// Run interpreter
+assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
+  stdout: "`ys6dh-5cjiq-5dc` : actor {main : shared query () -> async A__9<Text>}\n",
+  stderr: "",
+  result: { error: null },
+});
+
 // Check doc comments
 assert.match(astString, /"name":"\*","args":\["Program comment\\n      multi-line"/);
 assert.match(astString, /"name":"\*","args":\["Type comment"/);


### PR DESCRIPTION
* Refactors `pp_val` and related functions to receive type information (using `Type.Any` by default in some cases)
* Displays the text representation of actor IDs with surrounding backticks, such as `` `ys6dh-5cjiq-5dc` : actor {...}``

Resolves #4470.
