### PR TITLE
experiment: refined type-driven value printer

### DIFF
--- a/src/mo_values/value.ml
+++ b/src/mo_values/value.ml
@@ -252,9 +252,7 @@ and pp_val d ppf (t, v) =
     fprintf ppf "@[<1>?%a@]" (pp_val_nullary d) (t', v)
   | _, Variant (l, Tup []) -> fprintf ppf "#%s" l
   | t, Variant (l, v) ->
-    let fs = match t with  T.Variant fs -> fs | _ -> [] in
-    let t' = Option.value ~default:T.Non
-      (T.lookup_val_field_opt l fs) in
+    let t' = match t with T.Variant fs -> T.lookup_val_field l fs | _ -> T.Non in
     (match v with
     | Tup vs -> fprintf ppf "@[#%s@;<0 1>%a@]" l (pp_val d) (t', Tup vs)
     | _ -> fprintf ppf "@[#%s@;<0 1>(%a)@]" l (pp_val d) (t', v))

--- a/src/mo_values/value.ml
+++ b/src/mo_values/value.ml
@@ -209,14 +209,12 @@ let rec pp_val_nullary d ppf (t, v : T.typ * value) =
       (pp_print_list ~pp_sep:comma (pp_val d)) list
       (if List.length vs = 1 then "," else "")
   | t, Obj ve ->
-    let sort, fs = match t with  T.Obj (sort, fs) -> Some sort, fs | _ -> None, [] in
+    let sort, fs = match t with
+      | T.Obj (s, fs) -> T.string_of_obj_sort s, fs
+      | _ -> "", [] in
     if d = 0 then pr ppf "{...}" else
     fprintf ppf "@[<hv 2>%a{@;<0 0>%a@;<0 -2>}@]"
-      pr (match sort with
-      | Some T.Actor -> "actor "
-      | Some T.Module -> "module "
-      | Some T.Memory -> "memory "
-      | Some T.Object | None -> "")
+      pr sort
       (pp_print_list ~pp_sep:semi (pp_field d)) (List.map (fun (lab, v) ->
           let t = T.lookup_val_field_opt lab fs in
           (lab, Option.value t ~default:T.Non, v))

--- a/src/mo_values/value.ml
+++ b/src/mo_values/value.ml
@@ -236,9 +236,11 @@ let rec pp_val_nullary d ppf (t, v : T.typ * value) =
     fprintf ppf "@[<1>(%a)@]" (pp_val d) (t, v)
 
 and pp_field d ppf (lab, t, v) =
-    fprintf ppf "@[<2>%s =@ %a@]" lab (pp_val d) (t, v)
+  fprintf ppf "@[<2>%s =@ %a@]" lab (pp_val d) (t, v)
 
-and pp_val d ppf = function
+and pp_val d ppf (t, v) =
+  let t = T.normalize t in
+  match t, v with
   | T.Any, _ -> pr ppf "<any>"
   | _, Int i -> pr ppf (Int.to_pretty_string i)
   | _, Int8 i -> pr ppf (Int_8.(pos_sign (gt i zero) ^ to_pretty_string i))

--- a/src/mo_values/value.ml
+++ b/src/mo_values/value.ml
@@ -182,91 +182,96 @@ let comma ppf () = fprintf ppf ",@ "
 let semi ppf () = fprintf ppf ";@ "
 
 let rec pp_val_nullary d ppf (t, v : T.typ * value) =
-  let t = T.normalize t in
-  match t, v with
-  | T.Any, _ -> pr ppf "<any>"
-  | _, Null -> pr ppf "null"
-  | _, Bool b -> pr ppf (if b then "true" else "false")
-  | _, Int n when Int.(ge n zero) -> pr ppf (Int.to_pretty_string n)
-  | _, Int8 n when Int_8.(n = zero) -> pr ppf (Int_8.to_pretty_string n)
-  | _, Int16 n when Int_16.(n = zero) -> pr ppf (Int_16.to_pretty_string n)
-  | _, Int32 n when Int_32.(n = zero) -> pr ppf (Int_32.to_pretty_string n)
-  | _, Int64 n when Int_64.(n = zero) -> pr ppf (Int_64.to_pretty_string n)
-  | _, Nat8 n -> pr ppf (Nat8.to_pretty_string n)
-  | _, Nat16 n -> pr ppf (Nat16.to_pretty_string n)
-  | _, Nat32 n -> pr ppf (Nat32.to_pretty_string n)
-  | _, Nat64 n -> pr ppf (Nat64.to_pretty_string n)
-  | _, Float f -> pr ppf (Float.to_pretty_string f)
-  | _, Char c ->  pr ppf (string_of_string '\'' [c] '\'')
-  | _, Text t -> pr ppf (string_of_string '\"' (Lib.Utf8.decode t) '\"')
-  | T.Obj (T.Actor, _), Blob b ->
-    pr ppf (string_of_string '`' (Lib.Utf8.decode (Ic.Url.encode_principal b)) '`')
-  | _, Blob b -> pr ppf ("\"" ^ Blob.escape b ^ "\"")
-  | t, Tup vs ->
-    let list = match t with
-    | T.Tup ts -> List.combine ts vs
-    | _ -> List.map (fun v -> (T.Non, v)) vs in
-    fprintf ppf "@[<1>(%a%s)@]"
-      (pp_print_list ~pp_sep:comma (pp_val d)) list
-      (if List.length vs = 1 then "," else "")
-  | t, Obj ve ->
-    if d = 0 then pr ppf "{...}" else
-    let sort, lookup = match t with
-      | T.Obj (s, fs) ->
-        T.string_of_obj_sort s,
-        fun lab -> T.lookup_val_field_opt lab fs
-      | _ ->
-        "", fun lab -> Some T.Non
-    in
-    fprintf ppf "@[<hv 2>%a{@;<0 0>%a@;<0 -2>}@]"
-      pr sort
-      (pp_print_list ~pp_sep:semi (pp_field d)) (List.filter_map (fun (lab, v) ->
-          match lookup lab with
-          | Some t -> Some (lab, t, v)
-          | None -> None)
-        (Env.bindings ve))
-  | t, Array vs ->
-    let t' = match t with T.Array t' -> t' | _ -> T.Non in
-    fprintf ppf "@[<1>[%a%a]@]"
-      pr (match t' with T.Mut t -> "var " | _ -> "")
-      (pp_print_list ~pp_sep:comma (pp_val d)) (List.map (fun v -> (t', v)) (Array.to_list vs))
-  | _, Func (_, _) -> pr ppf "<func>"
-  | _, Comp _ -> pr ppf "<async*>"
-  | t, v ->
-    fprintf ppf "@[<1>(%a)@]" (pp_val d) (t, v)
+  match T.normalize t with
+  | T.Any -> pr ppf "<any>"
+  | t ->
+    match v with
+    | Null -> pr ppf "null"
+    | Bool b -> pr ppf (if b then "true" else "false")
+    | Int n when Int.(ge n zero) -> pr ppf (Int.to_pretty_string n)
+    | Int8 n when Int_8.(n = zero) -> pr ppf (Int_8.to_pretty_string n)
+    | Int16 n when Int_16.(n = zero) -> pr ppf (Int_16.to_pretty_string n)
+    | Int32 n when Int_32.(n = zero) -> pr ppf (Int_32.to_pretty_string n)
+    | Int64 n when Int_64.(n = zero) -> pr ppf (Int_64.to_pretty_string n)
+    | Nat8 n -> pr ppf (Nat8.to_pretty_string n)
+    | Nat16 n -> pr ppf (Nat16.to_pretty_string n)
+    | Nat32 n -> pr ppf (Nat32.to_pretty_string n)
+    | Nat64 n -> pr ppf (Nat64.to_pretty_string n)
+    | Float f -> pr ppf (Float.to_pretty_string f)
+    | Char c ->  pr ppf (string_of_string '\'' [c] '\'')
+    | Text t -> pr ppf (string_of_string '\"' (Lib.Utf8.decode t) '\"')
+    | Blob b ->
+      (match t with
+         T.Obj (T.Actor, _) ->
+         pr ppf (string_of_string '`' (Lib.Utf8.decode (Ic.Url.encode_principal b)) '`')
+       | _ -> pr ppf ("\"" ^ Blob.escape b ^ "\""))
+    | Tup vs ->
+      let list = match t with
+      | T.Tup ts -> List.combine ts vs
+      | _ -> List.map (fun v -> (T.Non, v)) vs in
+      fprintf ppf "@[<1>(%a%s)@]"
+        (pp_print_list ~pp_sep:comma (pp_val d)) list
+        (if List.length vs = 1 then "," else "")
+    | Obj ve ->
+      if d = 0 then pr ppf "{...}" else
+      let sort, lookup = match t with
+        | T.Obj (s, fs) ->
+          T.string_of_obj_sort s,
+          fun lab -> T.lookup_val_field_opt lab fs
+        | _ ->
+          "", fun lab -> Some T.Non
+      in
+      fprintf ppf "@[<hv 2>%a{@;<0 0>%a@;<0 -2>}@]"
+        pr sort
+        (pp_print_list ~pp_sep:semi (pp_field d)) (List.filter_map (fun (lab, v) ->
+            match lookup lab with
+            | Some t -> Some (lab, t, v)
+            | None -> None)
+          (Env.bindings ve))
+    | Array vs ->
+      let t' = match t with T.Array t' -> t' | _ -> T.Non in
+      fprintf ppf "@[<1>[%a%a]@]"
+        pr (match t' with T.Mut t -> "var " | _ -> "")
+        (pp_print_list ~pp_sep:comma (pp_val d)) (List.map (fun v -> (t', v)) (Array.to_list vs))
+
+    | Func (_, _) -> pr ppf "<func>"
+    | Comp _ -> pr ppf "<async*>"
+    | v ->
+      fprintf ppf "@[<1>(%a)@]" (pp_val d) (t, v)
 
 and pp_field d ppf (lab, t, v) =
   fprintf ppf "@[<2>%s =@ %a@]" lab (pp_val d) (t, v)
 
 and pp_val d ppf (t, v) =
-  let t = T.normalize t in
-  match t, v with
-  | T.Any, _ -> pr ppf "<any>"
-  | _, Int i -> pr ppf (Int.to_pretty_string i)
-  | _, Int8 i -> pr ppf (Int_8.(pos_sign (gt i zero) ^ to_pretty_string i))
-  | _, Int16 i -> pr ppf (Int_16.(pos_sign (gt i zero) ^ to_pretty_string i))
-  | _, Int32 i -> pr ppf (Int_32.(pos_sign (gt i zero) ^ to_pretty_string i))
-  | _, Int64 i -> pr ppf (Int_64.(pos_sign (gt i zero) ^ to_pretty_string i))
-  | t, Opt v ->
-    let t' = match t with T.Opt t' -> t' | _ -> T.Non in
-    fprintf ppf "@[<1>?%a@]" (pp_val_nullary d) (t', v)
-  | _, Variant (l, Tup []) -> fprintf ppf "#%s" l
-  | t, Variant (l, v) ->
-    let t' = match t with T.Variant fs -> T.lookup_val_field l fs | _ -> T.Non in
-    (match v with
-    | Tup vs -> fprintf ppf "@[#%s@;<0 1>%a@]" l (pp_val d) (t', Tup vs)
-    | _ -> fprintf ppf "@[#%s@;<0 1>(%a)@]" l (pp_val d) (t', v))
-  | t, Async {result; waiters = []} ->
-    let t' = match t with T.Async (_, _, t') -> t' | _ -> T.Non in
-    fprintf ppf "@[<2>async@ %a@]" (pp_res d) (t', result)
-  | t, Async {result; waiters} ->
-    let t' = match t with T.Async (_, _, t') -> t' | _ -> T.Non in
-    fprintf ppf "@[<2>async[%d]@ %a@]"
-      (List.length waiters) (pp_res d) (t', result)
-  | t, Mut r ->
-    let t' = match t with T.Mut t' -> t' | _ -> T.Non in
-    pp_val d ppf (t', !r)
-  | t, v -> pp_val_nullary d ppf (t, v)
+  match T.normalize t with
+  | T.Any -> pr ppf "<any>"
+  | t ->
+    match v with
+    | Int i -> pr ppf (Int.to_pretty_string i)
+    | Int8 i -> pr ppf (Int_8.(pos_sign (gt i zero) ^ to_pretty_string i))
+    | Int16 i -> pr ppf (Int_16.(pos_sign (gt i zero) ^ to_pretty_string i))
+    | Int32 i -> pr ppf (Int_32.(pos_sign (gt i zero) ^ to_pretty_string i))
+    | Int64 i -> pr ppf (Int_64.(pos_sign (gt i zero) ^ to_pretty_string i))
+    | Opt v ->
+      let t' = match t with T.Opt t' -> t' | _ -> T.Non in
+      fprintf ppf "@[<1>?%a@]" (pp_val_nullary d) (t', v)
+    | Variant (l, Tup []) -> fprintf ppf "#%s" l
+    | Variant (l, v) ->
+      let t' = match t with T.Variant fs -> T.lookup_val_field l fs | _ -> T.Non in
+      (match v with
+      | Tup vs -> fprintf ppf "@[#%s@;<0 1>%a@]" l (pp_val d) (t', Tup vs)
+      | _ -> fprintf ppf "@[#%s@;<0 1>(%a)@]" l (pp_val d) (t', v))
+    | Async {result; waiters = []} ->
+      let t' = match t with T.Async (_, _, t') -> t' | _ -> T.Non in
+      fprintf ppf "@[<2>async@ %a@]" (pp_res d) (t', result)
+    | Async {result; waiters} ->
+      let t' = match t with T.Async (_, _, t') -> t' | _ -> T.Non in
+      fprintf ppf "@[<2>async[%d]@ %a@]"
+        (List.length waiters) (pp_res d) (t', result)
+    | Mut r ->
+      let t' = match t with T.Mut t' -> t' | _ -> T.Non in
+      pp_val d ppf (t', !r)
+    | v -> pp_val_nullary d ppf (t, v)
 
 and pp_res d ppf (t, result) =
   match Lib.Promise.value_opt result with

--- a/test/repl/ok/pretty-val.stdout.ok
+++ b/test/repl/ok/pretty-val.stdout.ok
@@ -467,4 +467,7 @@ let c : <T, U>(T, U) -> c<T, U> = func
           }
       }
   }
+>       let a : Any = 1
+>   let r : {a : Nat} = {a = 1; hidden = true}
+>   let r : Any = {a = 1; hidden = true}
 >   

--- a/test/repl/ok/pretty-val.stdout.ok
+++ b/test/repl/ok/pretty-val.stdout.ok
@@ -25,7 +25,7 @@ Motoko compiler (source XXX)
    57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
    75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92,
    93, 94, 95, 96, 97, 98, 99]
->   let a : <T>(T, T) -> [T] = func
+>   let a : <T>(T, T) -> [T] = <func>
 > let a1 : [{#A; #B}] = [#A, #B]
 > let a2 : [[{#A; #B}]] = [[#A, #B], [#A, #B]]
 > let a3 : [[[{#A; #B}]]] = [[[#A, #B], [#A, #B]], [[#A, #B], [#A, #B]]]
@@ -39,7 +39,7 @@ Motoko compiler (source XXX)
     [[[#A, #B], [#A, #B]], [[#A, #B], [#A, #B]]]],
    [[[[#A, #B], [#A, #B]], [[#A, #B], [#A, #B]]],
     [[[#A, #B], [#A, #B]], [[#A, #B], [#A, #B]]]]]
->   let r : <T, U>(T, U) -> {A : T; B : U} = func
+>   let r : <T, U>(T, U) -> {A : T; B : U} = <func>
 > let r1 : {A : {#A}; B : {#B}} = {A = #A; B = #B}
 > let r2 :
   {A : {A : {#A}; B : {#B}}; B : {A : {#A}; B : {#B}}} =
@@ -135,27 +135,27 @@ Motoko compiler (source XXX)
           }
       }
   }
->     let m : <T, U>(T, U) -> module {A : T; B : U} = func
+>     let m : <T, U>(T, U) -> module {A : T; B : U} = <func>
 > let m1 : module {...}
 > let m2 : module {...}
 > let m3 : module {...}
 > let m4 : module {...}
 > let m5 : module {...}
->   let f : <T, U>(T -> U) -> (U -> T) -> T -> U = func
-> let f1 : ({#B} -> {#A}) -> {#A} -> {#B} = func
+>   let f : <T, U>(T -> U) -> (U -> T) -> T -> U = <func>
+> let f1 : ({#B} -> {#A}) -> {#A} -> {#B} = <func>
 > let f2 :
   (({#A} -> {#B}) -> {#B} -> {#A}) -> ({#B} -> {#A}) -> {#A} -> {#B} =
-  func
+  <func>
 > let f3 :
   ((({#B} -> {#A}) -> {#A} -> {#B}) -> ({#A} -> {#B}) -> {#B} -> {#A}) ->
     (({#A} -> {#B}) -> {#B} -> {#A}) -> ({#B} -> {#A}) -> {#A} -> {#B} =
-  func
+  <func>
 > let f4 :
   (((({#A} -> {#B}) -> {#B} -> {#A}) -> ({#B} -> {#A}) -> {#A} -> {#B}) ->
      (({#B} -> {#A}) -> {#A} -> {#B}) -> ({#A} -> {#B}) -> {#B} -> {#A}) ->
     ((({#B} -> {#A}) -> {#A} -> {#B}) -> ({#A} -> {#B}) -> {#B} -> {#A}) ->
       (({#A} -> {#B}) -> {#B} -> {#A}) -> ({#B} -> {#A}) -> {#A} -> {#B} =
-  func
+  <func>
 > let f5 :
   ((((({#B} -> {#A}) -> {#A} -> {#B}) -> ({#A} -> {#B}) -> {#B} -> {#A}) ->
       (({#A} -> {#B}) -> {#B} -> {#A}) -> ({#B} -> {#A}) -> {#A} -> {#B}) ->
@@ -165,8 +165,8 @@ Motoko compiler (source XXX)
        (({#B} -> {#A}) -> {#A} -> {#B}) -> ({#A} -> {#B}) -> {#B} -> {#A}) ->
       ((({#B} -> {#A}) -> {#A} -> {#B}) -> ({#A} -> {#B}) -> {#B} -> {#A}) ->
         (({#A} -> {#B}) -> {#B} -> {#A}) -> ({#B} -> {#A}) -> {#A} -> {#B} =
-  func
->   let p : <T, U>(T, U) -> (T, U) = func
+  <func>
+>   let p : <T, U>(T, U) -> (T, U) = <func>
 > let p1 : ({#A}, {#B}) = (#A, #B)
 > let p2 : (({#A}, {#B}), ({#A}, {#B})) = ((#A, #B), (#A, #B))
 > let p3 :
@@ -186,7 +186,7 @@ Motoko compiler (source XXX)
     (((#A, #B), (#A, #B)), ((#A, #B), (#A, #B)))),
    ((((#A, #B), (#A, #B)), ((#A, #B), (#A, #B))),
     (((#A, #B), (#A, #B)), ((#A, #B), (#A, #B)))))
->   let v : <T, U>(T, U) -> {#A : T; #B : U} = func
+>   let v : <T, U>(T, U) -> {#A : T; #B : U} = <func>
 > let v1 : {#A : {#Foo}; #B : {#Bar}} = #A(#Foo)
 > let v2 :
   {#A : {#A : {#Foo}; #B : {#Bar}}; #B : {#A : {#Foo}; #B : {#Bar}}} =
@@ -277,14 +277,14 @@ Motoko compiler (source XXX)
       }
   } =
   #A(#A(#A(#A(#A(#Foo)))))
->   let o : <T, U>T -> ?T = func
+>   let o : <T, U>T -> ?T = <func>
 > let o1 : ?Nat = ?666
 > let o2 : ??Nat = ?(?666)
 > let o3 : ???Nat = ?(?(?666))
 > let o4 : ????Nat = ?(?(?(?666)))
 > let o5 : ?????Nat = ?(?(?(?(?666))))
 >         type c<T, U> = {type List<T_1> = ?(T_1, List<T_1>); A : T; B : U}
-let c : <T, U>(T, U) -> c<T, U> = func
+let c : <T, U>(T, U) -> c<T, U> = <func>
 > let c1 :
   {type List<T> = ?(T, List<T>); A : {#A}; B : {#B}} =
   {A = #A; B = #B}
@@ -467,7 +467,7 @@ let c : <T, U>(T, U) -> c<T, U> = func
           }
       }
   }
->       let a : Any = 1
->   let r : {a : Nat} = {a = 1; hidden = true}
->   let r : Any = {a = 1; hidden = true}
+>     let a : Any = <any>
+>   let r : {a : Nat} = {a = 1}
+>   let r : Any = <any>
 >   

--- a/test/repl/ok/type-lub-repl.stdout.ok
+++ b/test/repl/ok/type-lub-repl.stdout.ok
@@ -1,29 +1,29 @@
 Motoko compiler (source XXX)
 > [null, ?42, ?(-25)] : [?Int]
 > [null, null] : [Null]
-> [{a = 42}, {b = 42}] : [{}]
-> [{a = 42}, {a = 1; b = 42}, {a = -25}] : [{a : Int}]
+> [{}, {}] : [{}]
+> [{a = 42}, {a = 1}, {a = -25}] : [{a : Int}]
 > [(12, -1), (-42, 25)] : [(Int, Int)]
 > [-1, 25] : [Int]
 > [[-42], [25]] : [[Int]]
-> [func, func] : [None -> Int]
-> [func, func] : [[Nat] -> Int]
+> [<func>, <func>] : [None -> Int]
+> [<func>, <func>] : [[Nat] -> Int]
 > 3 : Int
 > -42 : Int
-> [func, func] : [<A>[Nat] -> Int]
+> [<func>, <func>] : [<A>[Nat] -> Int]
 > 3 : Int
 > -42 : Int
-> [func, func] : [<A>[Nat] -> Int]
+> [<func>, <func>] : [<A>[Nat] -> Int]
 > 3 : Int
 > -42 : Int
-> [func, func] : [<A, B>([A], B) -> A]
->   [func, func] : [{#bar} -> ()]
-> > >   [[42], [25], [77]] : [Any]
->   [42, 77, [1, 2, 3]] : [Any]
-> [77, [1, 2, 3], 42] : [Any]
-> [func, func] : [Nat -> Int]
+> [<func>, <func>] : [<A, B>([A], B) -> A]
+>   [<func>, <func>] : [{#bar} -> ()]
+> > >   [<any>, <any>, <any>] : [Any]
+>   [<any>, <any>, <any>] : [Any]
+> [<any>, <any>, <any>] : [Any]
+> [<func>, <func>] : [Nat -> Int]
 > 25 : Int
 > 42 : Int
->   func : (C, D) -> [C]
+>   <func> : (C, D) -> [C]
 > [async (?4), async (?(-42))] : [async<$top-level> ?Int]
 > 

--- a/test/repl/pretty-val.sh
+++ b/test/repl/pretty-val.sh
@@ -69,4 +69,12 @@ let c3 = c(c2, c2);
 let c4 = c(c3, c3);
 let c5 = c(c4, c4);
 
+
+// subtyping hides values
+let a : Any = 1;
+
+let r : {a : Nat} = { a = 1; hidden = true};
+
+let r : Any = { a = 1; hidden = true};
+
 __END__

--- a/test/repl/pretty-val.sh
+++ b/test/repl/pretty-val.sh
@@ -69,7 +69,6 @@ let c3 = c(c2, c2);
 let c4 = c(c3, c3);
 let c5 = c(c4, c4);
 
-
 // subtyping hides values
 let a : Any = 1;
 


### PR DESCRIPTION
builds on #4471 but:

* prints values at type Any/functions/computations as opaque `<any>`, `<func>`, `<async*>`
* elides dynamic fields of objects not visible from static type,
* prints all fields of objects only when  printing at sentinel type `T.Non`.



