### PR TITLE
experiment: remove regression in idl_sub 

### DIFF
--- a/rts/motoko-rts/src/idl.rs
+++ b/rts/motoko-rts/src/idl.rs
@@ -1208,23 +1208,33 @@ unsafe extern "C" fn idl_sub_buf_init(rel_buf: *mut u32, typtbl_size1: u32, typt
 }
 
 #[ic_mem_fn]
-unsafe fn idl_sub<M: Memory>(
+unsafe fn idl_alloc_typtbl<M: Memory>(
     mem: &mut M,
+    candid_data: Value,
+    type_offsets: Value,
+    typtbl_out: *mut *mut *mut u8,
+    typtbl_end_out: *mut *mut u8,
+    typtbl_size_out: *mut u32,
+) {
+    let mut type_descriptor = TypeDescriptor::new(candid_data, type_offsets);
+    *typtbl_out = type_descriptor.build_type_table(mem);
+    *typtbl_end_out = type_descriptor.type_table_end();
+    *typtbl_size_out = type_descriptor.type_count() as u32;
+}
+
+#[no_mangle]
+unsafe extern "C" fn idl_sub(
     rel_buf: *mut u32, // a buffer with at least 2 * typtbl_size1 * typtbl_size2 bits
     typtbl1: *mut *mut u8,
+    typtbl2: *mut *mut u8,
     typtbl_end1: *mut u8,
+    typtbl_end2: *mut u8,
     typtbl_size1: u32,
-    candid_data2: Value,
-    type_offsets2: Value,
+    typtbl_size2: u32,
     t1: i32,
     t2: i32,
 ) -> bool {
     debug_assert!(rel_buf != (0 as *mut u32));
-
-    let mut type_descriptor2 = TypeDescriptor::new(candid_data2, type_offsets2);
-    let typtbl2 = type_descriptor2.build_type_table(mem);
-    let typtbl_end2 = type_descriptor2.type_table_end();
-    let typtbl_size2 = type_descriptor2.type_count() as u32;
 
     let rel = BitRel {
         ptr: rel_buf,

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -7724,7 +7724,7 @@ module Serialization = struct
       Stack.with_words env "get_typtbl_ptr" 1l (fun get_typtbl_ptr ->
       Stack.with_words env "get_maintyps_ptr" 1l (fun get_maintyps_ptr ->
 
-      (* Allocate space for out parameters of idl_sub_alloc_typtbl *)
+      (* Allocate space for out parameters of idl_alloc_typtbl *)
       Stack.with_words env "get_global_typtbl_ptr" 1l (fun get_global_typtbl_ptr ->
       Stack.with_words env "get_global_typtbl_end_ptr" 1l (fun get_global_typtbl_end_ptr ->
       Stack.with_words env "get_global_typtbl_size_ptr" 1l (fun get_global_typtbl_size_ptr ->

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -6995,10 +6995,11 @@ module Serialization = struct
       let get_typtbl = Registers.get_typtbl env in
       let get_typtbl_end = Registers.get_typtbl_end env in
       let get_typtbl_size = Registers.get_typtbl_size env in
+(*
       let get_global_typtbl = Registers.get_global_typtbl env in
       let get_global_typtbl_end = Registers.get_global_typtbl_end env in
       let get_global_typtbl_size = Registers.get_global_typtbl_size env in
-
+*)
       (* Check recursion depth (protects against empty record etc.) *)
       (* Factor 2 because at each step, the expected type could go through one
          level of opt that is not present in the value type

--- a/test/bench/candid-subtype-cost.mo
+++ b/test/bench/candid-subtype-cost.mo
@@ -1,0 +1,143 @@
+// measure cost of repeated candid subtype checks
+import { Array_tabulate; performanceCounter; debugPrint; rts_heap_size } = "mo:⛔";
+
+actor {
+
+  func counters() : (Int, Nat64) = (rts_heap_size(), performanceCounter(0));
+
+  public func go() : async () {
+    let a0 : [Self] = Array_tabulate<Self>(1024, func _ { actor "aaaaa-aa" : Self } );
+    let b = to_candid (a0);
+    let (m0, n0) = counters();
+    let o : ?[Self] = from_candid b;
+    let (m1, n1) = counters();
+    assert (?a0 == o);
+    debugPrint(debug_show {heap_bytes = m1 - m0; cycles = n1 - n0});
+  };
+
+  // stolen from https://github.com/krpeacock/ic-management-canister
+
+  public type bitcoin_address = Text;
+  public type bitcoin_network = { #mainnet; #testnet };
+  public type block_hash = [Nat8];
+  public type canister_id = Principal;
+  public type canister_settings = {
+    freezing_threshold : ?Nat;
+    controllers : ?[Principal];
+    memory_allocation : ?Nat;
+    compute_allocation : ?Nat;
+  };
+  public type definite_canister_settings = {
+    freezing_threshold : Nat;
+    controllers : [Principal];
+    memory_allocation : Nat;
+    compute_allocation : Nat;
+  };
+  public type ecdsa_curve = { #secp256k1 };
+  public type get_balance_request = {
+    network : bitcoin_network;
+    address : bitcoin_address;
+    min_confirmations : ?Nat32;
+  };
+  public type get_current_fee_percentiles_request = {
+    network : bitcoin_network;
+  };
+  public type get_utxos_request = {
+    network : bitcoin_network;
+    filter : ?{ #page : [Nat8]; #min_confirmations : Nat32 };
+    address : bitcoin_address;
+  };
+  public type get_utxos_response = {
+    next_page : ?[Nat8];
+    tip_height : Nat32;
+    tip_block_hash : block_hash;
+    utxos : [utxo];
+  };
+  public type http_header = { value : Text; name : Text };
+  public type http_response = {
+    status : Nat;
+    body : [Nat8];
+    headers : [http_header];
+  };
+  public type millisatoshi_per_byte = Nat64;
+  public type outpoint = { txid : [Nat8]; vout : Nat32 };
+  public type satoshi = Nat64;
+  public type send_transaction_request = {
+    transaction : [Nat8];
+    network : bitcoin_network;
+  };
+  public type user_id = Principal;
+  public type utxo = { height : Nat32; value : satoshi; outpoint : outpoint };
+  public type wasm_module = [Nat8];
+  public type Self = actor {
+    bitcoin_get_balance : shared get_balance_request -> async satoshi;
+    bitcoin_get_current_fee_percentiles : shared get_current_fee_percentiles_request -> async [
+        millisatoshi_per_byte
+      ];
+    bitcoin_get_utxos : shared get_utxos_request -> async get_utxos_response;
+    bitcoin_send_transaction : shared send_transaction_request -> async ();
+    canister_status : shared { canister_id : canister_id } -> async {
+        status : { #stopped; #stopping; #running };
+        memory_size : Nat;
+        cycles : Nat;
+        settings : definite_canister_settings;
+        idle_cycles_burned_per_day : Nat;
+        module_hash : ?[Nat8];
+      };
+    create_canister : shared { settings : ?canister_settings } -> async {
+        canister_id : canister_id;
+      };
+    delete_canister : shared { canister_id : canister_id } -> async ();
+    deposit_cycles : shared { canister_id : canister_id } -> async ();
+    ecdsa_public_key : shared {
+        key_id : { name : Text; curve : ecdsa_curve };
+        canister_id : ?canister_id;
+        derivation_path : [[Nat8]];
+      } -> async { public_key : [Nat8]; chain_code : [Nat8] };
+    http_request : shared {
+        url : Text;
+        method : { #get; #head; #post };
+        max_response_bytes : ?Nat64;
+        body : ?[Nat8];
+        transform : ?{
+          function : shared query {
+              context : [Nat8];
+              response : http_response;
+            } -> async http_response;
+          context : [Nat8];
+        };
+        headers : [http_header];
+      } -> async http_response;
+    install_code : shared {
+        arg : [Nat8];
+        wasm_module : wasm_module;
+        mode : { #reinstall; #upgrade; #install };
+        canister_id : canister_id;
+      } -> async ();
+    provisional_create_canister_with_cycles : shared {
+        settings : ?canister_settings;
+        specified_id : ?canister_id;
+        amount : ?Nat;
+      } -> async { canister_id : canister_id };
+    provisional_top_up_canister : shared {
+        canister_id : canister_id;
+        amount : Nat;
+      } -> async ();
+    raw_rand : shared () -> async [Nat8];
+    sign_with_ecdsa : shared {
+        key_id : { name : Text; curve : ecdsa_curve };
+        derivation_path : [[Nat8]];
+        message_hash : [Nat8];
+      } -> async { signature : [Nat8] };
+    start_canister : shared { canister_id : canister_id } -> async ();
+    stop_canister : shared { canister_id : canister_id } -> async ();
+    uninstall_code : shared { canister_id : canister_id } -> async ();
+    update_settings : shared {
+        canister_id : Principal;
+        settings : canister_settings;
+      } -> async ();
+  }
+
+}
+
+//CALL ingress go 0x4449444C0000

--- a/test/bench/ok/bignum.drun-run.ok
+++ b/test/bench/ok/bignum.drun-run.ok
@@ -2,5 +2,5 @@ ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a000000000000000001
 ingress Completed: Reply: 0x4449444c0000
 debug.print: {cycles = 2_626_994; size = +60_128}
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 107_960_739; size = +1_826_952}
+debug.print: {cycles = 107_960_717; size = +1_826_952}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/bignum.drun-run.ok
+++ b/test/bench/ok/bignum.drun-run.ok
@@ -1,6 +1,6 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 2_627_084; size = +60_128}
+debug.print: {cycles = 2_626_994; size = +60_128}
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 107_960_332; size = +1_826_940}
+debug.print: {cycles = 107_960_739; size = +1_826_952}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/candid-subtype-cost.drun-run.ok
+++ b/test/bench/ok/candid-subtype-cost.drun-run.ok
@@ -1,0 +1,4 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: {cycles = 4_602_994; heap_bytes = +1_691_932}
+ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/candid-subtype-cost.drun-run.ok
+++ b/test/bench/ok/candid-subtype-cost.drun-run.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 2_657_458; heap_bytes = +291_100}
+debug.print: {cycles = 998_235; heap_bytes = +16_936}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/candid-subtype-cost.drun-run.ok
+++ b/test/bench/ok/candid-subtype-cost.drun-run.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 998_235; heap_bytes = +16_936}
+debug.print: {cycles = 998_213; heap_bytes = +16_936}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/candid-subtype-cost.drun-run.ok
+++ b/test/bench/ok/candid-subtype-cost.drun-run.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 4_602_994; heap_bytes = +1_691_932}
+debug.print: {cycles = 2_657_458; heap_bytes = +291_100}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/max-stack-variant.mo
+++ b/test/run-drun/max-stack-variant.mo
@@ -2,7 +2,7 @@
 import { errorMessage; debugPrint; } = "mo:⛔";
 
 actor {
-    let expectedMinimumSize = 26_000;
+    let expectedMinimumSize = 31_000;
 
     public func ser() : async () { await go(false) };
     public func deser() : async () { await go(true) };
@@ -37,9 +37,9 @@ actor {
             done := true
           }
         };
-        
+
         assert(i > expectedMinimumSize);
-        
+
         let b = to_candid(l);
         debugPrint("serialized");
 

--- a/test/run-drun/max-stack.mo
+++ b/test/run-drun/max-stack.mo
@@ -27,7 +27,7 @@ actor {
                if deserialize
                  from_candid(b)
                else null;
-              
+
               ()
             };
           } catch e {
@@ -37,7 +37,7 @@ actor {
         };
 
         assert i > expectedMinimumSize;
-        
+
         let b = to_candid(l);
         debugPrint("serialized");
 

--- a/test/run/idl.mo
+++ b/test/run/idl.mo
@@ -45,7 +45,7 @@ assert(arrayNat == deserArrayInt (serArrayNat arrayNat));
 assert(arrayNat == deserArrayInt (serArrayInt arrayNat));
 assert(arrayInt == deserArrayInt (serArrayInt arrayInt));
 let heapDifference = Prim.rts_heap_size() : Int - started_with;
-assert(heapDifference == 5_340);  
+assert(heapDifference == 5_388);
 
 //SKIP run
 //SKIP run-ir


### PR DESCRIPTION
Builds on #4193 

Builds the absolute global type table just once on entry to (candid) deserializer, not once on every call to idl_sub, avoiding 
repeated allocation.

The global type table data is stored in additional "Registers" (i.e. globals) to avoid passing them down the stack, but must be reset between GC runs as the type descriptors can be moved by GC.

Compare perf output
Master/EOP unpooled: [00285ba](https://github.com/dfinity/motoko/pull/4497/commits/00285ba840936466f545f458ac3fc30eb97e2ba3)
EOP unpooled/EOP pooled: [34937d9](https://github.com/dfinity/motoko/pull/4497/commits/34937d965f27e8b53a1aa6bf0019df847bd71472)
EOP pooled/this branch: [52c5f7f](https://github.com/dfinity/motoko/pull/4497/commits/52c5f7f3355ff577d8ff5d03285bd2e57a07a168)

TODO:
[ ] Should we remove the new benchmark? It's totally artificial... 