### PR TITLE
ci(Mergify): configuration update to use macos-12 not macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
         nix-store --gc --print-roots | grep /motoko/
 
     - name: "nix-build"
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && github.event_name == 'pull_request'
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 
     - name: Calculate performance delta

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - status-success=tests (ubuntu-latest)
-      - status-success=tests (macos-latest)
+      - status-success=tests (macos-12)
 
 pull_request_rules:
   - name: Automatic merge (squash)
@@ -12,7 +12,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - status-success=tests (ubuntu-latest)
-      - status-success=tests (macos-latest)
+      - status-success=tests (macos-12)
       - base=master
       - label=automerge-squash
     actions:
@@ -27,7 +27,7 @@ pull_request_rules:
   - name: Automatically closing successful trials
     conditions:
       - status-success=tests (ubuntu-latest)
-      - status-success=tests (macos-latest)
+      - status-success=tests (macos-12)
       - label=autoclose
     actions:
       close:


### PR DESCRIPTION
This change has been made by @crusso from Mergify config editor.