### PR TITLE
chore: remove GH no-longer required task `test (macos-latest)`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,10 @@ on:
      branches: [ master ]
   pull_request: {}
 jobs:
-  # macos-latest is now M1, so testing is pro forma only and
-  # faked (see "nix-build").
-  # This is to satisfy current GH branchprotection rules and allow merges.
   tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-latest ]
+        os: [ ubuntu-latest, macos-12 ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,7 +57,6 @@ jobs:
         nix-store --gc --print-roots | grep /motoko/
 
     - name: "nix-build"
-      if: matrix.os != 'macos-latest'
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 
     - name: Calculate performance delta


### PR DESCRIPTION
Our branch protection rules now require check `test (macos-12)`, not `test (macos-latest)`.

We build `test (macos-12)`, since `macos-latest`, since April 24, is now an M1 target, breaking our builds (`macos-12` is x86 and the previous default for `macos-latest`).

