### PR TITLE
experiment: precise heap tags for actors and shared functions

### DIFF
--- a/rts/motoko-rts-tests/src/gc.rs
+++ b/rts/motoko-rts-tests/src/gc.rs
@@ -289,10 +289,14 @@ fn check_dynamic_heap(
                         tag == TAG_ARRAY_I
                             || tag == TAG_ARRAY_M
                             || tag == TAG_ARRAY_T
+                            || tag == TAG_ARRAY_S
                             || tag >= TAG_ARRAY_SLICE_MIN
                     );
                 } else {
-                    assert!(tag == TAG_ARRAY_I || tag == TAG_ARRAY_M || tag == TAG_ARRAY_T)
+                    assert!(tag == TAG_ARRAY_I
+                            || tag == TAG_ARRAY_M
+                            || tag == TAG_ARRAY_T
+                            || tag == TAG_ARRAY_S)
                 }
 
                 if is_forwarded {

--- a/rts/motoko-rts-tests/src/gc.rs
+++ b/rts/motoko-rts-tests/src/gc.rs
@@ -293,10 +293,12 @@ fn check_dynamic_heap(
                             || tag >= TAG_ARRAY_SLICE_MIN
                     );
                 } else {
-                    assert!(tag == TAG_ARRAY_I
+                    assert!(
+                        tag == TAG_ARRAY_I
                             || tag == TAG_ARRAY_M
                             || tag == TAG_ARRAY_T
-                            || tag == TAG_ARRAY_S)
+                            || tag == TAG_ARRAY_S
+                    )
                 }
 
                 if is_forwarded {

--- a/rts/motoko-rts-tests/src/gc/compacting/mark_stack.rs
+++ b/rts/motoko-rts-tests/src/gc/compacting/mark_stack.rs
@@ -33,12 +33,13 @@ fn test_push_pop() {
         .unwrap();
 }
 
-static TAGS: [Tag; 22] = [
+static TAGS: [Tag; 24] = [
     TAG_OBJECT,
     TAG_OBJ_IND,
     TAG_ARRAY_I,
     TAG_ARRAY_M,
     TAG_ARRAY_T,
+    TAG_ARRAY_S,
     TAG_BITS64_U,
     TAG_BITS64_S,
     TAG_BITS64_F,
@@ -49,6 +50,7 @@ static TAGS: [Tag; 22] = [
     TAG_BLOB_B,
     TAG_BLOB_T,
     TAG_BLOB_P,
+    TAG_BLOB_A,
     TAG_FWD_PTR,
     TAG_BITS32_U,
     TAG_BITS32_S,

--- a/rts/motoko-rts-tests/src/gc/incremental/array_slicing.rs
+++ b/rts/motoko-rts-tests/src/gc/incremental/array_slicing.rs
@@ -1,8 +1,7 @@
 use motoko_rts::{
     gc::incremental::array_slicing::slice_array,
     memory::alloc_array,
-    types::{Tag, Words,
-            TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_T, TAG_ARRAY_S, TAG_ARRAY_SLICE_MIN },
+    types::{Tag, Words, TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_S, TAG_ARRAY_SLICE_MIN, TAG_ARRAY_T},
 };
 
 use crate::memory::TestMemory;

--- a/rts/motoko-rts-tests/src/gc/incremental/array_slicing.rs
+++ b/rts/motoko-rts-tests/src/gc/incremental/array_slicing.rs
@@ -1,7 +1,8 @@
 use motoko_rts::{
     gc::incremental::array_slicing::slice_array,
     memory::alloc_array,
-    types::{Tag, Words, TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_SLICE_MIN, TAG_ARRAY_T},
+    types::{Tag, Words,
+            TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_T, TAG_ARRAY_S, TAG_ARRAY_SLICE_MIN },
 };
 
 use crate::memory::TestMemory;
@@ -9,7 +10,7 @@ use crate::memory::TestMemory;
 pub unsafe fn test() {
     println!("  Testing array slicing...");
 
-    let tags = vec![TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_T];
+    let tags = vec![TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_T, TAG_ARRAY_S];
 
     for tag in tags.into_iter() {
         let mut mem = TestMemory::new(Words(1024 * 1024));

--- a/rts/motoko-rts-tests/src/gc/incremental/partitioned_heap.rs
+++ b/rts/motoko-rts-tests/src/gc/incremental/partitioned_heap.rs
@@ -14,8 +14,9 @@ use motoko_rts::{
     },
     memory::{alloc_array, alloc_blob, Memory},
     types::{
-        Array, Blob, Bytes, Obj, Tag, Value, Words, TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_T,
-        TAG_BLOB_B, TAG_BLOB_P, TAG_BLOB_T,
+        Array, Blob, Bytes, Obj, Tag, Value, Words,
+        TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_T, TAG_ARRAY_S,
+        TAG_BLOB_B, TAG_BLOB_P, TAG_BLOB_T, TAG_BLOB_A
     },
 };
 
@@ -415,10 +416,10 @@ impl PartitionedTestHeap {
 
 unsafe fn block_size(block: *const Tag) -> usize {
     match *block {
-        TAG_ARRAY_I | TAG_ARRAY_M | TAG_ARRAY_T => {
+        TAG_ARRAY_I | TAG_ARRAY_M | TAG_ARRAY_T | TAG_ARRAY_S => {
             size_of::<Array>() + (block as *const Array).len() as usize * WORD_SIZE as usize
         }
-        TAG_BLOB_B | TAG_BLOB_T | TAG_BLOB_P => {
+        TAG_BLOB_B | TAG_BLOB_T | TAG_BLOB_P | TAG_BLOB_A => {
             size_of::<Blob>() + (block as *const Blob).len().as_usize()
         }
         _ => unimplemented!(),

--- a/rts/motoko-rts-tests/src/gc/incremental/partitioned_heap.rs
+++ b/rts/motoko-rts-tests/src/gc/incremental/partitioned_heap.rs
@@ -14,9 +14,8 @@ use motoko_rts::{
     },
     memory::{alloc_array, alloc_blob, Memory},
     types::{
-        Array, Blob, Bytes, Obj, Tag, Value, Words,
-        TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_T, TAG_ARRAY_S,
-        TAG_BLOB_B, TAG_BLOB_P, TAG_BLOB_T, TAG_BLOB_A
+        Array, Blob, Bytes, Obj, Tag, Value, Words, TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_S,
+        TAG_ARRAY_T, TAG_BLOB_A, TAG_BLOB_B, TAG_BLOB_P, TAG_BLOB_T,
     },
 };
 

--- a/rts/motoko-rts/src/debug.rs
+++ b/rts/motoko-rts/src/debug.rs
@@ -165,7 +165,7 @@ pub(crate) unsafe fn print_boxed_object(buf: &mut WriteBuf, p: usize) {
             let obj_ind = obj as *const ObjInd;
             let _ = write!(buf, "<ObjInd field={:#x}>", (*obj_ind).field.get_raw());
         }
-        TAG_ARRAY_I | TAG_ARRAY_M | TAG_ARRAY_T | TAG_ARRAY_SLICE_MIN.. => {
+        TAG_ARRAY_I | TAG_ARRAY_M | TAG_ARRAY_T | TAG_ARRAY_S | TAG_ARRAY_SLICE_MIN.. => {
             let array = obj as *mut Array;
             let _ = write!(buf, "<Array len={:#x}", (*array).len);
 

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -333,7 +333,11 @@ impl Value {
 
     pub unsafe fn is_array(self) -> bool {
         let tag = self.tag();
-        tag == TAG_ARRAY_I || tag == TAG_ARRAY_M || tag == TAG_ARRAY_T || tag == TAG_ARRAY_S || tag >= TAG_ARRAY_SLICE_MIN
+        tag == TAG_ARRAY_I
+            || tag == TAG_ARRAY_M
+            || tag == TAG_ARRAY_T
+            || tag == TAG_ARRAY_S
+            || tag >= TAG_ARRAY_SLICE_MIN
     }
 
     /// Get the pointer as `Obj` using forwarding. In debug mode panics if the value is not a pointer.
@@ -471,7 +475,7 @@ pub const TAG_VARIANT: Tag = 25;
 pub const TAG_BLOB_B: Tag = 27;
 pub const TAG_BLOB_T: Tag = 29;
 pub const TAG_BLOB_P: Tag = 31;
-pub const TAG_BLOB_A: Tag  = 33;
+pub const TAG_BLOB_A: Tag = 33;
 pub const TAG_FWD_PTR: Tag = 35; // Only used by the copying GC - not to be confused with forwarding pointer in the header used for incremental GC.
 pub const TAG_BITS32_U: Tag = 37;
 pub const TAG_BITS32_S: Tag = 39;
@@ -492,10 +496,11 @@ pub const TAG_FREE_SPACE: Tag = 53;
 pub const TAG_ARRAY_SLICE_MIN: Tag = 54;
 
 pub fn slice_tag(array_tag: Tag, slice_start: u32) -> Tag {
-    debug_assert!(array_tag == TAG_ARRAY_I
-                  || array_tag == TAG_ARRAY_M
-                  || array_tag == TAG_ARRAY_T
-                  || array_tag == TAG_ARRAY_S
+    debug_assert!(
+        array_tag == TAG_ARRAY_I
+            || array_tag == TAG_ARRAY_M
+            || array_tag == TAG_ARRAY_T
+            || array_tag == TAG_ARRAY_S
     );
     debug_assert!(slice_start >= TAG_ARRAY_SLICE_MIN && slice_start < (1 << 30));
     (((array_tag - TAG_ARRAY_I) / 2) << 30) | slice_start

--- a/rts/motoko-rts/src/visitor.rs
+++ b/rts/motoko-rts/src/visitor.rs
@@ -43,7 +43,7 @@ pub unsafe fn visit_pointer_fields<C, F, G>(
             }
         }
 
-        TAG_ARRAY_I | TAG_ARRAY_M | TAG_ARRAY_T | TAG_ARRAY_SLICE_MIN.. => {
+        TAG_ARRAY_I | TAG_ARRAY_M | TAG_ARRAY_T | TAG_ARRAY_S | TAG_ARRAY_SLICE_MIN.. => {
             let (_, slice_start) = slice_start(tag);
             let array = obj as *mut Array;
             debug_assert!(slice_start <= array.len());
@@ -122,7 +122,7 @@ pub unsafe fn visit_pointer_fields<C, F, G>(
         }
 
         TAG_BITS32_U | TAG_BITS32_S | TAG_BITS32_F | TAG_BITS64_U | TAG_BITS64_S | TAG_BITS64_F
-        | TAG_BLOB_B | TAG_BLOB_T | TAG_BLOB_P | TAG_BIGINT => {
+        | TAG_BLOB_B | TAG_BLOB_T | TAG_BLOB_P | TAG_BLOB_A | TAG_BIGINT => {
             // These don't have pointers, skip
         }
 

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -292,6 +292,12 @@ let prim trap =
       in go (fun xs -> xs) k 0
     | _ -> assert false
     )
+
+
+  | "blobOfPrincipal" -> fun _ v k -> k v
+  | "principalOfBlob" -> fun _ v k -> k v
+  | "principalOfActor" -> fun _ v k -> k v
+
   | "blobToArray" -> fun _ v k ->
     k (Array (Array.of_seq (Seq.map (fun c ->
       Nat8 (Nat8.of_int (Char.code c))

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -427,10 +427,10 @@ func @install_actor_helper(
         (#install, principal1)
       };
       case (#reinstall actor1) {
-        (#reinstall, (prim "cast" : (actor {}) -> Principal) actor1) /* FIXME */
+        (#reinstall, (prim "actorToPrincipal" : (actor {}) -> Principal) actor1)
       };
       case (#upgrade actor2) {
-        (#upgrade, (prim "cast" : (actor {}) -> Principal) actor2) /* FIXME */
+        (#upgrade, (prim "actorToPrincipal" : (actor {}) -> Principal) actor2)
       }
     };
   await @ic00.install_code {

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -427,10 +427,10 @@ func @install_actor_helper(
         (#install, principal1)
       };
       case (#reinstall actor1) {
-        (#reinstall, (prim "actorToPrincipal" : (actor {}) -> Principal) actor1)
+        (#reinstall, (prim "principalOfActor" : (actor {}) -> Principal) actor1)
       };
       case (#upgrade actor2) {
-        (#upgrade, (prim "actorToPrincipal" : (actor {}) -> Principal) actor2)
+        (#upgrade, (prim "principalOfActor" : (actor {}) -> Principal) actor2)
       }
     };
   await @ic00.install_code {

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -427,10 +427,10 @@ func @install_actor_helper(
         (#install, principal1)
       };
       case (#reinstall actor1) {
-        (#reinstall, (prim "cast" : (actor {}) -> Principal) actor1)
+        (#reinstall, (prim "cast" : (actor {}) -> Principal) actor1) /* FIXME */
       };
       case (#upgrade actor2) {
-        (#upgrade, (prim "cast" : (actor {}) -> Principal) actor2)
+        (#upgrade, (prim "cast" : (actor {}) -> Principal) actor2) /* FIXME */
       }
     };
   await @ic00.install_code {

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -307,15 +307,16 @@ func time() : Nat64 = (prim "time" : () -> Nat64)();
 
 // Principal
 
-func blobOfPrincipal(id : Principal) : Blob = (prim "principalToBlob" : Principal -> Blob) id;
+func blobOfPrincipal(id : Principal) : Blob = (prim "blobOfPrincipal" : Principal -> Blob) id;
 func principalOfBlob(act : Blob) : Principal {
+  // TODO: better: check size in prim "principalOfBob" instead
   if (act.size() > 29) {
     trap("blob too long for principal");
   };
-  (prim "blobToPrincipal" : Blob -> Principal) act;
+  (prim "principalOfBlob" : Blob -> Principal) act;
 };
 
-func principalOfActor(act : actor {}) : Principal = (prim "actorToPrincipal" : (actor {}) -> Principal) act;
+func principalOfActor(act : actor {}) : Principal = (prim "principalOfActor" : (actor {}) -> Principal) act;
 func isController(p : Principal) : Bool = (prim "is_controller" : Principal -> Bool) p;
 func canisterVersion() : Nat64 = (prim "canister_version" : () -> Nat64)();
 

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -307,15 +307,15 @@ func time() : Nat64 = (prim "time" : () -> Nat64)();
 
 // Principal
 
-func blobOfPrincipal(id : Principal) : Blob = (prim "cast" : Principal -> Blob) id; /* FIXME */
+func blobOfPrincipal(id : Principal) : Blob = (prim "principalToBlob" : Principal -> Blob) id;
 func principalOfBlob(act : Blob) : Principal {
   if (act.size() > 29) {
     trap("blob too long for principal");
   };
-  (prim "cast" : Blob -> Principal) act; /* FIXME */
+  (prim "blobToPrincipal" : Blob -> Principal) act;
 };
 
-func principalOfActor(act : actor {}) : Principal = (prim "cast" : (actor {}) -> Principal) act; //* FIXME */
+func principalOfActor(act : actor {}) : Principal = (prim "actorToPrincipal" : (actor {}) -> Principal) act;
 func isController(p : Principal) : Bool = (prim "is_controller" : Principal -> Bool) p;
 func canisterVersion() : Nat64 = (prim "canister_version" : () -> Nat64)();
 

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -307,15 +307,15 @@ func time() : Nat64 = (prim "time" : () -> Nat64)();
 
 // Principal
 
-func blobOfPrincipal(id : Principal) : Blob = (prim "cast" : Principal -> Blob) id;
+func blobOfPrincipal(id : Principal) : Blob = (prim "cast" : Principal -> Blob) id; /* FIXME */
 func principalOfBlob(act : Blob) : Principal {
   if (act.size() > 29) {
     trap("blob too long for principal");
   };
-  (prim "cast" : Blob -> Principal) act;
+  (prim "cast" : Blob -> Principal) act; /* FIXME */
 };
 
-func principalOfActor(act : actor {}) : Principal = (prim "cast" : (actor {}) -> Principal) act;
+func principalOfActor(act : actor {}) : Principal = (prim "cast" : (actor {}) -> Principal) act; //* FIXME */
 func isController(p : Principal) : Bool = (prim "is_controller" : Principal -> Bool) p;
 func canisterVersion() : Nat64 = (prim "canister_version" : () -> Nat64)();
 


### PR DESCRIPTION
builds on #4544 

Introduce two new tags:
`TAG_BLOB_A` : a blob representing an actor reference (distinct from a raw principal).
`TAG_ARRAY_S`:  a pair representing a shared function as an actor reference (TAG_BLOB_A) paired with a method name as a text blob (TAG_BLOB_T).

Adding these tags now, to distinguish from other values, will hopefully give us some leverage if we ever want to change their representation in the future (perhaps adding type descriptors to drive dynamic serialization, for example).

Requires some additional coercions primitives to convert from blobs to principals (missing from #4544) and actors to blobs, copying payload with a different tag.

TODO: 

- [x] fix prim "cast" uses
- [x] rename new coercions to match Prim.* names
- [x] implement interpreter prims (and new values?)
- [x] add _LINE_ directives to debug tagging