### PR TITLE
experiment: reimplement M0200 for #4580

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -11253,10 +11253,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
     E.call_import env "rts" "log" (* musl *)
 
   | OtherPrim "componentCall", [e] ->
-    if not !Flags.import_component then (
-      Printf.printf "%s" (Diag.string_of_message (
-        Diag.error_message at "M0200" "import" (Printf.sprintf "component import is unavailable (pass `-import-component` flag)")));
-      exit 1);
+    assert !Flags.import_component;
     SR.UnboxedWord32 Type.Nat32,
     compile_exp_as env ae (SR.UnboxedWord32 Type.Nat32) e ^^
     E.call_import env "component" "call"

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -160,7 +160,10 @@ let check_deprecation env at desc id depr =
        | _ -> fun _ _ _ _ -> ())
        env at code
        "this code is (or uses) the deprecated library `ExperimentalStableMemory`.\nPlease use the `Region` library instead: https://internetcomputer.org/docs/current/motoko/main/stable-memory/stable-regions/#the-region-library or compile with flag `--experimental-stable-memory 1` to suppress this message."
-    end
+      end
+  | Some ("M0200" as code) ->
+    if not !Flags.import_component then
+      error env at code "component import is unavailable (pass `-import-component` flag)"
   | Some msg ->
     warn env at "M0154" "%s %s is deprecated:\n%s" desc id msg
   | None -> ()

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -269,6 +269,7 @@ func log(f : Float) : Float = (prim "flog" : Float -> Float) f;
 
 // Wasm component model functions
 
+/// @deprecated M0200
 func componentCall(n : Nat32) : Nat32 = (prim "componentCall" : Nat32 -> Nat32) n;
 
 // Array utilities

--- a/test/fail/ok/M0200.tc.ok
+++ b/test/fail/ok/M0200.tc.ok
@@ -1,1 +1,1 @@
-M0200.mo:3.8-3.28: import error [M0200], component import is unavailable (pass `-import-component` flag)
+M0200.mo:3.8-3.23: type error [M0200], component import is unavailable (pass `-import-component` flag)

--- a/test/fail/ok/no-timer-canc.tc.ok
+++ b/test/fail/ok/no-timer-canc.tc.ok
@@ -73,6 +73,7 @@ no-timer-canc.mo:3.10-3.21: type error [M0119], object field cancelTimer is not 
     clzNat32 : Nat32 -> Nat32;
     clzNat64 : Nat64 -> Nat64;
     clzNat8 : Nat8 -> Nat8;
+    componentCall : Nat32 -> Nat32;
     cos : Float -> Float;
     createActor : (Blob, Blob) -> async Principal;
     ctzInt16 : Int16 -> Int16;

--- a/test/fail/ok/no-timer-set.tc.ok
+++ b/test/fail/ok/no-timer-set.tc.ok
@@ -73,6 +73,7 @@ no-timer-set.mo:3.10-3.18: type error [M0119], object field setTimer is not cont
     clzNat32 : Nat32 -> Nat32;
     clzNat64 : Nat64 -> Nat64;
     clzNat8 : Nat8 -> Nat8;
+    componentCall : Nat32 -> Nat32;
     cos : Float -> Float;
     createActor : (Blob, Blob) -> async Principal;
     ctzInt16 : Int16 -> Int16;


### PR DESCRIPTION
Builds on #4580.

Moves M0200 error detection from compile.ml to typing.ml, using special #deprecation M0200  in Prim.ml (the same trick we use to selectively deprecate stable memory prims).
 