### PR TITLE
EOP: Relaxed Upgrade Compatibility Check

### DIFF
--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -174,6 +174,7 @@ let error_codes : (string * string option) list =
     "M0168", None; (* Type union or intersection on forward types *)
     "M0169", None; (* Stable variable will be discarded. This may cause data loss. *)
     "M0170", None; (* Stable variable must subtype *)
+    (* "M0171" DEFUNCT Stable variable changing mutability *)
     "M0172", None; (* to_candid produces Blob, not -- *)
     "M0173", None; (* to_candid arg must have shared type, not -- *)
     "M0174", None; (* from_candid produces an optional shared, not -- *)

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -172,7 +172,7 @@ let error_codes : (string * string option) list =
     "M0166", None; (* Type intersection results in abstract type *)
     "M0167", None; (* Type union results in bottom type *)
     "M0168", None; (* Type union or intersection on forward types *)
-    "M0169", None; (* Stable variable cannot be discarded *)
+    "M0169", None; (* Stable variable will be discarded. This may cause data loss. *)
     "M0170", None; (* Stable variable must subtype *)
     "M0171", None; (* Stable variable changing mutability *)
     "M0172", None; (* to_candid produces Blob, not -- *)

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -174,7 +174,6 @@ let error_codes : (string * string option) list =
     "M0168", None; (* Type union or intersection on forward types *)
     "M0169", None; (* Stable variable will be discarded. This may cause data loss. *)
     "M0170", None; (* Stable variable must subtype *)
-    "M0171", None; (* Stable variable changing mutability *)
     "M0172", None; (* to_candid produces Blob, not -- *)
     "M0173", None; (* to_candid arg must have shared type, not -- *)
     "M0174", None; (* from_candid produces an optional shared, not -- *)

--- a/src/mo_frontend/stability.ml
+++ b/src/mo_frontend/stability.ml
@@ -49,7 +49,7 @@ let match_stab_sig tfs1 tfs2 : unit Diag.result =
       | tf1 :: tfs1', [] ->
         (* dropping fields is allowed, but with a warning *)
         warning_discard s tf1;
-        Some ()
+        go tfs1' []
       | tf1::tfs1', tf2::tfs2' ->
         (match Type.compare_field tf1 tf2 with
          | 0 ->

--- a/src/mo_frontend/stability.ml
+++ b/src/mo_frontend/stability.ml
@@ -47,7 +47,7 @@ let match_stab_sig tfs1 tfs2 : unit Diag.result =
       | [], _ ->
         Some () (* no or additional fields ok *)
       | tf1 :: tfs1', [] ->
-        (* dropping fields is allowed, but with a warning *)
+        (* dropped field is allowed with warning, recurse on tfs1' *)
         warning_discard s tf1;
         go tfs1' []
       | tf1::tfs1', tf2::tfs2' ->
@@ -57,7 +57,7 @@ let match_stab_sig tfs1 tfs2 : unit Diag.result =
               error_sub s tf1 tf2;
             go tfs1' tfs2'
          | -1 ->
-           (* dropped field is allowed with warning, recurse of tfs1' *)
+           (* dropped field is allowed with warning, recurse on tfs1' *)
            warning_discard s tf1;
            go tfs1' tfs2 
          | _ ->

--- a/src/mo_frontend/stability.ml
+++ b/src/mo_frontend/stability.ml
@@ -22,7 +22,7 @@ let error_sub s tf1 tf2 =
 
 (* Relaxed rules with enhanced orthogonal persistence for more flexible upgrades.
    - Mutability of stable fields can be changed (because they are never aliased).
-   - Stable fields can be dropped (abdandoning the transitivity property of upgrades).
+   - Stable fields can be dropped (abandoning the transitivity property of upgrades).
 
    Upgrade transitivity means that an upgrade from a program A to B and then from B to C 
    should have the same effect as directly upgrading from A to C. If B discards a field 

--- a/src/mo_frontend/stability.ml
+++ b/src/mo_frontend/stability.ml
@@ -56,12 +56,12 @@ let match_stab_sig tfs1 tfs2 : unit Diag.result =
             if not (sub (as_immut tf1.typ) (as_immut tf2.typ)) then
               error_sub s tf1 tf2;
             go tfs1' tfs2'
-        | -1 ->
-          (* dropped field is allowed with warning, recurse of tfs1' *)
-          warning_discard s tf1;
-          go tfs1' tfs2 
-        | _ ->
-          go tfs1 tfs2' (* new field ok, recurse on tfs2' *)
+         | -1 ->
+           (* dropped field is allowed with warning, recurse of tfs1' *)
+           warning_discard s tf1;
+           go tfs1' tfs2 
+         | _ ->
+           go tfs1 tfs2' (* new field ok, recurse on tfs2' *)
         )
     in go tfs1 tfs2)
   in

--- a/src/mo_frontend/stability.ml
+++ b/src/mo_frontend/stability.ml
@@ -10,16 +10,7 @@ let cat = "Compatibility"
    c.f. (simpler) Types.match_sig.
 *)
 
-let display_typ = Lib.Format.display Type.pp_typ
-
 let display_typ_expand = Lib.Format.display Type.pp_typ_expand
-
-let error_discard s tf =
-  Diag.add_msg s
-    (Diag.error_message Source.no_region "M0169" cat
-      (Format.asprintf "stable variable %s of previous type%a\ncannot be discarded; promote to type `Any` instead"
-        tf.lab
-        display_typ tf.typ))
 
 let error_sub s tf1 tf2 =
   Diag.add_msg s
@@ -29,37 +20,31 @@ let error_sub s tf1 tf2 =
         display_typ_expand tf1.typ
         display_typ_expand tf2.typ))
 
-let error_mut s tf1 tf2 =
-  Diag.add_msg s
-    (Diag.error_message Source.no_region "M0171" cat
-      (Format.asprintf "stable variable %s changes mutability from previous type%a\nto new type %a"
-         tf1.lab
-         display_typ_expand tf1.typ
-         display_typ_expand tf2.typ))
+(* Relaxed rules with enhanced orthogonal persistence for more flexible upgrades.
+   - Mutability of stable fields can be changed (because they are never aliased).
+   - Stable fields can be dropped (abdandoning the transitivity property of upgrades).
 
+   Upgrade transitivity means that an upgrade from a program A to B and then from B to C 
+   should have the same effect as directly upgrading from A to C. If B discards a field 
+   and C re-adds it, this transitivity is no longer maintained. However, rigorous upgrade 
+   transitivity was also not guaranteed before, since B may contain initialization logic
+   or pre-/post-upgrade hooks that alter the stable data.
+*)
 let match_stab_sig tfs1 tfs2 : unit Diag.result =
   (* Assume that tfs1 and tfs2 are sorted. *)
   let res = Diag.with_message_store (fun s ->
-    (* Should we insist on monotonic preservation of fields, or relax? *)
     let rec go tfs1 tfs2 = match tfs1, tfs2 with
-      | [], _ ->
-        Some () (* no or additional fields ok *)
-      | tf1 :: tfs1', [] ->
-        error_discard s tf1;
-        go tfs1' []
+      | [], _ | _, [] -> 
+        (* same amount of fields, new fields, or dropped fields ok *)
+        Some ()
       | tf1::tfs1', tf2::tfs2' ->
         (match Type.compare_field tf1 tf2 with
          | 0 ->
-           (* Should we enforce equal mutability or not?
-              Seems unnecessary since upgrade is read-once *)
-            if Type.is_mut tf1.typ <> Type.is_mut tf2.typ then
-              error_mut s tf1 tf2;
             if not (sub (as_immut tf1.typ) (as_immut tf2.typ)) then
               error_sub s tf1 tf2;
             go tfs1' tfs2'
-       | -1 ->
-          error_discard s tf1;
-          go tfs1' tfs2
+        | -1 ->
+          go tfs1' tfs2 (* dropped field ok, recurse of tfs1' *)
         | _ ->
           go tfs1 tfs2' (* new field ok, recurse on tfs2' *)
         )

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1821,22 +1821,18 @@ let _ = str := string_of_typ
 
 let rec match_stab_sig tfs1 tfs2 =
   (* Assume that tfs1 and tfs2 are sorted. *)
-  (* Should we insist on monotonic preservation of fields, or relax? *)
   match tfs1, tfs2 with
-  | [], _ ->
-    true (* no or additional fields ok *)
-  | _, [] ->
-    false (* true, should we allow fields to be dropped *)
+  | [], _ | _, [] ->
+    (* same amount of fields, new fields, or dropped fields ok *)
+    true
   | tf1::tfs1', tf2::tfs2' ->
     (match compare_field tf1 tf2 with
      | 0 ->
-       is_mut tf1.typ = is_mut tf2.typ &&
        sub (as_immut tf1.typ) (as_immut tf2.typ) &&
-         (* should we enforce equal mutability or not? Seems unncessary
-            since upgrade is read-once *)
        match_stab_sig tfs1' tfs2'
      | -1 ->
-       false (* match_sig tfs1' tfs2', should we allow fields to be dropped *)
+       (* dropped field ok *)
+       match_stab_sig tfs1' tfs2
      | _ ->
        (* new field ok *)
        match_stab_sig tfs1 tfs2'

--- a/test/cmp/ok/mut-x-x.cmp.ok
+++ b/test/cmp/ok/mut-x-x.cmp.ok
@@ -1,5 +1,1 @@
-(unknown location): Compatibility error [M0171], stable variable x changes mutability from previous type
-  var Nat
-to new type 
-  Nat
-FALSE
+TRUE

--- a/test/cmp/ok/neg-xyz-x.cmp.ok
+++ b/test/cmp/ok/neg-xyz-x.cmp.ok
@@ -1,7 +1,1 @@
-(unknown location): Compatibility error [M0169], stable variable y of previous type
-  Int
-cannot be discarded; promote to type `Any` instead
-(unknown location): Compatibility error [M0169], stable variable z of previous type
-  Bool
-cannot be discarded; promote to type `Any` instead
-FALSE
+TRUE

--- a/test/cmp/ok/neg-xyz-x.cmp.ok
+++ b/test/cmp/ok/neg-xyz-x.cmp.ok
@@ -1,4 +1,7 @@
 (unknown location): warning [M0169], stable variable y of previous type
   Int
  will be discarded. This may cause data loss. Are you sure?
+(unknown location): warning [M0169], stable variable z of previous type
+  Bool
+ will be discarded. This may cause data loss. Are you sure?
 TRUE

--- a/test/cmp/ok/neg-xyz-x.cmp.ok
+++ b/test/cmp/ok/neg-xyz-x.cmp.ok
@@ -1,1 +1,4 @@
+(unknown location): warning [M0169], stable variable y of previous type
+  Int
+ will be discarded. This may cause data loss. Are you sure?
 TRUE

--- a/test/cmp/ok/neg-xyz-y.cmp.ok
+++ b/test/cmp/ok/neg-xyz-y.cmp.ok
@@ -1,7 +1,1 @@
-(unknown location): Compatibility error [M0169], stable variable x of previous type
-  Nat
-cannot be discarded; promote to type `Any` instead
-(unknown location): Compatibility error [M0169], stable variable z of previous type
-  Bool
-cannot be discarded; promote to type `Any` instead
-FALSE
+TRUE

--- a/test/cmp/ok/neg-xyz-y.cmp.ok
+++ b/test/cmp/ok/neg-xyz-y.cmp.ok
@@ -1,1 +1,7 @@
+(unknown location): warning [M0169], stable variable x of previous type
+  Nat
+ will be discarded. This may cause data loss. Are you sure?
+(unknown location): warning [M0169], stable variable z of previous type
+  Bool
+ will be discarded. This may cause data loss. Are you sure?
 TRUE

--- a/test/cmp/ok/old-new.cmp.ok
+++ b/test/cmp/ok/old-new.cmp.ok
@@ -1,1 +1,7 @@
+(unknown location): warning [M0169], stable variable config_royalty_address of previous type
+  var Text
+ will be discarded. This may cause data loss. Are you sure?
+(unknown location): warning [M0169], stable variable config_royalty_fee of previous type
+  var Nat64
+ will be discarded. This may cause data loss. Are you sure?
 TRUE

--- a/test/cmp/ok/old-new.cmp.ok
+++ b/test/cmp/ok/old-new.cmp.ok
@@ -1,7 +1,1 @@
-(unknown location): Compatibility error [M0169], stable variable config_royalty_address of previous type
-  var Text
-cannot be discarded; promote to type `Any` instead
-(unknown location): Compatibility error [M0169], stable variable config_royalty_fee of previous type
-  var Nat64
-cannot be discarded; promote to type `Any` instead
-FALSE
+TRUE

--- a/test/cmp/ok/x-mut-x.cmp.ok
+++ b/test/cmp/ok/x-mut-x.cmp.ok
@@ -1,5 +1,1 @@
-(unknown location): Compatibility error [M0171], stable variable x changes mutability from previous type
-  Nat
-to new type 
-  var Nat
-FALSE
+TRUE


### PR DESCRIPTION
# Relaxed Upgrade Compatibility Check
This is used by `dfx` to check the upgrade compatibility with regard to the stable variables.

**Note**: With EOP, the Motoko RTS implements an atomic and authoritative upgrade compatibility check that cannot be bypassed. Hence, the `dfx` check only provides an additional help for the user. 

## Relaxed Rules for Stable Variables
Enhanced orthogonal persistence offers more liberal rules for more flexible upgrades:
- Mutability of stable fields can be changed because they are never aliased.
- Stable fields can be dropped, however, with a warning of potential data loss. For this, we give up the transitivity property of upgrades.

**Note**: Upgrade transitivity means that an upgrade from a program `A` to `B` and then from `B` to `C` has the same effect as directly upgrading from `A` to `C`. Now, if `B` discards a field and `C` re-adds it, this transitivity is no longer maintained. However, rigorous upgrade transitivity was also not guaranteed before, since `B` may contain initialization logic or pre-/post-upgrade hooks that alter the stable data.