### PR TITLE
chore: add Motoko logo to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 A safe, simple, actor-based programming language for authoring [Internet Computer](https://internetcomputer.org/) (IC) canister smart contracts.
 
+![Motoko Logo](https://github.com/user-attachments/assets/844ca364-4d71-42b3-aaec-4a6c3509ee2e)
+
 ## User Documentation & Samples
 
 * [Building, installing, and developing on Motoko](Building.md).


### PR DESCRIPTION
This one:
![Motoko logo](https://github.com/user-attachments/assets/844ca364-4d71-42b3-aaec-4a6c3509ee2e)
I sourced it from https://dfinity.frontify.com/d/pD7yZhsmpqos/motoko#/-/logo (just download the `.zip` and unpack)