### PR TITLE
feat: print source code on error

### DIFF
--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -55,6 +55,7 @@ let argspec = [
     set_mode Compile ()), (* similar to --stable-types *)
       " compile and emit Candid IDL specification to `.did` file";
   "--print-deps", Arg.Unit (set_mode PrintDeps), " prints the dependencies for a given source file";
+  "--print-source-on-error", Arg.Set Flags.print_source_on_error, " prints the source code for error messages";
   "--explain", Arg.String (fun c -> explain_code := c; set_mode Explain ()), " provides a detailed explanation of an error message";
   "-o", Arg.Set_string out_file, "<file>  output file";
 

--- a/src/lang_utils/diag.ml
+++ b/src/lang_utils/diag.ml
@@ -68,7 +68,12 @@ let string_of_message msg =
     | Error -> Printf.sprintf "%s error" msg.cat
     | Warning -> "warning"
     | Info -> "info" in
-  Printf.sprintf "%s: %s%s, %s\n" (Source.string_of_region msg.at) label code msg.text
+  let src = if !Flags.print_source_on_error then
+    match Source.read_region_with_markers msg.at with
+    | Some(src) -> Printf.sprintf "> %s\n\n" src
+    | None -> ""
+  else "" in
+  Printf.sprintf "%s: %s%s, %s\n%s" (Source.string_of_region msg.at) label code msg.text src
 
 let print_message msg =
   if msg.sev <> Error && not !Flags.print_warnings

--- a/src/lang_utils/source.ml
+++ b/src/lang_utils/source.ml
@@ -25,6 +25,52 @@ let string_of_region r =
   r.left.file ^ ":" ^ string_of_pos r.left ^
   (if r.right = r.left then "" else "-" ^ string_of_pos r.right)
 
+(* read source code from region *)
+let read_region_with_markers r =
+  try
+    let in_channel = open_in r.left.file in
+    let rec skip_lines n =
+      if n > 0 then begin
+        ignore (input_line in_channel);
+        skip_lines (n - 1)
+      end
+    in
+    let mark_line line start_marker end_marker =
+      let len = String.length line in
+      match (start_marker, end_marker) with
+      | (Some start_col, Some end_col) ->
+          String.sub line 0 start_col ^ "**" ^
+          String.sub line start_col (end_col - start_col) ^ "**" ^
+          String.sub line end_col (len - end_col)
+      | (Some start_col, None) ->
+          String.sub line 0 start_col ^ "**" ^ String.sub line start_col (len - start_col)
+      | (None, Some end_col) ->
+          String.sub line 0 end_col ^ "**" ^ String.sub line end_col (len - end_col)
+      | (None, None) -> line
+    in
+    let rec read_lines start_line end_line acc =
+      if start_line > end_line then
+        String.concat "\n" (List.rev acc)
+      else
+        let line = input_line in_channel in
+        let marked_line =
+          if start_line = r.left.line && start_line = r.right.line then
+            mark_line line (Some r.left.column) (Some r.right.column)
+          else if start_line = r.left.line then
+            mark_line line (Some r.left.column) None
+          else if start_line = r.right.line then
+            mark_line line None (Some r.right.column)
+          else
+            line
+        in
+        read_lines (start_line + 1) end_line (marked_line :: acc)
+    in
+    skip_lines (r.left.line - 1);
+    let result = read_lines r.left.line r.right.line [] in
+    close_in in_channel;
+    Some result
+  with e -> None
+
 (* generic parse error *)
 
 exception ParseError of region * string

--- a/src/lang_utils/source.mli
+++ b/src/lang_utils/source.mli
@@ -15,4 +15,6 @@ val between : region -> region -> region
 val annotate : 'b -> 'a -> region -> ('a, 'b) annotated_phrase
 val (@@) : 'a -> region -> 'a phrase
 
+val read_region_with_markers : region -> string option
+
 exception ParseError of region * string

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -10,6 +10,7 @@ let trace = ref false
 let verbose = ref false
 let print_warnings = ref true
 let warnings_are_errors = ref false
+let print_source_on_error = ref false
 let print_depth = ref 2
 let release_mode = ref false
 let compile_mode = ref ICMode


### PR DESCRIPTION
Add `--print-source-on-error` to print the source code for error messages.