### PR TITLE
chore: skip redundant `repl` test on CI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -532,7 +532,6 @@ rec {
       fail       = test_subdir "fail"       [ moc ];
       fail-eop   = enhanced_orthogonal_persistence_subdir "fail"       [ moc ];
       repl       = test_subdir "repl"       [ moc ];
-      repl-eop   = enhanced_orthogonal_persistence_subdir "repl"       [ moc ];
       ld         = test_subdir "ld"         ([ mo-ld ] ++ ldTestDeps);
       ld-eop     = enhanced_orthogonal_persistence_subdir "ld" ([ mo-ld ] ++ ldTestDeps);
       idl        = test_subdir "idl"        [ didc ];


### PR DESCRIPTION
As the test only runs in the interpreter, there is no need for distinguishing between EOP and classical persistence.