### PR TITLE
perf: use less cycles in `@timer_helper`

### DIFF
--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -612,10 +612,10 @@ func @timer_helper() : async () {
   ignore (prim "global_timer_set" : Nat64 -> Nat64) exp;
   if (exp == 0) @timers := null;
 
-  for (o in thunks.vals()) {
+  label out for (o in thunks.vals()) {
     switch o {
-      case (?thunk) { ignore thunk() };
-      case _ { }
+      case (?thunk) ignore thunk();
+      case _ break out
     }
   }
 };

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -612,10 +612,10 @@ func @timer_helper() : async () {
   ignore (prim "global_timer_set" : Nat64 -> Nat64) exp;
   if (exp == 0) @timers := null;
 
-  label out for (o in thunks.vals()) {
+  for (o in thunks.vals()) {
     switch o {
       case (?thunk) ignore thunk();
-      case _ break out
+      case _ return
     }
   }
 };


### PR DESCRIPTION
Since the observation of a `null` in the expiration array means there will be no more found, it is pointless to stay in the loop. I expect 1 expiration per callback in the frequent case.