### PR TITLE
chore: use `macos-13` as `macos-12` is deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-latest, macos-13 ]
     needs: changelog
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-latest, macos-13 ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -125,7 +125,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'build_artifacts')
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-latest, macos-13 ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,14 +4,14 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - status-success=tests (ubuntu-latest)
-      - status-success=tests (macos-12)
+      - status-success=tests (macos-13)
       - base=master
       - label=automerge-squash
     merge_conditions:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - status-success=tests (ubuntu-latest)
-      - status-success=tests (macos-12)
+      - status-success=tests (macos-13)
     merge_method: squash
     commit_message_template: |
       {{ title }} (#{{ number }})
@@ -25,7 +25,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - status-success=tests (ubuntu-latest)
-      - status-success=tests (macos-12)
+      - status-success=tests (macos-13)
       - base=master
       - label=automerge-squash
     actions:
@@ -34,7 +34,7 @@ pull_request_rules:
   - name: Automatically closing successful trials
     conditions:
       - status-success=tests (ubuntu-latest)
-      - status-success=tests (macos-12)
+      - status-success=tests (macos-13)
       - label=autoclose
     actions:
       close:


### PR DESCRIPTION
See: https://github.com/actions/runner-images/issues/10721