### PR TITLE
experiment: support migration via extended stable interfaces

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -336,6 +336,5 @@
 <prog> ::= 
     <list(<imp>, ';')> <list(<dec>, ';')> 
 
-    <list(<typ_dec>, ';')> 'actor' '(' '{' <list(<stab_field>, ';')> '}' ',' '{' <list(<stab_field>, ';')> '}' ')'
 
 

--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -336,5 +336,6 @@
 <prog> ::= 
     <list(<imp>, ';')> <list(<dec>, ';')> 
 
+    <list(<typ_dec>, ';')> 'actor' '(' '{' <list(<stab_field>, ';')> '}' ',' '{' <list(<stab_field>, ';')> '}' ')'
 
 

--- a/src/gen-grammar/grammar.sed
+++ b/src/gen-grammar/grammar.sed
@@ -12,7 +12,7 @@ s/<id>/ID/g
 /^<parse_module_header> ::=/,+2d
 /^<stab_field> ::=/,+2d
 /^<typ_dec> ::=/,+2d
-/^<parse_stab_sig> ::=/,+2d
+/^<parse_stab_sig> ::=/,+5d
 /.*PRIM.*/d
 /^<bl> ::=/,+2d
 /^<ob> ::=/,+2d

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -541,7 +541,7 @@ and build_actor at ts exp_opt self_id es obj_typ =
   let pairs = List.map2 stabilize stabs ds in
   let idss = List.map fst pairs in
   let ids = List.concat idss in
-  let sig_ = List.sort T.compare_field
+  let sig_post = List.sort T.compare_field
     (List.map (fun (i,t) -> T.{lab = i; typ = t; src = empty_src}) ids)
   in
   let fields = List.map (fun (i,t) -> T.{lab = i; typ = T.Opt (T.as_immut t); src = T.empty_src}) ids in
@@ -550,8 +550,9 @@ and build_actor at ts exp_opt self_id es obj_typ =
   let state = fresh_var "state" (T.Mut (T.Opt ty)) in
   let get_state = fresh_var "getState" (T.Func(T.Local, T.Returns, [], [], [ty])) in
   let ds = List.map (fun mk_d -> mk_d get_state) mk_ds in
-  let stable_type, migration = match exp_opt with
+  let sig_, stable_type, migration = match exp_opt with
     | None ->
+      T.Single sig_post,
       I.{pre = ty; post = ty},
       primE (I.ICStableRead ty) [] (* as before *)
     | Some exp0 ->
@@ -559,21 +560,30 @@ and build_actor at ts exp_opt self_id es obj_typ =
       let [@warning "-8"] (_s,_c, [], [dom], [rng]) = T.as_func (exp0.note.S.note_typ) in
       let [@warning "-8"] (T.Object, dom_fields) = T.as_obj dom in
       let [@warning "-8"] (T.Object, rng_fields) = T.as_obj rng in
+      let sig_pre =
+         List.sort T.compare_field
+           (dom_fields @
+              (List.filter_map
+                 (fun (i,t) ->
+                   match T.lookup_val_field_opt i dom_fields with
+                   | Some t ->
+                     (* ignore overriden *)
+                     None
+                   | None ->
+                    (* retain others *)
+                   Some T.{lab = i; typ = t; src = T.empty_src})                                                   ids))
+      in
       let fields' =
            List.map
-             (fun (i,t) ->
-                T.{lab = i; typ = T.Opt (T.as_immut t); src = T.empty_src})
-             ((List.map (fun T.{lab;typ;_} -> (lab,typ)) dom_fields) @
-                (List.filter_map
-                   (fun (i,t) ->
-                     match T.lookup_val_field_opt i dom_fields with
-                     | Some t -> None (* ignore overriden *)
-                     | None -> Some (i, t) (* retain others *))
-                   ids)) in
-      let ty' = T.Obj (T.Memory, List.sort T.compare_field fields') in
+             (fun tf ->
+               { tf with T.typ = T.Opt (T.as_immut tf.T.typ) })
+             sig_pre
+      in
+      let ty' = T.Obj (T.Memory, fields') in
       let v = fresh_var "v" ty' in
       let v_dom = fresh_var "v_dom" dom in
       let v_rng = fresh_var "v_rng" rng in
+      T.PrePost (sig_pre, sig_post),
       I.{pre = ty'; post = ty},
       ifE (primE (I.OtherPrim "rts_in_install") [])
         (primE (I.ICStableRead ty) [])

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -477,7 +477,7 @@ and export_runtime_information self_id =
   let scope_con2 = Cons.fresh "T2" (Abs ([], Any)) in
   let bind1  = typ_arg scope_con1 Scope scope_bound in
   let bind2 = typ_arg scope_con2 Scope scope_bound in
-  let gc_strategy = 
+  let gc_strategy =
     let open Mo_config in
     let strategy = match !Flags.gc_strategy with
     | Flags.Default -> "default"
@@ -513,19 +513,19 @@ and export_runtime_information self_id =
            (asyncE T.Fut bind2
               (blockE ([
                   letD caller (primE I.ICCallerPrim []);
-                  expD (ifE (orE 
+                  expD (ifE (orE
                       (primE (I.RelPrim (principal, Operator.EqOp)) [varE caller; selfRefE principal])
                       (primE (I.OtherPrim "is_controller") [varE caller]))
-                    (unitE()) 
+                    (unitE())
                     (primE (Ir.OtherPrim "trap")
                       [textE "Unauthorized call of __motoko_runtime_information"]))
                   ] @
-                  (List.map2 (fun field (_, load_info, _) -> 
+                  (List.map2 (fun field (_, load_info, _) ->
                     letD field load_info
                   ) fields information))
                 (newObjE T.Object
-                  (List.map2 (fun field (name, _, typ) -> 
-                      { it = Ir.{name; var = id_of_var field}; at = no_region; note = typ }) 
+                  (List.map2 (fun field (name, _, typ) ->
+                      { it = Ir.{name; var = id_of_var field}; at = no_region; note = typ })
                     fields information
                   ) ret_typ))
               (Con (scope_con1, []))))
@@ -560,9 +560,9 @@ and build_actor at ts exp_opt self_id es obj_typ =
       primE (I.ICStableRead mem_ty) [] (* as before *)
     | Some exp0 ->
       let e = exp exp0 in
-      let [@warning "-8"] (_s,_c, [], [dom], [rng]) = T.as_func (exp0.note.S.note_typ) in
-      let [@warning "-8"] (T.Object, dom_fields) = T.as_obj dom in
-      let [@warning "-8"] (T.Object, rng_fields) = T.as_obj rng in
+      let dom, rng = T.as_mono_func_sub (exp0.note.S.note_typ) in
+      let (_dom_sort, dom_fields) = T.as_obj (T.normalize dom) in
+      let (_rng_sort, rng_fields) = T.as_obj (T.promote rng) in
       let stab_fields_pre =
         List.sort T.compare_field
           (dom_fields @
@@ -1138,7 +1138,7 @@ let import_compiled_class (lib : S.comp_unit) wasm : import_declaration =
           (callE (varE install_actor_helper) cs'
             (tupE [
               install_arg;
-              boolE ((!Mo_config.Flags.enhanced_orthogonal_persistence)); 
+              boolE ((!Mo_config.Flags.enhanced_orthogonal_persistence));
               varE wasm_blob;
               primE (Ir.SerializePrim ts1') [seqE (List.map varE vs)]])))
         (primE (Ir.CastPrim (T.principal, t_actor)) [varE principal]))

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -235,7 +235,11 @@ and prog' = dec list
 (* Signatures (stable variables) *)
 
 type stab_sig = (stab_sig', prog_note) Source.annotated_phrase
-and stab_sig' = (dec list * typ_field list)      (* type declarations & stable actor fields *)
+and stab_sig' = (dec list * stab_body)      (* type declarations & stable actor fields *)
+and stab_body = stab_body' Source.phrase    (* type declarations & stable actor fields *)
+and stab_body' =
+  | Single of typ_field list
+  | PrePost of typ_field list * typ_field list
 
 (* Compilation units *)
 

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -997,7 +997,22 @@ stab_field :
 parse_stab_sig :
   | start ds=seplist(typ_dec, semicolon) ACTOR LCURLY sfs=seplist(stab_field, semicolon) RCURLY
     { let trivia = !triv_table in
-      fun filename -> { it = (ds, sfs); at = at $sloc; note = { filename; trivia }}
+      let sigs = Single sfs in
+      fun filename -> {
+          it = (ds, {it=sigs; at = at $sloc; note = ()});
+          at = at $sloc;
+          note =
+          { filename; trivia }}
+    }
+  | start ds=seplist(typ_dec, semicolon)
+       ACTOR LPAR LCURLY sfs_pre=seplist(stab_field, semicolon) RCURLY COMMA
+             LCURLY sfs_post=seplist(stab_field, semicolon) RCURLY  RPAR
+    { let trivia = !triv_table in
+      let sigs = PrePost(sfs_pre, sfs_post) in (* FIX ME*)
+      fun filename -> {
+          it = (ds, {it=sigs; at = at $sloc; note = ()});
+          at = at $sloc;
+          note = { filename; trivia }}
     }
 
 %%

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -1008,7 +1008,7 @@ parse_stab_sig :
        ACTOR LPAR LCURLY sfs_pre=seplist(stab_field, semicolon) RCURLY COMMA
              LCURLY sfs_post=seplist(stab_field, semicolon) RCURLY  RPAR
     { let trivia = !triv_table in
-      let sigs = PrePost(sfs_pre, sfs_post) in (* FIX ME*)
+      let sigs = PrePost(sfs_pre, sfs_post) in
       fun filename -> {
           it = (ds, {it=sigs; at = at $sloc; note = ()});
           at = at $sloc;

--- a/src/mo_frontend/stability.mli
+++ b/src/mo_frontend/stability.mli
@@ -6,4 +6,4 @@ open Mo_types
    c.f. (simpler) Types.match_sig.
 *)
 
-val match_stab_sig : Type.field list -> Type.field list -> unit Diag.result
+val match_stab_sig : Type.stab_sig -> Type.stab_sig -> unit Diag.result

--- a/src/mo_frontend/typing.mli
+++ b/src/mo_frontend/typing.mli
@@ -10,6 +10,6 @@ val infer_prog : ?viper_mode:bool -> scope -> string option -> Async_cap.async_c
 
 val check_lib : scope -> string option -> Syntax.lib -> scope Diag.result
 val check_actors : ?viper_mode:bool -> ?check_actors:bool -> scope -> Syntax.prog list -> unit Diag.result
-val check_stab_sig : scope -> Syntax.stab_sig -> (field list) Diag.result
+val check_stab_sig : scope -> Syntax.stab_sig -> Type.stab_sig Diag.result
 
 val heartbeat_type : typ

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1789,18 +1789,18 @@ and pp_stab_sig ppf sig_ =
     match sig_ with
     | Single tfs ->
       fprintf ppf "@[<v 2>%s{@;<0 0>%a@;<0 -2>}@]"
-       (string_of_obj_sort Actor)
-       (pp_print_list ~pp_sep:semi (pp_stab_field vs)) tfs
+        (string_of_obj_sort Actor)
+        (pp_print_list ~pp_sep:semi (pp_stab_field vs)) tfs
     | PrePost (pre, post) ->
       fprintf ppf "@[<v 2>%s({@;<0 0>%a@;<0 -2>}, {@;<0 0>%a@;<0 -2>}) @]"
-       (string_of_obj_sort Actor)
-       (pp_print_list ~pp_sep:semi (pp_stab_field vs)) pre
-       (pp_print_list ~pp_sep:semi (pp_stab_field vs)) post
+        (string_of_obj_sort Actor)
+        (pp_print_list ~pp_sep:semi (pp_stab_field vs)) pre
+        (pp_print_list ~pp_sep:semi (pp_stab_field vs)) post
   in
-    fprintf ppf "@[<v 0>%a%a%a;@]"
-      (pp_print_list ~pp_sep:semi (pp_field vs)) fs
-      (if fs = [] then fun ppf () -> () else semi) ()
-      pp_stab_actor sig_
+  fprintf ppf "@[<v 0>%a%a%a;@]"
+    (pp_print_list ~pp_sep:semi (pp_field vs)) fs
+    (if fs = [] then fun ppf () -> () else semi) ()
+    pp_stab_actor sig_
 
 let rec pp_typ_expand' vs ppf t =
   match t with

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1792,7 +1792,7 @@ and pp_stab_sig ppf sig_ =
        (string_of_obj_sort Actor)
        (pp_print_list ~pp_sep:semi (pp_stab_field vs)) tfs
     | PrePost (pre, post) ->
-      fprintf ppf "@[<v 2>%s({@;<0 0>%a@;<0 -2>}, {@;<0 0>%a@;<0 -2>} @]"
+      fprintf ppf "@[<v 2>%s({@;<0 0>%a@;<0 -2>}, {@;<0 0>%a@;<0 -2>}) @]"
        (string_of_obj_sort Actor)
        (pp_print_list ~pp_sep:semi (pp_stab_field vs)) pre
        (pp_print_list ~pp_sep:semi (pp_stab_field vs)) post

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -72,6 +72,11 @@ and kind =
 
 let empty_src = {depr = None; region = Source.no_region}
 
+(* Stable signatures *)
+type stab_sig =
+  | Single of field list
+  | PrePost of field list * field list
+
 (* Efficient comparison *)
 let tag_prim = function
   | Null -> 0
@@ -1754,11 +1759,15 @@ and pp_kind ppf k =
   pp_kind' vs ppf k
 
 and pp_stab_sig ppf sig_ =
+  let all_fields = match sig_ with
+    | Single tfs -> tfs
+    | PrePost (pre, post) -> pre @ post
+  in
   let cs = List.fold_right
     (cons_field false)
     (* false here ^ means ignore unreferenced Typ c components
        that would produce unreferenced bindings when unfolded *)
-    sig_ ConSet.empty in
+    all_fields ConSet.empty in
   let vs = vs_of_cs cs in
   let ds =
     let cs' = ConSet.filter (fun c ->
@@ -1776,15 +1785,22 @@ and pp_stab_sig ppf sig_ =
           typ = Typ c;
           src = empty_src }) ds)
   in
-  let pp_stab_fields ppf sig_ =
-    fprintf ppf "@[<v 2>%s{@;<0 0>%a@;<0 -2>}@]"
-      (string_of_obj_sort Actor)
-      (pp_print_list ~pp_sep:semi (pp_stab_field vs)) sig_
+  let pp_stab_actor ppf sig_ =
+    match sig_ with
+    | Single tfs ->
+      fprintf ppf "@[<v 2>%s{@;<0 0>%a@;<0 -2>}@]"
+       (string_of_obj_sort Actor)
+       (pp_print_list ~pp_sep:semi (pp_stab_field vs)) tfs
+    | PrePost (pre, post) ->
+      fprintf ppf "@[<v 2>%s({@;<0 0>%a@;<0 -2>}, {@;<0 0>%a@;<0 -2>} @]"
+       (string_of_obj_sort Actor)
+       (pp_print_list ~pp_sep:semi (pp_stab_field vs)) pre
+       (pp_print_list ~pp_sep:semi (pp_stab_field vs)) post
   in
-  fprintf ppf "@[<v 0>%a%a%a;@]"
-   (pp_print_list ~pp_sep:semi (pp_field vs)) fs
-   (if fs = [] then fun ppf () -> () else semi) ()
-   pp_stab_fields sig_
+    fprintf ppf "@[<v 0>%a%a%a;@]"
+      (pp_print_list ~pp_sep:semi (pp_field vs)) fs
+      (if fs = [] then fun ppf () -> () else semi) ()
+      pp_stab_actor sig_
 
 let rec pp_typ_expand' vs ppf t =
   match t with
@@ -1850,7 +1866,20 @@ let _ = str := string_of_typ
 
 (* Stable signatures *)
 
-let rec match_stab_sig tfs1 tfs2 =
+let pre = function
+  | Single tfs -> tfs
+  | PrePost (tfs, _) -> tfs
+
+let post = function
+  | Single tfs -> tfs
+  | PrePost (_, tfs) -> tfs
+
+let rec match_stab_sig sig1 sig2 =
+  let tfs1 = post sig1 in
+  let tfs2 = pre sig2 in
+  match_stab_fields tfs1 tfs2
+
+and match_stab_fields tfs1 tfs2 =
   (* Assume that tfs1 and tfs2 are sorted. *)
   match tfs1, tfs2 with
   | [], _ | _, [] ->
@@ -1860,16 +1889,17 @@ let rec match_stab_sig tfs1 tfs2 =
     (match compare_field tf1 tf2 with
      | 0 ->
        sub (as_immut tf1.typ) (as_immut tf2.typ) &&
-       match_stab_sig tfs1' tfs2'
+       match_stab_fields tfs1' tfs2'
      | -1 ->
        (* dropped field ok *)
-       match_stab_sig tfs1' tfs2
+       match_stab_fields tfs1' tfs2
      | _ ->
        (* new field ok *)
-       match_stab_sig tfs1 tfs2'
+       match_stab_fields tfs1 tfs2'
     )
 
-let string_of_stab_sig fields : string =
+let string_of_stab_sig stab_sig : string =
   let module Pretty = MakePretty(ParseableStamps) in
-  "// Version: 1.0.0\n" ^
-  Format.asprintf "@[<v 0>%a@]@\n" (fun ppf -> Pretty.pp_stab_sig ppf) fields
+  "// Version: 2.0\n" ^
+  Format.asprintf "@[<v 0>%a@]@\n" (fun ppf -> Pretty.pp_stab_sig ppf) stab_sig
+

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1900,6 +1900,8 @@ and match_stab_fields tfs1 tfs2 =
 
 let string_of_stab_sig stab_sig : string =
   let module Pretty = MakePretty(ParseableStamps) in
-  "// Version: 2.0\n" ^
+  (match stab_sig with
+  | Single _ -> "// Version: 1.0.0\n"
+  | PrePost _-> "// Version: 2.0.0\n") ^
   Format.asprintf "@[<v 0>%a@]@\n" (fun ppf -> Pretty.pp_stab_sig ppf) stab_sig
 

--- a/src/mo_types/type.mli
+++ b/src/mo_types/type.mli
@@ -262,9 +262,16 @@ val scope_bind : bind
 
 (* Signatures *)
 
-val match_stab_sig : field list -> field list -> bool
+type stab_sig =
+  | Single of field list
+  | PrePost of field list * field list
 
-val string_of_stab_sig : field list -> string
+val pre : stab_sig -> field list
+val post : stab_sig -> field list
+
+val match_stab_sig : stab_sig -> stab_sig -> bool
+
+val string_of_stab_sig : stab_sig -> string
 
 val motoko_runtime_information_type : typ
 


### PR DESCRIPTION
builds on #4829 and #4812, addressing syntactic stable signatures.

A stable signature is now either a single interface of stable fields (as before) or (the new bit)  a dual interface recording the pre and post upgrade interface when performing migration.

The pre and post fields are implicitly identical for a singleton interface and provide for backwards compatibility and ordinary upgrades (sans explicit migration).

Stability compatibility now checks the post interface of old module is compatible with the pre-interface of the new module.

````
<stab_sig> ::=
  <typ_dec>;* actor { <stab_field>;* }
  <typ_dec>;* actor ( { <stab_field>;* },  <stab_field>;* } )
````

Done this way, there should be no need to modify dfx, which defers to moc for the compatibility check anyway.

- [x] fig grammar.sed to delete new production
- [ ] add some tests to test/cmp