### PR TITLE
bugfix: check that timer servicing worked

### DIFF
--- a/src/ir_def/construct.ml
+++ b/src/ir_def/construct.ml
@@ -112,6 +112,7 @@ let primE prim es =
     | DeserializePrim ts -> T.seq ts
     | DeserializeOptPrim ts -> T.Opt (T.seq ts)
     | OtherPrim "trap" -> T.Non
+    | OtherPrim "global_timer_set" -> T.nat64
     | OtherPrim "call_perform_status" -> T.(Prim Nat32)
     | OtherPrim "call_perform_message" -> T.text
     | OtherPrim "array_len"
@@ -267,6 +268,12 @@ let nat32E n =
   { it = LitE (Nat32Lit n);
     at = no_region;
     note = Note.{ def with typ = T.(Prim Nat32) }
+  }
+
+let nat64E n =
+  { it = LitE (Nat64Lit n);
+    at = no_region;
+    note = Note.{ def with typ = T.nat64 }
   }
 
 let natE n =

--- a/src/ir_def/construct.mli
+++ b/src/ir_def/construct.mli
@@ -66,6 +66,7 @@ val let_else_switch : pat -> exp -> exp -> exp
 val natE : Mo_values.Numerics.Nat.t -> exp
 val intE : Mo_values.Numerics.Int.t -> exp
 val nat32E : Mo_values.Numerics.Nat32.t -> exp
+val nat64E : Mo_values.Numerics.Nat64.t -> exp
 val textE : string -> exp
 val blobE : string -> exp
 val letE : var -> exp -> exp -> exp

--- a/src/ir_passes/await.ml
+++ b/src/ir_passes/await.ml
@@ -684,7 +684,8 @@ and t_ignore_throw context exp = t_on_throw context exp (tupE[])
 (* if self-call queue full: expire global timer soon and retry *)
 and t_timer_throw context exp =
   t_on_throw context exp
-    (blockE [expD (primE
+    (blockE
+       [expD (primE
                 (OtherPrim "global_timer_set")
                 [Mo_values.Numerics.Nat64.of_int 1 |> nat64E])]
        (tupE[]))

--- a/src/ir_passes/await.ml
+++ b/src/ir_passes/await.ml
@@ -653,14 +653,14 @@ and t_comp_unit context = function
         preupgrade = t_exp LabelEnv.empty preupgrade;
         postupgrade = t_exp LabelEnv.empty postupgrade;
         heartbeat = t_ignore_throw LabelEnv.empty heartbeat;
-        timer = t_ignore_throw LabelEnv.empty timer;
+        timer = t_timer_throw LabelEnv.empty timer;
         inspect = t_exp LabelEnv.empty inspect;
         stable_record = t_exp LabelEnv.empty stable_record;
         stable_type;
       },
       t)
 
-and t_ignore_throw context exp =
+and t_on_throw context exp t_exp =
   match exp.it with
   | Ir.PrimE (Ir.TupPrim, []) ->
      exp
@@ -671,7 +671,7 @@ and t_ignore_throw context exp =
          (LabelEnv.add Throw (Cont throw) context) in
      let e = fresh_var "e" T.catch in
      { (blockE [
-          funcD throw e (tupE[]);
+          funcD throw e t_exp;
         ]
         (c_exp context' exp (meta (T.unit) (fun v1 -> tupE []))))
        (* timer logic requires us to preserve any source location,
@@ -679,6 +679,14 @@ and t_ignore_throw context exp =
        with at = exp.at
      }
 
+and t_ignore_throw context exp = t_on_throw context exp (tupE[])
+
+and t_timer_throw context exp =
+  let check_timer_send_type = T.(Func (Local, Returns, [], [], [])) in
+  t_on_throw context exp
+    (callE
+       (varE (var "@check_timer_send" check_timer_send_type)) []
+       (unitE()))
 
 and t_prog (prog, flavor) =
   (t_comp_unit LabelEnv.empty prog, { flavor with has_await = false })

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -20,8 +20,6 @@ want to recognize for better user experience.
 let id_of_full_path (fp : string) : string =
   "file$" ^ fp
 
-let check_timer_send_type = T.(Func (Local, Returns, [], [], []))
-
 (* Combinators used in the desugaring *)
 
 let apply_sign op l = Syntax.(match op, l with
@@ -370,9 +368,7 @@ and call_system_func_opt name es obj_typ =
              blockE
                [ expD T.(callE (varE (var id.it note)) [Any]
                    (varE (var "@set_global_timer" Mo_frontend.Typing.global_timer_set_type))) ]
-               (callE
-                  (varE (var "@check_timer_send" check_timer_send_type)) []
-                  (unitE())) in
+               (unitE()) in
            { timer with at }
         | "heartbeat" ->
           blockE
@@ -610,9 +606,7 @@ and build_actor at ts self_id es obj_typ =
           | None when !Mo_config.Flags.global_timer ->
             blockE
               [ expD T.(callE (varE (var "@timer_helper" Mo_frontend.Typing.heartbeat_type)) [unit] (unitE())) ]
-              (callE
-                 (varE (var "@check_timer_send" check_timer_send_type)) []
-                 (unitE()))
+              (unitE())
           | None -> tupE []);
        inspect =
          (match call_system_func_opt "inspect" es obj_typ with

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -367,7 +367,7 @@ and call_system_func_opt name es obj_typ =
            let timer =
              blockE
                [ expD T.(callE (varE (var id.it note)) [Any]
-                   (varE (var "@set_global_timer" Mo_frontend.Typing.global_timer_set_type))) ]
+                   (varE (var "@set_global_timer" T.global_timer_set_type))) ]
                (unitE()) in
            { timer with at }
         | "heartbeat" ->
@@ -605,7 +605,7 @@ and build_actor at ts self_id es obj_typ =
           | Some call -> call
           | None when !Mo_config.Flags.global_timer ->
             blockE
-              [ expD T.(callE (varE (var "@timer_helper" Mo_frontend.Typing.heartbeat_type)) [unit] (unitE())) ]
+              [ expD T.(callE (varE (var "@timer_helper" T.heartbeat_type)) [unit] (unitE())) ]
               (unitE())
           | None -> tupE []);
        inspect =

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -367,8 +367,10 @@ and call_system_func_opt name es obj_typ =
            let timer =
              blockE
                [ expD T.(callE (varE (var id.it note)) [Any]
-                   (varE (var "@set_global_timer" (Func (Local, Returns, [], [Prim Nat64], []))))) ]
-               (unitE ()) in
+                   (varE (var "@set_global_timer" Mo_frontend.Typing.global_timer_set_type))) ]
+               (callE
+                  (varE (var "@check_timer_send" T.(Func (Local, Returns, [], [], [])))) [T.Any]
+                  (unitE())) in
            { timer with at }
         | "heartbeat" ->
           blockE

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -20,6 +20,8 @@ want to recognize for better user experience.
 let id_of_full_path (fp : string) : string =
   "file$" ^ fp
 
+let check_timer_send_type = T.(Func (Local, Returns, [], [], []))
+
 (* Combinators used in the desugaring *)
 
 let apply_sign op l = Syntax.(match op, l with
@@ -368,9 +370,9 @@ and call_system_func_opt name es obj_typ =
              blockE
                [ expD T.(callE (varE (var id.it note)) [Any]
                    (varE (var "@set_global_timer" Mo_frontend.Typing.global_timer_set_type))) ]
-               T.(callE
-                    (varE (var "@check_timer_send" (Func (Local, Returns, [], [], [])))) []
-                    (unitE())) in
+               (callE
+                  (varE (var "@check_timer_send" check_timer_send_type)) []
+                  (unitE())) in
            { timer with at }
         | "heartbeat" ->
           blockE
@@ -608,9 +610,9 @@ and build_actor at ts self_id es obj_typ =
           | None when !Mo_config.Flags.global_timer ->
             blockE
               [ expD T.(callE (varE (var "@timer_helper" Mo_frontend.Typing.heartbeat_type)) [unit] (unitE())) ]
-              T.(callE
-                   (varE (var "@check_timer_send" (Func (Local, Returns, [], [], [])))) []
-                   (unitE()))
+              (callE
+                 (varE (var "@check_timer_send" check_timer_send_type)) []
+                 (unitE()))
           | None -> tupE []);
        inspect =
          (match call_system_func_opt "inspect" es obj_typ with

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -369,7 +369,7 @@ and call_system_func_opt name es obj_typ =
                [ expD T.(callE (varE (var id.it note)) [Any]
                    (varE (var "@set_global_timer" Mo_frontend.Typing.global_timer_set_type))) ]
                T.(callE
-                    (varE (var "@check_timer_send" (Func (Local, Returns, [], [], [])))) [Any]
+                    (varE (var "@check_timer_send" (Func (Local, Returns, [], [], [])))) []
                     (unitE())) in
            { timer with at }
         | "heartbeat" ->
@@ -609,7 +609,7 @@ and build_actor at ts self_id es obj_typ =
             blockE
               [ expD T.(callE (varE (var "@timer_helper" Mo_frontend.Typing.heartbeat_type)) [unit] (unitE())) ]
               T.(callE
-                   (varE (var "@check_timer_send" (Func (Local, Returns, [], [], [])))) [Any]
+                   (varE (var "@check_timer_send" (Func (Local, Returns, [], [], [])))) []
                    (unitE()))
           | None -> tupE []);
        inspect =

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -368,9 +368,9 @@ and call_system_func_opt name es obj_typ =
              blockE
                [ expD T.(callE (varE (var id.it note)) [Any]
                    (varE (var "@set_global_timer" Mo_frontend.Typing.global_timer_set_type))) ]
-               (callE
-                  (varE (var "@check_timer_send" T.(Func (Local, Returns, [], [], [])))) [T.Any]
-                  (unitE())) in
+               T.(callE
+                    (varE (var "@check_timer_send" (Func (Local, Returns, [], [], [])))) [Any]
+                    (unitE())) in
            { timer with at }
         | "heartbeat" ->
           blockE
@@ -608,7 +608,9 @@ and build_actor at ts self_id es obj_typ =
           | None when !Mo_config.Flags.global_timer ->
             blockE
               [ expD T.(callE (varE (var "@timer_helper" Mo_frontend.Typing.heartbeat_type)) [unit] (unitE())) ]
-              (unitE ())
+              T.(callE
+                   (varE (var "@check_timer_send" (Func (Local, Returns, [], [], [])))) [Any]
+                   (unitE()))
           | None -> tupE []);
        inspect =
          (match call_system_func_opt "inspect" es obj_typ with

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -386,20 +386,10 @@ let infer_mut mut : T.typ -> T.typ =
 
 (* System method types *)
 
-let heartbeat_type =
-  T.(Func (Local, Returns, [scope_bind], [], [Async (Fut, Var (default_scope_var, 0), unit)]))
-
-let global_timer_set_type = T.(Func (Local, Returns, [], [Prim Nat64], []))
-
-let timer_type =
-  T.(Func (Local, Returns, [scope_bind],
-    [global_timer_set_type],
-    [Async (Fut, Var (default_scope_var, 0), unit)]))
-
 let system_funcs tfs =
   [
-    ("heartbeat", heartbeat_type);
-    ("timer", timer_type);
+    ("heartbeat", T.heartbeat_type);
+    ("timer", T.timer_type);
     T.("preupgrade", Func (Local, Returns, [scope_bind], [], []));
     T.("postupgrade", Func (Local, Returns, [scope_bind], [], []));
     ("inspect",

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -389,9 +389,11 @@ let infer_mut mut : T.typ -> T.typ =
 let heartbeat_type =
   T.(Func (Local, Returns, [scope_bind], [], [Async (Fut, Var (default_scope_var, 0), unit)]))
 
+let global_timer_set_type = T.(Func (Local, Returns, [], [Prim Nat64], []))
+
 let timer_type =
   T.(Func (Local, Returns, [scope_bind],
-    [Func (Local, Returns, [], [Prim Nat64], [])],
+    [global_timer_set_type],
     [Async (Fut, Var (default_scope_var, 0), unit)]))
 
 let system_funcs tfs =

--- a/src/mo_frontend/typing.mli
+++ b/src/mo_frontend/typing.mli
@@ -13,3 +13,4 @@ val check_actors : ?viper_mode:bool -> ?check_actors:bool -> scope -> Syntax.pro
 val check_stab_sig : scope -> Syntax.stab_sig -> (field list) Diag.result
 
 val heartbeat_type : typ
+val global_timer_set_type : typ

--- a/src/mo_frontend/typing.mli
+++ b/src/mo_frontend/typing.mli
@@ -11,6 +11,3 @@ val infer_prog : ?viper_mode:bool -> scope -> string option -> Async_cap.async_c
 val check_lib : scope -> string option -> Syntax.lib -> scope Diag.result
 val check_actors : ?viper_mode:bool -> ?check_actors:bool -> scope -> Syntax.prog list -> unit Diag.result
 val check_stab_sig : scope -> Syntax.stab_sig -> (field list) Diag.result
-
-val heartbeat_type : typ
-val global_timer_set_type : typ

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -307,7 +307,7 @@ let compare_field f1 f2 =
   | {lab = l1; typ = _; _}, {lab = l2; typ = _; _} -> compare l1 l2
 
 
-(* Short-hands *)
+(* Shorthands *)
 
 let unit = Tup []
 let bool = Prim Bool
@@ -320,6 +320,7 @@ let error = Prim Error
 let char = Prim Char
 let principal = Prim Principal
 let region = Prim Region
+
 
 let fields flds =
   List.sort compare_field
@@ -1340,6 +1341,19 @@ let scope_var var = "$" ^ var
 let default_scope_var = scope_var ""
 let scope_bound = Any
 let scope_bind = { var = default_scope_var; sort = Scope; bound = scope_bound }
+
+(* Shorthands for replica callbacks *)
+
+let heartbeat_type =
+  Func (Local, Returns, [scope_bind], [], [Async (Fut, Var (default_scope_var, 0), unit)])
+
+let global_timer_set_type = Func (Local, Returns, [], [Prim Nat64], [])
+
+let timer_type =
+  Func (Local, Returns, [scope_bind],
+        [global_timer_set_type],
+        [Async (Fut, Var (default_scope_var, 0), unit)])
+
 
 (* Well-known fields *)
 

--- a/src/mo_types/type.mli
+++ b/src/mo_types/type.mli
@@ -84,7 +84,7 @@ end
 val is_shared_sort : 'a shared -> bool
 
 
-(* Short-hands *)
+(* Shorthands *)
 
 val unit : typ
 val bool : typ
@@ -97,6 +97,9 @@ val error : typ
 val char : typ
 val principal : typ
 val region : typ
+val heartbeat_type : typ
+val timer_type : typ
+val global_timer_set_type : typ
 
 val sum : (lab * typ) list -> typ
 val obj : obj_sort -> (lab * typ) list -> typ

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -676,12 +676,3 @@ func @cancelTimer(id : Nat) {
 };
 
 func @set_global_timer(time : Nat64) = ignore (prim "global_timer_set" : Nat64 -> Nat64) time;
-
-// Function called by backend to check if self-send worked.
-// DO NOT RENAME without modifying compilation.
-func @check_timer_send() {
-  if ((prim "call_perform_status" : () -> Nat32) () != 0) {
-    // i.e. self-call queue full: expire soon and retry
-    ignore (prim "global_timer_set" : Nat64 -> Nat64) 1;
-  }
-};

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -675,5 +675,11 @@ func @cancelTimer(id : Nat) {
   }
 };
 
-
 func @set_global_timer(time : Nat64) = ignore (prim "global_timer_set" : Nat64 -> Nat64) time;
+
+func @check_timer_send() {
+  if not @call_succeeded() {
+    // i.e. self-call queue full: expire soon and retry
+    ignore (prim "global_timer_set" : Nat64 -> Nat64) 1;
+  }
+};

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -680,7 +680,7 @@ func @set_global_timer(time : Nat64) = ignore (prim "global_timer_set" : Nat64 -
 // Function called by backend to check if self-send worked.
 // DO NOT RENAME without modifying compilation.
 func @check_timer_send() {
-  if (not @call_succeeded()) {
+  if ((prim "call_perform_status" : () -> Nat32) () != 0) {
     // i.e. self-call queue full: expire soon and retry
     ignore (prim "global_timer_set" : Nat64 -> Nat64) 1;
   }

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -677,6 +677,8 @@ func @cancelTimer(id : Nat) {
 
 func @set_global_timer(time : Nat64) = ignore (prim "global_timer_set" : Nat64 -> Nat64) time;
 
+// Function called by backend to check if self-send worked.
+// DO NOT RENAME without modifying compilation.
 func @check_timer_send() {
   if (not @call_succeeded()) {
     // i.e. self-call queue full: expire soon and retry

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -678,7 +678,7 @@ func @cancelTimer(id : Nat) {
 func @set_global_timer(time : Nat64) = ignore (prim "global_timer_set" : Nat64 -> Nat64) time;
 
 func @check_timer_send() {
-  if not @call_succeeded() {
+  if (not @call_succeeded()) {
     // i.e. self-call queue full: expire soon and retry
     ignore (prim "global_timer_set" : Nat64 -> Nat64) 1;
   }

--- a/test/fail/ok/illegal-await.tc.ok
+++ b/test/fail/ok/illegal-await.tc.ok
@@ -24,14 +24,14 @@ illegal-await.mo:24.11: info, start of scope $@anon-async-24.11 mentioned in err
 illegal-await.mo:26.5: info, end of scope $@anon-async-24.11 mentioned in error at illegal-await.mo:25.7-25.14
 illegal-await.mo:22.10: info, start of scope $@anon-async-22.10 mentioned in error at illegal-await.mo:25.7-25.14
 illegal-await.mo:27.3: info, end of scope $@anon-async-22.10 mentioned in error at illegal-await.mo:25.7-25.14
-illegal-await.mo:35.11-35.12: type error [M0087], ill-scoped await: expected async type from current scope $Rec, found async type from other scope $__15
+illegal-await.mo:35.11-35.12: type error [M0087], ill-scoped await: expected async type from current scope $Rec, found async type from other scope $__19
   scope $Rec is illegal-await.mo:33.44-40.2
-  scope $__15 is illegal-await.mo:33.1-40.2
+  scope $__19 is illegal-await.mo:33.1-40.2
 illegal-await.mo:33.44: info, start of scope $Rec mentioned in error at illegal-await.mo:35.5-35.12
 illegal-await.mo:40.1: info, end of scope $Rec mentioned in error at illegal-await.mo:35.5-35.12
-illegal-await.mo:33.1: info, start of scope $__15 mentioned in error at illegal-await.mo:35.5-35.12
-illegal-await.mo:40.1: info, end of scope $__15 mentioned in error at illegal-await.mo:35.5-35.12
+illegal-await.mo:33.1: info, start of scope $__19 mentioned in error at illegal-await.mo:35.5-35.12
+illegal-await.mo:40.1: info, end of scope $__19 mentioned in error at illegal-await.mo:35.5-35.12
 illegal-await.mo:38.20-38.21: type error [M0096], expression of type
-  async<$__15> ()
+  async<$__19> ()
 cannot produce expected type
   async<$Rec> ()


### PR DESCRIPTION
This fixes a disappearing timer situation described by Timo in https://dfinity.slack.com/archives/CPL67E7MX/p1736347600078339.

It turns out that under high message load the `async` timer servicing routine cannot be run. The fix is simple, check if the self-call succeeded (causes a `throw` already), and if not, set a very near global timer to retry ASAP (in the top-level `catch`).

TODO:
- [x] `catch` send errors for user workers (and mitigate) — see #4852
- [ ] document that the user thunk may be called more than once, and thus should have no side effects other than submitting the self-call — see https://github.com/dfinity/motoko-base/pull/682