### PR TITLE
feat: passing cycles to `call_raw`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Motoko compiler changelog
 
+## 0.13.7 (FUTURE)
+
+* motoko (`moc`)
+
+  * Support passing cycles in primitive `call_raw` (resp. `ExperimentalInternetComputer.call`) (#4868).
+
 ## 0.13.6 (2025-01-21)
 
 * motoko (`moc`)

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -445,7 +445,7 @@ func @install_actor_helper(
     switch install_arg {
       case (#new settings) {
         let available = (prim "cyclesAvailable" : () -> Nat) ();
-        let accepted = (prim "cyclesAccept" : Nat -> Nat) (available);
+        let accepted = (prim "cyclesAccept" : Nat -> Nat) available;
         let sender_canister_version = ?(prim "canister_version" : () -> Nat64)();
         @cycles += accepted;
         let { canister_id } =
@@ -509,7 +509,7 @@ func @create_actor_helper(wasm_module : Blob, arg : Blob) : async Principal = as
 func @call_raw(p : Principal, m : Text, a : Blob) : async Blob {
   let available = (prim "cyclesAvailable" : () -> Nat) ();
   if (available != 0) {
-    @cycles := (prim "cyclesAccept" : Nat -> Nat) (available);
+    @cycles := (prim "cyclesAccept" : Nat -> Nat) available;
   };
   await (prim "call_raw" : (Principal, Text, Blob) -> async Blob) (p, m, a);
 };

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -17,7 +17,7 @@ func @add_cycles<system>() {
   let cycles = @cycles;
   @reset_cycles();
   if (cycles != 0) {
-    (prim "cyclesAdd" : Nat -> ()) (cycles);
+    (prim "cyclesAdd" : Nat -> ()) cycles;
   }
 };
 
@@ -507,6 +507,10 @@ func @create_actor_helper(wasm_module : Blob, arg : Blob) : async Principal = as
 
 // raw calls
 func @call_raw(p : Principal, m : Text, a : Blob) : async Blob {
+  let available = (prim "cyclesAvailable" : () -> Nat) ();
+  if (available != 0) {
+    @cycles := (prim "cyclesAccept" : Nat -> Nat) (available);
+  };
   await (prim "call_raw" : (Principal, Text, Blob) -> async Blob) (p, m, a);
 };
 

--- a/test/run-drun/call-raw.mo
+++ b/test/run-drun/call-raw.mo
@@ -1,4 +1,5 @@
 import P "mo:⛔";
+import Cycles = "cycles/cycles";
 
 actor self {
 
@@ -41,6 +42,10 @@ actor self {
     P.trap("ohoh");
   };
 
+  public shared func cycles() : async () {
+    assert P.cyclesAvailable() == 424242
+  };
+
   public shared func supercalifragilisticexpialidocious() : async () {
     P.debugPrint("supercalifragilisticexpialidocious");
   };
@@ -50,38 +55,38 @@ actor self {
 
     do {
       let arg : Blob = "DIDL\00\00";
-      let res = await P.call_raw(p,"unit", arg);
-      assert (res == arg);
+      let res = await P.call_raw(p, "unit", arg);
+      assert res == arg;
     };
 
     do {
       let arg : Blob = "DIDL\00\01\7c\01";
-      let res = await P.call_raw(p,"int", arg);
-      assert (res == arg);
+      let res = await P.call_raw(p, "int", arg);
+      assert res == arg;
      };
 
     do {
       let arg : Blob = "DIDL\00\01\7c\02";
-      let res = await P.call_raw(p,"int", arg);
-      assert (res == arg);
+      let res = await P.call_raw(p, "int", arg);
+      assert res == arg;
     };
 
     do {
       let arg : Blob = "DIDL\00\01\71\05\68\65\6c\6c\6f";
-      let res = await P.call_raw(p,"text", arg);
-      assert (res == arg);
+      let res = await P.call_raw(p, "text", arg);
+      assert res == arg;
     };
 
     do {
       let arg : Blob = "DIDL\00\03\7d\7e\79\01\01\61\00\00\00";
-      let res = await P.call_raw(p,"tuple", arg);
-      assert (res == arg);
+      let res = await P.call_raw(p, "tuple", arg);
+      assert res == arg;
     };
 
     do {
       let arg : Blob = "DIDL\00\01\7c\01";
       try {
-        let res = await P.call_raw(p,"trapInt", arg);
+        let res = await P.call_raw(p, "trapInt", arg);
         assert false;
       }
       catch e {
@@ -93,9 +98,15 @@ actor self {
       let m = "super"#"cali"#"fragilisticexpialidocious";
       let arg : Blob = "DIDL\00\00";
       let res = await P.call_raw(p, m, arg);
-      assert (res == arg);
+      assert res == arg;
     };
 
+    do {
+      let arg : Blob = "DIDL\00\00";
+      Cycles.add<system> 424242;
+      let res = await P.call_raw(p, "cycles", arg);
+      assert res == arg;
+    }
   }
 };
 

--- a/test/run-drun/ok/call-raw.tc.ok
+++ b/test/run-drun/ok/call-raw.tc.ok
@@ -1,2 +1,2 @@
-call-raw.mo:40.30-40.31: warning [M0194], unused identifier n (delete or rename to wildcard `_` or `_n`)
-call-raw.mo:84.13-84.16: warning [M0194], unused identifier res (delete or rename to wildcard `_` or `_res`)
+call-raw.mo:41.30-41.31: warning [M0194], unused identifier n (delete or rename to wildcard `_` or `_n`)
+call-raw.mo:89.13-89.16: warning [M0194], unused identifier res (delete or rename to wildcard `_` or `_res`)


### PR DESCRIPTION
This was not possible before, as the attached cycles would go to the self-call, unutilised. Now we use the same logic as with actor class instantiation and delegate them in `@call_raw`.