### PR TITLE
doc: `make doc` without requiring nix magic

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -27,6 +27,7 @@ html:
 	for f in md/*/*.md; do pandoc -f gfm --toc -t html -s --metadata title="$$f" -o html/$$(basename $$f .md).html $$f; done
 
 
+# for building inside nix using a locally built interpreter
 preview:
 	make -C ../src moc_interpreter.js
 	cp -f ../src/moc_interpreter.js docusaurus/static
@@ -37,7 +38,6 @@ doc:
 
 	rm -f docusaurus/static/moc_interpreter.js
 	wget -O docusaurus/static/moc_interpreter.js https://github.com/dfinity/motoko/releases/download/$(RELEASE)/moc-interpreter-$(RELEASE).js
-	echo "ok"
 	cd docusaurus; npm install; npm run clear; npm start
 
 .PHONY: base

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,5 +1,6 @@
 all: overview-slides.html html
 
+RELEASE=0.14.0
 SHELL=bash
 OUT=md
 
@@ -31,9 +32,17 @@ preview:
 	cp -f ../src/moc_interpreter.js docusaurus/static
 	cd docusaurus; npm install; npm run clear; npm start
 
+# for building outside nix using a downloaded interpreter
+doc:
+
+	rm -f docusaurus/static/moc_interpreter.js
+	wget -O docusaurus/static/moc_interpreter.js https://github.com/dfinity/motoko/releases/download/$(RELEASE)/moc-interpreter-$(RELEASE).js
+	echo "ok"
+	cd docusaurus; npm install; npm run clear; npm start
 
 .PHONY: base
 .PHONY: md
 .PHONY: html
 .PHONY: preview
+.PHONY: doc
 

--- a/doc/docusaurus/src/pages/index.js
+++ b/doc/docusaurus/src/pages/index.js
@@ -17,7 +17,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/motoko">
+            to="/docs/writing-motoko/writing-intro">
             Docs
           </Link>
         </div>

--- a/doc/docusaurus/static/load_moc.ts
+++ b/doc/docusaurus/static/load_moc.ts
@@ -1,6 +1,6 @@
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 
-const MOC_VERSION = "0.7.2"; /* This may be slightly behind the base files we have locally in nix/sources.json */
+const MOC_VERSION = "0.14.0"; /* This may be slightly behind the base files we have locally in nix/sources.json */
 
 async function addPackage(name, repo, version, dir) {
   const meta_url = `https://data.jsdelivr.com/v1/package/gh/${repo}@${version}/flat`;


### PR DESCRIPTION
Add a new make target that builds a documentation preview outside of nix.

Might require installation of `make`, `node` and `npm` if not available.

```
cd doc
make doc
```
 
or
 

`make -C doc doc`
