### PR TITLE
fix: improve error highlighting range for `M0072`

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1477,7 +1477,7 @@ and infer_exp'' env exp : T.typ =
         check_deprecation env exp.at "field" id.it (T.lookup_val_deprecation id.it tfs);
       t
     | exception Invalid_argument _ ->
-      error env exp1.at "M0072"
+      error env id.at "M0072"
         "field %s does not exist in %a%s"
         id.it
         display_obj (s, tfs)

--- a/test/fail/ok/M0028.tc.ok
+++ b/test/fail/ok/M0028.tc.ok
@@ -1,2 +1,2 @@
-M0028.mo:2.13-2.14: type error [M0028], field Y does not exist in type:
+M0028.mo:2.11-2.12: type error [M0028], field Y does not exist in type:
   module {}

--- a/test/fail/ok/M0028.tc.ok
+++ b/test/fail/ok/M0028.tc.ok
@@ -1,2 +1,2 @@
-M0028.mo:2.11-2.12: type error [M0028], field Y does not exist in type:
+M0028.mo:2.13-2.14: type error [M0028], field Y does not exist in type:
   module {}

--- a/test/fail/ok/modexp1.tc.ok
+++ b/test/fail/ok/modexp1.tc.ok
@@ -1,2 +1,2 @@
-modexp1.mo:8.13-8.14: type error [M0072], field g does not exist in type:
+modexp1.mo:8.15-8.16: type error [M0072], field g does not exist in type:
   module {f : () -> ()}

--- a/test/fail/ok/pretty.tc.ok
+++ b/test/fail/ok/pretty.tc.ok
@@ -45,7 +45,7 @@ pretty.mo:28.23-28.24: type error [M0096], expression of type
   }
 cannot produce expected type
   Nat
-pretty.mo:40.1-40.12: type error [M0072], field foo does not exist in type:
+pretty.mo:40.13-40.16: type error [M0072], field foo does not exist in type:
   module {
     bar1 : Nat;
     bar2 : Nat;

--- a/test/fail/ok/suggest-long-ai.tc.ok
+++ b/test/fail/ok/suggest-long-ai.tc.ok
@@ -1,4 +1,4 @@
-suggest-long-ai.mo:4.1-4.5: type error [M0072], field stableM does not exist in type:
+suggest-long-ai.mo:4.6-4.13: type error [M0072], field stableM does not exist in type:
   module {
     type ErrorCode =
       {

--- a/test/fail/ok/suggest-long.tc.ok
+++ b/test/fail/ok/suggest-long.tc.ok
@@ -1,2 +1,2 @@
-suggest-long.mo:3.1-3.5: type error [M0072], field stableM does not exist in module.
+suggest-long.mo:3.6-3.13: type error [M0072], field stableM does not exist in module.
 Did you mean field stableMemoryGrow, stableMemorySize, stableMemoryLoadBlob, stableMemoryLoadInt8, stableMemoryLoadNat8, stableMemoryLoadFloat, stableMemoryLoadInt16, stableMemoryLoadInt32, stableMemoryLoadInt64, stableMemoryLoadNat16, stableMemoryLoadNat32, stableMemoryLoadNat64, stableMemoryStoreBlob, stableMemoryStoreInt8, stableMemoryStoreNat8, stableMemoryStoreFloat, stableMemoryStoreInt16, stableMemoryStoreInt32, stableMemoryStoreInt64, stableMemoryStoreNat16, stableMemoryStoreNat32 or stableMemoryStoreNat64?

--- a/test/fail/ok/suggest-short-ai.tc.ok
+++ b/test/fail/ok/suggest-short-ai.tc.ok
@@ -1,4 +1,4 @@
-suggest-short-ai.mo:4.1-4.5: type error [M0072], field s does not exist in type:
+suggest-short-ai.mo:4.6-4.7: type error [M0072], field s does not exist in type:
   module {
     type ErrorCode =
       {

--- a/test/fail/ok/suggest-short.tc.ok
+++ b/test/fail/ok/suggest-short.tc.ok
@@ -1,2 +1,2 @@
-suggest-short.mo:3.1-3.5: type error [M0072], field s does not exist in module.
+suggest-short.mo:3.6-3.7: type error [M0072], field s does not exist in module.
 Did you mean field sin, setTimer, shiftLeft, shiftRight, stableVarQuery, setCandidLimits, setCertifiedData, stableMemoryGrow, stableMemorySize, stableMemoryLoadBlob, stableMemoryLoadInt8, stableMemoryLoadNat8, stableMemoryLoadFloat, stableMemoryLoadInt16, stableMemoryLoadInt32, stableMemoryLoadInt64, stableMemoryLoadNat16, stableMemoryLoadNat32, stableMemoryLoadNat64, stableMemoryStoreBlob, stableMemoryStoreInt8, stableMemoryStoreNat8, stableMemoryStoreFloat, stableMemoryStoreInt16, stableMemoryStoreInt32, stableMemoryStoreInt64, stableMemoryStoreNat16, stableMemoryStoreNat32 or stableMemoryStoreNat64?


### PR DESCRIPTION
Changes the `field * does not exist in type` error message to use the AST range of the field identifier rather than the parent expression. 

Mostly relevant for the Motoko VS Code extension, Motoko Playground, and ICP Ninja.