### PR TITLE
bugfix: extend `mo-doc` to produce documentation for `actor` and `actor class` compilation units

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 * motoko (`moc`)
 
-  * bugfix: `mo-doc` will now generate documentation for actors and actor classes (#TBC).
+  * bugfix: `mo-doc` will now generate documentation for `actor`s and `actor class`es (#4905).
 
 
 ## 0.14.1 (2025-02-13)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * bugfix: `mo-doc` will now generate documentation for actors and actor classes (#TBC).
+
+
 ## 0.14.1 (2025-02-13)
 
 * motoko (`moc`)

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -66,7 +66,7 @@ let un_prog prog =
       imports
   in
   match body.it with
-  | ProgU decs -> Ok ([], []) (* treat all fields as private*)
+  | ProgU decs -> Ok ([], []) (* treat all fields as private *)
   | ModuleU (_, decs) -> Ok (imports, decs)
   | ActorU (_, _, decs) -> Ok (imports, decs)
   | ActorClassU (_, _, _, _, _, _, _, decs) ->

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -66,8 +66,16 @@ let un_prog prog =
       imports
   in
   match body.it with
+  | ProgU decs -> Ok ([], []) (* treat all fields as private*)
   | ModuleU (_, decs) -> Ok (imports, decs)
-  | _ -> Error "Couldn't find a module expression"
+  | ActorU (_, _, decs) -> Ok (imports, decs)
+  | ActorClassU (_, _, _, _, _, _, _, decs) ->
+     let _, decs = CompUnit.decs_of_lib comp_unit in
+     let decs = List.map (fun d ->
+      {vis = Public None @@ no_region; dec = d; stab = None} @@ d.at) decs
+     in
+     Ok (imports, decs)
+(*  | _ -> Error "Couldn't find a module expression" *)
 
 module PosTable = Trivia.PosHashtbl
 

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -70,11 +70,14 @@ let un_prog prog =
   | ModuleU (_, decs) -> Ok (imports, decs)
   | ActorU (_, _, decs) -> Ok (imports, decs)
   | ActorClassU (_, _, _, _, _, _, _, decs) ->
-     let _, decs = CompUnit.decs_of_lib comp_unit in
-     let decs = List.map (fun d ->
-      {vis = Public None @@ no_region; dec = d; stab = None} @@ d.at) decs
-     in
-     Ok (imports, decs)
+      let _, decs = CompUnit.decs_of_lib comp_unit in
+      let decs =
+        List.map
+          (fun d ->
+            { vis = Public None @@ no_region; dec = d; stab = None } @@ d.at)
+          decs
+      in
+      Ok (imports, decs)
 
 module PosTable = Trivia.PosHashtbl
 

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -75,7 +75,6 @@ let un_prog prog =
       {vis = Public None @@ no_region; dec = d; stab = None} @@ d.at) decs
      in
      Ok (imports, decs)
-(*  | _ -> Error "Couldn't find a module expression" *)
 
 module PosTable = Trivia.PosHashtbl
 


### PR DESCRIPTION
Fixes #4901.


Unfortunately, we don't seem to have a test-suite for `mo-doc`, so hard to add tests at the moment.
 