### PR TITLE
fix: change `M0061` and `M0062` from warnings to errors

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1279,12 +1279,12 @@ and infer_exp'' env exp : T.typ =
         error_bin_op env exp.at t1 t2;
       if not (eq env exp1.at t t1 || eq env exp2.at t t2) && not (sub env exp1.at T.nat t1 && sub env exp2.at T.nat t2) then
         if eq env exp.at t1 t2 then
-          warn env exp.at "M0061"
+          error env exp.at "M0061"
             "comparing abstract type%a\nto itself at supertype%a"
             display_typ_expand t1
             display_typ_expand t
         else
-          warn env exp.at "M0062"
+          error env exp.at "M0062"
             "comparing incompatible types%a\nand%a\nat common supertype%a"
             display_typ_expand t1
             display_typ_expand t2

--- a/test/fail/ok/structural_equality.tc.ok
+++ b/test/fail/ok/structural_equality.tc.ok
@@ -10,23 +10,23 @@ structural_equality.mo:6.1-6.11: type error [M0060], operator is not defined for
   {inner : () -> Nat}
 and
   {inner : () -> Nat}
-structural_equality.mo:8.9-8.37: warning [M0062], comparing incompatible types
+structural_equality.mo:8.9-8.37: type error [M0062], comparing incompatible types
   {x : Nat}
 and
   {var x : Nat}
 at common supertype
   {}
-structural_equality.mo:10.8-10.18: warning [M0062], comparing incompatible types
+structural_equality.mo:10.8-10.18: type error [M0062], comparing incompatible types
   Nat
 and
   Text
 at common supertype
   Any
-structural_equality.mo:12.37-12.43: warning [M0061], comparing abstract type
+structural_equality.mo:12.37-12.43: type error [M0061], comparing abstract type
   A__10
 to itself at supertype
   Any
-structural_equality.mo:13.41-13.47: warning [M0062], comparing incompatible types
+structural_equality.mo:13.41-13.47: type error [M0062], comparing incompatible types
   A__11
 and
   B


### PR DESCRIPTION
This PR promotes `M0061` ("comparing abstract type to itself at supertype") and `M0062` ("comparing incompatible types at common supertype") from warnings to errors. 

This is motivated by the unintuitive behavior of comparing at supertype `Any`, which always returns `true`. For instance, comparing `5` and `?4` returns `true` and therefore can result in buggy behavior or false positive test cases. 