### PR TITLE
LSP:  Implement a cache for typechecking (Serokell, Milestone-1)

### DIFF
--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -157,14 +157,14 @@ let js_parse_motoko s =
     end)
     in Js.some (js_of_sexpr (Arrange.prog prog)))
 
-let js_parse_motoko_with_deps s =
-  let main_file = "" in
+let js_parse_motoko_with_deps main_file s =
+  let main_file = Js.to_string main_file in
   let s = Js.to_string s in
   let prog_and_deps_result =
     let open Diag.Syntax in
     let* prog, _ = Pipeline.parse_string main_file s in
     let* deps =
-      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ()) prog s
+      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ()) prog main_file
     in
     Diag.return (prog, deps)
   in

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -157,8 +157,8 @@ let js_parse_motoko s =
     end)
     in Js.some (js_of_sexpr (Arrange.prog prog)))
 
-let js_parse_motoko_with_deps main_file s =
-  let main_file = Js.to_string main_file in
+let js_parse_motoko_with_deps path s =
+  let main_file = Js.to_string path in
   let s = Js.to_string s in
   let prog_and_deps_result =
     let open Diag.Syntax in

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -194,17 +194,17 @@ module Map_conversion (Map : Map.S) = struct
     (from_key : 'k Js.t -> Map.key)
     (from_data : 'd Js.t -> data)
     : data Map.t
-  =
-  let result = ref Map.empty in
-  let callback =
-    (* [forEach] in JS gives value, key, and map, in this order. *)
-    Js.wrap_callback (fun v k _m ->
-      let k = from_key k in
-      let v = from_data v in
-      result := Map.add k v !result)
-  in
-  ignore (Js.Unsafe.meth_call map "forEach" [|Js.Unsafe.inject callback|]);
-  !result
+    =
+    let result = ref Map.empty in
+    let callback =
+      (* [forEach] in JS gives value, key, and map, in this order. *)
+      Js.wrap_callback (fun v k _m ->
+          let k = from_key k in
+          let v = from_data v in
+          result := Map.add k v !result)
+    in
+    ignore (Js.Unsafe.meth_call map "forEach" [|Js.Unsafe.inject callback|]);
+    !result
 
   let to_js
     (type data)
@@ -212,13 +212,13 @@ module Map_conversion (Map : Map.S) = struct
     (from_key : Map.key -> Js.Unsafe.top Js.t)
     (from_data : data -> Js.Unsafe.top Js.t)
     : _ Js.t
-  =
-  let js_map = Js.Unsafe.new_obj (Js.Unsafe.pure_js_expr "Map") [||] in
-  Map.iter
-    (fun k v ->
-      ignore (Js.Unsafe.meth_call js_map "set" [| from_key k; from_data v |]))
-    map;
-  js_map
+    =
+    let js_map = Js.Unsafe.new_obj (Js.Unsafe.pure_js_expr "Map") [||] in
+    Map.iter
+      (fun k v ->
+         ignore (Js.Unsafe.meth_call js_map "set" [| from_key k; from_data v |]))
+      map;
+    js_map
 
   let from_ocaml = to_js
   let to_ocaml = from_js

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -228,11 +228,15 @@ let js_parse_motoko_typed paths scope_cache =
   let paths = paths |> Js.to_array |> Array.to_list |> List.map Js.to_string in
   let module String_map_conversion = Map_conversion (Mo_types.Type.Env) in
   let scope_cache =
-    (* The data of the map has TypeScript [type Scope = unknown], and such
-       scopes are always produced by the compiler. The language server takes
-       scopes as outputs and gives them as inputs without touching them at all.
-       Hence, the use of [Obj.magic] is legitimate here. *)
-    String_map_conversion.from_js scope_cache Js.to_string Obj.magic
+    Js.Opt.case
+      scope_cache
+      (fun () -> Mo_types.Type.Env.empty)
+      (fun scope_cache ->
+        (* The data of the map has TypeScript [type Scope = unknown], and such
+           scopes are always produced by the compiler. The language server takes
+           scopes as outputs and gives them as inputs without touching them at
+           all. Hence, the use of [Obj.magic] is legitimate here. *)
+        String_map_conversion.from_js scope_cache Js.to_string Obj.magic)
   in
   let load_result =
     Mo_types.Cons.session (fun () ->

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -34,6 +34,7 @@ let () =
       method compileWasm mode s = Flags.compiled := true; js_compile_wasm mode s
       method parseCandid s = js_parse_candid s
       method parseMotoko s = js_parse_motoko s
-      method parseMotokoTyped paths = js_parse_motoko_typed paths
+      method parseMotokoWithDeps s = js_parse_motoko_with_deps s
+      method parseMotokoTyped paths scopeCache = js_parse_motoko_typed paths scopeCache
       method printDeps file = print_deps file
      end);

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -34,7 +34,7 @@ let () =
       method compileWasm mode s = Flags.compiled := true; js_compile_wasm mode s
       method parseCandid s = js_parse_candid s
       method parseMotoko s = js_parse_motoko s
-      method parseMotokoWithDeps s = js_parse_motoko_with_deps s
+      method parseMotokoWithDeps path s = js_parse_motoko_with_deps path s
       method parseMotokoTyped paths scopeCache = js_parse_motoko_typed paths scopeCache
       method printDeps file = print_deps file
      end);

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -33,6 +33,8 @@ let () =
       method stableCompatible pre post = js_stable_compatible pre post
       method compileWasm mode s = Flags.compiled := true; js_compile_wasm mode s
       method parseCandid s = js_parse_candid s
+      (* The methods [parseMotoko{,WithDeps,Typed,TypedWithScopeCache}] exist
+         for backwards compability. They're mostly used by the language server. *)
       method parseMotoko s = js_parse_motoko s
       method parseMotokoWithDeps path s = js_parse_motoko_with_deps path s
       method parseMotokoTyped paths = js_parse_motoko_typed paths

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -35,6 +35,7 @@ let () =
       method parseCandid s = js_parse_candid s
       method parseMotoko s = js_parse_motoko s
       method parseMotokoWithDeps path s = js_parse_motoko_with_deps path s
-      method parseMotokoTyped paths scopeCache = js_parse_motoko_typed paths scopeCache
+      method parseMotokoTyped paths = js_parse_motoko_typed paths
+      method parseMotokoTypedWithScopeCache paths scopeCache = js_parse_motoko_typed_with_scope_cache paths scopeCache
       method printDeps file = print_deps file
      end);

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -345,8 +345,7 @@ type load_result_cached =
     ( Syntax.lib list
     * (Syntax.prog * string list) list
     * Scope.t
-    * scope_cache )
-  Diag.result
+    * scope_cache ) Diag.result
 
 type load_result =
   (Syntax.lib list * Syntax.prog list * Scope.scope) Diag.result

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -328,7 +328,6 @@ let check_prim () : Syntax.lib * stat_env =
       let senv1 = Scope.adjoin senv0 sscope in
       lib, senv1
 
-
 (* Imported file loading *)
 
 (*
@@ -340,6 +339,14 @@ When we load a declaration (i.e from the REPL), we also care about the type
 and the newly added scopes, so these are returned separately.
 *)
 
+type scope_cache = Scope.t Type.Env.t
+
+type load_result_cached =
+    ( Syntax.lib list
+    * (Syntax.prog * string list) list
+    * Scope.t
+    * scope_cache )
+  Diag.result
 
 type load_result =
   (Syntax.lib list * Syntax.prog list * Scope.scope) Diag.result
@@ -347,7 +354,16 @@ type load_result =
 type load_decl_result =
   (Syntax.lib list * Syntax.prog * Scope.scope * Type.typ * Scope.scope) Diag.result
 
-let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.result =
+let resolved_import_name ri =
+  match ri.Source.it with
+  | Syntax.Unresolved -> "/* unresolved */"
+  | Syntax.LibPath { Syntax.package = _; path }
+  | Syntax.IDLPath (path, _) -> path
+  | Syntax.PrimPath -> "@prim"
+
+let chase_imports_cached parsefn senv0 imports scopes_map
+    : (Syntax.lib list * Scope.scope * scope_cache) Diag.result
+  =
   (*
   This function loads and type-checkes the files given in `imports`,
   including any further dependencies.
@@ -359,14 +375,27 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
   * To avoid duplicates, i.e. load each file at most once, we check the
     senv.
   * We accumulate the resulting libraries in reverse order, for O(1) appending.
+  * There is a cache that can be queried to avoid recomputing unchanged dependencies.
   *)
+
+  let open Diag.Syntax in
 
   let open ResolveImport.S in
   let pending = ref empty in
   let senv = ref senv0 in
   let libs = ref [] in
+  let cache = ref scopes_map in
 
-  let rec go pkg_opt ri = match ri.Source.it with
+  let rec go_cached pkg_opt ri =
+    match Type.Env.find_opt (resolved_import_name ri) !cache with
+    | None -> go pkg_opt ri
+    | Some sscope ->
+      senv := Scope.adjoin !senv sscope;
+      Diag.return ()
+  and go pkg_opt ri =
+    let it = ri.Source.it in
+    let ri_name = resolved_import_name ri in
+    match it with
     | Syntax.PrimPath ->
       (* a bit of a hack, lib_env should key on resolved_import *)
       if Type.Env.mem "@prim" !senv.Scope.lib_env then
@@ -375,20 +404,20 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
         let lib, sscope = check_prim () in
         libs := lib :: !libs; (* NB: Conceptually an append *)
         senv := Scope.adjoin !senv sscope;
+        cache := Type.Env.add ri_name sscope !cache;
         Diag.return ()
     | Syntax.Unresolved -> assert false
     | Syntax.(LibPath {path = f; package = lib_pkg_opt}) ->
       if Type.Env.mem f !senv.Scope.lib_env then
         Diag.return ()
-      else if mem ri.Source.it !pending then
+      else if mem it !pending then
         Diag.error
           ri.Source.at
           "M0003"
           "import"
           (Printf.sprintf "file %s must not depend on itself" f)
       else begin
-        pending := add ri.Source.it !pending;
-        let open Diag.Syntax in
+        pending := add it !pending;
         let* prog, base = parsefn ri.Source.at f in
         let* () = Static.prog prog in
         let* more_imports = ResolveImport.resolve (resolve_flags ()) prog base in
@@ -398,11 +427,14 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
         let* sscope = check_lib !senv cur_pkg_opt lib in
         libs := lib :: !libs; (* NB: Conceptually an append *)
         senv := Scope.adjoin !senv sscope;
-        pending := remove ri.Source.it !pending;
+        cache := Type.Env.add ri_name sscope !cache;
+        pending := remove it !pending;
         Diag.return ()
       end
     | Syntax.IDLPath (f, _) ->
-      let open Diag.Syntax in
+      (* TODO: [Idllib.Pipeline.check_file] will perform a similar pipeline,
+         going recursively through imports of the IDL path to parse and
+         typecheck them. We should extend the cache system to it as well. *)
       let* prog, idl_scope, actor_opt = Idllib.Pipeline.check_file f in
       if actor_opt = None then
         Diag.error
@@ -423,21 +455,45 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
         | actor ->
           let sscope = Scope.lib f actor in
           senv := Scope.adjoin !senv sscope;
+          cache := Type.Env.add ri_name sscope !cache;
           Diag.return ()
-  and go_set pkg_opt todo = Diag.traverse_ (go pkg_opt) todo
+  and go_set pkg_opt todo = Diag.traverse_ (go_cached pkg_opt) todo
   in
-  Diag.map (fun () -> (List.rev !libs, !senv)) (go_set None imports)
+  Diag.map (fun () -> List.rev !libs, !senv, !cache) (go_set None imports)
 
-let load_progs ?(viper_mode=false) ?(check_actors=false) parsefn files senv : load_result =
+let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.result =
+  let open Diag.Syntax in
+  let cache = Type.Env.empty in
+  let* libs, senv, _cache = chase_imports_cached parsefn senv0 imports cache in
+  Diag.return (libs, senv)
+
+let load_progs_cached ?viper_mode ?check_actors parsefn files senv scope_cache : load_result_cached =
   let open Diag.Syntax in
   let* parsed = Diag.traverse (parsefn Source.no_region) files in
   let* rs = resolve_progs parsed in
-  let progs' = List.map fst rs in
+  let progs = List.map fst rs in
   let libs = List.concat_map snd rs in
-  let* libs, senv' = chase_imports parsefn senv libs in
-  let* () = Typing.check_actors ~viper_mode ~check_actors senv' progs' in
-  let* senv'' = check_progs ~viper_mode senv' progs' in
-  Diag.return (libs, progs', senv'')
+  let* libs, senv, scope_cache =
+    chase_imports_cached parsefn senv libs scope_cache
+  in
+  let* () = Typing.check_actors ?viper_mode ?check_actors senv progs in
+  (* [infer_prog] seems to annotate the AST with types by mutating some of its
+     nodes, therefore, we always run the type checker for programs. *)
+  let* senv = check_progs ?viper_mode senv progs in
+  Diag.return
+    ( libs
+    , List.map (fun (prog, rims) -> prog, List.map resolved_import_name rims) rs
+    , senv
+    , scope_cache )
+
+let load_progs ?viper_mode ?check_actors parsefn files senv : load_result =
+  let open Diag.Syntax in
+  let scope_cache = Type.Env.empty in
+  let* libs, rs, senv, _scope_cache =
+    load_progs_cached ?viper_mode ?check_actors parsefn files senv scope_cache
+  in
+  let progs = List.map fst rs in
+  Diag.return (libs, progs, senv)
 
 let load_decl parse_one senv : load_decl_result =
   let open Diag.Syntax in
@@ -688,7 +744,7 @@ let load_as_rts () =
   let rts = match (!Flags.enhanced_orthogonal_persistence, !Flags.sanity, !Flags.gc_strategy) with
     | (true, false, Flags.Incremental) -> Rts.wasm_eop_release
     | (true, true, Flags.Incremental) -> Rts.wasm_eop_debug
-    | (false, false, Flags.Copying) 
+    | (false, false, Flags.Copying)
     | (false, false, Flags.MarkCompact)
     | (false, false, Flags.Generational) -> Rts.wasm_non_incremental_release
     | (false, true, Flags.Copying)

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -35,7 +35,30 @@ type compile_result =
 
 val compile_files : Flags.compile_mode -> bool -> string list -> compile_result
 
-(* For use in the IDE server *)
+val resolve_flags : unit -> ResolveImport.flags
+val resolved_import_name : Syntax.resolved_import Source.phrase -> string
+
+(* For use in the language server *)
+
+type scope_cache = Scope.t Type.Env.t
+
+type load_result_cached =
+    ( Syntax.lib list
+    * (Syntax.prog * string list) list
+    * Scope.t
+    * scope_cache )
+  Diag.result
+
+val load_progs_cached
+  :  ?viper_mode:bool
+  -> ?check_actors:bool
+  -> parse_fn
+  -> string list
+  -> Scope.t
+  -> scope_cache
+  -> load_result_cached
+
 type load_result =
   (Syntax.lib list * Syntax.prog list * Scope.scope) Diag.result
+
 val load_progs : ?viper_mode:bool -> ?check_actors:bool -> parse_fn -> string list -> Scope.scope -> load_result

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -159,6 +159,7 @@ assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
 const astFile = Motoko.readFile("ast.mo");
 for (const ast of [
   Motoko.parseMotoko(astFile),
+  Motoko.parseMotokoTyped(["ast.mo"]).code[0].ast,
   Motoko.parseMotokoTypedWithScopeCache(["ast.mo"], new Map()).code[0][0].ast, // { diagnostics; code: [[{ ast; immediateImports }], cache] }
 ]) {
   const astString = JSON.stringify(ast);

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -159,7 +159,7 @@ assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
 const astFile = Motoko.readFile("ast.mo");
 for (const ast of [
   Motoko.parseMotoko(astFile),
-  Motoko.parseMotokoTyped(["ast.mo"], new Map()).code[0][0].ast, // { diagnostics; code: [[{ ast; immediateImports }], cache] }
+  Motoko.parseMotokoTypedWithScopeCache(["ast.mo"], new Map()).code[0][0].ast, // { diagnostics; code: [[{ ast; immediateImports }], cache] }
 ]) {
   const astString = JSON.stringify(ast);
 

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -1,6 +1,10 @@
 process.on("unhandledRejection", (error) => {
-  assert.fail(error);
+  console.log(`Unhandled promise rejection:\n${error}`)
 });
+
+process.on("uncaughtException", (error) => {
+  console.log(`Uncaught exception:\n${error}`);
+})
 
 const assert = require("assert").strict;
 

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -159,7 +159,7 @@ assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
 const astFile = Motoko.readFile("ast.mo");
 for (const ast of [
   Motoko.parseMotoko(astFile),
-  Motoko.parseMotokoTyped(astFile, new Map())[0].ast,
+  Motoko.parseMotokoTyped(["ast.mo"], new Map()).code[0][0].ast, // { diagnostics; code: [[{ ast; immediateImports }], cache] }
 ]) {
   const astString = JSON.stringify(ast);
 

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -143,24 +143,33 @@ assert.deepStrictEqual(Motoko.check("bad.mo"), {
   code: null,
 });
 
-const astString = JSON.stringify(
-  Motoko.parseMotoko(Motoko.readFile("ast.mo"))
-);
-
 // Run interpreter
 assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
-  stdout: "`ys6dh-5cjiq-5dc` : actor {main : shared query () -> async A__9<Text>}\n",
+  stdout:
+    "`ys6dh-5cjiq-5dc` : actor {main : shared query () -> async A__9<Text>}\n",
   stderr: "",
   result: { error: null },
 });
 
-// Check doc comments
-assert.match(astString, /"name":"\*","args":\["Program comment\\n      multi-line"/);
-assert.match(astString, /"name":"\*","args":\["Type comment"/);
-assert.match(astString, /"name":"\*","args":\["Variable comment"/);
-assert.match(astString, /"name":"\*","args":\["Function comment"/);
-assert.match(astString, /"name":"\*","args":\["Sub-module comment"/);
-assert.match(astString, /"name":"\*","args":\["Class comment"/);
+// Check AST format
+const astFile = Motoko.readFile("ast.mo");
+for (const ast of [
+  Motoko.parseMotoko(astFile),
+  Motoko.parseMotokoTyped(astFile, new Map())[0].ast,
+]) {
+  const astString = JSON.stringify(ast);
+
+  // Check doc comments
+  assert.match(
+    astString,
+    /"name":"\*","args":\["Program comment\\n      multi-line"/
+  );
+  assert.match(astString, /"name":"\*","args":\["Type comment"/);
+  assert.match(astString, /"name":"\*","args":\["Variable comment"/);
+  assert.match(astString, /"name":"\*","args":\["Function comment"/);
+  assert.match(astString, /"name":"\*","args":\["Sub-module comment"/);
+  assert.match(astString, /"name":"\*","args":\["Class comment"/);
+}
 
 // Check that long text literals type-check without error
 assert.deepStrictEqual(Motoko.check("text.mo"), {
@@ -168,7 +177,9 @@ assert.deepStrictEqual(Motoko.check("text.mo"), {
   diagnostics: [],
 });
 
-const candid = `
+// Check Candid format
+const candid =
+  `
 type T = nat;
 /// Program comment
 ///       multi-line
@@ -176,42 +187,44 @@ service : {
   /// Function comment
   main: () -> (T) query;
 }
-`.trim() + '\n';
-assert.deepStrictEqual(Motoko.candid('ast.mo'), {
+`.trim() + "\n";
+assert.deepStrictEqual(Motoko.candid("ast.mo"), {
   diagnostics: [
     {
-      category: 'type',
-      code: 'M0194',
-      message: 'unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)',
+      category: "type",
+      code: "M0194",
+      message:
+        "unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)",
       range: {
         end: {
           character: 13,
-          line: 3
+          line: 3,
         },
         start: {
           character: 9,
-          line: 3
-        }
+          line: 3,
+        },
       },
       severity: 2,
-      source: 'ast.mo'
+      source: "ast.mo",
     },
     {
-      category: 'type',
-      code: 'M0194',
-      message: 'unused identifier M (delete or rename to wildcard `_` or `_M`)',
+      category: "type",
+      code: "M0194",
+      message: "unused identifier M (delete or rename to wildcard `_` or `_M`)",
       range: {
         end: {
           character: 12,
-          line: 13
+          line: 13,
         },
         start: {
           character: 11,
-          line: 13
-        }
+          line: 13,
+        },
       },
       severity: 2,
-      source: 'ast.mo'
-    }
-  ], code: candid
+      source: "ast.mo",
+    },
+  ],
+  code: candid,
 });


### PR DESCRIPTION
In order to improve the performance of the LSP server we need to be able to cache and pass cached the type checking context (`Scope.t`). It's helpful in two situations: 
* When the server initializes, it scans all files in the vscode workspace, and a library code (e.g. `mo:base`) is parsed and type-checked as many times as it's imported (transitively) in any other file. Caching fixes this by allowing dependency type information to be reused.
* Imagine that an IDE user is working on a file, so the content of the file is changed often while its dependencies are not. Scope caching then significantly reduces the compiler effort needed to get a new type information for the file.

**Changes:**
* `src/pipeline/`
  * Add `load_progs_cached`/`chase_imports_cached` that are like `load_progs`/`chase_imports` but also take the scope cache and populates it. Note, expiring logic is implemented in the TS part of the server, see adjoint MR: https://github.com/dfinity/vscode-motoko/pull/329). 
  * Expose these changes in parseMotokoTyped. Create parseMotokoWithDeps that is like parseMotoko but also returns immediate dependencies
* `src/js` (IDE API)
  * Replace `parseMotokoTyped paths` which returns typed AST with `parseMotokoTyped path scopeCache` which returns typed AST and updated `scopeCache`
  * Add new method `parseMotokoWithDeps` which is like `parseMotoko` but also returns a list of immediate imports 

See also interface changes in the `node-motoko`: https://github.com/dfinity/node-motoko/pull/113