### PR TITLE
Add `ocaml-lsp` dependency to `default.nix`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -832,6 +832,7 @@ EOF
           ocamlPackages.merlin
           ocamlPackages.utop
           ocamlformat
+          ocamlPackages.ocaml-lsp
           fswatch
           niv
           nix-update


### PR DESCRIPTION
Adds the `ocaml-lsp` dependency.