### PR TITLE
chore: add `memory_metrics` to `canister_status`

### DIFF
--- a/test/bench/candid-subtype-cost.mo
+++ b/test/bench/candid-subtype-cost.mo
@@ -79,6 +79,16 @@ actor {
     canister_status : shared { canister_id : canister_id } -> async {
         status : { #stopped; #stopping; #running };
         memory_size : Nat;
+        memory_metrics : {
+            wasm_memory_size : Nat;
+            stable_memory_size : Nat;
+            global_memory_size : Nat;
+            wasm_binary_size : Nat;
+            custom_sections_size : Nat;
+            canister_history_size : Nat;
+            wasm_chunk_store_size : Nat;
+            snapshots_size : Nat;
+        };
         cycles : Nat;
         settings : definite_canister_settings;
         idle_cycles_burned_per_day : Nat;

--- a/test/bench/ok/candid-subtype-cost.drun-run.ok
+++ b/test/bench/ok/candid-subtype-cost.drun-run.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 902_591; heap_bytes = +12_564}
+debug.print: {cycles = 911_177; heap_bytes = +12_568}
 ingress Completed: Reply: 0x4449444c0000


### PR DESCRIPTION
See: dfinity/portal#5240.

I have also filed krpeacock/ic-management-canister#1.