### PR TITLE
LSP: Add parser error recovery (Serokell, Milestone-2)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -92,6 +92,7 @@ let commonBuildInputs = pkgs:
     pkgs.ocamlPackages.ppxlib
     pkgs.ocamlPackages.ppx_blob
     pkgs.ocamlPackages.ppx_inline_test
+    pkgs.ocamlPackages.ppx_expect
     pkgs.ocamlPackages.bisect_ppx
     pkgs.ocamlPackages.uucp
     pkgs.obelisk

--- a/default.nix
+++ b/default.nix
@@ -80,6 +80,8 @@ let commonBuildInputs = pkgs:
     pkgs.ocamlPackages.findlib
     pkgs.ocamlPackages.menhir
     pkgs.ocamlPackages.menhirLib
+    pkgs.ocamlPackages.menhirSdk
+    pkgs.ocamlPackages.ocaml-recovery-parser
     pkgs.ocamlPackages.cow
     pkgs.ocamlPackages.num
     pkgs.ocamlPackages.stdint

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -78,6 +78,23 @@ let
                 };
               };
 
+              ocaml-recovery-parser = super.ocamlPackages.buildDunePackage {
+                pname = "ocaml-recovery-parser";
+                version = "0.3.0";
+                src = self.fetchFromGitHub {
+                  owner = "serokell";
+                  repo = "ocaml-recovery-parser";
+                  rev = "b8207b0c919b84d5096486e59985d0137c0c4d82";
+                  sha256 = "1xp88i26vlwjsvnlzbfvk7zx31s18pfwq9w4g2fb2xq7bbnlhm24";
+                };
+                buildInputs = with super.ocamlPackages; [
+                  menhirSdk
+                  menhirLib
+                  fix
+                  base
+                ];
+              };
+
               # No testing of atdgen, as it pulls in python stuff, tricky on musl
               atdgen = super.ocamlPackages.atdgen.overrideAttrs { doCheck = false; };
             };

--- a/src/gen-grammar/gen-grammar.sh
+++ b/src/gen-grammar/gen-grammar.sh
@@ -3,7 +3,12 @@
 set -e
 set -o pipefail
 
-obelisk -i $1 |
+# workaround until https://github.com/Lelio-Brun/Obelisk/issues/15
+TEMP_FILE="/tmp/$(basename $1)"
+cp $1 ${TEMP_FILE}
+sed -i 's/\[@recover\..*\]//' ${TEMP_FILE}
+
+obelisk -i ${TEMP_FILE} |
 # Insert new line after def
 sed -e 's/::= /&\n    /' |
 # Transform

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -157,14 +157,14 @@ let js_parse_motoko s =
     end)
     in Js.some (js_of_sexpr (Arrange.prog prog)))
 
-let js_parse_motoko_with_deps s =
-  let main_file = "" in
+let js_parse_motoko_with_deps main_file s =
+  let main_file = Js.to_string main_file in
   let s = Js.to_string s in
   let prog_and_deps_result =
     let open Diag.Syntax in
     let* prog, _ = Pipeline.parse_string main_file s in
     let* deps =
-      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ()) prog s
+      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ()) prog main_file
     in
     Diag.return (prog, deps)
   in

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -59,7 +59,9 @@ let js_version = Js.string Source_id.id
 
 let js_check source =
   Mo_types.Cons.session (fun _ -> 
-    js_result (Pipeline.check_files [Js.to_string source]) (fun _ -> Js.null))
+    js_result
+      (Pipeline.check_files ~recovery_enabled:true [Js.to_string source])
+      (fun _ -> Js.null))
 
 let js_set_run_step_limit limit =
   Mo_interpreter.Interpret.step_limit := limit

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -60,7 +60,7 @@ let js_version = Js.string Source_id.id
 let js_check source =
   Mo_types.Cons.session (fun _ -> 
     js_result
-      (Pipeline.check_files ~recovery_enabled:true [Js.to_string source])
+      (Pipeline.check_files ~enable_recovery:true [Js.to_string source])
       (fun _ -> Js.null))
 
 let js_set_run_step_limit limit =
@@ -145,9 +145,9 @@ let js_parse_candid s =
   js_result parse_result (fun (prog, _) ->
     Js.some (js_of_sexpr (Idllib.Arrange_idl.prog prog)))
 
-let js_parse_motoko recovery_enabled s =
+let js_parse_motoko enable_recovery s =
   let main_file = "" in
-  let parse_fn = if Js.Opt.get recovery_enabled (fun () -> false)
+  let parse_fn = if Js.Opt.get enable_recovery (fun () -> false)
     then Pipeline.parse_string_with_recovery
     else Pipeline.parse_string
   in
@@ -163,10 +163,10 @@ let js_parse_motoko recovery_enabled s =
     end)
     in Js.some (js_of_sexpr (Arrange.prog prog)))
 
-let js_parse_motoko_with_deps recovery_enabled path s =
+let js_parse_motoko_with_deps enable_recovery path s =
   let main_file = Js.to_string path in
   let s = Js.to_string s in
-  let parse_fn = if Js.Opt.get recovery_enabled (fun () -> false)
+  let parse_fn = if Js.Opt.get enable_recovery (fun () -> false)
     then Pipeline.parse_string_with_recovery
     else Pipeline.parse_string
   in
@@ -234,7 +234,7 @@ module Map_conversion (Map : Map.S) = struct
   let to_ocaml = from_js
 end
 
-let js_parse_motoko_typed recovery_enabled paths scope_cache =
+let js_parse_motoko_typed enable_recovery paths scope_cache =
   let paths = paths |> Js.to_array |> Array.to_list |> List.map Js.to_string in
   let module String_map_conversion = Map_conversion (Mo_types.Type.Env) in
   let scope_cache =
@@ -248,7 +248,7 @@ let js_parse_motoko_typed recovery_enabled paths scope_cache =
            all. Hence, the use of [Obj.magic] is legitimate here. *)
         String_map_conversion.from_js scope_cache Js.to_string Obj.magic)
   in
-  let parse_fn = if Js.Opt.get recovery_enabled (fun () -> false)
+  let parse_fn = if Js.Opt.get enable_recovery (fun () -> false)
     then Pipeline.parse_file_with_recovery
     else Pipeline.parse_file
   in

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -157,8 +157,8 @@ let js_parse_motoko s =
     end)
     in Js.some (js_of_sexpr (Arrange.prog prog)))
 
-let js_parse_motoko_with_deps main_file s =
-  let main_file = Js.to_string main_file in
+let js_parse_motoko_with_deps path s =
+  let main_file = Js.to_string path in
   let s = Js.to_string s in
   let prog_and_deps_result =
     let open Diag.Syntax in

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -194,17 +194,17 @@ module Map_conversion (Map : Map.S) = struct
     (from_key : 'k Js.t -> Map.key)
     (from_data : 'd Js.t -> data)
     : data Map.t
-  =
-  let result = ref Map.empty in
-  let callback =
-    (* [forEach] in JS gives value, key, and map, in this order. *)
-    Js.wrap_callback (fun v k _m ->
-      let k = from_key k in
-      let v = from_data v in
-      result := Map.add k v !result)
-  in
-  ignore (Js.Unsafe.meth_call map "forEach" [|Js.Unsafe.inject callback|]);
-  !result
+    =
+    let result = ref Map.empty in
+    let callback =
+      (* [forEach] in JS gives value, key, and map, in this order. *)
+      Js.wrap_callback (fun v k _m ->
+          let k = from_key k in
+          let v = from_data v in
+          result := Map.add k v !result)
+    in
+    ignore (Js.Unsafe.meth_call map "forEach" [|Js.Unsafe.inject callback|]);
+    !result
 
   let to_js
     (type data)
@@ -212,13 +212,13 @@ module Map_conversion (Map : Map.S) = struct
     (from_key : Map.key -> Js.Unsafe.top Js.t)
     (from_data : data -> Js.Unsafe.top Js.t)
     : _ Js.t
-  =
-  let js_map = Js.Unsafe.new_obj (Js.Unsafe.pure_js_expr "Map") [||] in
-  Map.iter
-    (fun k v ->
-      ignore (Js.Unsafe.meth_call js_map "set" [| from_key k; from_data v |]))
-    map;
-  js_map
+    =
+    let js_map = Js.Unsafe.new_obj (Js.Unsafe.pure_js_expr "Map") [||] in
+    Map.iter
+      (fun k v ->
+         ignore (Js.Unsafe.meth_call js_map "set" [| from_key k; from_data v |]))
+      map;
+    js_map
 
   let from_ocaml = to_js
   let to_ocaml = from_js

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -228,11 +228,15 @@ let js_parse_motoko_typed paths scope_cache =
   let paths = paths |> Js.to_array |> Array.to_list |> List.map Js.to_string in
   let module String_map_conversion = Map_conversion (Mo_types.Type.Env) in
   let scope_cache =
-    (* The data of the map has TypeScript [type Scope = unknown], and such
-       scopes are always produced by the compiler. The language server takes
-       scopes as outputs and gives them as inputs without touching them at all.
-       Hence, the use of [Obj.magic] is legitimate here. *)
-    String_map_conversion.from_js scope_cache Js.to_string Obj.magic
+    Js.Opt.case
+      scope_cache
+      (fun () -> Mo_types.Type.Env.empty)
+      (fun scope_cache ->
+        (* The data of the map has TypeScript [type Scope = unknown], and such
+           scopes are always produced by the compiler. The language server takes
+           scopes as outputs and gives them as inputs without touching them at
+           all. Hence, the use of [Obj.magic] is legitimate here. *)
+        String_map_conversion.from_js scope_cache Js.to_string Obj.magic)
   in
   let load_result =
     Mo_types.Cons.session (fun () ->

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -34,6 +34,7 @@ let () =
       method compileWasm mode s = Flags.compiled := true; js_compile_wasm mode s
       method parseCandid s = js_parse_candid s
       method parseMotoko s = js_parse_motoko s
-      method parseMotokoTyped paths = js_parse_motoko_typed paths
+      method parseMotokoWithDeps s = js_parse_motoko_with_deps s
+      method parseMotokoTyped paths scopeCache = js_parse_motoko_typed paths scopeCache
       method printDeps file = print_deps file
      end);

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -34,7 +34,7 @@ let () =
       method compileWasm mode s = Flags.compiled := true; js_compile_wasm mode s
       method parseCandid s = js_parse_candid s
       method parseMotoko s = js_parse_motoko s
-      method parseMotokoWithDeps s = js_parse_motoko_with_deps s
+      method parseMotokoWithDeps path s = js_parse_motoko_with_deps path s
       method parseMotokoTyped paths scopeCache = js_parse_motoko_typed paths scopeCache
       method printDeps file = print_deps file
      end);

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -33,8 +33,8 @@ let () =
       method stableCompatible pre post = js_stable_compatible pre post
       method compileWasm mode s = Flags.compiled := true; js_compile_wasm mode s
       method parseCandid s = js_parse_candid s
-      method parseMotoko s = js_parse_motoko s
-      method parseMotokoWithDeps path s = js_parse_motoko_with_deps path s
-      method parseMotokoTyped paths scopeCache = js_parse_motoko_typed paths scopeCache
+      method parseMotoko enableRecovery s = js_parse_motoko enableRecovery s
+      method parseMotokoWithDeps enableRecovery path s = js_parse_motoko_with_deps enableRecovery path s
+      method parseMotokoTyped enableRecovery paths scopeCache = js_parse_motoko_typed enableRecovery paths scopeCache
       method printDeps file = print_deps file
      end);

--- a/src/lang_utils/diag.ml
+++ b/src/lang_utils/diag.ml
@@ -84,12 +84,12 @@ let print_messages = List.iter print_message
 
 let is_error_free (ms: msg_store) = not (has_errors (get_msgs ms))
 
-let with_message_store f =
+let with_message_store ?(allow_errors = false) f =
   let s = ref [] in
   let r = f s in
   let msgs = get_msgs s in
   match r with
-  | Some x when not (has_errors msgs) -> Ok (x, msgs)
+  | Some x when not (has_errors msgs) || allow_errors -> Ok (x, msgs)
   | _ -> Error msgs
 
 let flush_messages : 'a result -> 'a option = function

--- a/src/lang_utils/diag.mli
+++ b/src/lang_utils/diag.mli
@@ -60,5 +60,4 @@ type msg_store
 val is_error_free : msg_store -> bool
 val add_msg : msg_store -> message -> unit
 val add_msgs : msg_store -> messages -> unit
-val with_message_store : (msg_store -> 'a option) -> 'a result
-
+val with_message_store : ?allow_errors:bool -> (msg_store -> 'a option) -> 'a result

--- a/src/mo_frontend/dune
+++ b/src/mo_frontend/dune
@@ -1,13 +1,33 @@
 (library
   (name mo_frontend)
-  (libraries menhirLib lib lang_utils mo_config mo_def mo_types mo_values wasm_exts)
+  (libraries menhirLib lib lang_utils mo_config mo_def mo_types mo_values wasm_exts ocaml-recovery-parser.menhirRecoveryLib)
+  (modules (:standard \ test_recovery))
   (instrumentation (backend bisect_ppx --bisect-silent yes))
 )
+
 (menhir
   (modules parser assertions)
   (merge_into parser)
-  (flags --table --inspection -v --strict)
+  (flags --table --inspection -v --strict --cmly)
   (infer true)
 )
 
+(rule
+  (targets recover_parser.ml)
+  (deps parser.cmly)
+  (action
+    (with-stdout-to recover_parser.ml
+      (run ocaml-recovery-parser.menhir-recovery-generator parser.cmly)
+    )
+  )
+)
+
 (ocamllex source_lexer)
+
+(library
+  (name test_recovery)
+  (inline_tests)
+  (modules test_recovery)
+  (libraries mo_frontend menhirLib lib lang_utils mo_config mo_def mo_types mo_values wasm_exts ocaml-recovery-parser.menhirRecoveryLib )
+  (flags (:standard -w -40))
+  (preprocess (pps ppx_inline_test ppx_expect)))

--- a/src/mo_frontend/menhir_error_reporting.ml
+++ b/src/mo_frontend/menhir_error_reporting.ml
@@ -150,27 +150,6 @@ module Make
       ) []
     )
 
-  (* We drive the parser in the usual way, but records the last [InputNeeded]
-     checkpoint. If a syntax error is detected, we go back to this checkpoint
-     and analyze it in order to produce a meaningful diagnostic. *)
-
-  (* exception Error of (Lexing.position * Lexing.position) * explanation list *)
-
-  (* TODO: remove to give control of parsing outside *)
-  (* let entry (start : 'a I.checkpoint) lexer = *)
-  (*   let fail (inputneeded : 'a I.checkpoint) (checkpoint : 'a I.checkpoint) = *)
-  (*     (\* The parser signals a syntax error. Note the position of the *)
-  (*        problematic token, which is useful. Then, go back to the *)
-  (*        last [InputNeeded] checkpoint and investigate. *\) *)
-  (*     match checkpoint with *)
-  (*     | HandlingError env -> *)
-  (*         let (startp, _) as positions = positions env in *)
-  (*         raise (Error (positions, investigate startp inputneeded)) *)
-  (*     | _ -> *)
-  (*         assert false *)
-  (*   in *)
-  (*   I.loop_handle_undo Fun.id fail lexer start *)
-
   (* TEMPORARY could also publish a list of the terminal symbols that
      do not cause an error *)
 

--- a/src/mo_frontend/menhir_error_reporting.ml
+++ b/src/mo_frontend/menhir_error_reporting.ml
@@ -154,21 +154,22 @@ module Make
      checkpoint. If a syntax error is detected, we go back to this checkpoint
      and analyze it in order to produce a meaningful diagnostic. *)
 
-  exception Error of (Lexing.position * Lexing.position) * explanation list
+  (* exception Error of (Lexing.position * Lexing.position) * explanation list *)
 
-  let entry (start : 'a I.checkpoint) lexer =
-    let fail (inputneeded : 'a I.checkpoint) (checkpoint : 'a I.checkpoint) =
-      (* The parser signals a syntax error. Note the position of the
-         problematic token, which is useful. Then, go back to the
-         last [InputNeeded] checkpoint and investigate. *)
-      match checkpoint with
-      | HandlingError env ->
-          let (startp, _) as positions = positions env in
-          raise (Error (positions, investigate startp inputneeded))
-      | _ ->
-          assert false
-    in
-    I.loop_handle_undo Fun.id fail lexer start
+  (* TODO: remove to give control of parsing outside *)
+  (* let entry (start : 'a I.checkpoint) lexer = *)
+  (*   let fail (inputneeded : 'a I.checkpoint) (checkpoint : 'a I.checkpoint) = *)
+  (*     (\* The parser signals a syntax error. Note the position of the *)
+  (*        problematic token, which is useful. Then, go back to the *)
+  (*        last [InputNeeded] checkpoint and investigate. *\) *)
+  (*     match checkpoint with *)
+  (*     | HandlingError env -> *)
+  (*         let (startp, _) as positions = positions env in *)
+  (*         raise (Error (positions, investigate startp inputneeded)) *)
+  (*     | _ -> *)
+  (*         assert false *)
+  (*   in *)
+  (*   I.loop_handle_undo Fun.id fail lexer start *)
 
   (* TEMPORARY could also publish a list of the terminal symbols that
      do not cause an error *)

--- a/src/mo_frontend/menhir_error_reporting.mli
+++ b/src/mo_frontend/menhir_error_reporting.mli
@@ -70,10 +70,14 @@ module Make
   (* We build lists of explanations. These explanations may originate in
      distinct LR(1) states. They may have different pasts, because  *)
 
-  exception Error of (Lexing.position * Lexing.position) * explanation list
+  (* TODO: remove me *)
+  (* exception Error of (Lexing.position * Lexing.position) * explanation list *)
 
   (* TEMPORARY *)
 
-  val entry: 'a I.checkpoint -> I.supplier -> 'a
+  (* TODO: remove me *)
+  (* val entry: 'a I.checkpoint -> I.supplier -> 'a *)
 
+  (* TODO: doc me  *)
+  val investigate: Lexing.position -> 'a checkpoint -> explanation list
 end

--- a/src/mo_frontend/menhir_error_reporting.mli
+++ b/src/mo_frontend/menhir_error_reporting.mli
@@ -70,14 +70,8 @@ module Make
   (* We build lists of explanations. These explanations may originate in
      distinct LR(1) states. They may have different pasts, because  *)
 
-  (* TODO: remove me *)
-  (* exception Error of (Lexing.position * Lexing.position) * explanation list *)
+  (* [investigate pos checkpoint] returns explanations of the error happened
+     on position [pos] and with last [checkpoint] of type InputNeeded *)
 
-  (* TEMPORARY *)
-
-  (* TODO: remove me *)
-  (* val entry: 'a I.checkpoint -> I.supplier -> 'a *)
-
-  (* TODO: doc me  *)
   val investigate: Lexing.position -> 'a checkpoint -> explanation list
 end

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -321,6 +321,9 @@ and objblock eo s id ty dec_fields =
 %type<Mo_def.Syntax.typ_field list> seplist(stab_field,semicolon)
 %type<Mo_def.Syntax.typ_field> stab_field
 
+%[@recover.default_cost_of_symbol     1000]
+%[@recover.default_cost_of_production 1]
+
 %type<unit> start
 %start<string -> Mo_def.Syntax.prog> parse_prog
 %start<string -> Mo_def.Syntax.prog> parse_prog_interactive
@@ -334,7 +337,7 @@ and objblock eo s id ty dec_fields =
 
 seplist(X, SEP) :
   | (* empty *) { [] }
-  | x=X { [x] }
+  | x=X { [x] } [@recover.cost inf]
   | x=X SEP xs=seplist(X, SEP) { x::xs }
 
 seplist1(X, SEP) :

--- a/src/mo_frontend/parsing.ml
+++ b/src/mo_frontend/parsing.ml
@@ -122,6 +122,9 @@ let handle_error lexbuf error_detail message_store (start, end_) explanations =
   in
   Diag.add_msg message_store (Diag.error_message at "M0001" "syntax" msg)
 
+(* We drive the parser in the usual way, but records the last [InputNeeded]
+   checkpoint. If a syntax error is detected, we go back to this checkpoint
+   and analyze it in order to produce a meaningful diagnostic. *)
 
 let parse ?(recovery = false) mode error_detail start lexer lexbuf =
   Diag.with_message_store ~allow_errors:recovery (fun m ->

--- a/src/mo_frontend/parsing.mli
+++ b/src/mo_frontend/parsing.mli
@@ -8,7 +8,8 @@ type error_detail = int  (* TODO: make this a datatype! *)
 
 exception Error of string * Lexing.position * Lexing.position
 
-val parse : Lexer_lib.mode ->
+val parse : ?recovery:bool ->
+            Lexer_lib.mode ->
             error_detail ->
             'a Parser.MenhirInterpreter.checkpoint ->
             Parser.MenhirInterpreter.supplier ->

--- a/src/mo_frontend/test_recovery.ml
+++ b/src/mo_frontend/test_recovery.ml
@@ -1,0 +1,248 @@
+
+let parse_from_lexbuf lexbuf : Mo_def.Syntax.prog Diag.result =
+  let open Mo_frontend in
+  let open Diag.Syntax in
+  let name = "test.mo" in
+  let lexer_mode = Lexer.mode in
+  let lexer, triv_table = Lexer.tokenizer lexer_mode lexbuf in
+  let start =  Parser.Incremental.parse_prog lexbuf.Lexing.lex_start_p in
+  let error_details = !Mo_config.Flags.error_detail in
+  let* mk_syntax = Mo_frontend.Parsing.parse ~recovery:true lexer_mode error_details start lexer lexbuf
+  in Diag.return @@ mk_syntax name
+
+let parse_from_string s : Mo_def.Syntax.prog Diag.result =
+  let lexbuf = Lexing.from_string s in
+  parse_from_lexbuf lexbuf
+
+let show  (r: Mo_def.Syntax.prog Diag.result) : String.t =
+  let show_msgs msgs =
+    String.concat "\n" (List.map Diag.string_of_message msgs) in
+  match r with
+  | Ok (prog, msgs) ->
+    "Ok: " ^ Wasm.Sexpr.to_string 80 (Mo_def.Arrange.prog prog)
+    ^ "\n with errors:\n" ^ show_msgs msgs
+  | Error msgs -> "Errors:\n" ^ show_msgs msgs
+
+
+let _parse_test input (expected : string) =
+  let actual = parse_from_string input in
+  if String.equal (show actual) expected then
+    true
+  else
+    (Printf.printf "\nExpected:\n  %s\nbut got:\n  %s\n" (expected) (show actual); false)
+
+let%expect_test "test1" =
+  let s = "actor {
+  let x : Int = 1
+
+  let y : Int = 2;
+
+  let z : Int = 3
+
+  let t : Int = 4
+}" in
+  Printf.printf "%s" @@ show (parse_from_string s);
+  [%expect {|
+    Ok: (Prog
+      (ExpD
+        (AwaitE
+          (AsyncE
+            _
+            ($@anon-async-1.1 (PrimT Any))
+            (ObjBlockE
+              _
+              Actor
+              _
+              (DecField
+                (LetD (VarP x) (AnnotE (LitE (PreLit 1 Nat)) (PathT (IdH Int))))
+                Private
+                Flexible
+              )
+              (DecField
+                (LetD (VarP y) (AnnotE (LitE (PreLit 2 Nat)) (PathT (IdH Int))))
+                Private
+                Flexible
+              )
+              (DecField
+                (LetD (VarP z) (AnnotE (LitE (PreLit 3 Nat)) (PathT (IdH Int))))
+                Private
+                Flexible
+              )
+              (DecField
+                (LetD (VarP t) (AnnotE (LitE (PreLit 4 Nat)) (PathT (IdH Int))))
+                Private
+                Flexible
+              )
+            )
+          )
+        )
+      )
+    )
+
+     with errors:
+    (unknown location): syntax error [M0001], unexpected token 'let', expected one of token or <phrase> sequence:
+      }
+      .<nat>
+      !
+      <exp_nullary(ob)>
+      <binop> <exp(ob)>
+      ; seplist(<dec_field>,<semicolon>)
+      |> <exp_bin(ob)>
+      or <exp_bin(ob)>
+      <unassign> <exp(ob)>
+      implies <exp_bin(ob)>
+      <relop> <exp_bin(ob)>
+      else <exp_nest>
+      . <id>
+      : <typ_nobin>
+      <binop> <exp_bin(ob)>
+      <binassign> <exp(ob)>
+      and <exp_bin(ob)>
+      <unop> <exp_bin(ob)>
+      <inst> <exp_nullary(ob)>
+      [ <exp(ob)> ]
+
+    (unknown location): syntax error [M0001], unexpected token 'let', expected one of token or <phrase> sequence:
+      }
+      .<nat>
+      !
+      <exp_nullary(ob)>
+      <binop> <exp(ob)>
+      ; seplist(<dec_field>,<semicolon>)
+      |> <exp_bin(ob)>
+      or <exp_bin(ob)>
+      <unassign> <exp(ob)>
+      implies <exp_bin(ob)>
+      <relop> <exp_bin(ob)>
+      else <exp_nest>
+      . <id>
+      : <typ_nobin>
+      <binop> <exp_bin(ob)>
+      <binassign> <exp(ob)>
+      and <exp_bin(ob)>
+      <unop> <exp_bin(ob)>
+      <inst> <exp_nullary(ob)>
+      [ <exp(ob)> ] |}]
+
+let%expect_test "test2" =
+  let s = "actor {
+  let x : Int = 1 +
+
+  let y : Int = 2;
+}" in
+  Printf.printf "%s" @@ show (parse_from_string s);
+  [%expect {|
+    Ok: (Prog
+      (ExpD
+        (AwaitE
+          (AsyncE
+            _
+            ($@anon-async-1.1 (PrimT Any))
+            (ObjBlockE
+              _
+              Actor
+              _
+              (DecField
+                (LetD
+                  (VarP x)
+                  (AnnotE
+                    (BinE ??? (LitE (PreLit 1 Nat)) AddOp (VarE _))
+                    (PathT (IdH Int))
+                  )
+                )
+                Private
+                Flexible
+              )
+              (DecField
+                (LetD (VarP y) (AnnotE (LitE (PreLit 2 Nat)) (PathT (IdH Int))))
+                Private
+                Flexible
+              )
+            )
+          )
+        )
+      )
+    )
+
+     with errors:
+    (unknown location): syntax error [M0001], unexpected token 'let', expected one of token or <phrase> sequence:
+      <exp_bin(ob)> |}]
+
+let%expect_test "test3" =
+  let s = "actor {
+  private func(a Int) {
+    return
+  }
+
+  private func bar(y: Int) : Int { return 2; }
+
+  let y : Int = 2;
+}" in
+  Printf.printf "%s" @@ show (parse_from_string s);
+  [%expect {|
+    Ok: (Prog
+      (ExpD
+        (AwaitE
+          (AsyncE
+            _
+            ($@anon-async-1.1 (PrimT Any))
+            (ObjBlockE
+              _
+              Actor
+              _
+              (DecField
+                (ExpD
+                  (FuncE
+                    ???
+                    Local
+                    @anon-func-2.11
+                    (TupP (VarP a) (VarP Int))
+                    _
+
+                    (BlockE (ExpD (RetE (TupE))))
+                  )
+                )
+                Private
+                (Flexible)
+              )
+              (DecField
+                (LetD
+                  (VarP bar)
+                  (FuncE
+                    ???
+                    Local
+                    bar
+                    (ParP (AnnotP (VarP y) (PathT (IdH Int))))
+                    (PathT (IdH Int))
+
+                    (BlockE (ExpD (RetE (LitE (PreLit 2 Nat)))))
+                  )
+                )
+                Private
+                Flexible
+              )
+              (DecField
+                (LetD (VarP y) (AnnotE (LitE (PreLit 2 Nat)) (PathT (IdH Int))))
+                Private
+                Flexible
+              )
+            )
+          )
+        )
+      )
+    )
+
+     with errors:
+    (unknown location): syntax error [M0001], unexpected token 'Int', expected one of token or <phrase> sequence:
+      )
+      or <pat_bin>
+      , seplist(<pat_bin>,,)
+      : <typ>
+
+    (unknown location): syntax error [M0001], unexpected token 'private', expected one of token or <phrase> sequence:
+      }
+      ; seplist(<dec_field>,<semicolon>)
+
+    (unknown location): syntax error [M0001], unexpected token 'let', expected one of token or <phrase> sequence:
+      }
+      ; seplist(<dec_field>,<semicolon>) |}] 

--- a/src/mo_frontend/test_recovery.ml
+++ b/src/mo_frontend/test_recovery.ml
@@ -5,6 +5,7 @@ let parse_from_lexbuf lexbuf : Mo_def.Syntax.prog Diag.result =
   let name = "test.mo" in
   let lexer_mode = Lexer.mode in
   let lexer, triv_table = Lexer.tokenizer lexer_mode lexbuf in
+  let () = Parser_lib.triv_table := triv_table in
   let start =  Parser.Incremental.parse_prog lexbuf.Lexing.lex_start_p in
   let error_details = !Mo_config.Flags.error_detail in
   let* mk_syntax = Mo_frontend.Parsing.parse ~recovery:true lexer_mode error_details start lexer lexbuf
@@ -246,3 +247,117 @@ let%expect_test "test3" =
     (unknown location): syntax error [M0001], unexpected token 'let', expected one of token or <phrase> sequence:
       }
       ; seplist(<dec_field>,<semicolon>) |}] 
+
+
+let%expect_test "test4" =
+  let s = "import { print } \"mo:base/Debug\";
+
+actor Main {
+
+    let x = 1
+
+    public query test() : async Nat {
+        123
+    }
+};" in
+  Printf.printf "%s" @@ show (parse_from_string s);
+  [%expect{|
+    Ok: (Prog
+      (LetD (ObjP (print (VarP print))) (ImportE mo:base/Debug))
+      (LetD
+        (VarP Main)
+        (AwaitE
+          (AsyncE
+            _
+            ($@anon-async-3.1 (PrimT Any))
+            (ObjBlockE
+              _
+              Actor
+              Main
+              (DecField (LetD (VarP x) (LitE (PreLit 1 Nat))) Private Flexible)
+              (DecField
+                (ExpD
+                  (FuncE
+                    ???
+                    (Query (VarP test))
+                    @anon-func-7.12
+                    ($ (PrimT Any))
+                    (TupP)
+                    (AsyncT (PathT (IdH $)) (PathT (IdH Nat)))
+
+                    (AsyncE
+                      _
+                      ($@anon-func-7.12 (PrimT Any))
+                      (BlockE (ExpD (LitE (PreLit 123 Nat))))
+                    )
+                  )
+                )
+                Public
+                (Flexible)
+              )
+            )
+          )
+        )
+      )
+    )
+
+     with errors:
+    (unknown location): syntax error [M0001], unexpected token 'public', expected one of token or <phrase> sequence:
+      }
+      .<nat>
+      !
+      <exp_nullary(ob)>
+      <binop> <exp(ob)>
+      ; seplist(<dec_field>,<semicolon>)
+      |> <exp_bin(ob)>
+      or <exp_bin(ob)>
+      <unassign> <exp(ob)>
+      implies <exp_bin(ob)>
+      <relop> <exp_bin(ob)>
+      else <exp_nest>
+      . <id>
+      : <typ_nobin>
+      <binop> <exp_bin(ob)>
+      <binassign> <exp(ob)>
+      and <exp_bin(ob)>
+      <unop> <exp_bin(ob)>
+      <inst> <exp_nullary(ob)>
+      [ <exp(ob)> ]
+
+    (unknown location): syntax error [M0001], unexpected token '(', expected one of token or <phrase> sequence:
+      func <pat_plain> <annot_opt> <func_body>
+      class <pat_plain> <annot_opt> <class_body>
+      object class <pat_plain> <annot_opt> <class_body>
+      module class <pat_plain> <annot_opt> <class_body>
+      func <id> <pat_plain> <annot_opt> <func_body>
+      class <id> <pat_plain> <annot_opt> <class_body>
+      actor class <pat_plain> <annot_opt> <class_body>
+      persistent actor class <pat_plain> <annot_opt> <class_body>
+      object class <id> <pat_plain> <annot_opt> <class_body>
+      module class <id> <pat_plain> <annot_opt> <class_body>
+      actor class <id> <pat_plain> <annot_opt> <class_body>
+      persistent actor class <id> <pat_plain> <annot_opt> <class_body>
+      func < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <func_body>
+      class < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      object class < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      module class < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      func < system (, <typ_bind>)* > <pat_plain> <annot_opt> <func_body>
+      func <id> < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <func_body>
+      class < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body>
+      class <id> < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      actor class < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      persistent actor class < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      object class < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body>
+      object class <id> < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      module class < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body>
+      module class <id> < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      func <id> < system (, <typ_bind>)* > <pat_plain> <annot_opt> <func_body>
+      class <id> < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body>
+      actor class < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body>
+      actor class <id> < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      persistent actor class < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body>
+      persistent actor class <id> < seplist(<typ_bind>,,) > <pat_plain> <annot_opt> <class_body>
+      object class <id> < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body>
+      module class <id> < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body>
+      actor class <id> < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body>
+      persistent actor class <id> < system (, <typ_bind>)* > <pat_plain> <annot_opt> <class_body> |}]

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -112,7 +112,7 @@ let parse_string' ?(recovery=false) mode name s : parse_result =
   let open Diag.Syntax in
   let lexer = Lexing.from_string s in
   let parse = Parser.Incremental.parse_prog in
-  let* prog = parse_with mode lexer parse name in
+  let* prog = parse_with ~recovery mode lexer parse name in
   Diag.return (prog, name)
 
 let parse_string = parse_string' Lexer.mode

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -108,7 +108,7 @@ let parse_with ?(recovery=false) mode lexer parser name : Syntax.prog Diag.resul
   dump_prog Flags.dump_parse prog;
   Diag.return prog
 
-let parse_string' mode name s : parse_result =
+let parse_string' ?(recovery=false) mode name s : parse_result =
   let open Diag.Syntax in
   let lexer = Lexing.from_string s in
   let parse = Parser.Incremental.parse_prog in
@@ -116,6 +116,7 @@ let parse_string' mode name s : parse_result =
   Diag.return (prog, name)
 
 let parse_string = parse_string' Lexer.mode
+let parse_string_with_recovery = parse_string' ~recovery:true Lexer.mode
 
 let parse_file' ?(recovery=false) mode at filename : (Syntax.prog * rel_path) Diag.result =
   let ic, messages = Lib.FilePath.open_in filename in

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -566,8 +566,8 @@ type check_result = unit Diag.result
 let check_files' parsefn files : check_result =
   Diag.map ignore (load_progs parsefn files initial_stat_env)
 
-let check_files ?(recovery_enabled=false) files : check_result =
-  let parsefn = if recovery_enabled
+let check_files ?(enable_recovery=false) files : check_result =
+  let parsefn = if enable_recovery
     then parse_file_with_recovery
     else parse_file
   in

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -345,8 +345,7 @@ type load_result_cached =
     ( Syntax.lib list
     * (Syntax.prog * string list) list
     * Scope.t
-    * scope_cache )
-  Diag.result
+    * scope_cache ) Diag.result
 
 type load_result =
   (Syntax.lib list * Syntax.prog list * Scope.scope) Diag.result

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -328,7 +328,6 @@ let check_prim () : Syntax.lib * stat_env =
       let senv1 = Scope.adjoin senv0 sscope in
       lib, senv1
 
-
 (* Imported file loading *)
 
 (*
@@ -340,6 +339,14 @@ When we load a declaration (i.e from the REPL), we also care about the type
 and the newly added scopes, so these are returned separately.
 *)
 
+type scope_cache = Scope.t Type.Env.t
+
+type load_result_cached =
+    ( Syntax.lib list
+    * (Syntax.prog * string list) list
+    * Scope.t
+    * scope_cache )
+  Diag.result
 
 type load_result =
   (Syntax.lib list * Syntax.prog list * Scope.scope) Diag.result
@@ -347,7 +354,16 @@ type load_result =
 type load_decl_result =
   (Syntax.lib list * Syntax.prog * Scope.scope * Type.typ * Scope.scope) Diag.result
 
-let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.result =
+let resolved_import_name ri =
+  match ri.Source.it with
+  | Syntax.Unresolved -> "/* unresolved */"
+  | Syntax.LibPath { Syntax.package = _; path }
+  | Syntax.IDLPath (path, _) -> path
+  | Syntax.PrimPath -> "@prim"
+
+let chase_imports_cached parsefn senv0 imports scopes_map
+    : (Syntax.lib list * Scope.scope * scope_cache) Diag.result
+  =
   (*
   This function loads and type-checkes the files given in `imports`,
   including any further dependencies.
@@ -359,14 +375,27 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
   * To avoid duplicates, i.e. load each file at most once, we check the
     senv.
   * We accumulate the resulting libraries in reverse order, for O(1) appending.
+  * There is a cache that can be queried to avoid recomputing unchanged dependencies.
   *)
+
+  let open Diag.Syntax in
 
   let open ResolveImport.S in
   let pending = ref empty in
   let senv = ref senv0 in
   let libs = ref [] in
+  let cache = ref scopes_map in
 
-  let rec go pkg_opt ri = match ri.Source.it with
+  let rec go_cached pkg_opt ri =
+    match Type.Env.find_opt (resolved_import_name ri) !cache with
+    | None -> go pkg_opt ri
+    | Some sscope ->
+      senv := Scope.adjoin !senv sscope;
+      Diag.return ()
+  and go pkg_opt ri =
+    let it = ri.Source.it in
+    let ri_name = resolved_import_name ri in
+    match it with
     | Syntax.PrimPath ->
       (* a bit of a hack, lib_env should key on resolved_import *)
       if Type.Env.mem "@prim" !senv.Scope.lib_env then
@@ -375,20 +404,20 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
         let lib, sscope = check_prim () in
         libs := lib :: !libs; (* NB: Conceptually an append *)
         senv := Scope.adjoin !senv sscope;
+        cache := Type.Env.add ri_name sscope !cache;
         Diag.return ()
     | Syntax.Unresolved -> assert false
     | Syntax.(LibPath {path = f; package = lib_pkg_opt}) ->
       if Type.Env.mem f !senv.Scope.lib_env then
         Diag.return ()
-      else if mem ri.Source.it !pending then
+      else if mem it !pending then
         Diag.error
           ri.Source.at
           "M0003"
           "import"
           (Printf.sprintf "file %s must not depend on itself" f)
       else begin
-        pending := add ri.Source.it !pending;
-        let open Diag.Syntax in
+        pending := add it !pending;
         let* prog, base = parsefn ri.Source.at f in
         let* () = Static.prog prog in
         let* more_imports = ResolveImport.resolve (resolve_flags ()) prog base in
@@ -398,11 +427,14 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
         let* sscope = check_lib !senv cur_pkg_opt lib in
         libs := lib :: !libs; (* NB: Conceptually an append *)
         senv := Scope.adjoin !senv sscope;
-        pending := remove ri.Source.it !pending;
+        cache := Type.Env.add ri_name sscope !cache;
+        pending := remove it !pending;
         Diag.return ()
       end
     | Syntax.IDLPath (f, _) ->
-      let open Diag.Syntax in
+      (* TODO: [Idllib.Pipeline.check_file] will perform a similar pipeline,
+         going recursively through imports of the IDL path to parse and
+         typecheck them. We should extend the cache system to it as well. *)
       let* prog, idl_scope, actor_opt = Idllib.Pipeline.check_file f in
       if actor_opt = None then
         Diag.error
@@ -423,21 +455,45 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
         | actor ->
           let sscope = Scope.lib f actor in
           senv := Scope.adjoin !senv sscope;
+          cache := Type.Env.add ri_name sscope !cache;
           Diag.return ()
-  and go_set pkg_opt todo = Diag.traverse_ (go pkg_opt) todo
+  and go_set pkg_opt todo = Diag.traverse_ (go_cached pkg_opt) todo
   in
-  Diag.map (fun () -> (List.rev !libs, !senv)) (go_set None imports)
+  Diag.map (fun () -> List.rev !libs, !senv, !cache) (go_set None imports)
 
-let load_progs ?(viper_mode=false) ?(check_actors=false) parsefn files senv : load_result =
+let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.result =
+  let open Diag.Syntax in
+  let cache = Type.Env.empty in
+  let* libs, senv, _cache = chase_imports_cached parsefn senv0 imports cache in
+  Diag.return (libs, senv)
+
+let load_progs_cached ?viper_mode ?check_actors parsefn files senv scope_cache : load_result_cached =
   let open Diag.Syntax in
   let* parsed = Diag.traverse (parsefn Source.no_region) files in
   let* rs = resolve_progs parsed in
-  let progs' = List.map fst rs in
+  let progs = List.map fst rs in
   let libs = List.concat_map snd rs in
-  let* libs, senv' = chase_imports parsefn senv libs in
-  let* () = Typing.check_actors ~viper_mode ~check_actors senv' progs' in
-  let* senv'' = check_progs ~viper_mode senv' progs' in
-  Diag.return (libs, progs', senv'')
+  let* libs, senv, scope_cache =
+    chase_imports_cached parsefn senv libs scope_cache
+  in
+  let* () = Typing.check_actors ?viper_mode ?check_actors senv progs in
+  (* [infer_prog] seems to annotate the AST with types by mutating some of its
+     nodes, therefore, we always run the type checker for programs. *)
+  let* senv = check_progs ?viper_mode senv progs in
+  Diag.return
+    ( libs
+    , List.map (fun (prog, rims) -> prog, List.map resolved_import_name rims) rs
+    , senv
+    , scope_cache )
+
+let load_progs ?viper_mode ?check_actors parsefn files senv : load_result =
+  let open Diag.Syntax in
+  let scope_cache = Type.Env.empty in
+  let* libs, rs, senv, _scope_cache =
+    load_progs_cached ?viper_mode ?check_actors parsefn files senv scope_cache
+  in
+  let progs = List.map fst rs in
+  Diag.return (libs, progs, senv)
 
 let load_decl parse_one senv : load_decl_result =
   let open Diag.Syntax in
@@ -688,7 +744,7 @@ let load_as_rts () =
   let rts = match (!Flags.enhanced_orthogonal_persistence, !Flags.sanity, !Flags.gc_strategy) with
     | (true, false, Flags.Incremental) -> Rts.wasm_eop_release
     | (true, true, Flags.Incremental) -> Rts.wasm_eop_debug
-    | (false, false, Flags.Copying) 
+    | (false, false, Flags.Copying)
     | (false, false, Flags.MarkCompact)
     | (false, false, Flags.Generational) -> Rts.wasm_non_incremental_release
     | (false, true, Flags.Copying)

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -8,12 +8,12 @@ type no_region_parse_fn = string -> (Syntax.prog * string) Diag.result
 type parse_fn = Source.region -> no_region_parse_fn
 
 val parse_file: parse_fn
+val parse_file_with_recovery: parse_fn
 val parse_string: string -> no_region_parse_fn
 
 val print_deps: string -> unit
 
-val check_files  : string list -> unit Diag.result
-val check_files' : parse_fn -> string list -> unit Diag.result
+val check_files  : ?recovery_enabled:bool -> string list -> unit Diag.result
 
 val viper_files : string list -> (string * (Source.region -> Source.region option)) Diag.result
 

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -15,7 +15,7 @@ val parse_string_with_recovery: string -> no_region_parse_fn
 
 val print_deps: string -> unit
 
-val check_files  : ?recovery_enabled:bool -> string list -> unit Diag.result
+val check_files  : ?enable_recovery:bool -> string list -> unit Diag.result
 
 val viper_files : string list -> (string * (Source.region -> Source.region option)) Diag.result
 

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -9,7 +9,9 @@ type parse_fn = Source.region -> no_region_parse_fn
 
 val parse_file: parse_fn
 val parse_file_with_recovery: parse_fn
+
 val parse_string: string -> no_region_parse_fn
+val parse_string_with_recovery: string -> no_region_parse_fn
 
 val print_deps: string -> unit
 

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -35,7 +35,30 @@ type compile_result =
 
 val compile_files : Flags.compile_mode -> bool -> string list -> compile_result
 
-(* For use in the IDE server *)
+val resolve_flags : unit -> ResolveImport.flags
+val resolved_import_name : Syntax.resolved_import Source.phrase -> string
+
+(* For use in the language server *)
+
+type scope_cache = Scope.t Type.Env.t
+
+type load_result_cached =
+    ( Syntax.lib list
+    * (Syntax.prog * string list) list
+    * Scope.t
+    * scope_cache )
+  Diag.result
+
+val load_progs_cached
+  :  ?viper_mode:bool
+  -> ?check_actors:bool
+  -> parse_fn
+  -> string list
+  -> Scope.t
+  -> scope_cache
+  -> load_result_cached
+
 type load_result =
   (Syntax.lib list * Syntax.prog list * Scope.scope) Diag.result
+
 val load_progs : ?viper_mode:bool -> ?check_actors:bool -> parse_fn -> string list -> Scope.scope -> load_result

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -171,7 +171,9 @@ assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
 const astFile = Motoko.readFile("ast.mo");
 for (const ast of [
   Motoko.parseMotoko(/*enable_recovery=*/false, astFile),
+  Motoko.parseMotoko(/*enable_recovery=*/true, astFile),
   Motoko.parseMotokoTyped(/*enable_recovery=*/false, ["ast.mo"], new Map()).code[0][0].ast, // { diagnostics; code: [[{ ast; immediateImports }], cache] }
+  Motoko.parseMotokoTyped(/*enable_recovery=*/true, ["ast.mo"], new Map()).code[0][0].ast, // { diagnostics; code: [[{ ast; immediateImports }], cache] }
 ]) {
   const astString = JSON.stringify(ast);
 

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -246,3 +246,14 @@ assert.deepStrictEqual(Motoko.candid("ast.mo"), {
   ],
   code: candid,
 });
+
+// Check error recovery
+const badAstFile = Motoko.readFile("bad.mo");
+
+assert(Motoko.parseMotoko(/*enable_recovery=*/false, badAstFile).code == null);
+assert(Motoko.parseMotoko(/*enable_recovery=*/true, badAstFile).code != null);
+assert(Motoko.parseMotokoTyped(/*enable_recovery=*/false, ["bad.mo"], new Map()).code == null);
+
+// TODO: This requires avoid dropping 'code' field in all checks though all pipeline e.g. infer_prog
+// assert(Motoko.parseMotokoTyped(/*enable_recovery=*/true, ["bad.mo"], new Map()).code != null);
+

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -1,6 +1,10 @@
 process.on("unhandledRejection", (error) => {
-  assert.fail(error);
+  console.log(`Unhandled promise rejection:\n${error}`)
 });
+
+process.on("uncaughtException", (error) => {
+  console.log(`Uncaught exception:\n${error}`);
+})
 
 const assert = require("assert").strict;
 

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -143,6 +143,18 @@ assert.deepStrictEqual(Motoko.check("bad.mo"), {
       message:
         "unexpected end of input, expected one of token or <phrase> sequence:\n  <exp_bin(ob)>",
     },
+    {
+        source: 'bad.mo',
+        severity: 1,
+        range: {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 }
+        },
+        code: 'M0057',
+        category: 'type',
+        message: 'unbound variable _'
+      }
+
   ],
   code: null,
 });

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -159,7 +159,7 @@ assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
 const astFile = Motoko.readFile("ast.mo");
 for (const ast of [
   Motoko.parseMotoko(astFile),
-  Motoko.parseMotokoTyped(astFile, new Map())[0].ast,
+  Motoko.parseMotokoTyped(["ast.mo"], new Map()).code[0][0].ast, // { diagnostics; code: [[{ ast; immediateImports }], cache] }
 ]) {
   const astString = JSON.stringify(ast);
 

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -143,24 +143,33 @@ assert.deepStrictEqual(Motoko.check("bad.mo"), {
   code: null,
 });
 
-const astString = JSON.stringify(
-  Motoko.parseMotoko(Motoko.readFile("ast.mo"))
-);
-
 // Run interpreter
 assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
-  stdout: "`ys6dh-5cjiq-5dc` : actor {main : shared query () -> async A__9<Text>}\n",
+  stdout:
+    "`ys6dh-5cjiq-5dc` : actor {main : shared query () -> async A__9<Text>}\n",
   stderr: "",
   result: { error: null },
 });
 
-// Check doc comments
-assert.match(astString, /"name":"\*","args":\["Program comment\\n      multi-line"/);
-assert.match(astString, /"name":"\*","args":\["Type comment"/);
-assert.match(astString, /"name":"\*","args":\["Variable comment"/);
-assert.match(astString, /"name":"\*","args":\["Function comment"/);
-assert.match(astString, /"name":"\*","args":\["Sub-module comment"/);
-assert.match(astString, /"name":"\*","args":\["Class comment"/);
+// Check AST format
+const astFile = Motoko.readFile("ast.mo");
+for (const ast of [
+  Motoko.parseMotoko(astFile),
+  Motoko.parseMotokoTyped(astFile, new Map())[0].ast,
+]) {
+  const astString = JSON.stringify(ast);
+
+  // Check doc comments
+  assert.match(
+    astString,
+    /"name":"\*","args":\["Program comment\\n      multi-line"/
+  );
+  assert.match(astString, /"name":"\*","args":\["Type comment"/);
+  assert.match(astString, /"name":"\*","args":\["Variable comment"/);
+  assert.match(astString, /"name":"\*","args":\["Function comment"/);
+  assert.match(astString, /"name":"\*","args":\["Sub-module comment"/);
+  assert.match(astString, /"name":"\*","args":\["Class comment"/);
+}
 
 // Check that long text literals type-check without error
 assert.deepStrictEqual(Motoko.check("text.mo"), {
@@ -168,7 +177,9 @@ assert.deepStrictEqual(Motoko.check("text.mo"), {
   diagnostics: [],
 });
 
-const candid = `
+// Check Candid format
+const candid =
+  `
 type T = nat;
 /// Program comment
 ///       multi-line
@@ -176,42 +187,44 @@ service : {
   /// Function comment
   main: () -> (T) query;
 }
-`.trim() + '\n';
-assert.deepStrictEqual(Motoko.candid('ast.mo'), {
+`.trim() + "\n";
+assert.deepStrictEqual(Motoko.candid("ast.mo"), {
   diagnostics: [
     {
-      category: 'type',
-      code: 'M0194',
-      message: 'unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)',
+      category: "type",
+      code: "M0194",
+      message:
+        "unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)",
       range: {
         end: {
           character: 13,
-          line: 3
+          line: 3,
         },
         start: {
           character: 9,
-          line: 3
-        }
+          line: 3,
+        },
       },
       severity: 2,
-      source: 'ast.mo'
+      source: "ast.mo",
     },
     {
-      category: 'type',
-      code: 'M0194',
-      message: 'unused identifier M (delete or rename to wildcard `_` or `_M`)',
+      category: "type",
+      code: "M0194",
+      message: "unused identifier M (delete or rename to wildcard `_` or `_M`)",
       range: {
         end: {
           character: 12,
-          line: 13
+          line: 13,
         },
         start: {
           character: 11,
-          line: 13
-        }
+          line: 13,
+        },
       },
       severity: 2,
-      source: 'ast.mo'
-    }
-  ], code: candid
+      source: "ast.mo",
+    },
+  ],
+  code: candid,
 });

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -170,8 +170,8 @@ assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
 // Check AST format
 const astFile = Motoko.readFile("ast.mo");
 for (const ast of [
-  Motoko.parseMotoko(astFile),
-  Motoko.parseMotokoTyped(["ast.mo"], new Map()).code[0][0].ast, // { diagnostics; code: [[{ ast; immediateImports }], cache] }
+  Motoko.parseMotoko(/*enable_recovery=*/false, astFile),
+  Motoko.parseMotokoTyped(/*enable_recovery=*/false, ["ast.mo"], new Map()).code[0][0].ast, // { diagnostics; code: [[{ ast; immediateImports }], cache] }
 ]) {
   const astString = JSON.stringify(ast);
 


### PR DESCRIPTION
In order to be able to work with files that are editing and report multiple syntax errors in the LSP server we have added error recovery to the parser via [serokell/ocaml-recovery-parser](https://github.com/serokell/ocaml-recovery-parser).

Also, the js API has been updated to enable recovery and get recovered AST or fast fail (the argument is optional for backward compatibility):
```js

moc.parseMotoko(file, /* enableRecovery=*/true)
```

This PR follows #4931