### PR TITLE
chore: use the stock `js_of_ocaml`

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -44,28 +44,6 @@ let
             # Additional ocaml package
             ocamlPackages = super.ocamlPackages // rec {
 
-              # upgrade `js_of_ocaml(-compiler)` until we have figured out the bug related to 4.1.0 (which is in nixpkgs)
-              js_of_ocaml-compiler = super.ocamlPackages.js_of_ocaml-compiler.overrideAttrs rec {
-                version = "5.0.1";
-                src = self.fetchurl {
-                  url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-                  sha256 = "sha256-eiEPHKFqdCOBlH3GfD2Nn0yU+/IHOHRLE1OJeYW2EGk=";
-                };
-              };
-
-              # inline recipe from https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
-              js_of_ocaml = with super.ocamlPackages; buildDunePackage {
-                pname = "js_of_ocaml";
-
-                inherit (js_of_ocaml-compiler) version src;
-                duneVersion = "3";
-
-                buildInputs = [ ppxlib ];
-                propagatedBuildInputs = [ js_of_ocaml-compiler uchar ];
-
-                meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
-              };
-
               # downgrade wasm until we have support for 2.0.1
               # (https://github.com/dfinity/motoko/pull/3364)
               wasm_1 = super.ocamlPackages.wasm.overrideAttrs rec {

--- a/test/test-moc_interpreter.js
+++ b/test/test-moc_interpreter.js
@@ -10,7 +10,7 @@ moc.Motoko.saveFile('empty.mo', '');
 moc.Motoko.saveFile('ok.mo', '1');
 moc.Motoko.saveFile('warn.mo', '2 - 1');
 moc.Motoko.saveFile('bad.mo', '1+');
-moc.Motoko.saveFile('limit.mo', 'var i = 0; while (i < 10000) { i += 1 }; i');
+moc.Motoko.saveFile('limit.mo', 'var i = 0; while (i < 7600) { i += 1 }; i');
 moc.Motoko.saveFile('text.mo', `let s = "${'⛔|'.repeat(10000)}"; s.size()`); // #3822
 
 try {
@@ -43,7 +43,7 @@ try {
       error: null,
     },
     stderr: '',
-    stdout: '10_000 : Nat\n'
+    stdout: '7_600 : Nat\n'
   });
 
   moc.Motoko.setRunStepLimit(5000);


### PR DESCRIPTION
We used to build v5.0.1 ourselves, as there were correctness problems with v4.1.x. This reverts back to the supplied one that is bundled with OCaml 4.13.

------------
there is some fallout, though, as the `limit.mo` test won't let us to iterate up to 10000. I had to reduce it to the 7600 mark due to a stack overflow:
``` diff
>   {
    result: {
+     error: {}
-     error: null
    },
+   stderr: 'limit.mo:1.23-1.27: internal error, Stack overflow\n' +
+     '\n' +
+     'Last environment:\n' +
+     '@ManagementCanister = {}\n' +
+     '@add_cycles = <func>\n' +
```

I am trying to figure out where this started happening in #4969.