### PR TITLE
feat: detect lost fields in records (extensions)

### DIFF
--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -218,4 +218,5 @@ let error_codes : (string * string option) list =
     "M0212", Some([%blob "lang_utils/error_codes/M0212.md"]); (* Unrecognised attribute in parenthetical note *)
     "M0213", None; (* Parenthetical note on shared functions is disallowed *)
     "M0214", None; (* Expected type of field in parenthetical note differs from inferred *)
+    "M0215", None; (* Field is lost in record used at supertype *)
   ]

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2044,7 +2044,9 @@ and detect_lost_fields env t = function
          | Some _ -> ()
          | None ->
             warn env fld.at "M0215"
-              "lost_field %s" id)
+              "Field %s is ignored in record of type%a"
+              id
+              display_typ t)
       flds
   | _ -> ()
 

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2034,9 +2034,15 @@ and check_exp_field env (ef : exp_field) fts =
     ignore (infer_exp env exp)
 
 and detect_lost_fields env t = function
-  | ObjE (_::_, fld::flds) ->
-    warn env fld.at "M0101999"
-      "lost_field %s" fld.it.id.it
+  | ObjE (_::_, flds) ->
+     let [@warning "-8"] T.Obj (_, fts) = t in
+     List.iter (fun (fld : exp_field) ->
+         let id = fld.it.id.it in
+         match List.find_opt (fun ft -> ft.T.lab = id) fts with
+         | Some _ -> ()
+         | None ->
+          warn env fld.at "M0101999"
+      "lost_field %s" id) flds
   | _ -> ()
 
 and infer_call env exp1 inst exp2 at t_expect_opt =

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2001,7 +2001,7 @@ and check_exp' env0 t exp : T.typ =
     let {T.typ; _} = List.find (fun T.{lab; typ;_} -> lab = id.it) fs in
     check_exp env typ exp1 ;
     t
-  | _ ->
+  | e, _ ->
     let t' = infer_exp env0 exp in
     if not (sub env exp.at t' t) then
     begin
@@ -2011,6 +2011,7 @@ and check_exp' env0 t exp : T.typ =
         display_typ_expand t
         (Suggest.suggest_conversion env.libs env.vals t' t)
     end;
+    detect_lost_fields env t e;
     t'
 
 and check_exp_field env (ef : exp_field) fts =
@@ -2031,6 +2032,12 @@ and check_exp_field env (ef : exp_field) fts =
     check_exp env t exp
   | None ->
     ignore (infer_exp env exp)
+
+and detect_lost_fields env t = function
+  | ObjE (_::_, fld::flds) ->
+    warn env fld.at "M0101999"
+      "lost_field %s" fld.it.id.it
+  | _ -> ()
 
 and infer_call env exp1 inst exp2 at t_expect_opt =
   let n = match inst.it with None -> 0 | Some (_, typs) -> List.length typs in

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2035,6 +2035,7 @@ and check_exp_field env (ef : exp_field) fts =
     ignore (infer_exp env exp)
 
 and detect_lost_fields env t = function
+  | _ when env.pre || not (T.is_obj t) -> ()
   | ObjE (_, flds) ->
     let [@warning "-8"] T.Obj (_, fts) = t in
     List.iter
@@ -2044,7 +2045,7 @@ and detect_lost_fields env t = function
          | Some _ -> ()
          | None ->
             warn env fld.at "M0215"
-              "Field %s is ignored in record of type%a"
+              "Field `%s` is ignored in record of type%a"
               id
               display_typ t)
       flds

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1872,14 +1872,17 @@ and check_exp' env0 t exp : T.typ =
     check_ids env "object" "field"
       (List.map (fun (ef : exp_field) -> ef.it.id) exp_fields);
     List.iter (fun ef -> check_exp_field env ef fts) exp_fields;
-    List.iter (fun ft ->
+    if List.for_all (fun ft ->
       if not (List.exists (fun (ef : exp_field) -> ft.T.lab = ef.it.id.it) exp_fields)
-      then local_error env exp.at "M0151"
+      then begin
+      local_error env exp.at "M0151"
         "object literal is missing field %s from expected type%a"
         ft.T.lab
         display_typ_expand t;
-    ) fts;
-    detect_lost_fields env t e;
+        false
+      end else true
+    ) fts
+    then detect_lost_fields env t e;
     t
   | OptE exp1, _ when T.is_opt t ->
     check_exp env (T.as_opt t) exp1;
@@ -2011,8 +2014,8 @@ and check_exp' env0 t exp : T.typ =
         display_typ_expand t'
         display_typ_expand t
         (Suggest.suggest_conversion env.libs env.vals t' t)
-    end;
-    detect_lost_fields env t e;
+    end
+    else detect_lost_fields env t e;
     t'
 
 and check_exp_field env (ef : exp_field) fts =

--- a/test/fail/migration.mo
+++ b/test/fail/migration.mo
@@ -4,11 +4,11 @@ import Prim "mo:prim";
   func({unstable1 : () -> () }) :
     { unstable2 : () -> (); // not stable
       var three : Text; // wrong type, reject
-      var versoin : (); // unrequired/mispelled, reject
+      var version : (); // unrequired/mispelled, reject
     } {
     { var three = "";
       var unused = ();
-      var versoin = ();
+      var version = ();
       unstable2 = func () {};
     }})
 actor {

--- a/test/fail/migration.mo
+++ b/test/fail/migration.mo
@@ -4,11 +4,11 @@ import Prim "mo:prim";
   func({unstable1 : () -> () }) :
     { unstable2 : () -> (); // not stable
       var three : Text; // wrong type, reject
-      var version : (); // unrequired/mispelled, reject
+      var versoin : (); // unrequired/mispelled, reject
     } {
     { var three = "";
       var unused = ();
-      var version = ();
+      var versoin = ();
       unstable2 = func () {};
     }})
 actor {

--- a/test/fail/ok/check-record.tc.ok
+++ b/test/fail/ok/check-record.tc.ok
@@ -9,6 +9,8 @@ check-record.mo:12.11-12.16: type error [M0149], expected mutable 'var' field a 
 but found immutable field (insert 'var'?)
 check-record.mo:14.9-14.11: type error [M0151], object literal is missing field a from expected type
   {a : Nat}
+check-record.mo:16.18-16.23: warning [M0215], Field `b` is ignored in record of type
+  {a : Nat}
 check-record.mo:21.30-21.31: type error [M0057], unbound variable c
 check-record.mo:24.9-24.27: type error [M0096], expression of type
   {a : Nat}

--- a/test/fail/ok/migration.tc.ok
+++ b/test/fail/ok/migration.tc.ok
@@ -1,5 +1,5 @@
 migration.mo:3.7-13.7: type error [M0201], expected stable type, but migration expression produces non-stable type
-  {var three : Text; unstable2 : () -> (); var version : ()}
+  {var three : Text; unstable2 : () -> (); var versoin : ()}
 migration.mo:3.7-13.7: type error [M0201], expected stable type, but migration expression consumes non-stable type
   {unstable1 : () -> ()}
 migration.mo:3.7-13.7: type error [M0204], migration expression produces field `three` of type
@@ -10,7 +10,7 @@ migration.mo:3.7-13.7: type error [M0205], migration expression produces unexpec
   () -> ()
 
 The actor should declare a corresponding `stable` field.
-migration.mo:3.7-13.7: type error [M0205], migration expression produces unexpected field `version` of type
+migration.mo:3.7-13.7: type error [M0205], migration expression produces unexpected field `versoin` of type
   var ()
 
 Did you mean field version?

--- a/test/fail/ok/migration.tc.ok
+++ b/test/fail/ok/migration.tc.ok
@@ -1,5 +1,5 @@
 migration.mo:3.7-13.7: type error [M0201], expected stable type, but migration expression produces non-stable type
-  {var three : Text; unstable2 : () -> (); var versoin : ()}
+  {var three : Text; unstable2 : () -> (); var version : ()}
 migration.mo:3.7-13.7: type error [M0201], expected stable type, but migration expression consumes non-stable type
   {unstable1 : () -> ()}
 migration.mo:3.7-13.7: type error [M0204], migration expression produces field `three` of type
@@ -10,7 +10,7 @@ migration.mo:3.7-13.7: type error [M0205], migration expression produces unexpec
   () -> ()
 
 The actor should declare a corresponding `stable` field.
-migration.mo:3.7-13.7: type error [M0205], migration expression produces unexpected field `versoin` of type
+migration.mo:3.7-13.7: type error [M0205], migration expression produces unexpected field `version` of type
   var ()
 
 Did you mean field version?

--- a/test/fail/ok/migration.tc.ok
+++ b/test/fail/ok/migration.tc.ok
@@ -1,3 +1,5 @@
+migration.mo:10.7-10.22: warning [M0215], Field `unused` is ignored in record of type
+  {var three : Text; unstable2 : () -> (); var versoin : ()}
 migration.mo:3.7-13.7: type error [M0201], expected stable type, but migration expression produces non-stable type
   {var three : Text; unstable2 : () -> (); var versoin : ()}
 migration.mo:3.7-13.7: type error [M0201], expected stable type, but migration expression consumes non-stable type

--- a/test/repl/ok/pretty-val.stderr.ok
+++ b/test/repl/ok/pretty-val.stderr.ok
@@ -1,0 +1,2 @@
+stdin:72.30-72.43: warning [M0215], Field `hidden` is ignored in record of type
+  {a : Nat}

--- a/test/run-drun/ok/data-params.tc.ok
+++ b/test/run-drun/ok/data-params.tc.ok
@@ -1,0 +1,2 @@
+data-params.mo:57.41-57.47: warning [M0215], Field `z` is ignored in record of type
+  {x : Nat; y : Nat}

--- a/test/run-drun/ok/issue2317.tc.ok
+++ b/test/run-drun/ok/issue2317.tc.ok
@@ -1,0 +1,2 @@
+issue2317.mo:3.15-3.20: warning [M0215], Field `b` is ignored in record of type
+  {}

--- a/test/run/object-extend.mo
+++ b/test/run/object-extend.mo
@@ -66,3 +66,7 @@ func mux<A <: { a : Int }, B <: { b : Char }>(a : A, b : B) : { a : Int; b : Cha
 // extending iterators
 let tb_ok : { next : () -> ?Char; bar : Nat } = { "Text base".chars() with bar = 42 };
 let ab_ok : { next : () -> ?Text; bar : Nat } = { ["Array base"].values() with bar = 42 };
+
+// detecting lost fields
+let ab_ok_warn : { next : () -> ?Text; bar : Nat } = { ab_ok with bur = 42 };
+let foo_warn : { foo : Text } = { foo = "FOO"; quux = "QUUX" };

--- a/test/run/ok/object-extend.tc.ok
+++ b/test/run/ok/object-extend.tc.ok
@@ -1,6 +1,9 @@
-object-extend.mo:46.16-46.21: warning [M0215], lost_field l
-object-extend.mo:71.67-71.75: warning [M0215], lost_field bur
-object-extend.mo:72.48-72.61: warning [M0215], lost_field quux
+object-extend.mo:46.16-46.21: warning [M0215], Field l is ignored in record of type
+  {}
+object-extend.mo:71.67-71.75: warning [M0215], Field bur is ignored in record of type
+  {bar : Nat; next : () -> ?Text}
+object-extend.mo:72.48-72.61: warning [M0215], Field quux is ignored in record of type
+  {foo : Text}
 object-extend.mo:56.6-56.9: warning [M0194], unused identifier mix (delete or rename to wildcard `_` or `_mix`)
 object-extend.mo:59.6-59.9: warning [M0194], unused identifier mox (delete or rename to wildcard `_` or `_mox`)
 object-extend.mo:62.6-62.9: warning [M0194], unused identifier mux (delete or rename to wildcard `_` or `_mux`)

--- a/test/run/ok/object-extend.tc.ok
+++ b/test/run/ok/object-extend.tc.ok
@@ -1,8 +1,8 @@
-object-extend.mo:46.16-46.21: warning [M0215], Field l is ignored in record of type
+object-extend.mo:46.16-46.21: warning [M0215], Field `l` is ignored in record of type
   {}
-object-extend.mo:71.67-71.75: warning [M0215], Field bur is ignored in record of type
+object-extend.mo:71.67-71.75: warning [M0215], Field `bur` is ignored in record of type
   {bar : Nat; next : () -> ?Text}
-object-extend.mo:72.48-72.61: warning [M0215], Field quux is ignored in record of type
+object-extend.mo:72.48-72.61: warning [M0215], Field `quux` is ignored in record of type
   {foo : Text}
 object-extend.mo:56.6-56.9: warning [M0194], unused identifier mix (delete or rename to wildcard `_` or `_mix`)
 object-extend.mo:59.6-59.9: warning [M0194], unused identifier mox (delete or rename to wildcard `_` or `_mox`)

--- a/test/run/ok/object-extend.tc.ok
+++ b/test/run/ok/object-extend.tc.ok
@@ -1,5 +1,9 @@
+object-extend.mo:46.16-46.21: warning [M0215], lost_field l
+object-extend.mo:71.67-71.75: warning [M0215], lost_field bur
+object-extend.mo:72.48-72.61: warning [M0215], lost_field quux
 object-extend.mo:56.6-56.9: warning [M0194], unused identifier mix (delete or rename to wildcard `_` or `_mix`)
 object-extend.mo:59.6-59.9: warning [M0194], unused identifier mox (delete or rename to wildcard `_` or `_mox`)
 object-extend.mo:62.6-62.9: warning [M0194], unused identifier mux (delete or rename to wildcard `_` or `_mux`)
 object-extend.mo:67.5-67.10: warning [M0194], unused identifier tb_ok (delete or rename to wildcard `_` or `_tb_ok`)
-object-extend.mo:68.5-68.10: warning [M0194], unused identifier ab_ok (delete or rename to wildcard `_` or `_ab_ok`)
+object-extend.mo:71.5-71.15: warning [M0194], unused identifier ab_ok_warn (delete or rename to wildcard `_` or `_ab_ok_warn`)
+object-extend.mo:72.5-72.13: warning [M0194], unused identifier foo_warn (delete or rename to wildcard `_` or `_foo_warn`)


### PR DESCRIPTION
This now warns when a user constructs a record with a field that will be dropped because the result is used as a supertype.

It cross-checks user-provided explicit fields (i.e. ignoring bases) and warns for those that don't appear in the expected type (in checking mode).

Resolves #4976.

TODOs:
- Do we want this for `object`s and `class`es too? (see #4981)