### PR TITLE
chore: bump `rustPlatform_moz_stable` (used for `drun`)

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -92,9 +92,9 @@ let
         (self: super: let
           rust-channel = self.moz_overlay.rustChannelOf { version = "1.85.0"; channel = "stable"; };
         in {
-          rustPlatform_moz_stable = self.makeRustPlatform {
+          rustPlatform_moz_stable = self.makeRustPlatform rec {
             rustc = rust-channel.rust;
-            cargo = rust-channel.rust;
+            cargo = rustc;
           };
         })
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -90,7 +90,7 @@ let
 
         # Rust stable
         (self: super: let
-          rust-channel = self.moz_overlay.rustChannelOf { version = "1.78.0"; channel = "stable"; };
+          rust-channel = self.moz_overlay.rustChannelOf { version = "1.85.0"; channel = "stable"; };
         in {
           rustPlatform_moz_stable = self.makeRustPlatform {
             rustc = rust-channel.rust;

--- a/nix/drun.nix
+++ b/nix/drun.nix
@@ -36,7 +36,7 @@ pkgs:
          config.flag("-Wno-strict-aliasing");
          config.flag("-Wno-invalid-offsetof");
 +        if target.contains("darwin") {
-+            config.flag("-faligned-allocation");config.flag("-faligned-allocation");
++            config.flag("-faligned-allocation");
 +        }    
      }
 

--- a/nix/drun.nix
+++ b/nix/drun.nix
@@ -36,7 +36,7 @@ pkgs:
          config.flag("-Wno-strict-aliasing");
          config.flag("-Wno-invalid-offsetof");
 +        if target.contains("darwin") {
-+            config.flag("-faligned-allocation");
++            config.flag("-faligned-allocation");config.flag("-faligned-allocation");
 +        }    
      }
 


### PR DESCRIPTION
to 1.85.1