### PR TITLE
chore: Revert "deactivate `performance delta` for now"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 
     - name: Calculate performance delta
-      if: github.actor != 'dependabot[bot]' && runner.os == 'LinuxXXX' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
       run: |
         from="$(git merge-base origin/${{ github.base_ref }} HEAD)"
         to="${{ github.event.pull_request.head.sha }}"
@@ -65,14 +65,14 @@ jobs:
           --argstr to "$to"
 
     - name: Read performance delta
-      if: github.actor != 'dependabot[bot]' && runner.os == 'LinuxLinuxXXX' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
       id: perf
       uses: juliangruber/read-file-action@v1
       with:
         path: ./perf-delta.txt
 
     - name: Find performance comment
-      if: github.actor != 'dependabot[bot]' && runner.os == 'LinuxLinuxXXX' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
       uses: peter-evans/find-comment@v3
       id: fc
       with:
@@ -83,7 +83,7 @@ jobs:
     # Forks can't add comments so this job does not run on forks, see
     # motoko#2864.
     - name: Create or update performance comment
-      if: github.actor != 'dependabot[bot]' && runner.os == 'LinuxLinuxXXX' && runner.arch == 'X64' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
This reverts commit 4d5595ac1064a09c5ea3e6bbb74e2db97f8c4603, which was a critical ingredient for #5002 to pass, but the functionality needs to be restored.