### PR TITLE
chore: automatically push accepted `test/bench` numbers on `x86_64-linux`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         echo "Branch name: ${{ github.event.pull_request.head.ref }}"
         echo "Branch namehere: ${{ github.head_ref || github.ref_name }}"
         git diff --no-index $(nix-build -A tests.bench)/share test/bench/ok | patch -p1 -R
-        # git switch ${github.event.pull_request.head.ref}
+        git switch ${{ github.event.pull_request.head.ref }}
 
     - name: Commit `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Discover `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
-      run: git diff --no-index $(nix-build -A tests.bench) test/bench/ok
+      run: git diff --no-index $(nix-build -A tests.bench)/share test/bench/ok | patch -p1 -R
 
     - name: Commit `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
         fetch-depth: 0
         # fetch PR commit, not predicted merge commit
         ref: ${{ github.event.pull_request.head.sha }}
+        # This is needed to be able to push and trigger CI with that push
+        token: ${{ secrets.NIV_UPDATER_TOKEN }}
     - uses: cachix/install-nix-action@v31
 
     # We are using the ic-hs-test cachix cache that is also used by

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
     - run: nix-env -iA nix-build-uncached -f nix/
 
     - name: "nix-build"
-      run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
+      run: nix-build-uncached --max-jobs ${{ runner.cpuCount }} -A all-systems-go -build-flags -L
 
     - name: Commit `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
@@ -71,7 +71,7 @@ jobs:
         from="$(git merge-base origin/${{ github.base_ref }} HEAD)"
         to="${{ github.event.pull_request.head.sha }}"
         echo "Comparing changes from $from to $to"
-        nix-build --max-jobs 4 perf-delta.nix -o perf-delta.txt \
+        nix-build --max-jobs ${{ runner.cpuCount }} perf-delta.nix -o perf-delta.txt \
           --argstr ref HEAD \
           --argstr from "$from" \
           --argstr to "$to"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       run: nix-build-uncached --max-jobs auto -A all-systems-go -build-flags -L
 
     - name: Discover `test/bench` changes
-      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
       run: |
         echo "Branch name: ${{ github.event.pull_request.head.ref }}"
         echo "Branch here: ${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         committer_name: GitHub Actions
         committer_email: actions@github.com
         message: "Updating `test/bench` numbers"
-        commit: --porcelain -- test/bench/ok
+        commit: -- test/bench/ok
 
     - name: Calculate performance delta
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         committer_name: GitHub Actions
         committer_email: actions@github.com
         message: "Updating `test/bench` numbers"
-        commit: -- test/bench/ok
+        commit: --porcelain -- test/bench/ok
 
     - name: Calculate performance delta
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,10 @@ jobs:
     - name: Discover `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
       run: |
-        echo "Branch name: ${github.event.pull_request.head.ref}"
+        echo "Branch name: ${{ github.event.pull_request.head.ref }}"
+        echo "Branch namehere: ${{ github.head_ref || github.ref_name }}"
         git diff --no-index $(nix-build -A tests.bench)/share test/bench/ok | patch -p1 -R
-        git switch ${github.event.pull_request.head.ref}
+        # git switch ${github.event.pull_request.head.ref}
 
     - name: Commit `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,10 @@ jobs:
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
       run: |
         echo "Branch name: ${{ github.event.pull_request.head.ref }}"
-        echo "Branch namehere: ${{ github.head_ref || github.ref_name }}"
+        echo "Branch here: ${{ github.head_ref || github.ref_name }}"
         git diff --no-index $(nix-build -A tests.bench)/share test/bench/ok | patch -p1 -R
         git switch ${{ github.event.pull_request.head.ref }}
+        git branch --show-current
 
     - name: Commit `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,10 @@ jobs:
 
     - name: Discover `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
-      run: git diff --no-index $(nix-build -A tests.bench)/share test/bench/ok | patch -p1 -R
+      run: |
+        echo "Branch name: ${github.event.pull_request.head.ref}"
+        git diff --no-index $(nix-build -A tests.bench)/share test/bench/ok | patch -p1 -R
+        git switch ${github.event.pull_request.head.ref}
 
     - name: Commit `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,6 @@ jobs:
     - name: Discover `test/bench` changes
       if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
       run: |
-        echo "Branch name: ${{ github.event.pull_request.head.ref }}"
-        echo "Branch here: ${{ github.head_ref || github.ref_name }}"
         git diff --no-index $(nix-build -A tests.bench)/share test/bench/ok | patch -p1 -R
         git switch ${{ github.event.pull_request.head.ref }}
         git branch --show-current

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
     - run: nix-env -iA nix-build-uncached -f nix/
 
     - name: "nix-build"
-      run: nix-build-uncached --max-jobs ${{ runner.cpuCount }} -A all-systems-go -build-flags -L
+      run: nix-build-uncached --max-jobs auto -A all-systems-go -build-flags -L
 
     - name: Discover `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
@@ -75,7 +75,7 @@ jobs:
         from="$(git merge-base origin/${{ github.base_ref }} HEAD)"
         to="${{ github.event.pull_request.head.sha }}"
         echo "Comparing changes from $from to $to"
-        nix-build --max-jobs ${{ runner.cpuCount }} perf-delta.nix -o perf-delta.txt \
+        nix-build --max-jobs auto perf-delta.nix -o perf-delta.txt \
           --argstr ref HEAD \
           --argstr from "$from" \
           --argstr to "$to"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,18 @@ jobs:
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 
+    - name: Commit `test/bench` changes
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      uses: EndBug/add-and-commit@v9
+      with:
+        default_author: github_actions
+        author_name: Cycle and memory benchmark updater
+        github_token: ${{ secrets.NIV_UPDATER_TOKEN }}
+        committer_name: GitHub Actions
+        committer_email: actions@github.com
+        message: "Updating `test/bench` numbers"
+        commit: -- test/bench/ok
+
     - name: Calculate performance delta
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,6 @@ jobs:
         fetch-depth: 0
         # fetch PR commit, not predicted merge commit
         ref: ${{ github.event.pull_request.head.sha }}
-        # This is needed to be able to push and trigger CI with that push
-        token: ${{ secrets.NIV_UPDATER_TOKEN }}
     - uses: cachix/install-nix-action@v31
 
     # We are using the ic-hs-test cachix cache that is also used by

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,10 @@ jobs:
     - name: "nix-build"
       run: nix-build-uncached --max-jobs ${{ runner.cpuCount }} -A all-systems-go -build-flags -L
 
+    - name: Discover `test/bench` changes
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      run: git diff --no-index $(nix-build -A tests.bench) test/bench/ok
+
     - name: Commit `test/bench` changes
       if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
       uses: EndBug/add-and-commit@v9

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -18,7 +18,7 @@ jobs:
         token: ${{ secrets.NIV_UPDATER_TOKEN }}
     - uses: cachix/install-nix-action@v31
       with:
-        nix_path: nixpkgs=channel:nixos-22.11
+        nix_path: nixpkgs=channel:nixos-24.11
     - uses: cachix/cachix-action@v16
       with:
         name: ic-hs-test
@@ -31,7 +31,7 @@ jobs:
       run: |
         nix shell -f default.nix nix-update -c nix-update --version=skip ic-wasm
     - name: Commit changes
-      uses: EndBug/add-and-commit@v9.1.4
+      uses: EndBug/add-and-commit@v9
       with:
         default_author: github_actions
         author_name: Nix hash updater

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -13,9 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        # This is needed to be able to push and trigger CI with that push
-        token: ${{ secrets.NIV_UPDATER_TOKEN }}
     - uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-24.11

--- a/default.nix
+++ b/default.nix
@@ -369,7 +369,7 @@ rec {
             export ESM=${nixpkgs.sources.esm}
             export VIPER_SERVER=${viperServer}
             type -p moc && moc --version
-            make -C ${dir} ${nixpkgs.lib.optionalString accept "accept"}
+            make -C ${dir}${nixpkgs.lib.optionalString accept " accept"}
           '';
       };
 

--- a/default.nix
+++ b/default.nix
@@ -541,8 +541,8 @@ rec {
       inherit qc lsp unit candid coverage;
     }
     // nixpkgs.lib.optionalAttrs
-         (system == "aarch64-darwin")
-         (fix_names { bench = perf_subdir "bench" [ moc nixpkgs.drun ic-wasm ];})
+         (system == "x86_64-linux")
+         (fix_names { bench = perf_subdir "bench accept" [ moc nixpkgs.drun ic-wasm ];})
     // { recurseForDerivations = true; };
 
   samples = stdenv.mkDerivation {

--- a/default.nix
+++ b/default.nix
@@ -371,8 +371,8 @@ rec {
             type -p moc && moc --version
             make -C ${dir}${nixpkgs.lib.optionalString accept " accept"}
           '';
-
-          installPhase = nixpkgs.lib.optionalString accept ''
+      } // nixpkgs.lib.optionalAttrs accept {
+        installPhase = nixpkgs.lib.optionalString accept ''
             mkdir -p $out/share
             cp -v ${dir}/ok/*.ok $out/share
           '';

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 {
   replay ? 0,
   system ? builtins.currentSystem,
+  accept-bench ? "x86_64-linux",
   officialRelease ? false,
 }:
 
@@ -359,7 +360,7 @@ rec {
       };
 
     acceptable_subdir = accept: dir: deps:
-      testDerivation {
+      testDerivation ({
         src = test_src dir;
         buildInputs = deps ++ testDerivationDeps;
 
@@ -376,7 +377,7 @@ rec {
             mkdir -p $out/share
             cp -v ${dir}/ok/*.ok $out/share
           '';
-      };
+      });
 
     test_subdir = dir: deps: acceptable_subdir false dir deps;
 
@@ -548,7 +549,7 @@ rec {
       inherit qc lsp unit candid coverage;
     }
     // nixpkgs.lib.optionalAttrs
-         (system == "x86_64-linux")
+         (system == accept-bench)
          (fix_names { bench = perf_subdir true "bench" [ moc nixpkgs.drun ic-wasm ];})
     // { recurseForDerivations = true; };
 

--- a/default.nix
+++ b/default.nix
@@ -371,6 +371,11 @@ rec {
             type -p moc && moc --version
             make -C ${dir}${nixpkgs.lib.optionalString accept " accept"}
           '';
+
+          installPhase = nixpkgs.lib.optionalString accept ''
+            mkdir -p $out/share
+            cp -v ${dir}/ok/*.ok $out/share
+          '';
       };
 
     test_subdir = dir: deps: acceptable_subdir false dir deps;

--- a/test/bench/ok/palindrome.drun-run.ok
+++ b/test/bench/ok/palindrome.drun-run.ok
@@ -2,7 +2,7 @@ ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a000000000000000001
 ingress Completed: Reply: 0x4449444c0000
 debug.print: (true, +1_188, 12_573)
 debug.print: (false, +1_188, 11_622)
-debug.print: (false, +1_188, 12_552)
+debug.print: (false, +1_188, 12_553)
 debug.print: (true, +868, 12_713)
 debug.print: (false, +868, 11_176)
 debug.print: (false, +868, 12_661)

--- a/test/bench/ok/palindrome.drun-run.ok
+++ b/test/bench/ok/palindrome.drun-run.ok
@@ -2,7 +2,7 @@ ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a000000000000000001
 ingress Completed: Reply: 0x4449444c0000
 debug.print: (true, +1_188, 12_573)
 debug.print: (false, +1_188, 11_622)
-debug.print: (false, +1_188, 12_555)
+debug.print: (false, +1_188, 12_552)
 debug.print: (true, +868, 12_713)
 debug.print: (false, +868, 11_176)
 debug.print: (false, +868, 12_661)

--- a/test/bench/ok/palindrome.drun-run.ok
+++ b/test/bench/ok/palindrome.drun-run.ok
@@ -2,7 +2,7 @@ ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a000000000000000001
 ingress Completed: Reply: 0x4449444c0000
 debug.print: (true, +1_188, 12_573)
 debug.print: (false, +1_188, 11_622)
-debug.print: (false, +1_188, 12_553)
+debug.print: (false, +1_188, 12_555)
 debug.print: (true, +868, 12_713)
 debug.print: (false, +868, 11_176)
 debug.print: (false, +868, 12_661)

--- a/test/bench/ok/region-mem.drun-run.ok
+++ b/test/bench/ok/region-mem.drun-run.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {heap_diff = 0; instr_diff = 5_286_359_401}
+debug.print: {heap_diff = 0; instr_diff = 5_290_967_401}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/region0-mem.drun-run.ok
+++ b/test/bench/ok/region0-mem.drun-run.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {heap_diff = 0; instr_diff = 5_714_178_409}
+debug.print: {heap_diff = 0; instr_diff = 5_718_786_409}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/stable-mem.drun-run.ok
+++ b/test/bench/ok/stable-mem.drun-run.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {heap_diff = 0; instr_diff = 3_927_404_905}
+debug.print: {heap_diff = 0; instr_diff = 3_932_012_905}
 ingress Completed: Reply: 0x4449444c0000


### PR DESCRIPTION
Looks like our local build environments are too diverse to single out one platform for local testing. So I went with CI-side updating of the numbers, creating commits.

This will require folks to do either a `git pull` at times or a `git pull --rebase` if you added commits in the meantime. Trying to push without that will be rejected. I hope that is acceptable!