### PR TITLE
chore: fixes warnings in `src/`

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 ; -w arguments below are documented in https://ocaml.org/manual/comp.html
 ; (search for "-w warning-list" in that page)
 (env
- (dev (flags "-w" "+a-4-23-27-30-32-42-44-45-58"))
+ (dev (flags "-w" "+a-4-23-27-30-32-42-44-45-58-70"))
  (release (flags "-w" "+a-4-23-27-30-32-42-44-45-58-60-69-70" "-warn-error" "+a"))
  (release-static (flags "-w" "+a-4-23-27-30-32-42-44-45-58-60-69-70" "-warn-error" "+a" "-cclib" "-static"))
 )

--- a/src/idllib/pipeline.ml
+++ b/src/idllib/pipeline.ml
@@ -105,7 +105,7 @@ let chase_imports senv imports =
         pending := S.add file !pending;
         let open Diag.Syntax in
         let* prog, base = parse_file file in
-        let* imports = Resolve_import.resolve prog base in
+        let imports = Resolve_import.resolve prog base in
         let* () = go_set imports in
         let* base_env = merge_env imports senv !lib_env in
         let* scope, _ = check_prog base_env prog in
@@ -119,7 +119,7 @@ let chase_imports senv imports =
 let load_prog parse senv =
   let open Diag.Syntax in
   let* prog, base = parse in
-  let* imports = Resolve_import.resolve prog base in
+  let imports = Resolve_import.resolve prog base in
   let* lib_env = chase_imports senv imports in
   let* base_env = merge_env imports senv lib_env in
   let* scope, actor = check_prog base_env prog in

--- a/src/idllib/resolve_import.ml
+++ b/src/idllib/resolve_import.ml
@@ -3,7 +3,6 @@ type filepath = string
 module Set = Set.Make(String)
 
 type env = {
-  msgs : Diag.msg_store;
   base : filepath Lazy.t;
   imported : Set.t ref;
 }
@@ -20,15 +19,11 @@ and dec env d = match d.it with
              else f in
      fp := f;
      env.imported := Set.add f !(env.imported)
-         
+
 let prog env p = decs env p.it.decs
-   
-let resolve : Syntax.prog -> filepath -> filepath list Diag.result = fun p base ->
-  Diag.with_message_store (fun msgs ->
-      let base = lazy (if Sys.is_directory base then base else Filename.dirname base) in
-      let env = { msgs; base; imported = ref Set.empty } in
-      prog env p;
-      Some (Set.elements !(env.imported))
-    )
-    
-       
+
+let resolve : Syntax.prog -> filepath -> filepath list = fun p base ->
+  let base = lazy (if Sys.is_directory base then base else Filename.dirname base) in
+  let env = { base; imported = ref Set.empty } in
+  prog env p;
+  Set.elements !(env.imported)

--- a/src/idllib/resolve_import.mli
+++ b/src/idllib/resolve_import.mli
@@ -1,3 +1,3 @@
 module Set : Set.S with type elt = String.t
 
-val resolve : Syntax.prog -> string -> string list Diag.result                                   
+val resolve : Syntax.prog -> string -> string list

--- a/src/languageServer/declaration_index.ml
+++ b/src/languageServer/declaration_index.ml
@@ -60,7 +60,6 @@ module Index = Map.Make (String)
 
 type declaration_index = {
   modules : ide_decl list Index.t;
-  actors : ide_decl list Index.t;
   package_map : Pipeline.ResolveImport.package_map;
   ic_aliases : Pipeline.ResolveImport.aliases;
   actor_idl_path : Pipeline.ResolveImport.actor_idl_path;
@@ -193,7 +192,6 @@ let empty : string -> t =
   in
   {
     modules = Index.empty;
-    actors = Index.empty;
     package_map =
       Flags.M.map (Lib.FilePath.make_absolute cwd) resolved_flags.packages;
     ic_aliases = resolved_flags.aliases;


### PR DESCRIPTION
Just saw these run by when building fresh

In `src/` `make clean && make` should now compile without warnings.

I decided to ignore warning 70 (missing .mli files) during development, as we seem to generally not mandate interface files.