### PR TITLE
chore: support for splitting tests between `release` and `debug` builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
 
     - run: nix-env -iA nix-build-uncached -f nix/
 
-    - name: "nix-build"
+    - name: "nix-build-${{ matrix.build_type }}"
       run: nix-build-uncached --max-jobs auto -A ${{ matrix.build_type }}-systems-go -build-flags -L
 
     - name: Discover `test/bench` changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-13, ubuntu-24.04-arm, macos-latest ]
+        build_type: [ release, debug ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -51,17 +52,17 @@ jobs:
     - run: nix-env -iA nix-build-uncached -f nix/
 
     - name: "nix-build"
-      run: nix-build-uncached --max-jobs auto -A all-systems-go -build-flags -L
+      run: nix-build-uncached --max-jobs auto -A ${{ matrix.build_type }}-systems-go -build-flags -L
 
     - name: Discover `test/bench` changes
-      if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request' && matrix.build_type == 'release'
       run: |
         git diff --no-index $(nix-build -A tests.bench)/share test/bench/ok | patch -p1 -R
         git switch ${{ github.event.pull_request.head.ref }}
         git branch --show-current
 
     - name: Commit `test/bench` changes
-      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request' && matrix.build_type == 'release'
       uses: EndBug/add-and-commit@v9
       with:
         default_author: github_actions
@@ -73,7 +74,7 @@ jobs:
         commit: -- test/bench/ok
 
     - name: Calculate performance delta
-      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request' && matrix.build_type == 'release'
       run: |
         from="$(git merge-base origin/${{ github.base_ref }} HEAD)"
         to="${{ github.event.pull_request.head.sha }}"
@@ -84,14 +85,14 @@ jobs:
           --argstr to "$to"
 
     - name: Read performance delta
-      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request' && matrix.build_type == 'release'
       id: perf
       uses: juliangruber/read-file-action@v1
       with:
         path: ./perf-delta.txt
 
     - name: Find performance comment
-      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request'
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request' && matrix.build_type == 'release'
       uses: peter-evans/find-comment@v3
       id: fc
       with:
@@ -102,7 +103,7 @@ jobs:
     # Forks can't add comments so this job does not run on forks, see
     # motoko#2864.
     - name: Create or update performance comment
-      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      if: github.actor != 'dependabot[bot]' && runner.os == 'Linux' && runner.arch == 'X64' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.build_type == 'release'
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/default.nix
+++ b/default.nix
@@ -808,62 +808,68 @@ rec {
       # Get the actual derivations for the selected names
       builtins.map (name: tests.${name}) selected_names;
 
-  # Release version - excludes debug tests.
-  let release-systems-go = nixpkgs.releaseTools.aggregate {
-    name = "release-systems-go";
-    constituents = [
-      moc
-      mo-ide
-      mo-doc
-      didc
-      deser
-      samples
-      rts
-      base-src
-      base-tests
-      base-doc
-      docs
-      report-site
-      shell
-      check-formatting
-      check-rts-formatting
-      check-generated
-      check-grammar
-      check-error-codes
-    ] ++
-    filter_tests "release" tests  # Only include release tests.
-    ++ builtins.attrValues js
-    ;
-  };
+  # Release version - excludes debug tests
+  release-systems-go = let
+    release-systems-go = nixpkgs.releaseTools.aggregate {
+      name = "release-systems-go";
+      constituents = [
+        moc
+        mo-ide
+        mo-doc
+        didc
+        deser
+        samples
+        rts
+        base-src
+        base-tests
+        base-doc
+        docs
+        report-site
+        shell
+        check-formatting
+        check-rts-formatting
+        check-generated
+        check-grammar
+        check-error-codes
+      ] ++
+      filter_tests "release" tests  # Only include release tests
+      ++ builtins.attrValues js
+      ;
+    };
+  in
+    release-systems-go;
 
-  # Debug version - only includes debug tests.
-  let debug-systems-go = nixpkgs.releaseTools.aggregate {
-    name = "debug-systems-go";
-    constituents = [
-      moc
-      mo-ide
-      mo-doc
-      didc
-      deser
-      samples
-      rts
-      base-src
-      base-tests
-      base-doc
-      docs
-      report-site
-      shell
-      check-formatting
-      check-rts-formatting
-      check-generated
-      check-grammar
-      check-error-codes
-    ] ++
-    filter_tests "debug" tests  # Only include debug tests.
-    ++ builtins.attrValues js
-    ;
-  };
-
+  # Debug version - only includes debug tests
+  debug-systems-go = let
+    debug-systems-go = nixpkgs.releaseTools.aggregate {
+      name = "debug-systems-go";
+      constituents = [
+        moc
+        mo-ide
+        mo-doc
+        didc
+        deser
+        samples
+        rts
+        base-src
+        base-tests
+        base-doc
+        docs
+        report-site
+        shell
+        check-formatting
+        check-rts-formatting
+        check-generated
+        check-grammar
+        check-error-codes
+      ] ++
+      filter_tests "debug" tests  # Only include debug tests
+      ++ builtins.attrValues js
+      ;
+    };
+  in
+    debug-systems-go;
+    
   viperServer = nixpkgs.fetchurl {
     url = https://github.com/viperproject/viperserver/releases/download/v.22.11-release/viperserver.jar;
     sha256 = "sha256-debC8ZpbIjgpEeISCISU0EVySJvf+WsUkUaLuJ526wA=";

--- a/default.nix
+++ b/default.nix
@@ -832,8 +832,7 @@ rec {
     name = "release-systems-go";
     constituents = common-constituents ++
     filter_tests "release" tests  # Only include release tests
-    ++ builtins.attrValues js
-    ;
+    ++ builtins.attrValues js;
   };
 
   # Debug version - only includes debug tests

--- a/default.nix
+++ b/default.nix
@@ -787,6 +787,75 @@ rec {
       '';
   };
 
+  # Helper function to filter tests by type.
+  filter_tests = type: tests:
+    builtins.filter (test: 
+      if type == "debug" then
+        # Match tests ending in -dbg or -debug
+        builtins.match ".*-dbg$" test.name != null || 
+        builtins.match ".*-debug$" test.name != null
+      else
+        # Match tests that don't end in -dbg or -debug
+        builtins.match ".*-dbg$" test.name == null && 
+        builtins.match ".*-debug$" test.name == null
+    ) (builtins.attrValues tests);
+
+  # Release version - excludes debug tests.
+  release-systems-go = nixpkgs.releaseTools.aggregate {
+    name = "release-systems-go";
+    constituents = [
+      moc
+      mo-ide
+      mo-doc
+      didc
+      deser
+      samples
+      rts
+      base-src
+      base-tests
+      base-doc
+      docs
+      report-site
+      shell
+      check-formatting
+      check-rts-formatting
+      check-generated
+      check-grammar
+      check-error-codes
+    ] ++
+    filter_tests "release" tests  # Only include release tests.
+    ++ builtins.attrValues js
+    ;
+  };
+
+  # Debug version - only includes debug tests
+  debug-systems-go = nixpkgs.releaseTools.aggregate {
+    name = "debug-systems-go";
+    constituents = [
+      moc
+      mo-ide
+      mo-doc
+      didc
+      deser
+      samples
+      rts
+      base-src
+      base-tests
+      base-doc
+      docs
+      report-site
+      shell
+      check-formatting
+      check-rts-formatting
+      check-generated
+      check-grammar
+      check-error-codes
+    ] ++
+    filter_tests "debug" tests  # Only include debug tests.
+    ++ builtins.attrValues js
+    ;
+  };
+
   all-systems-go = nixpkgs.releaseTools.aggregate {
     name = "all-systems-go";
     constituents = [

--- a/default.nix
+++ b/default.nix
@@ -840,8 +840,7 @@ rec {
     name = "debug-systems-go";
     constituents = common-constituents ++
     filter_tests "debug" tests  # Only include debug tests
-    ++ builtins.attrValues js
-    ;
+    ++ builtins.attrValues js;
   };
 
   viperServer = nixpkgs.fetchurl {

--- a/default.nix
+++ b/default.nix
@@ -809,66 +809,60 @@ rec {
       builtins.map (name: tests.${name}) selected_names;
 
   # Release version - excludes debug tests
-  release-systems-go = let
-    release-systems-go = nixpkgs.releaseTools.aggregate {
-      name = "release-systems-go";
-      constituents = [
-        moc
-        mo-ide
-        mo-doc
-        didc
-        deser
-        samples
-        rts
-        base-src
-        base-tests
-        base-doc
-        docs
-        report-site
-        shell
-        check-formatting
-        check-rts-formatting
-        check-generated
-        check-grammar
-        check-error-codes
-      ] ++
-      filter_tests "release" tests  # Only include release tests
-      ++ builtins.attrValues js
-      ;
-    };
-  in
-    release-systems-go;
+  release-systems-go = nixpkgs.releaseTools.aggregate {
+    name = "release-systems-go";
+    constituents = [
+      moc
+      mo-ide
+      mo-doc
+      didc
+      deser
+      samples
+      rts
+      base-src
+      base-tests
+      base-doc
+      docs
+      report-site
+      shell
+      check-formatting
+      check-rts-formatting
+      check-generated
+      check-grammar
+      check-error-codes
+    ] ++
+    filter_tests "release" tests  # Only include release tests
+    ++ builtins.attrValues js
+    ;
+  };
 
   # Debug version - only includes debug tests
-  debug-systems-go = let
-    debug-systems-go = nixpkgs.releaseTools.aggregate {
-      name = "debug-systems-go";
-      constituents = [
-        moc
-        mo-ide
-        mo-doc
-        didc
-        deser
-        samples
-        rts
-        base-src
-        base-tests
-        base-doc
-        docs
-        report-site
-        shell
-        check-formatting
-        check-rts-formatting
-        check-generated
-        check-grammar
-        check-error-codes
-      ] ++
-      filter_tests "debug" tests  # Only include debug tests
-      ++ builtins.attrValues js
-      ;
-    };
-  in
-    debug-systems-go;
+  debug-systems-go = nixpkgs.releaseTools.aggregate {
+    name = "debug-systems-go";
+    constituents = [
+      moc
+      mo-ide
+      mo-doc
+      didc
+      deser
+      samples
+      rts
+      base-src
+      base-tests
+      base-doc
+      docs
+      report-site
+      shell
+      check-formatting
+      check-rts-formatting
+      check-generated
+      check-grammar
+      check-error-codes
+    ] ++
+    filter_tests "debug" tests  # Only include debug tests
+    ++ builtins.attrValues js
+    ;
+  };
     
   viperServer = nixpkgs.fetchurl {
     url = https://github.com/viperproject/viperserver/releases/download/v.22.11-release/viperserver.jar;

--- a/default.nix
+++ b/default.nix
@@ -808,29 +808,31 @@ rec {
       # Get the actual derivations for the selected names
       builtins.map (name: tests.${name}) selected_names;
 
+  common-constituents = [
+    moc
+    mo-ide
+    mo-doc
+    didc
+    deser
+    samples
+    rts
+    base-src
+    base-tests
+    base-doc
+    docs
+    report-site
+    shell
+    check-formatting
+    check-rts-formatting
+    check-generated
+    check-grammar
+    check-error-codes
+  ];
+
   # Release version - excludes debug tests
   release-systems-go = nixpkgs.releaseTools.aggregate {
     name = "release-systems-go";
-    constituents = [
-      moc
-      mo-ide
-      mo-doc
-      didc
-      deser
-      samples
-      rts
-      base-src
-      base-tests
-      base-doc
-      docs
-      report-site
-      shell
-      check-formatting
-      check-rts-formatting
-      check-generated
-      check-grammar
-      check-error-codes
-    ] ++
+    constituents = common-constituents ++
     filter_tests "release" tests  # Only include release tests
     ++ builtins.attrValues js
     ;
@@ -839,31 +841,12 @@ rec {
   # Debug version - only includes debug tests
   debug-systems-go = nixpkgs.releaseTools.aggregate {
     name = "debug-systems-go";
-    constituents = [
-      moc
-      mo-ide
-      mo-doc
-      didc
-      deser
-      samples
-      rts
-      base-src
-      base-tests
-      base-doc
-      docs
-      report-site
-      shell
-      check-formatting
-      check-rts-formatting
-      check-generated
-      check-grammar
-      check-error-codes
-    ] ++
+    constituents = common-constituents ++
     filter_tests "debug" tests  # Only include debug tests
     ++ builtins.attrValues js
     ;
   };
-    
+
   viperServer = nixpkgs.fetchurl {
     url = https://github.com/viperproject/viperserver/releases/download/v.22.11-release/viperserver.jar;
     sha256 = "sha256-debC8ZpbIjgpEeISCISU0EVySJvf+WsUkUaLuJ526wA=";

--- a/default.nix
+++ b/default.nix
@@ -808,8 +808,8 @@ rec {
       # Get the actual derivations for the selected names
       builtins.map (name: tests.${name}) selected_names;
 
-  # Release version - excludes debug tests
-  release-systems-go = nixpkgs.releaseTools.aggregate {
+  # Release version - excludes debug tests.
+  let release-systems-go = nixpkgs.releaseTools.aggregate {
     name = "release-systems-go";
     constituents = [
       moc
@@ -836,8 +836,8 @@ rec {
     ;
   };
 
-  # Debug version - only includes debug tests
-  debug-systems-go = nixpkgs.releaseTools.aggregate {
+  # Debug version - only includes debug tests.
+  let debug-systems-go = nixpkgs.releaseTools.aggregate {
     name = "debug-systems-go";
     constituents = [
       moc
@@ -860,34 +860,6 @@ rec {
       check-error-codes
     ] ++
     filter_tests "debug" tests  # Only include debug tests.
-    ++ builtins.attrValues js
-    ;
-  };
-
-  all-systems-go = nixpkgs.releaseTools.aggregate {
-    name = "all-systems-go";
-    constituents = [
-      moc
-      mo-ide
-      mo-doc
-      didc
-      deser
-      samples
-      rts
-      base-src
-      base-tests
-      base-doc
-      docs
-      report-site
-      # ic-ref-run
-      shell
-      check-formatting
-      check-rts-formatting
-      check-generated
-      check-grammar
-      check-error-codes
-    ] ++
-    builtins.attrValues tests
     ++ builtins.attrValues js
     ;
   };

--- a/default.nix
+++ b/default.nix
@@ -525,12 +525,12 @@ rec {
 
   in fix_names {
       run        = test_subdir "run"        [ moc ] ;
-      run-dbg    = snty_subdir "run"        [ moc ] ;
+      run-debug  = snty_subdir "run"        [ moc ] ;
       run-eop-release = enhanced_orthogonal_persistence_subdir "run" [ moc ];
       run-eop-debug = snty_enhanced_orthogonal_persistence_subdir "run" [ moc ];
       # ic-ref-run = test_subdir "run-drun"   [ moc ic-ref-run ];
       drun       = test_subdir "run-drun"   [ moc nixpkgs.drun ];
-      drun-dbg   = snty_subdir "run-drun"   [ moc nixpkgs.drun ];
+      drun-debug = snty_subdir "run-drun"   [ moc nixpkgs.drun ];
       drun-compacting-gc = snty_compacting_gc_subdir "run-drun" [ moc nixpkgs.drun ] ;
       drun-generational-gc = snty_generational_gc_subdir "run-drun" [ moc nixpkgs.drun ] ;
       drun-incremental-gc = snty_incremental_gc_subdir "run-drun" [ moc nixpkgs.drun ] ;
@@ -792,13 +792,11 @@ rec {
     let
       # Get all test names that match the pattern
       debug_tests = builtins.filter (name: 
-        builtins.match ".*-dbg$" name != null || 
         builtins.match ".*-debug$" name != null
       ) (builtins.attrNames tests);
       
       # Get all test names that don't match the pattern
       release_tests = builtins.filter (name:
-        builtins.match ".*-dbg$" name == null && 
         builtins.match ".*-debug$" name == null
       ) (builtins.attrNames tests);
       


### PR DESCRIPTION
This PR splits the CI testing pipeline between release and debug builds, adding more fine-grained control and parallelism for running the tests.