### PR TITLE
Stable Functions: Display Function Names in RTS Errors

### DIFF
--- a/rts/motoko-rts-tests/src/gc/enhanced.rs
+++ b/rts/motoko-rts-tests/src/gc/enhanced.rs
@@ -27,6 +27,7 @@ impl GC {
                     unused_root,
                     unused_root,
                     unused_root,
+                    unused_root,
                 ];
                 IncrementalGC::instance(heap, get_incremental_gc_state())
                     .empty_call_stack_increment(roots);

--- a/rts/motoko-rts-tests/src/gc/incremental/roots.rs
+++ b/rts/motoko-rts-tests/src/gc/incremental/roots.rs
@@ -138,6 +138,7 @@ unsafe fn get_roots(heap: &MotokoHeap) -> Roots {
         unused_root,
         unused_root,
         unused_root,
+        unused_root,
     ]
 }
 

--- a/rts/motoko-rts/src/gc/incremental/roots/enhanced.rs
+++ b/rts/motoko-rts/src/gc/incremental/roots/enhanced.rs
@@ -17,7 +17,7 @@ static mut STATIC_VARIABLES: Value = crate::types::NULL_POINTER;
 static mut INITIALIZED_VARIABLES: usize = 0;
 
 /// GC root set.
-pub type Roots = [*mut Value; 8];
+pub type Roots = [*mut Value; 9];
 
 pub unsafe fn visit_roots<C, V: Fn(&mut C, *mut Value)>(
     roots: Roots,
@@ -35,7 +35,7 @@ pub unsafe fn visit_roots<C, V: Fn(&mut C, *mut Value)>(
 pub unsafe fn root_set() -> Roots {
     use crate::{
         continuation_table::continuation_table_loc,
-        persistence::{stable_actor_location, stable_function_state, stable_type_descriptor},
+        persistence::{stable_actor_location, stable_function_state, stable_type_descriptor, name_table_location},
         region::region0_get_ptr_loc,
     };
     [
@@ -47,6 +47,7 @@ pub unsafe fn root_set() -> Roots {
         region0_get_ptr_loc(),
         stable_function_state().virtual_table_location(),
         stable_function_state().literal_table_location(),
+        name_table_location(),
     ]
 }
 

--- a/rts/motoko-rts/src/gc/incremental/roots/enhanced.rs
+++ b/rts/motoko-rts/src/gc/incremental/roots/enhanced.rs
@@ -35,7 +35,10 @@ pub unsafe fn visit_roots<C, V: Fn(&mut C, *mut Value)>(
 pub unsafe fn root_set() -> Roots {
     use crate::{
         continuation_table::continuation_table_loc,
-        persistence::{stable_actor_location, stable_function_state, stable_type_descriptor, name_table_location},
+        persistence::{
+            name_table_location, stable_actor_location, stable_function_state,
+            stable_type_descriptor,
+        },
         region::region0_get_ptr_loc,
     };
     [

--- a/rts/motoko-rts/src/persistence.rs
+++ b/rts/motoko-rts/src/persistence.rs
@@ -3,8 +3,8 @@
 //! Persistent metadata table, located at 6MB, in the static partition space.
 
 pub mod compatibility;
-pub mod stable_functions;
 mod name_resolution;
+pub mod stable_functions;
 
 use compatibility::MemoryCompatibilityTest;
 use motoko_rts_macros::ic_mem_fn;

--- a/rts/motoko-rts/src/persistence/name_resolution.rs
+++ b/rts/motoko-rts/src/persistence/name_resolution.rs
@@ -2,12 +2,12 @@
 //!
 //! Currently only used for stable function names, to yield better error messages
 //! for missing or incompatible stable functions.
-//! 
+//!
 //! Can be extended to also cover field and option names, for e.g. data visualizer.
 
-use crate::types::{block_size, Blob, Value};
 use crate::algorithms::SortedArray;
 use crate::persistence::load_name_table;
+use crate::types::{block_size, Blob, Value};
 use alloc::string::{String, ToString};
 use core::slice::from_raw_parts;
 use core::str::from_utf8;

--- a/rts/motoko-rts/src/persistence/name_resolution.rs
+++ b/rts/motoko-rts/src/persistence/name_resolution.rs
@@ -67,7 +67,8 @@ impl NameTable {
 
     unsafe fn text_section_length(self: *const Self) -> usize {
         let length = block_size(self as usize).to_bytes().as_usize();
-        length - self.text_section_start() as usize
+        let end = self as usize + length;
+        end - self.text_section_start() as usize
     }
 
     unsafe fn text_section_read(self: *mut Self, offset: usize, length: usize) -> String {
@@ -92,7 +93,7 @@ impl SortedArray<NameHash> for *mut NameTable {
 }
 
 fn undefined_name(hash: NameHash) -> String {
-    let buffer = format!(100, "unknown<{hash}>");
+    let buffer = format!(100, "<{hash}>");
     from_utf8(&buffer).unwrap().to_string()
 }
 

--- a/rts/motoko-rts/src/persistence/name_resolution.rs
+++ b/rts/motoko-rts/src/persistence/name_resolution.rs
@@ -1,0 +1,107 @@
+//! Resolution of name hashes for debugging or introspection purposes.
+//!
+//! Currently only used for stable function names, to yield better error messages
+//! for missing or incompatible stable functions.
+//! 
+//! Can be extended to also cover field and option names, for e.g. data visualizer.
+
+use crate::types::{block_size, Blob, Value};
+use crate::algorithms::SortedArray;
+use crate::persistence::load_name_table;
+use alloc::string::{String, ToString};
+use core::slice::from_raw_parts;
+use core::str::from_utf8;
+
+// Not using `u32` or `u64` to avoid implicit padding issues in `NameRecord`.
+type NameHash = usize;
+
+#[repr(C)]
+struct NameRecord {
+    hash: NameHash,
+    // Offset in text section.
+    offset: usize,
+    // Length in text section.
+    length: usize,
+}
+
+#[repr(C)]
+pub struct NameTable {
+    header: Blob,
+    // Number of hash entries.
+    size: usize,
+    // Series of `NameRecord` of length `size`, sorted by `hash`.
+    // UTF8 text section, texts are looked up by `offset` and `length`.
+}
+
+impl NameTable {
+    unsafe fn from_blob(value: Value) -> *mut Self {
+        value.as_blob_mut() as *mut Self
+    }
+
+    unsafe fn size(self: *const Self) -> usize {
+        (*self).size
+    }
+
+    unsafe fn get(self: *mut Self, index: usize) -> *mut NameRecord {
+        assert!(index <= self.size());
+        let base = self.add(1) as *mut NameRecord; // Skip `NameTable` header
+        let record = base.add(index);
+        debug_assert!((record as usize) < self.text_section_start() as usize);
+        record
+    }
+
+    unsafe fn lookup(self: *mut Self, hash: NameHash) -> String {
+        match self.index_of(hash) {
+            None => undefined_name(hash),
+            Some(index) => {
+                let record = self.get(index);
+                self.text_section_read((*record).offset, (*record).length)
+            }
+        }
+    }
+
+    unsafe fn text_section_start(self: *const Self) -> *const u8 {
+        let base = self.add(1) as *mut NameRecord; // Skip `NameTable` header
+        base.add(self.size()) as usize as *const u8
+    }
+
+    unsafe fn text_section_length(self: *const Self) -> usize {
+        let length = block_size(self as usize).to_bytes().as_usize();
+        length - self.text_section_start() as usize
+    }
+
+    unsafe fn text_section_read(self: *mut Self, offset: usize, length: usize) -> String {
+        debug_assert!(offset + length < self.text_section_length());
+        let section = self.text_section_start();
+        let slice = from_raw_parts(section.add(offset), length);
+        from_utf8(slice).unwrap().to_string()
+    }
+}
+
+impl SortedArray<NameHash> for *mut NameTable {
+    fn get_length(&self) -> usize {
+        unsafe { self.size() }
+    }
+
+    fn value_at(&self, index: usize) -> NameHash {
+        unsafe {
+            let record = self.get(index);
+            (*record).hash
+        }
+    }
+}
+
+fn undefined_name(hash: NameHash) -> String {
+    let buffer = format!(100, "unknown<{hash}>");
+    from_utf8(&buffer).unwrap().to_string()
+}
+
+pub unsafe fn lookup_name(hash: NameHash) -> String {
+    let value = load_name_table();
+    if value.is_non_null_ptr() {
+        let table = NameTable::from_blob(value);
+        table.lookup(hash)
+    } else {
+        undefined_name(hash)
+    }
+}

--- a/rts/motoko-rts/src/persistence/stable_functions.rs
+++ b/rts/motoko-rts/src/persistence/stable_functions.rs
@@ -340,8 +340,7 @@ impl StableFunctionMap {
     }
 }
 
-/// Garbage collect the stable functions in the old version on an upgrade.
-/// Called on EOP upgrade and graph copy stabilization start.
+/// Garbage collect the stable functions in the old version on an EOP upgrade.
 pub unsafe fn collect_stable_functions<M: Memory>(mem: &mut M, old_actor: Value) {
     // Retrieve the persistent virtual, or, if not present, initialize an empty one.
     let virtual_table = prepare_virtual_table(mem);

--- a/rts/motoko-rts/src/persistence/stable_functions.rs
+++ b/rts/motoko-rts/src/persistence/stable_functions.rs
@@ -110,9 +110,9 @@ use crate::{
     algorithms::SortedArray,
     barriers::{allocation_barrier, write_with_barrier},
     memory::{alloc_blob, Memory},
+    persistence::name_resolution::lookup_name,
     rts_trap_with,
     types::{Blob, Bytes, Value, NULL_POINTER, TAG_BLOB_B, TAG_CLOSURE},
-    persistence::name_resolution::lookup_name,
 };
 
 use super::{compatibility::MemoryCompatibilityTest, stable_function_state};

--- a/rts/motoko-rts/src/persistence/stable_functions.rs
+++ b/rts/motoko-rts/src/persistence/stable_functions.rs
@@ -112,6 +112,7 @@ use crate::{
     memory::{alloc_blob, Memory},
     rts_trap_with,
     types::{Blob, Bytes, Value, NULL_POINTER, TAG_BLOB_B, TAG_CLOSURE},
+    persistence::name_resolution::lookup_name,
 };
 
 use super::{compatibility::MemoryCompatibilityTest, stable_function_state};
@@ -420,7 +421,8 @@ unsafe fn update_existing_functions(
         let marked = (*virtual_table_entry).marked;
         if marked {
             if stable_function_entry == null_mut() {
-                let buffer = format!(200, "Incompatible upgrade: Stable function {name_hash} is missing in the new program version");
+                let name = lookup_name(name_hash);
+                let buffer = format!(200, "Incompatible upgrade: Stable function {name} is missing in the new program version");
                 let message = from_utf8(&buffer).unwrap();
                 rts_trap_with(message);
             }
@@ -431,9 +433,10 @@ unsafe fn update_existing_functions(
             if type_test
                 .is_some_and(|test| !test.is_compatible(old_closure as i32, new_closure as i32))
             {
+                let name = lookup_name(name_hash);
                 let buffer = format!(
                     200,
-                    "Memory-incompatible closure type of stable function {name_hash}"
+                    "Memory-incompatible closure type of stable function {name}"
                 );
                 let message = from_utf8(&buffer).unwrap();
                 rts_trap_with(message);

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -8922,7 +8922,6 @@ module StableFunctionGC = struct
       in
       let root_types = stable_actor.Ir.post::stable_closures in
       let map, _ = List.fold_left (collect_types true) (TM.empty, 0) root_types in
-      TM.iter (fun typ id -> Printf.printf "REACHABLE id %i %s\n" id (string_of_typ typ)) map;
       map
 
   let get_type_index reachable_types typ =

--- a/test/run-drun/dropping-stable-functions.drun
+++ b/test/run-drun/dropping-stable-functions.drun
@@ -1,0 +1,5 @@
+# ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+# SKIP ic-ref-run
+install $ID dropping-stable-functions/version0.mo ""
+upgrade $ID dropping-stable-functions/version1.mo ""
+upgrade $ID dropping-stable-functions/version2.mo ""

--- a/test/run-drun/dropping-stable-functions/migration.mo
+++ b/test/run-drun/dropping-stable-functions/migration.mo
@@ -1,0 +1,14 @@
+module {
+    type OldActor = {
+        required: stable () -> ();
+        optional: stable () -> ();
+    };
+
+    type NewActor = {
+        retained: stable () -> ();
+    };
+
+    public func run(old: OldActor): NewActor {
+        { retained = old.required }
+    }
+}

--- a/test/run-drun/dropping-stable-functions/version0.mo
+++ b/test/run-drun/dropping-stable-functions/version0.mo
@@ -1,0 +1,16 @@
+import Prim "mo:prim";
+
+persistent actor {
+    func requiredFunction() {
+        Prim.debugPrint("REQUIRED FUNCTION VERSION 0");
+    };
+
+    func optionalFunction() {
+        Prim.debugPrint("OPTIONAL FUNCTION VERSION 0");
+    };
+
+    let required = requiredFunction;
+    let optional = optionalFunction;
+    required();
+    optional();
+}

--- a/test/run-drun/dropping-stable-functions/version1.mo
+++ b/test/run-drun/dropping-stable-functions/version1.mo
@@ -1,0 +1,18 @@
+import Prim "mo:prim";
+import Migration "migration";
+
+(with migration = Migration.run)
+persistent actor {
+    func requiredFunction() {
+        Prim.debugPrint("REQUIRED FUNCTION VERSION 1");
+    };
+
+    // Need to keep this function, as it may be still called by migration logic!
+    func optionalFunction() {
+        Prim.debugPrint("OPTIONAL FUNCTION VERSION 1");
+    };
+
+    var retained = optionalFunction;
+    retained := requiredFunction;
+    retained();
+}

--- a/test/run-drun/dropping-stable-functions/version2.mo
+++ b/test/run-drun/dropping-stable-functions/version2.mo
@@ -1,0 +1,10 @@
+import Prim "mo:prim";
+
+persistent actor {
+    func requiredFunction() {
+        Prim.debugPrint("REQUIRED FUNCTION VERSION 2");
+    };
+
+    var retained = requiredFunction;
+    retained();
+}

--- a/test/run-drun/dropping-stable-functions/version2.mo
+++ b/test/run-drun/dropping-stable-functions/version2.mo
@@ -5,6 +5,6 @@ persistent actor {
         Prim.debugPrint("REQUIRED FUNCTION VERSION 2");
     };
 
-    var retained = requiredFunction;
+    let retained = requiredFunction;
     retained();
 }

--- a/test/run-drun/missing-stable-functions.drun
+++ b/test/run-drun/missing-stable-functions.drun
@@ -1,0 +1,4 @@
+# ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+# SKIP ic-ref-run
+install $ID missing-stable-functions/version0.mo ""
+upgrade $ID missing-stable-functions/version1.mo ""

--- a/test/run-drun/missing-stable-functions/version0.mo
+++ b/test/run-drun/missing-stable-functions/version0.mo
@@ -1,0 +1,16 @@
+import Prim "mo:prim";
+
+actor {
+    func requiredFunction() {
+        Prim.debugPrint("REQUIRED FUNCTION");
+    };
+
+    func optionalFunction() {
+        Prim.debugPrint("OPTIONAL FUNCTION");
+    };
+
+    stable let required = requiredFunction;
+    stable let optional = optionalFunction;
+    required();
+    optional();
+}

--- a/test/run-drun/missing-stable-functions/version1.mo
+++ b/test/run-drun/missing-stable-functions/version1.mo
@@ -1,0 +1,12 @@
+import Prim "mo:prim";
+
+actor {
+    func otherFunction() {
+        Prim.debugPrint("OPTIONAL FUNCTION");
+    };
+
+    stable let required = otherFunction;
+    stable let optional = otherFunction;
+    required();
+    optional();
+}

--- a/test/run-drun/ok/dropping-stable-functions.drun.ok
+++ b/test/run-drun/ok/dropping-stable-functions.drun.ok
@@ -1,0 +1,8 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+debug.print: REQUIRED FUNCTION VERSION 0
+debug.print: OPTIONAL FUNCTION VERSION 0
+ingress Completed: Reply: 0x4449444c0000
+debug.print: REQUIRED FUNCTION VERSION 1
+ingress Completed: Reply: 0x4449444c0000
+debug.print: REQUIRED FUNCTION VERSION 2
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/missing-stable-functions.drun.ok
+++ b/test/run-drun/ok/missing-stable-functions.drun.ok
@@ -1,5 +1,6 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
-debug.print: VERSION 1 "HELLO!"
+debug.print: REQUIRED FUNCTION
+debug.print: OPTIONAL FUNCTION
 ingress Completed: Reply: 0x4449444c0000
-ingress Err: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'RTS error: Memory-incompatible closure type of stable function TestClass1.testFunction'.
+ingress Err: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'RTS error: Incompatible upgrade: Stable function optionalFunction is missing in the new program version'.
 Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://internetcomputer.org/docs/current/references/execution-errors#trapped-explicitly


### PR DESCRIPTION
Through table lookup for resolving RTS-internal name hash to the fully-qualified name.
Used to report missing stable functions or mismatching closure types.