### PR TITLE
feat: defines a tree-sitter based Motoko mode for Emacs

### DIFF
--- a/emacs/motoko-ts-mode.el
+++ b/emacs/motoko-ts-mode.el
@@ -23,8 +23,7 @@
       "private" "public" "return" "shared"
       "try" "throw" "query" "switch" "type"
       "var" "while" "with" "stable" "flexible" "system"
-      "assert" "ignore" "async" "persistent" "transient"
-      ]
+      "assert" "ignore" "async" "persistent" "transient"]
      @font-lock-keyword-face)
 
    :language 'motoko
@@ -65,9 +64,19 @@
    '((dec_func function_name: (name) @font-lock-function-name-face))
    ))
 
-;; (defvar motoko-ts-indent-rules
-;;   `((motoko
-;;      ((parent-is "block_expr") column-0 0))))
+
+(defvar motoko-ts-indent 2)
+
+;; For debugging
+; (setq treesit--indent-verbose t)
+(defvar motoko-ts-indent-rules
+  `((motoko
+     ((node-is "}") parent-bol 0)
+     ((parent-is "object") parent-bol motoko-ts-indent)
+     ((parent-is "block") parent-bol motoko-ts-indent)
+     ((parent-is "dec_obj") parent-bol motoko-ts-indent)
+     ((parent-is "dec_let") parent-bol motoko-ts-indent)
+     )))
 
 (defun motoko-ts-setup ()
   "Setup treesit for motoko-ts-mode."
@@ -79,8 +88,7 @@
 
   (setq-local treesit-font-lock-settings (motoko-ts-font-lock-rules))
 
-  ;; This handles indentation -- again, more on that below.
-  ;; (setq-local treesit-simple-indent-rules motoko-ts-indent-rules)
+  (setq-local treesit-simple-indent-rules motoko-ts-indent-rules)
 
   (treesit-major-mode-setup))
 
@@ -91,6 +99,9 @@
     (motoko-ts-setup)))
 
 (add-to-list 'auto-mode-alist '("\\.mo\\'" . motoko-ts-mode))
-(add-to-list 'treesit-language-source-alist '(motoko "https://github.com/christoph-dfinity/tree-sitter-motoko"))
+
+(when 'treesit-language-source-alist
+  (add-to-list 'treesit-language-source-alist '(motoko "https://github.com/christoph-dfinity/tree-sitter-motoko")))
+
 
 (provide 'motoko-ts-mode)

--- a/emacs/motoko-ts-mode.el
+++ b/emacs/motoko-ts-mode.el
@@ -1,0 +1,96 @@
+;; -*- lexical-binding: t; -*-
+
+(defun motoko-ts-font-lock-rules ()
+  (treesit-font-lock-rules
+   :language 'motoko
+   :override t
+   :feature 'delimiter
+   '((["(" ")" "[" "]" "{" "}" "<" ">"] @font-lock-bracket-face)
+     ([";", ","] @font-lock-delimiter-face))
+
+   :language 'motoko
+   :override t
+   :feature 'comment
+   '([(line_comment) (block_comment) (doc_comment)] @font-lock-comment-face)
+
+   :language 'motoko
+   :override t
+   :feature 'keyword
+   '(["actor" "and" "await" "break" "case" "catch"
+      "class" "continue" "composite" "debug" "do"
+      "else" "finally" "for" "func" "if" "in" "import"
+      "module" "not" "object" "or" "label" "let" "loop"
+      "private" "public" "return" "shared"
+      "try" "throw" "query" "switch" "type"
+      "var" "while" "with" "stable" "flexible" "system"
+      "assert" "ignore" "async" "persistent" "transient"
+      ]
+     @font-lock-keyword-face)
+
+   :language 'motoko
+   :override t
+   :feature 'calls
+   '((call_exp invoked_value: (variable) @font-lock-function-call-face)
+     (call_exp invoked_value: (exp_post (member key: (name) @font-lock-function-call-face))))
+
+   :language 'motoko
+   :override t
+   :feature 'keyword
+   '((dec_type type_name: (name) @font-lock-type-face))
+
+   :language 'motoko
+   :override t
+   :feature 'keyword
+   '((typ_id type_name: (name) @font-lock-type-face)
+     (typ_bind type_parameter_name: (name) @font-lock-type-face))
+
+   :language 'motoko
+   :override t
+   :feature 'constant
+   '((text) @font-lock-string-face)
+
+   :language 'motoko
+   :override t
+   :feature 'constant
+   '([(nat) (float)] @font-lock-number-face)
+
+   :language 'motoko
+   :override t
+   :feature 'constant
+   '("null" @font-lock-constant-face)
+
+   :language 'motoko
+   :override t
+   :feature 'declaration
+   '((dec_func function_name: (name) @font-lock-function-name-face))
+   ))
+
+;; (defvar motoko-ts-indent-rules
+;;   `((motoko
+;;      ((parent-is "block_expr") column-0 0))))
+
+(defun motoko-ts-setup ()
+  "Setup treesit for motoko-ts-mode."
+
+  (setq-local treesit-font-lock-feature-list
+              '((comment)
+                (constant keyword calls)
+                (declaration)))
+
+  (setq-local treesit-font-lock-settings (motoko-ts-font-lock-rules))
+
+  ;; This handles indentation -- again, more on that below.
+  ;; (setq-local treesit-simple-indent-rules motoko-ts-indent-rules)
+
+  (treesit-major-mode-setup))
+
+(define-derived-mode motoko-ts-mode prog-mode "Motoko"
+  "Major mode for editing Motoko source files"
+  (when (treesit-ready-p 'motoko)
+    (treesit-parser-create 'motoko)
+    (motoko-ts-setup)))
+
+(add-to-list 'auto-mode-alist '("\\.mo\\'" . motoko-ts-mode))
+(add-to-list 'treesit-language-source-alist '(motoko "https://github.com/christoph-dfinity/tree-sitter-motoko"))
+
+(provide 'motoko-ts-mode)


### PR DESCRIPTION
## Motivation

The existing `motoko-model.el` in this repo is based on `swift-mode`, which is a bit sad.

With Emacs 29+ we finally got built-in tree-sitter support, so now it's relatively easy to get nice syntax highlighting and auto-indentation behaviour. Most of the _actual work_ was done by this grammar author: https://github.com/polychromatist/tree-sitter-motoko

This is pretty bare-bones, but I intend on adding a few rules here or there as I spot things that don't highlight or indent nicely.

## Setup
Add this line to your config:
```lisp
(load "/path/to/motoko-ts-mode.el")
```

and run `treesit-install-language-grammar`, pass `motoko` as the grammar name and https://github.com/christoph-dfinity/tree-sitter-motoko as the grammar repo. The remaining prompts can stay as defaults.

Afterwards opening `.mo` files should give you highlighted files with basic indentation support.

![There are dozens of us](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2hraGg4cnlnMHdjMW5iNmF2YjR0cmU4N25idzFrY2I4ZGhwenF0NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ReBGGJtbXrjbQJwByP/giphy.gif)