### PR TITLE
chore: add missing tools to get `make -C test` working again

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -43,6 +43,8 @@ pkgs.mkShell {
         pkgs.ocamlPackages.ocaml-lsp
         pkgs.fswatch
         pkgs.rlwrap # for `rlwrap moc`
+        pkgs.moreutils # `chronic` for `make -C test quick`
+        pkgs.wabt # `wasm-validate` for `test/run.sh`
         pkgs.openjdk
         pkgs.z3_4_12 # for viper dev
         pkgs.difftastic


### PR DESCRIPTION
Not sure about `direnv`'s needs, though...