### PR TITLE
chore: add `drun` to nix shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -48,6 +48,7 @@ pkgs.mkShell {
         pkgs.openjdk
         pkgs.z3_4_12 # for viper dev
         pkgs.difftastic
+        pkgs.drun
       ] ++ pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Security
     ));
 


### PR DESCRIPTION
bring up `drun` in the nix shell, will help with manual running of tests.