### PR TITLE
chore: allow `drun` to run as app subnet

### DIFF
--- a/test/drun-wrapper.sh
+++ b/test/drun-wrapper.sh
@@ -21,6 +21,13 @@ then
   exit 1
 fi
 
+# check if we have a "--subnet-type application" arg
+EXTRA_DRUN_ARGS=""
+if [[ "$@" == *"--subnet-type application"* ]]
+then
+  EXTRA_DRUN_ARGS="--subnet-type application"
+fi
+
 export LANG=C.UTF-8
 
 # this could be used to delay drun to make it more deterministic, but
@@ -46,7 +53,7 @@ then
   # work around different IDs in ic-ref-run and drun
   ( echo "create"
     LANG=C perl -npe 's,\$ID,'$ID',g; s,\$PRINCIPAL,'$PRINCIPAL',g' $1
-  ) | drun -c "$CONFIG" --extra-batches $EXTRA_BATCHES /dev/stdin
+  ) | drun -c "$CONFIG" $EXTRA_DRUN_ARGS --extra-batches $EXTRA_BATCHES /dev/stdin
 else
   ( echo "create"
     echo "install $ID $1 0x"
@@ -54,5 +61,5 @@ else
     then
       LANG=C perl -ne 'print "$1 '$ID' $2\n" if m,^//CALL (ingress|query) (.*),;print "upgrade '$ID' '"$1"' 0x\n" if m,^//CALL upgrade,; ' $2
     fi
-  ) | drun -c "$CONFIG" --extra-batches $EXTRA_BATCHES /dev/stdin
+  ) | drun -c "$CONFIG" $EXTRA_DRUN_ARGS --extra-batches $EXTRA_BATCHES /dev/stdin
 fi

--- a/test/run-drun/check-app-subnet.drun
+++ b/test/run-drun/check-app-subnet.drun
@@ -1,0 +1,6 @@
+# APPLICATION-SUBNET
+
+install $ID check-app-subnet/check-app-subnet.mo ""
+ingress $ID test "DIDL\x00\x00"
+ingress $ID test "DIDL\x00\x00"
+

--- a/test/run-drun/check-app-subnet.drun
+++ b/test/run-drun/check-app-subnet.drun
@@ -1,4 +1,5 @@
 # APPLICATION-SUBNET
+# CLASSICAL-PERSISTENCE-ONLY
 
 install $ID check-app-subnet/check-app-subnet.mo ""
 ingress $ID test "DIDL\x00\x00"

--- a/test/run-drun/check-app-subnet.drun
+++ b/test/run-drun/check-app-subnet.drun
@@ -1,7 +1,5 @@
 # APPLICATION-SUBNET
-# CLASSICAL-PERSISTENCE-ONLY
 
 install $ID check-app-subnet/check-app-subnet.mo ""
-ingress $ID test "DIDL\x00\x00"
 ingress $ID test "DIDL\x00\x00"
 

--- a/test/run-drun/check-app-subnet/check-app-subnet.mo
+++ b/test/run-drun/check-app-subnet/check-app-subnet.mo
@@ -7,11 +7,16 @@ import Prim "mo:⛔";
 persistent actor  {
 
     public func test() : async () {
+        let balance = Prim.cyclesBalance();
+
         var j : Nat = 0;
-        while (j < 100_000) {
+        while (j < 3) {
             j += 1;
+            await async();
         };
 
-        Prim.debugPrint("Cycle balance: " # debug_show(Prim.cyclesBalance()));
+        if (balance > Prim.cyclesBalance()) {
+            Prim.debugPrint("Application subnet");
+        };
     }
 };

--- a/test/run-drun/check-app-subnet/check-app-subnet.mo
+++ b/test/run-drun/check-app-subnet/check-app-subnet.mo
@@ -1,0 +1,17 @@
+// A simple actor that checks if the subnet is an application subnet.
+// This is done by running some instructions and burning some cycles
+// and checking if the cycle balance is affected.
+
+import Prim "mo:⛔";
+
+persistent actor  {
+
+    public func test() : async () {
+        var j : Nat = 0;
+        while (j < 100_000) {
+            j += 1;
+        };
+
+        Prim.debugPrint("Cycle balance: " # debug_show(Prim.cyclesBalance()));
+    }
+};

--- a/test/run-drun/check-system-subnet.drun
+++ b/test/run-drun/check-system-subnet.drun
@@ -1,0 +1,5 @@
+
+install $ID check-system-subnet/check-system-subnet.mo ""
+ingress $ID test "DIDL\x00\x00"
+ingress $ID test "DIDL\x00\x00"
+

--- a/test/run-drun/check-system-subnet.drun
+++ b/test/run-drun/check-system-subnet.drun
@@ -1,5 +1,4 @@
 
 install $ID check-system-subnet/check-system-subnet.mo ""
 ingress $ID test "DIDL\x00\x00"
-ingress $ID test "DIDL\x00\x00"
 

--- a/test/run-drun/check-system-subnet/check-system-subnet.mo
+++ b/test/run-drun/check-system-subnet/check-system-subnet.mo
@@ -7,11 +7,16 @@ import Prim "mo:⛔";
 persistent actor  {
 
     public func test() : async () {
+        let balance = Prim.cyclesBalance();
+
         var j : Nat = 0;
-        while (j < 100_000) {
+        while (j < 3) {
             j += 1;
+            await async();
         };
 
-        Prim.debugPrint("Cycle balance: " # debug_show(Prim.cyclesBalance()));
+        if (balance == Prim.cyclesBalance()) {
+            Prim.debugPrint("System subnet");
+        };
     }
 };

--- a/test/run-drun/check-system-subnet/check-system-subnet.mo
+++ b/test/run-drun/check-system-subnet/check-system-subnet.mo
@@ -1,0 +1,17 @@
+// A simple actor that checks if the subnet is an application subnet.
+// This is done by running some instructions and burning some cycles
+// and checking if the cycle balance is affected.
+
+import Prim "mo:⛔";
+
+persistent actor  {
+
+    public func test() : async () {
+        var j : Nat = 0;
+        while (j < 100_000) {
+            j += 1;
+        };
+
+        Prim.debugPrint("Cycle balance: " # debug_show(Prim.cyclesBalance()));
+    }
+};

--- a/test/run-drun/ok/check-app-subnet.drun.ok
+++ b/test/run-drun/ok/check-app-subnet.drun.ok
@@ -1,0 +1,6 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: Cycle balance: 99_996_843_237_016
+ingress Completed: Reply: 0x4449444c0000
+debug.print: Cycle balance: 99_996_842_303_876
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/check-app-subnet.drun.ok
+++ b/test/run-drun/ok/check-app-subnet.drun.ok
@@ -1,6 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: Cycle balance: 99_996_843_237_016
-ingress Completed: Reply: 0x4449444c0000
-debug.print: Cycle balance: 99_996_842_303_876
+debug.print: Application subnet
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/check-system-subnet.drun.ok
+++ b/test/run-drun/ok/check-system-subnet.drun.ok
@@ -1,0 +1,6 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: Cycle balance: 100_000_000_000_000
+ingress Completed: Reply: 0x4449444c0000
+debug.print: Cycle balance: 100_000_000_000_000
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/check-system-subnet.drun.ok
+++ b/test/run-drun/ok/check-system-subnet.drun.ok
@@ -1,6 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: Cycle balance: 100_000_000_000_000
-ingress Completed: Reply: 0x4449444c0000
-debug.print: Cycle balance: 100_000_000_000_000
+debug.print: System subnet
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run.sh
+++ b/test/run.sh
@@ -521,6 +521,11 @@ do
           continue
         fi
       fi
+      if grep -q "# APPLICATION-SUBNET" $(basename $file)
+      then
+        # set drun args to use application subnet
+        EXTRA_DRUN_ARGS="--subnet-type application"
+      fi
       
       have_var_name="HAVE_${runner//-/_}"
       if [ ${!have_var_name} != yes ]
@@ -551,7 +556,9 @@ do
 
       # run wrapper
       wrap_var_name="WRAP_${runner//-/_}"
-      run $runner ${!wrap_var_name} $out/$base/$base.$runner.drun
+      run $runner ${!wrap_var_name} $out/$base/$base.$runner.drun $EXTRA_DRUN_ARGS
+      # clear EXTRA_DRUN_ARGS.
+      EXTRA_DRUN_ARGS=""
     done
 
   ;;


### PR DESCRIPTION
`run-drun` tests can now run as an application subnet, which is important for certain kinds of tests where subnet types differ.

To run under this mode, one needs to add
```
# APPLICATION-SUBNET
```

in their `.drun` test file. The default is still running as a system subnet.
