### PR TITLE
feat: uses a new tree-sitter grammar for the Emacs mode

### DIFF
--- a/emacs/motoko-ts-mode.el
+++ b/emacs/motoko-ts-mode.el
@@ -6,62 +6,64 @@
    :override t
    :feature 'delimiter
    '((["(" ")" "[" "]" "{" "}" "<" ">"] @font-lock-bracket-face)
-     ([";", ","] @font-lock-delimiter-face))
+     ([";" ","] @font-lock-delimiter-face))
 
    :language 'motoko
    :override t
    :feature 'comment
-   '([(line_comment) (block_comment) (doc_comment)] @font-lock-comment-face)
+   '(([(line_comment) (block_comment)] @font-lock-comment-face)
+     ((doc_comment) @font-lock-doc-face))
+
+   :language 'motoko
+   :override t
+   :feature 'constant
+   '(([(text_literal) (char_literal)] @font-lock-string-face)
+     ([(int_literal) (float_literal) (hex_literal)] @font-lock-number-face)
+     ([(null_literal) (bool_literal)] @font-lock-constant-face))
 
    :language 'motoko
    :override t
    :feature 'keyword
-   '(["actor" "and" "await" "break" "case" "catch"
+   '(["actor" "and" "await" "await*" "break" "case" "catch"
       "class" "continue" "composite" "debug" "do"
       "else" "finally" "for" "func" "if" "in" "import"
       "module" "not" "object" "or" "label" "let" "loop"
       "private" "public" "return" "shared"
       "try" "throw" "query" "switch" "type"
       "var" "while" "with" "stable" "flexible" "system"
-      "assert" "ignore" "async" "persistent" "transient"]
+      "assert" "ignore" "async" "async*" "persistent" "transient"]
      @font-lock-keyword-face)
 
    :language 'motoko
    :override t
+   :feature 'delimiter
+   '([(unop) (unassign_op) (binassign_op) (rel_op) (bin_op)] @font-lock-operator-face)
+
+   :language 'motoko
+   :override t
    :feature 'calls
-   '((call_exp invoked_value: (variable) @font-lock-function-call-face)
-     (call_exp invoked_value: (exp_post (member key: (name) @font-lock-function-call-face))))
+   '((call_exp_object (dot_exp_object (identifier) @font-lock-function-call-face))
+     (call_exp_object (var_exp (identifier) @font-lock-function-call-face))
+     (call_exp_block (dot_exp_block (identifier) @font-lock-function-call-face))
+     (call_exp_block (var_exp (identifier) @font-lock-function-call-face))
+     (tag_identifier) @font-lock-function-call-face)
+
+   :language 'motoko
+   :override t
+   :feature 'calls
+   '((exp_field (identifier) @font-lock-property-use-face)
+     (func_tf (identifier) @font-lock-property-name-face)
+     (val_tf (identifier) @font-lock-property-name-face))
 
    :language 'motoko
    :override t
    :feature 'keyword
-   '((dec_type type_name: (name) @font-lock-type-face))
-
-   :language 'motoko
-   :override t
-   :feature 'keyword
-   '((typ_id type_name: (name) @font-lock-type-face)
-     (typ_bind type_parameter_name: (name) @font-lock-type-face))
-
-   :language 'motoko
-   :override t
-   :feature 'constant
-   '((text) @font-lock-string-face)
-
-   :language 'motoko
-   :override t
-   :feature 'constant
-   '([(nat) (float)] @font-lock-number-face)
-
-   :language 'motoko
-   :override t
-   :feature 'constant
-   '("null" @font-lock-constant-face)
+   '((type_identifier) @font-lock-type-face)
 
    :language 'motoko
    :override t
    :feature 'declaration
-   '((dec_func function_name: (name) @font-lock-function-name-face))
+   '((func_dec name: (identifier) @font-lock-function-name-face))
    ))
 
 
@@ -71,18 +73,29 @@
 ; (setq treesit--indent-verbose t)
 (defvar motoko-ts-indent-rules
   `((motoko
-     ((node-is "}") parent-bol 0)
-     ((parent-is "object") parent-bol motoko-ts-indent)
-     ((parent-is "block") parent-bol motoko-ts-indent)
+     ((parent-is "source_file") column-0 0)
+     ((node-is ")") parent-bol 0)
+     ((node-is "]") parent-bol 0)
+     ((node-is "}") (and parent parent-bol) 0)
+     ((parent-is "func_dec") parent-bol motoko-ts-indent)
+     ((parent-is "obj_body") parent-bol motoko-ts-indent)
+     ((parent-is "object_exp") parent-bol motoko-ts-indent)
+     ((parent-is "block_exp") parent-bol motoko-ts-indent)
+     ((parent-is "par_exp") parent-bol motoko-ts-indent)
+     ((parent-is "obj_typ") parent-bol motoko-ts-indent)
      ((parent-is "dec_obj") parent-bol motoko-ts-indent)
-     ((parent-is "dec_let") parent-bol motoko-ts-indent)
+     ((parent-is "let_dec") parent-bol motoko-ts-indent)
+     ((parent-is "let_else_dec") parent-bol motoko-ts-indent)
+     ((parent-is "var_dec") parent-bol motoko-ts-indent)
+     ((parent-is "switch_exp") parent-bol motoko-ts-indent)
+     ((parent-is "tup_pat") parent-bol motoko-ts-indent)
      )))
 
 (defun motoko-ts-setup ()
   "Setup treesit for motoko-ts-mode."
 
   (setq-local treesit-font-lock-feature-list
-              '((comment)
+              '((comment delimiter)
                 (constant keyword calls)
                 (declaration)))
 
@@ -102,6 +115,5 @@
 
 (when 'treesit-language-source-alist
   (add-to-list 'treesit-language-source-alist '(motoko "https://github.com/christoph-dfinity/tree-sitter-motoko")))
-
 
 (provide 'motoko-ts-mode)


### PR DESCRIPTION
Handles a lot more cases for indentation and syntax highlighting.

After updating you need to run `treesit-install-language-grammar` once more to pull in the new grammar.

I've been using this for a while now, and am pretty happy with my Motoko experience in Emacs.