### PR TITLE
fix: removes more `mo-ide` leftovers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,6 @@ jobs:
         cachix watch-exec ic-hs-test -- \
           nix build --max-jobs 1 -L \
             .#release.moc \
-            .#release.mo-ide \
             .#release.mo-doc \
             .#js.moc \
             .#js.moc_interpreter

--- a/nix/release-files.nix
+++ b/nix/release-files.nix
@@ -28,10 +28,10 @@ let
 in
 pkgs.runCommandNoCC "motoko-release-${releaseVersion}" { } ''
   mkdir $out
-  cp ${as_tarball "x86_64-linux" (with linux.release; [ mo-ide mo-doc moc ])} $out/motoko-Linux-x86_64-${releaseVersion}.tar.gz
-  cp ${as_tarball "aarch64-linux" (with linuxArm.release; [ mo-ide mo-doc moc ])} $out/motoko-Linux-aarch64-${releaseVersion}.tar.gz
-  cp ${as_tarball "x86_64-darwin" (with darwin.release; [ mo-ide mo-doc moc ])} $out/motoko-Darwin-x86_64-${releaseVersion}.tar.gz
-  cp ${as_tarball "aarch64-darwin" (with darwinArm.release; [ mo-ide mo-doc moc ])} $out/motoko-Darwin-arm64-${releaseVersion}.tar.gz
+  cp ${as_tarball "x86_64-linux" (with linux.release; [ mo-doc moc ])} $out/motoko-Linux-x86_64-${releaseVersion}.tar.gz
+  cp ${as_tarball "aarch64-linux" (with linuxArm.release; [ mo-doc moc ])} $out/motoko-Linux-aarch64-${releaseVersion}.tar.gz
+  cp ${as_tarball "x86_64-darwin" (with darwin.release; [ mo-doc moc ])} $out/motoko-Darwin-x86_64-${releaseVersion}.tar.gz
+  cp ${as_tarball "aarch64-darwin" (with darwinArm.release; [ mo-doc moc ])} $out/motoko-Darwin-arm64-${releaseVersion}.tar.gz
 
   cp ${as_js "moc" linux.js.moc} $out/moc-${releaseVersion}.js
   cp ${as_js "moc-interpreter" linux.js.moc_interpreter} $out/moc-interpreter-${releaseVersion}.js


### PR DESCRIPTION
For some reason ripgrep missed these occurrences...

Fixes this CI failure: https://github.com/dfinity/motoko/actions/runs/14757948117/job/41431029555