### PR TITLE
chore: remove `macos + x86` from CI runs

### DIFF
--- a/.github/workflows/nightly-macos-test.yml
+++ b/.github/workflows/nightly-macos-test.yml
@@ -49,11 +49,7 @@ jobs:
 
   create-issue:
     needs: [common-tests, gc-tests, systems-go-tests]
-<<<<<<< HEAD
-    if: ${{ contains(needs.*.result, 'failure') }}
-=======
     if: ${{ always() && contains(needs.*.result, 'failure') }}
->>>>>>> master
     runs-on: ubuntu-latest # No need to run on macOS-13, the ubuntu runner should be cheaper to run.
     steps:
       - name: Create Issue
@@ -61,45 +57,10 @@ jobs:
         with:
           script: |
             const date = new Date().toISOString().split('T')[0];
-<<<<<<< HEAD
-            const failedJobs = ['common-tests', 'gc-tests', 'systems-go-tests']
-              .filter(job => needs[job].result === 'failure')
-              .join(', ');
-            
-=======
->>>>>>> master
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Nightly macOS-13 Test Failure (${date})`,
-<<<<<<< HEAD
-              body: `The following nightly tests for macOS-13 failed: ${failedJobs}\n\nPlease investigate.\n\nWorkflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              labels: ['macos-13-failure', 'bug']
-            });
-
-  artifacts:
-    needs: [common-tests, gc-tests, systems-go-tests]
-    runs-on: macos-13
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v16
-        with:
-          name: ic-hs-test
-      - name: nix-build
-        run: |
-          nix build .#release.moc
-      # upload-artifact doesn't work for symlink dir
-      # https://github.com/actions/upload-artifact/issues/92
-      - run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
-      - name: upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: moc-macos-13
-          path: ${{ env.UPLOAD_PATH }}
-          retention-days: 5 
-=======
               body: `Nightly tests for macOS-13 failed. Please investigate.\n\nWorkflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               labels: ['macos-13-failure', 'bug']
             }); 
->>>>>>> master

--- a/.github/workflows/nightly-macos-test.yml
+++ b/.github/workflows/nightly-macos-test.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Run at midnight UTC every day
   workflow_dispatch:  # Allow manual triggering
+  pull_request: {}  # Run on PR creation for testing purposes, will be removed before merging.
 
 jobs:
   common-tests:

--- a/.github/workflows/nightly-macos-test.yml
+++ b/.github/workflows/nightly-macos-test.yml
@@ -3,8 +3,7 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Run at midnight UTC every day
   workflow_dispatch:  # Allow manual triggering
-  pull_request: {}  # Run on PR creation for testing purposes, will be removed before merging.
-
+  
 jobs:
   common-tests:
     runs-on: macos-13

--- a/.github/workflows/nightly-macos-test.yml
+++ b/.github/workflows/nightly-macos-test.yml
@@ -67,4 +67,26 @@ jobs:
               title: `Nightly macOS-13 Test Failure (${date})`,
               body: `The following nightly tests for macOS-13 failed: ${failedJobs}\n\nPlease investigate.\n\nWorkflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               labels: ['macos-13-failure', 'bug']
-            }); 
+            });
+
+  artifacts:
+    needs: [common-tests, gc-tests, systems-go-tests]
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v16
+        with:
+          name: ic-hs-test
+      - name: nix-build
+        run: |
+          nix build .#release.moc
+      # upload-artifact doesn't work for symlink dir
+      # https://github.com/actions/upload-artifact/issues/92
+      - run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
+      - name: upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: moc-macos-13
+          path: ${{ env.UPLOAD_PATH }}
+          retention-days: 5 

--- a/.github/workflows/nightly-macos-test.yml
+++ b/.github/workflows/nightly-macos-test.yml
@@ -1,0 +1,70 @@
+name: "nightly-macos-test"
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run at midnight UTC every day
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  common-tests:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Common Tests
+        uses: ./.github/actions/test-blueprint
+        with:
+          os: macos-13
+          test-target: common-tests
+          test-name: macos-13-common-tests
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+  gc-tests:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run GC Tests
+        uses: ./.github/actions/test-blueprint
+        with:
+          os: macos-13
+          test-target: gc-tests
+          test-name: macos-13-gc-tests
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+  systems-go-tests:
+    strategy:
+      matrix:
+        build_type: [release, debug]
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Tests
+        uses: ./.github/actions/test-blueprint
+        with:
+          os: macos-13
+          test-target: ${{ matrix.build_type }}-systems-go
+          test-name: macos-13-${{ matrix.build_type }}-tests
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+  create-issue:
+    needs: [common-tests, gc-tests, systems-go-tests]
+    if: ${{ contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest # No need to run on macOS-13, the ubuntu runner should be cheaper to run.
+    steps:
+      - name: Create Issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().split('T')[0];
+            const failedJobs = ['common-tests', 'gc-tests', 'systems-go-tests']
+              .filter(job => needs[job].result === 'failure')
+              .join(', ');
+            
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Nightly macOS-13 Test Failure (${date})`,
+              body: `The following nightly tests for macOS-13 failed: ${failedJobs}\n\nPlease investigate.\n\nWorkflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              labels: ['macos-13-failure', 'bug']
+            }); 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   common-tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13, ubuntu-24.04-arm, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -25,7 +25,7 @@ jobs:
   gc-tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13, ubuntu-24.04-arm, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,7 +42,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13, ubuntu-24.04-arm, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest ]
         build_type: [ release, debug ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -99,7 +99,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'build_artifacts')
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13, ubuntu-24.04-arm, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`MacOS` tests on `x86` are now run and the respective artifacts are built on a nightly CI job. See: #5119 . We can therefore remove them from running on every CI invocation, speeding up the process.