### PR TITLE
fix: set unique branch names per `update_flake_lock_action`

### DIFF
--- a/.github/workflows/update-flake-lock-trial.yml
+++ b/.github/workflows/update-flake-lock-trial.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@main
         with:
+          branch: "update_flake_lock_action_trial"
           inputs: |
             nixpkgs
             ic-src

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@main
         with:
+          branch: "update_flake_lock_action_daily"
           inputs: |
             flake-utils
             nix-update-flake


### PR DESCRIPTION
Prevent the `update-flake-lock` and `update-flake-lock-trial` from force-pushing over each other's branches by configuring them to use their own branches.