### PR TITLE
chore: revert .#rts flake content-addressed

### DIFF
--- a/.github/actions/test-blueprint/action.yml
+++ b/.github/actions/test-blueprint/action.yml
@@ -42,8 +42,6 @@ runs:
         swap-storage: false
 
     - uses: cachix/install-nix-action@v31
-      with:
-        extra_nix_config: experimental-features = nix-command flakes ca-derivations
 
     - uses: cachix/cachix-action@v16
       with:

--- a/.github/actions/test-blueprint/action.yml
+++ b/.github/actions/test-blueprint/action.yml
@@ -42,6 +42,8 @@ runs:
         swap-storage: false
 
     - uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: experimental-features = nix-command flakes ca-derivations
 
     - uses: cachix/cachix-action@v16
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31
-      with:
-        extra_nix_config: experimental-features = nix-command flakes ca-derivations
     - uses: cachix/cachix-action@v16
       with:
         name: ic-hs-test
@@ -71,8 +69,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31
-      with:
-        extra_nix_config: experimental-features = nix-command flakes ca-derivations
     - uses: cachix/cachix-action@v16
       with:
         name: ic-hs-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: experimental-features = nix-command flakes ca-derivations
       - uses: cachix/cachix-action@v16
         with:
           name: ic-hs-test
@@ -106,8 +104,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: experimental-features = nix-command flakes ca-derivations
       - uses: cachix/cachix-action@v16
         with:
           name: ic-hs-test

--- a/Building.md
+++ b/Building.md
@@ -10,7 +10,7 @@ sh <(curl -L https://nixos.org/nix/install) --daemon
 This repository is also a Nix Flake which means you need to
 allow this feature by making sure the following is present in `/etc/nix/nix.conf`:
 ```
-extra-experimental-features = nix-command flakes ca-derivations
+extra-experimental-features = nix-command flakes
 ```
 
 You should also enable a nix cache to get all dependencies pre-built.

--- a/nix/rts.nix
+++ b/nix/rts.nix
@@ -50,7 +50,6 @@ in
 
 pkgs.stdenv.mkDerivation {
   name = "moc-rts";
-  __contentAddressed = true;
 
   src = ../rts;
 


### PR DESCRIPTION
This reverts commit 397b80a which enabled content-addressed derivations for the RTS.

Content-addressed derivations are causing caching issues where Nix rebuilds the RTS from scratch even when identical outputs exist in the cache. This significantly increases build times in CI and for developers.

References:
- https://discourse.nixos.org/t/solve-slow-man-cache-the-content-addressed-way-but-not-ca-derivation/58463