### PR TITLE
chore: replace `secrets.NIV_UPDATER_TOKEN` with `actions/create-github-app-token`

### DIFF
--- a/.github/actions/performance/action.yml
+++ b/.github/actions/performance/action.yml
@@ -17,9 +17,9 @@ inputs:
   is_fork:
     required: true
     description: "Whether this is a fork PR"
-  niv_updater_token:
+  token:
     required: true
-    description: "Token for updating niv dependencies"
+    description: "Token for pushing commits"
 
 runs:
   using: "composite"
@@ -37,7 +37,7 @@ runs:
       with:
         default_author: github_actions
         author_name: Cycle and memory benchmark updater
-        github_token: ${{ inputs.niv_updater_token }}
+        github_token: ${{ inputs.token }}
         committer_name: GitHub Actions
         committer_email: actions@github.com
         message: "Updating `test/bench` numbers"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,13 @@ jobs:
           test-name: ${{ matrix.os }}-${{ matrix.build_type }}-tests
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
       - name: Run Performance Tests
         if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && runner.os == 'Linux' && runner.arch == 'X64' && matrix.build_type == 'release'
         uses: ./.github/actions/performance
@@ -71,7 +78,7 @@ jobs:
           base_ref: ${{ github.base_ref }}
           pr_number: ${{ github.event.pull_request.number }}
           is_fork: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-          niv_updater_token: ${{ secrets.NIV_UPDATER_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
   reports:
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/update-flake-lock-trial.yml
+++ b/.github/workflows/update-flake-lock-trial.yml
@@ -24,6 +24,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Determinate Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@main
         with:
@@ -47,4 +53,4 @@ jobs:
             This PR is just to test if the above dependency bumps cause issues.
             If checks fail this PR remains open so we can investigate.
             If all checks succeed this PR is automatically closed.
-          token: ${{ secrets.NIV_UPDATER_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -24,6 +24,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Determinate Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@main
         with:
@@ -52,4 +58,4 @@ jobs:
             ```
             {{ env.GIT_COMMIT_MESSAGE }}
             ```
-          token: ${{ secrets.NIV_UPDATER_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -21,12 +21,18 @@ jobs:
     - name: Update drun cargo hash
       run: |
         nix run .#nix-update -- --flake --version=skip drun
+    - name: Create GitHub App Token
+      uses: actions/create-github-app-token@v2
+      id: app-token
+      with:
+        app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+        private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
     - name: Commit changes
       uses: EndBug/add-and-commit@v9
       with:
         default_author: github_actions
         author_name: Nix hash updater
-        github_token: ${{ secrets.NIV_UPDATER_TOKEN }}
+        github_token: ${{ steps.app-token.outputs.token }}
         committer_name: GitHub Actions
         committer_email: actions@github.com
         message: "Updating nix hashes"


### PR DESCRIPTION
The `dfinity-bot` got removed form GitHub. The GitHub actions in the motoko repo authenticated as this bot using the `NIV_UPDATER_TOKEN` secret which meant that these actions broke.

We're switching all repos to use [actions/create-github-app-token](https://github.com/actions/create-github-app-token) because it's more secure.