### PR TITLE
chore: update `author` for auto-approve rule in Mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -22,7 +22,6 @@ queue_rules:
 
       {{ body }}
 
-
 pull_request_rules:
   - name: Automatic merge (squash)
     conditions:
@@ -57,7 +56,7 @@ pull_request_rules:
           - autoclose
   - name: Auto-approve auto-PRs
     conditions:
-      - author=dfinity-bot
+      - author=pr-automation-bot-public
       - label=automerge-squash
     actions:
       review:


### PR DESCRIPTION
Changed the author condition in the auto-approve rule from `dfinity-bot` to `pr-automation-bot-public` to reflect the current bot used for automation.