### PR TITLE
chore: update author condition for auto-approve rule in Mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -56,7 +56,7 @@ pull_request_rules:
           - autoclose
   - name: Auto-approve auto-PRs
     conditions:
-      - author=pr-automation-bot-public
+      - author=app/pr-automation-bot-public
       - label=automerge-squash
     actions:
       review:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -56,7 +56,7 @@ pull_request_rules:
           - autoclose
   - name: Auto-approve auto-PRs
     conditions:
-      - author=app/pr-automation-bot-public
+      - author="app/pr-automation-bot-public"
       - label=automerge-squash
     actions:
       review:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -56,7 +56,7 @@ pull_request_rules:
           - autoclose
   - name: Auto-approve auto-PRs
     conditions:
-      - "author=app/pr-automation-bot-public"
+      - author=app\/pr-automation-bot-public
       - label=automerge-squash
     actions:
       review:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -56,7 +56,7 @@ pull_request_rules:
           - autoclose
   - name: Auto-approve auto-PRs
     conditions:
-      - author="app/pr-automation-bot-public"
+      - "author=app/pr-automation-bot-public"
       - label=automerge-squash
     actions:
       review:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -56,7 +56,7 @@ pull_request_rules:
           - autoclose
   - name: Auto-approve auto-PRs
     conditions:
-      - author=app\/pr-automation-bot-public
+      - author~=^app/pr-automation-bot-public$
       - label=automerge-squash
     actions:
       review:


### PR DESCRIPTION
Changed the author condition in the auto-approve rule from `pr-automation-bot-public` to `app/pr-automation-bot-public` to align with the current bot naming convention.
