### PR TITLE
feat: adds a primitive `Array_tabulateVar` function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * Adds a Prim.Array_tabulateVar function, that allows faster initialization of mutable Arrays
+
 ## 0.14.12 (2025-06-12)
 
 * motoko (`moc`)

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -4826,7 +4826,7 @@ module Arr = struct
     get_r ^^
     Tagged.allocation_barrier env
 
-  let tabulate env =
+  let tabulate env sort =
     let (set_f, get_f) = new_local env "f" in
     let (set_r, get_r) = new_local env "r" in
     let (set_i, get_i) = new_local env "i" in
@@ -4835,7 +4835,7 @@ module Arr = struct
     (* Allocate *)
     BigNum.to_word32 env ^^
     set_r ^^
-    alloc env Tagged.I get_r ^^
+    alloc env sort get_r ^^
     set_r ^^
 
     (* Initial index *)
@@ -12263,7 +12263,9 @@ and compile_prim_invocation (env : E.t) ae p es at =
   | OtherPrim "Array.init", [_;_] ->
     const_sr SR.Vanilla (Arr.init env)
   | OtherPrim "Array.tabulate", [_;_] ->
-    const_sr SR.Vanilla (Arr.tabulate env)
+    const_sr SR.Vanilla (Arr.tabulate env Tagged.I)
+  | OtherPrim "Array.tabulateVar", [_;_] ->
+    const_sr SR.Vanilla (Arr.tabulate env Tagged.M)
   | OtherPrim "btst8", [_;_] ->
     (* TODO: btstN returns Bool, not a small value *)
     const_sr (SR.UnboxedWord32 Type.Nat8) (TaggedSmallWord.btst_kernel env Type.Nat8)

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -4569,7 +4569,7 @@ module Arr = struct
     Tagged.allocation_barrier env
 
 
-  let tabulate env =
+  let tabulate env sort =
     let (set_f, get_f) = new_local env "f" in
     let (set_r, get_r) = new_local env "r" in
     let (set_i, get_i) = new_local env "i" in
@@ -4578,7 +4578,7 @@ module Arr = struct
     (* Allocate *)
     BigNum.to_word64 env ^^
     set_r ^^
-    alloc env Tagged.I get_r ^^
+    alloc env sort get_r ^^
     set_r ^^
 
     (* Initial index *)
@@ -12495,7 +12495,9 @@ and compile_prim_invocation (env : E.t) ae p es at =
   | OtherPrim "Array.init", [_;_] ->
     const_sr SR.Vanilla (Arr.init env)
   | OtherPrim "Array.tabulate", [_;_] ->
-    const_sr SR.Vanilla (Arr.tabulate env)
+    const_sr SR.Vanilla (Arr.tabulate env Tagged.I)
+  | OtherPrim "Array.tabulateVar", [_;_] ->
+    const_sr SR.Vanilla (Arr.tabulate env Tagged.M)
   | OtherPrim "btst8", [_;_] ->
     (* TODO: btstN returns Bool, not a small value *)
     const_sr (SR.UnboxedWord64 Type.Nat8) (TaggedSmallWord.btst_kernel env Type.Nat8)

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -321,6 +321,18 @@ let prim trap =
       in go (fun xs -> xs) k 0
     | _ -> assert false
     )
+  | "Array.tabulateVar" -> fun c v k ->
+    (match Value.as_tup v with
+    | [len; g] ->
+      let len_nat = Int.to_int (as_int len) in
+      let (_, g') = Value.as_func g in
+      let rec go prefix k i =
+        if i == len_nat
+        then k (Array (Array.of_list (prefix [])))
+        else g' c (Int (Int.of_int i)) (fun x -> go (fun tl -> prefix (Mut (ref x)::tl)) k (i + 1))
+      in go (fun xs -> xs) k 0
+    | _ -> assert false
+    )
 
 
   | "cast"

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -310,6 +310,7 @@ let prim trap =
     | _ -> assert false
     )
   | "Array.tabulate" -> fun c v k ->
+    (* TODO: optimize these (https://github.com/dfinity/motoko/pull/5256#discussion_r2143573548) *)
     (match Value.as_tup v with
     | [len; g] ->
       let len_nat = Int.to_int (as_int len) in

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -290,6 +290,10 @@ func Array_tabulate<T>(len : Nat, gen : Nat -> T) : [T] {
   (prim "Array.tabulate" : <T>(Nat, Nat -> T) -> [T]) <T>(len, gen);
 };
 
+func Array_tabulateVar<T>(len : Nat, gen : Nat -> T) : [var T] {
+  (prim "Array.tabulateVar" : <T>(Nat, Nat -> T) -> [var T]) <T>(len, gen);
+};
+
 func blobToArray(b : Blob) : [Nat8] = (prim "blobToArray" : (Blob) -> [Nat8]) b;
 func blobToArrayMut(b : Blob) : [var Nat8] = (prim "blobToArrayMut" : (Blob) -> [var Nat8]) b;
 func arrayToBlob(a : [Nat8]) : Blob = (prim "arrayToBlob" : [Nat8] -> Blob) a;

--- a/test/fail/ok/no-timer-canc.tc.ok
+++ b/test/fail/ok/no-timer-canc.tc.ok
@@ -13,6 +13,7 @@ no-timer-canc.mo:3.10-3.21: type error [M0119], object field cancelTimer is not 
       };
     Array_init : <T>(len : Nat, x : T) -> [var T];
     Array_tabulate : <T>(len : Nat, gen : Nat -> T) -> [T];
+    Array_tabulateVar : <T>(len : Nat, gen : Nat -> T) -> [var T];
     Ret : <T>() -> T;
     Types :
       module {

--- a/test/fail/ok/no-timer-set.tc.ok
+++ b/test/fail/ok/no-timer-set.tc.ok
@@ -13,6 +13,7 @@ no-timer-set.mo:3.10-3.18: type error [M0119], object field setTimer is not cont
       };
     Array_init : <T>(len : Nat, x : T) -> [var T];
     Array_tabulate : <T>(len : Nat, gen : Nat -> T) -> [T];
+    Array_tabulateVar : <T>(len : Nat, gen : Nat -> T) -> [var T];
     Ret : <T>() -> T;
     Types :
       module {

--- a/test/fail/ok/suggest-long-ai.tc.ok
+++ b/test/fail/ok/suggest-long-ai.tc.ok
@@ -13,6 +13,7 @@ suggest-long-ai.mo:4.6-4.13: type error [M0072], field stableM does not exist in
       };
     Array_init : <T>(len : Nat, x : T) -> [var T];
     Array_tabulate : <T>(len : Nat, gen : Nat -> T) -> [T];
+    Array_tabulateVar : <T>(len : Nat, gen : Nat -> T) -> [var T];
     Ret : <T>() -> T;
     Types :
       module {

--- a/test/fail/ok/suggest-short-ai.tc.ok
+++ b/test/fail/ok/suggest-short-ai.tc.ok
@@ -13,6 +13,7 @@ suggest-short-ai.mo:4.6-4.7: type error [M0072], field s does not exist in type:
       };
     Array_init : <T>(len : Nat, x : T) -> [var T];
     Array_tabulate : <T>(len : Nat, gen : Nat -> T) -> [T];
+    Array_tabulateVar : <T>(len : Nat, gen : Nat -> T) -> [var T];
     Ret : <T>() -> T;
     Types :
       module {

--- a/test/run/array-gen.mo
+++ b/test/run/array-gen.mo
@@ -17,6 +17,17 @@ for (i in b.keys()) {
   assert (b[i] == i);
 };
 
+let c = Prim.Array_tabulateVar<Nat>(10,func (x : Nat) : Nat = x);
+
+for (i in c.keys()) {
+  c[i] += 1;
+};
+
+assert(c.size() == 10);
+for (i in c.keys()) {
+  assert (c[i] == i + 1);
+};
+
 func init(length: Nat) {
     let array1 = Prim.Array_init<Nat>(length, 42);
     assert array1.size() == length;


### PR DESCRIPTION
This gives me a nice 2-3% speedup on the Hamt benchmarks.

Claudio wasn't sure if we needed extra write barriers compared to the non-mutable version for EOP, so I'm adding Luc to the reviewers.