### PR TITLE
Stable Functions: Minor Fix (Promoting Stable Functions with Generic Type Parameters)

### DIFF
--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -122,14 +122,7 @@ and exp' at note = function
     let tbs' = typ_binds tbs in
     let vars = List.map (fun (tb : I.typ_bind) -> T.Con (tb.it.I.con, [])) tbs' in
     let tys = List.map (T.open_ vars) res_tys in
-    let is_async = match typ_opt with
-      | Some { it = AsyncT _; _ } -> true
-      | _ -> false
-    in
-    let s = match s, is_async with
-    | T.Local T.Stable, true -> T.Local T.Flexible
-    | _ -> s
-    in
+    let (s, _, _, _, _) = T.as_func note.Note.typ in
     I.FuncE (name, s, control, tbs', args, tys, !closure, wrap (exp e))
   (* Primitive functions in the prelude have particular shapes *)
   | S.CallE (None, {it=S.AnnotE ({it=S.PrimE p;_}, _);note;_}, _, e)

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -112,7 +112,7 @@ and exp' at note = function
     let t = T.as_array note.Note.typ in
     I.PrimE (I.ArrayPrim (mut m, T.as_immut t), exps es)
   | S.IdxE (e1, e2) -> I.PrimE (I.IdxPrim, [exp e1; exp e2])
-  | S.FuncE (name, sp, tbs, p, _t_opt, _, closure, e) ->
+  | S.FuncE (name, sp, tbs, p, typ_opt, _, closure, e) ->
     let s, po = match sp.it with
       | T.Local ls -> (T.Local ls, None)
       | T.Shared (ss, {it = S.WildP; _} ) -> (* don't bother with ctxt pat *)
@@ -122,6 +122,14 @@ and exp' at note = function
     let tbs' = typ_binds tbs in
     let vars = List.map (fun (tb : I.typ_bind) -> T.Con (tb.it.I.con, [])) tbs' in
     let tys = List.map (T.open_ vars) res_tys in
+    let is_async = match typ_opt with
+      | Some { it = AsyncT _; _ } -> true
+      | _ -> false
+    in
+    let s = match s, is_async with
+    | T.Local T.Stable, true -> T.Local T.Flexible
+    | _ -> s
+    in
     I.FuncE (name, s, control, tbs', args, tys, !closure, wrap (exp e))
   (* Primitive functions in the prelude have particular shapes *)
   | S.CallE (None, {it=S.AnnotE ({it=S.PrimE p;_}, _);note;_}, _, e)

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1045,7 +1045,7 @@ let rec rel_typ d rel eq t1 t2 =
   | Tup ts1, Tup ts2 ->
     rel_list d rel_typ rel eq ts1 ts2
   | Func (s1, c1, tbs1, t11, t12), Func (s2, c2, tbs2, t21, t22) ->
-    rel_sort s1 s2 && c1 = c2 &&
+    rel_sort s1 s2 tbs1 && c1 = c2 &&
     (match rel_binds d eq eq tbs1 tbs2 with
     | Some ts ->
       rel_list d rel_typ rel eq (List.map (open_ ts) t21) (List.map (open_ ts) t11) &&
@@ -1059,9 +1059,13 @@ let rec rel_typ d rel eq t1 t2 =
   | _, _ -> false
   end
 
-and rel_sort s1 s2 =
+and rel_sort s1 s2 tbs1 =
   match s1, s2 with
-  | Local Stable, Local Flexible -> true (* stable function can be assigned to flexible function *)
+  | Local Stable, Local Flexible -> 
+    not (List.exists (fun b -> b.sort = Type) tbs1)
+    (* Stable functions can only be assigned to flexible functions, if they have no generic type parameters.
+       This is because type parameters of stable functions are implied to be stable too, while this is 
+       not necessarily the case for flexible function types. *)
   | _, _ -> s1 = s2
 
 and rel_fields d rel eq tfs1 tfs2 =

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -41,35 +41,35 @@ func @reset_cycles() {
 // Note that these return functions!
 // (Some optimizations in the backend might be feasible.)
 
-func @immut_array_get<A>(xs : [A]) : Nat -> A =
+let @immut_array_get = func<A>(xs : [A]) : Nat -> A =
   func (n : Nat) : A = xs[n];
-func @mut_array_get<A>(xs : [var A]) : Nat -> A =
+let @mut_array_get = func<A>(xs : [var A]) : Nat -> A =
   func (n : Nat) : A = xs[n];
-func @immut_array_size<A>(xs : [A]) : () -> Nat =
+let @immut_array_size = func<A>(xs : [A]) : () -> Nat =
   func () : Nat = (prim "array_len" : [A] -> Nat) xs;
-func @mut_array_size<A>(xs : [var A]) : () -> Nat =
+let @mut_array_size = func<A>(xs : [var A]) : () -> Nat =
   func () : Nat = (prim "array_len" : [var A] -> Nat) xs;
-func @mut_array_put<A>(xs : [var A]) : (Nat, A) -> () =
+let @mut_array_put = func<A>(xs : [var A]) : (Nat, A) -> () =
   func (n : Nat, x : A) = (xs[n] := x);
-func @immut_array_keys<A>(xs : [A]) : () -> @Iter<Nat> =
+let @immut_array_keys = func<A>(xs : [A]) : () -> @Iter<Nat> =
   func () : @Iter<Nat> = object {
     var i = 0;
     let l = xs.size();
     public func next() : ?Nat { if (i >= l) null else {let j = i; i += 1; ?j} };
   };
-func @mut_array_keys<A>(xs : [var A]) : () -> @Iter<Nat> =
+let @mut_array_keys = func<A>(xs : [var A]) : () -> @Iter<Nat> =
   func () : @Iter<Nat> = object {
     var i = 0;
     let l = xs.size();
     public func next() : ?Nat { if (i >= l) null else {let j = i; i += 1; ?j} };
   };
-func @immut_array_vals<A>(xs : [A]) : () -> @Iter<A> =
+let @immut_array_vals = func<A>(xs : [A]) : () -> @Iter<A> =
   func () : @Iter<A> = object {
     var i = 0;
     let l = xs.size();
     public func next() : ?A { if (i >= l) null else {let j = i; i += 1; ?xs[j]} };
   };
-func @mut_array_vals<A>(xs : [var A]) : () -> @Iter<A> =
+let @mut_array_vals = func<A>(xs : [var A]) : () -> @Iter<A> =
   func () : @Iter<A> = object {
     var i = 0;
     let l = xs.size();
@@ -228,7 +228,7 @@ func @text_needs_parens(t : Text) : Bool {
   }
 };
 
-func @text_of_option<T>(f : T -> Text, x : ?T) : Text {
+let @text_of_option = func<T>(f : T -> Text, x : ?T) : Text {
   switch (x) {
     case (?y) {
       let fy = f y;
@@ -239,14 +239,14 @@ func @text_of_option<T>(f : T -> Text, x : ?T) : Text {
   }
 };
 
-func @text_of_variant<T>(l : Text, f : T -> Text, x : T) : Text {
+let @text_of_variant = func<T>(l : Text, f : T -> Text, x : T) : Text {
   let fx = f x;
   if (fx == "()") "#" # l
   else if (@text_has_parens(fx)) "#" # l # fx
   else "#" # l # "(" # fx # ")"
 };
 
-func @text_of_array<T>(f : T -> Text, xs : [T]) : Text {
+let @text_of_array = func<T>(f : T -> Text, xs : [T]) : Text {
   var text = "[";
   var first = true;
   for (x in xs.values()) {
@@ -260,7 +260,7 @@ func @text_of_array<T>(f : T -> Text, xs : [T]) : Text {
   text # "]"
 };
 
-func @text_of_array_mut<T>(f : T -> Text, xs : [var T]) : Text {
+let @text_of_array_mut = func<T>(f : T -> Text, xs : [var T]) : Text {
   var text = "[var";
   var first = true;
   for (x in xs.values()) {
@@ -275,7 +275,7 @@ func @text_of_array_mut<T>(f : T -> Text, xs : [var T]) : Text {
   text # "]"
 };
 
-func @equal_array<T>(eq : (T, T) -> Bool, a : [T], b : [T]) : Bool {
+let @equal_array = func<T>(eq : (T, T) -> Bool, a : [T], b : [T]) : Bool {
   if (a.size() != b.size()) {
     return false;
   };
@@ -319,7 +319,7 @@ func @getSystemRefund() : @Refund {
 func @cleanup() {
 };
 
-func @new_async<T <: Any>() : (@Async<T>, @Cont<T>, @Cont<Error>, @CleanCont) {
+let @new_async = func<T <: Any>() : (@Async<T>, @Cont<T>, @Cont<Error>, @CleanCont) {
   let w_null = func(r : @Refund, t : T) { };
   let r_null = func(_ : Error) {};
   var result : ?(@Result<T>) = null;
@@ -572,7 +572,7 @@ func @nextExpiration(n : ?@Node) : Nat64 = switch n {
 // Function called by backend to run eligible timed actions.
 // DO NOT RENAME without modifying compilation.
 func @timer_helper() : async () {
-  func Array_init<T>(len : Nat,  x : T) : [var T] {
+  let Array_init = func<T>(len : Nat,  x : T) : [var T] {
     (prim "Array.init" : <T>(Nat, T) -> [var T])<T>(len, x)
   };
 

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -272,11 +272,11 @@ func log(f : Float) : Float = (prim "flog" : Float -> Float) f;
 
 // Array utilities
 
-func Array_init<T>(len : Nat, x : T) : [var T] {
+let Array_init = func<T>(len : Nat, x : T) : [var T] {
   (prim "Array.init" : <T>(Nat, T) -> [var T]) <T>(len, x);
 };
 
-func Array_tabulate<T>(len : Nat, gen : Nat -> T) : [T] {
+let Array_tabulate = func<T>(len : Nat, gen : Nat -> T) : [T] {
   (prim "Array.tabulate" : <T>(Nat, Nat -> T) -> [T]) <T>(len, gen);
 };
 
@@ -538,14 +538,14 @@ func getCandidLimits<system>() :
 
 // predicates for motoko-san
 
-func forall<T>(f: T -> Bool): Bool {
+let forall = func<T>(f: T -> Bool): Bool {
   (prim "forall" : <T>(T -> Bool) -> Bool) <T>(f);
 };
 
-func exists<T>(f: T -> Bool): Bool {
+let exists = func<T>(f: T -> Bool): Bool {
   (prim "exists" : <T>(T -> Bool) -> Bool) <T>(f);
 };
 
-func Ret<T>(): T {
+let Ret = func<T>(): T {
   (prim "viperRet" : <T>() -> T) ();
 };

--- a/test/fail/ok/stable-box1.tc.ok
+++ b/test/fail/ok/stable-box1.tc.ok
@@ -1,0 +1,4 @@
+stable-box1.mo:20.30-20.33: type error [M0096], expression of type
+  stable <T>(v : T) -> Box<T>
+cannot produce expected type
+  <T>(v : T) -> {get : stable () -> T; put : stable T -> ()}

--- a/test/fail/ok/stable-box1.tc.ret.ok
+++ b/test/fail/ok/stable-box1.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/stable-box2.tc.ok
+++ b/test/fail/ok/stable-box2.tc.ok
@@ -1,0 +1,6 @@
+stable-box2.mo:11.15-11.39: type error [M0218], Type argument
+  () -> ()
+has to be of a stable type to match the type parameter 
+stable-box2.mo:11.15-11.39: type error [M0218], Type argument
+  () -> ()
+has to be of a stable type to match the type parameter 

--- a/test/fail/ok/stable-box2.tc.ret.ok
+++ b/test/fail/ok/stable-box2.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/stable-class-generics1.tc.ok
+++ b/test/fail/ok/stable-class-generics1.tc.ok
@@ -1,0 +1,21 @@
+stable-class-generics1.mo:56.34-56.47: type error [M0096], expression of type
+  stable <K, V>(capacity : Nat, equal : Equality<K>, hash : Hash<K>) ->
+    SimpleHashMap<K, V>
+cannot produce expected type
+  <K, V>(capacity : Nat, equal : Equality<K>, hash : Hash<K>) ->
+    {get : stable K -> ?V; put : stable (K, V) -> ()}
+stable-class-generics1.mo:60.12-60.22: type error [M0097], expected function type, but expression produces type
+  ?(() -> Text)
+stable-class-generics1.mo:60.22: info, this looks like an unintended function call, perhaps a missing ';'?
+stable-class-generics1.mo:60.28-60.32: type error [M0096], expression of type
+  ?Text
+cannot produce expected type
+  None
+stable-class-generics1.mo:61.27-61.30: type error [M0050], literal of type
+  Text
+does not have expected type
+  () -> Text
+stable-class-generics1.mo:62.12-62.30: type error [M0060], operator is not defined for operand types
+  ?(() -> Text)
+and
+  ?(() -> Text)

--- a/test/fail/ok/stable-class-generics1.tc.ret.ok
+++ b/test/fail/ok/stable-class-generics1.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/stable-class-generics2.tc.ok
+++ b/test/fail/ok/stable-class-generics2.tc.ok
@@ -1,0 +1,6 @@
+stable-class-generics2.mo:49.15-49.68: type error [M0218], Type argument
+  () -> Text
+has to be of a stable type to match the type parameter 
+stable-class-generics2.mo:49.15-49.68: type error [M0218], Type argument
+  () -> Text
+has to be of a stable type to match the type parameter 

--- a/test/fail/ok/stable-class-generics2.tc.ret.ok
+++ b/test/fail/ok/stable-class-generics2.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/stable-box1.mo
+++ b/test/fail/stable-box1.mo
@@ -1,0 +1,31 @@
+//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+import Prim "mo:prim";
+
+persistent actor {
+    // a stable type
+    class Box<T>(v : T) {
+        var value = v;
+        public func get() : T = v;
+        public func put(v : T) = value := v
+    };
+
+    // a flexible type
+    type Super = <T>(v : T) ->
+    { put : stable T -> ();
+      get : stable ()-> T
+    };
+
+    // rejected due generic type parameter invariance
+    // stable type parameters cannot become flexible
+    transient let SuperBox = Box : Super;
+    
+    let map = SuperBox<() -> ()>(func () {});
+    map.put(func () {});
+    map.get()();
+};
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+
+//CALL upgrade ""

--- a/test/fail/stable-box2.mo
+++ b/test/fail/stable-box2.mo
@@ -1,0 +1,19 @@
+//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+import Prim "mo:prim";
+
+persistent actor {
+    class Box<T>(v : T) {
+        var value = v;
+        public func get() : T = v;
+        public func put(v : T) = value := v;
+    };
+
+    let box = Box<() -> ()>(func() {});
+    box.put(func() {});
+};
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+
+//CALL upgrade ""

--- a/test/fail/stable-class-generics1.mo
+++ b/test/fail/stable-class-generics1.mo
@@ -1,0 +1,69 @@
+//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+import Prim "mo:prim";
+
+persistent actor {
+    type Equality<T> = stable (first : T, second : T) -> Bool;
+    type Hash<T> = stable (value : T) -> Nat;
+
+    // a stable type
+    class SimpleHashMap<K, V>(capacity : Nat, equal : Equality<K>, hash : Hash<K>) {
+        private let table = Prim.Array_init<?(K, V)>(capacity, null);
+
+        public func put(key : K, value : V) {
+            let index = hash(key) % capacity;
+            switch (table[index]) {
+                case null table[index] := ?(key, value);
+                case (?(otherKey, _)) {
+                    if (equal(key, otherKey)) {
+                        table[index] := ?(key, value);
+                    } else {
+                        Prim.trap("Hash collision"); // simplification for testing
+                    };
+                };
+            };
+        };
+
+        public func get(key : K) : ?V {
+            let index = hash(key) % capacity;
+            switch (table[index]) {
+                case null null;
+                case (?(otherKey, value)) {
+                    if (equal(key, otherKey)) {
+                        ?value;
+                    } else {
+                        null;
+                    };
+                };
+            };
+        };
+    };
+
+    func natEqual(first : Nat, second : Nat) : Bool {
+        first == second;
+    };
+
+    func natHash(number : Nat) : Nat {
+        number;
+    };
+
+    // a flexible type
+    type Super = <K, V>(capacity : Nat, equal : Equality<K>, hash : Hash<K>) ->
+    { put : stable (K, V) -> ();
+      get : stable K -> ?V
+    };
+
+    // Not allowed, incompatible type parameter stability
+    transient let SuperHashMap = SimpleHashMap : Super;
+    let map = SuperHashMap<Nat, () -> Text>(10, natEqual, natHash);
+    map.put(1, func () = "A");
+    map.put(2, func () = "B");
+   assert (map.get(1)() == ?"A");
+   assert (map.get(2) == ?"B");
+   assert (map.get(3) == null);
+};
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+
+//CALL upgrade ""

--- a/test/fail/stable-class-generics2.mo
+++ b/test/fail/stable-class-generics2.mo
@@ -1,0 +1,58 @@
+//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+import Prim "mo:prim";
+
+persistent actor {
+    type Equality<T> = stable (first : T, second : T) -> Bool;
+    type Hash<T> = stable (value : T) -> Nat;
+
+    class SimpleHashMap<K, V>(capacity : Nat, equal : Equality<K>, hash : Hash<K>) {
+        private let table = Prim.Array_init<?(K, V)>(capacity, null);
+
+        public func put(key : K, value : V) {
+            let index = hash(key) % capacity;
+            switch (table[index]) {
+                case null table[index] := ?(key, value);
+                case (?(otherKey, _)) {
+                    if (equal(key, otherKey)) {
+                        table[index] := ?(key, value);
+                    } else {
+                        Prim.trap("Hash collision"); // simplification for testing
+                    };
+                };
+            };
+        };
+
+        public func get(key : K) : ?V {
+            let index = hash(key) % capacity;
+            switch (table[index]) {
+                case null null;
+                case (?(otherKey, value)) {
+                    if (equal(key, otherKey)) {
+                        ?value;
+                    } else {
+                        null;
+                    };
+                };
+            };
+        };
+    };
+
+    func natEqual(first : Nat, second : Nat) : Bool {
+        first == second;
+    };
+
+    func natHash(number : Nat) : Nat {
+        number;
+    };
+
+    // Rejected
+    let map = SimpleHashMap<Nat, () -> Text>(10, natEqual, natHash);
+    map.put(1, func () = "A");
+    map.put(2, func () = "B");
+};
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+
+//CALL upgrade ""


### PR DESCRIPTION
Fixing https://github.com/dfinity/motoko/pull/5143

Essence of fix:
* Can only promote stable function type to flexible type, when there are no generic type parameters.

This is because:
* Stable functions imply stable type parameters
* Flexible functions imply flexible type parameters
* Promotion requires generic invariance on stability