### PR TITLE
fix(mo-doc): rewords heading for package index

### DIFF
--- a/doc/md/base/index.md
+++ b/doc/md/base/index.md
@@ -1,4 +1,4 @@
-# Index of package base
+# Motoko base package
 
 * [Array](Array.md) Provides extended utility functions on Arrays.
 * [AssocList](AssocList.md) Map implemented as a linked-list of key-value pairs ("Associations").

--- a/doc/md/core/index.md
+++ b/doc/md/core/index.md
@@ -1,4 +1,4 @@
-# Index of package core
+# Motoko core package
 
 * [Array](Array.md) Provides extended utility functions on immutable Arrays (values of type `[T]`).
 * [Blob](Blob.md) Module for working with Blobs (immutable sequences of bytes).

--- a/src/docs/html.ml
+++ b/src/docs/html.ml
@@ -385,7 +385,7 @@ let make_index : string option -> render_input list -> string =
          (string
             (match package_opt with
             | None -> "Motoko package"
-            | Some s -> "Motoko " ^ s ^ " library"))
+            | Some s -> "Motoko " ^ s ^ " package"))
       ++ ul ~cls:"index-listing" ~licls:"index-item" (List.map make_link inputs)
       )
   in

--- a/src/docs/html.ml
+++ b/src/docs/html.ml
@@ -384,7 +384,7 @@ let make_index : string option -> render_input list -> string =
       (h1 ~cls:"index-header"
          (string
             (match package_opt with
-            | None -> "Motoko library"
+            | None -> "Motoko package"
             | Some s -> "Motoko " ^ s ^ " library"))
       ++ ul ~cls:"index-listing" ~licls:"index-item" (List.map make_link inputs)
       )

--- a/src/docs/html.ml
+++ b/src/docs/html.ml
@@ -384,8 +384,8 @@ let make_index : string option -> render_input list -> string =
       (h1 ~cls:"index-header"
          (string
             (match package_opt with
-            | None -> "Index of modules"
-            | Some s -> "Index of module in package " ^ s))
+            | None -> "Motoko library"
+            | Some s -> "Motoko " ^ s ^ " library"))
       ++ ul ~cls:"index-listing" ~licls:"index-item" (List.map make_link inputs)
       )
   in

--- a/src/docs/plain.ml
+++ b/src/docs/plain.ml
@@ -308,7 +308,7 @@ let render_docs : Common.render_input -> string =
 let make_index : string option -> Common.render_input list -> string =
  fun package_opt inputs ->
   let buf = Buffer.create 1024 in
-  bprintf buf "# Motoko %slibrary\n\n"
+  bprintf buf "# Motoko %spackage\n\n"
     (match package_opt with None -> "" | Some s -> s ^ " ");
   List.iter
     (fun (input : Common.render_input) ->

--- a/src/docs/plain.ml
+++ b/src/docs/plain.ml
@@ -308,8 +308,8 @@ let render_docs : Common.render_input -> string =
 let make_index : string option -> Common.render_input list -> string =
  fun package_opt inputs ->
   let buf = Buffer.create 1024 in
-  bprintf buf "# Index%s\n\n"
-    (match package_opt with None -> "" | Some s -> " of package " ^ s);
+  bprintf buf "# Motoko %slibrary\n\n"
+    (match package_opt with None -> "" | Some s -> s ^ " ");
   List.iter
     (fun (input : Common.render_input) ->
       bprintf buf "* [%s](%s) %s\n" input.current_path


### PR DESCRIPTION
Makes it so we produce the desired documentation output from #5285 