### PR TITLE
avoid JS 32-bit int limitation when compiling to 64-bit

### DIFF
--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -2603,7 +2603,7 @@ module TaggedSmallWord = struct
     )
 
   let vanilla_lit ty v =
-    Int64.(shift_left (of_int v) (to_int (shift_of_type ty)))
+    Int64.(shift_left v (to_int (shift_of_type ty)))
     |> Int64.logor (tag_of_type ty)
 
   (* Wrapping implementation for multiplication and exponentiation. *)
@@ -10592,19 +10592,20 @@ let nat64_to_int64 n =
   then sub_big_int n (power_int_positive_int 2 64)
   else n
 
+
 let const_lit_of_lit : Ir.lit -> Const.lit = function
   | BoolLit b     -> Const.Bool b
   | IntLit n
   | NatLit n      -> Const.BigInt (Numerics.Nat.to_big_int n)
-  | Int8Lit n     -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Int8 (Numerics.Int_8.to_int n))
-  | Nat8Lit n     -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Nat8 (Numerics.Nat8.to_int n))
-  | Int16Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Int16 (Numerics.Int_16.to_int n))
-  | Nat16Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Nat16 (Numerics.Nat16.to_int n))
-  | Int32Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Int32 (Numerics.Int_32.to_int n))
-  | Nat32Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Nat32 (Numerics.Nat32.to_int n))
+  | Int8Lit n     -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Int8 (Numerics.Int_8.to_int64 n))
+  | Nat8Lit n     -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Nat8 (Numerics.Nat8.to_int64 n))
+  | Int16Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Int16 (Numerics.Int_16.to_int64 n))
+  | Nat16Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Nat16 (Numerics.Nat16.to_int64 n))
+  | Int32Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Int32 (Numerics.Int_32.to_int64 n))
+  | Nat32Lit n    -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Nat32 (Numerics.Nat32.to_int64 n))
   | Int64Lit n    -> Const.Word64 (Type.Int64, (Big_int.int64_of_big_int (Numerics.Int_64.to_big_int n)))
   | Nat64Lit n    -> Const.Word64 (Type.Nat64, (Big_int.int64_of_big_int (nat64_to_int64 (Numerics.Nat64.to_big_int n))))
-  | CharLit c     -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Char c)
+  | CharLit c     -> Const.Vanilla (TaggedSmallWord.vanilla_lit Type.Char (Int64.of_int c))
   | NullLit       -> Const.Null
   | TextLit t     -> Const.Text t
   | BlobLit t     -> Const.Blob t
@@ -11822,8 +11823,8 @@ and compile_prim_invocation (env : E.t) ae p es at =
   | OtherPrim "Float->Text", [e] ->
     SR.Vanilla,
     compile_exp_as env ae SR.UnboxedFloat64 e ^^
-    compile_unboxed_const (TaggedSmallWord.vanilla_lit Type.Nat8 6) ^^
-    compile_unboxed_const (TaggedSmallWord.vanilla_lit Type.Nat8 0) ^^
+    compile_unboxed_const (TaggedSmallWord.vanilla_lit Type.Nat8 6L) ^^
+    compile_unboxed_const (TaggedSmallWord.vanilla_lit Type.Nat8 0L) ^^
     E.call_import env "rts" "float_fmt"
 
   | OtherPrim "fmtFloat->Text", [f; prec; mode] ->

--- a/src/mo_values/numerics.ml
+++ b/src/mo_values/numerics.ml
@@ -224,6 +224,10 @@ sig
   val compare : t -> t -> int
   val to_int : t -> int
   val of_int : int -> t
+  val to_int32 : t -> Int32.t
+  val of_int32 : Int32.t -> t
+  val to_int64 : t -> Int64.t
+  val of_int64 : Int64.t -> t
   val to_big_int : t -> Big_int.big_int
   val of_big_int : Big_int.big_int -> t
   val of_string : string -> t
@@ -260,8 +264,12 @@ struct
   let le = le_big_int
   let ge = ge_big_int
   let compare = compare_big_int
-  let to_int = int_of_big_int
+  let to_int i = int_of_big_int i
   let of_int = big_int_of_int
+  let to_int32 = int32_of_big_int
+  let of_int32 = big_int_of_int32
+  let to_int64 = int64_of_big_int
+  let of_int64 = big_int_of_int64
   let of_big_int i = i
   let to_big_int i = i
   let to_pretty_string i = group_num (string_of_big_int i)
@@ -274,7 +282,7 @@ struct
   let pow x y =
     if gt y max_int
     then raise (Invalid_argument "Int.pow")
-    else power_big_int_positive_int x (int_of_big_int y)
+    else power_big_int_positive_int x (to_int y)
 end
 
 module Nat : NumType with type t = Big_int.big_int =
@@ -345,6 +353,8 @@ struct
   let div a b = let res = Rep.div a b in check res
   let pow a b = let res = Rep.pow a b in check res
   let of_int i = let res = Rep.of_int i in check res
+  let of_int32 i = let res = Rep.of_int32 i in check res
+  let of_int64 i = let res = Rep.of_int64 i in check res
   let of_big_int i = let res = Rep.of_big_int i in check res
   let of_string s = let res = Rep.of_string s in check res
 

--- a/src/mo_values/numerics.mli
+++ b/src/mo_values/numerics.mli
@@ -22,6 +22,10 @@ sig
   val compare : t -> t -> int
   val to_int : t -> int
   val of_int : int -> t
+  val to_int32 : t -> Int32.t
+  val of_int32 : Int32.t -> t
+  val to_int64 : t -> Int64.t
+  val of_int64 : Int64.t -> t
   val to_big_int : t -> Big_int.big_int
   val of_big_int : Big_int.big_int -> t
   val of_string : string -> t


### PR DESCRIPTION
The eop backend assumes OCaml ints are 63-bit, which ain't true on ocamljs. This removes one of the uses of the assumption (there may be others).
