### PR TITLE
chore: fix warnings in moc_js

### DIFF
--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -9864,8 +9864,8 @@ module FuncDec = struct
              since the stabilization can also be run before the upgrade. *)
           Lifecycle.during_explicit_upgrade env ^^
           E.if1 I64Type
-            (compile_unboxed_const (Int64.of_int Flags.(!stabilization_instruction_limit.update_call)))
-            (compile_unboxed_const (Int64.of_int Flags.(!stabilization_instruction_limit.upgrade)))
+            (compile_unboxed_const (Flags.(!stabilization_instruction_limit.update_call)))
+            (compile_unboxed_const (Flags.(!stabilization_instruction_limit.upgrade)))
         )
       ) in
     E.add_export env (nr {
@@ -9877,8 +9877,8 @@ module FuncDec = struct
         Func.of_body env [] [I64Type] (fun env ->
           Lifecycle.during_explicit_upgrade env ^^
           E.if1 I64Type
-            (compile_unboxed_const (Int64.of_int Flags.(!stable_memory_access_limit.update_call)))
-            (compile_unboxed_const (Int64.of_int Flags.(!stable_memory_access_limit.upgrade)))
+            (compile_unboxed_const (Flags.(!stable_memory_access_limit.update_call)))
+            (compile_unboxed_const (Flags.(!stable_memory_access_limit.upgrade)))
         )
       ) in
     E.add_export env (nr {

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -228,15 +228,15 @@ let argspec = [
 
   "--stabilization-instruction-limit",
   Arg.Int (fun limit -> Flags.(stabilization_instruction_limit := {
-    upgrade = limit;
-    update_call = limit;
+    upgrade = Int64.of_int limit;
+    update_call = Int64.of_int limit;
   })),
   "<n>  set instruction limit for incremental graph-copy-based stabilization and destabilization (for testing)";
 
   "--stable-memory-access-limit",
   Arg.Int (fun limit -> Flags.(stable_memory_access_limit := {
-    upgrade = limit;
-    update_call = limit;
+    upgrade = Int64.of_int limit;
+    update_call = Int64.of_int limit;
   })),
   "<n>  set stable memory access limit for incremental graph-copy-based stabilization and destabilization (for testing)";
 

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -7,8 +7,8 @@ type compile_mode = WasmMode | ICMode | RefMode | WASIMode
 type gc_strategy = Default | MarkCompact | Copying | Generational | Incremental
 
 type instruction_limits = {
-  upgrade: int;
-  update_call: int;
+  upgrade: Int64.t;
+  update_call: Int64.t;
 }
 
 type actors = LegacyActors | RequirePersistentActors | DefaultPersistentActors
@@ -62,14 +62,14 @@ let enhanced_orthogonal_persistence = ref true
 let explicit_enhanced_orthogonal_persistence = ref false
 let share_code = ref false
 let stabilization_instruction_limit_default = {
-  upgrade = 180_000_000_000; (* 200 billion limit with 10% reserve *)
-  update_call = 18_000_000_000; (* 20 billion limit with 10% reserve *)
+  upgrade = 180_000_000_000L; (* 200 billion limit with 10% reserve *)
+  update_call = 18_000_000_000L; (* 20 billion limit with 10% reserve *)
 }
 let stabilization_instruction_limit = ref stabilization_instruction_limit_default
 let stable_memory_access_limit_default =
-  let gigabyte = 1024 * 1024 * 1024 in {
-  upgrade = 6 * gigabyte; (* 8 GB limit with 2 GB reserves *)
-  update_call = 1 * gigabyte; (* 2 GB limit with 1 GB reserve *)
+  let gigabyte = Int64.of_int (1024 * 1024 * 1024) in {
+  upgrade = Int64.mul 6L gigabyte; (* 8 GB limit with 2 GB reserves *)
+  update_call = Int64.mul 1L gigabyte; (* 2 GB limit with 1 GB reserve *)
 }
 let stable_memory_access_limit = ref stable_memory_access_limit_default
 let experimental_stable_memory_default = 0 (* _ < 0: error; _ = 0: warn, _ > 0: allow *)


### PR DESCRIPTION
Address the following mysterious js_of_ocaml warnings:

js_of_ocaml int are 32-bit and these constants exceed that (but do fit into 63-bit) Ocaml ints.

```
crusso@crusso-Virtual-Machine:~/motoko/src$ make moc.js
source_id/gen.sh
dune build --profile=release --profile=release _build/default/js/moc_js.bc.js
Warning: integer overflow: integer 0x29e8d60800 (180000000000) truncated to 0xe8d60800 (-388626432); the generated code might be incorrect.
Warning: integer overflow: integer 0x430e23400 (18000000000) truncated to 0x30e23400 (820130816); the generated code might be incorrect.
ls -al _build/default/js/moc_js.bc.js
-r--r--r-- 1 crusso crusso 2456599 Aug  7 16:12 _build/default/js/moc_js.bc.js
crusso@crusso-Virtual-Machine:~/motoko/src$ 
```
