### PR TITLE
Fix Intra-Partition Allocator

### DIFF
--- a/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
+++ b/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
@@ -903,7 +903,7 @@ impl PartitionedHeap {
             // Since the partition is allocated incrementally, we need to
             // ensure that the memory is allocated up to the end of the object,
             // which will also be the end of the dynamic_size of the partition.
-            mem.grow_memory(heap_pointer + size);
+            intra_partition_memory_grow(mem, heap_pointer + size);
 
             (*allocation_partition).dynamic_size += size;
             Value::from_ptr(heap_pointer)
@@ -1064,4 +1064,21 @@ pub(crate) unsafe fn allocate_initial_memory(heap_base: Bytes<usize>) {
     use crate::memory::ic::allocate_wasm_memory;
 
     allocate_wasm_memory(heap_base);
+}
+
+#[cfg(feature = "ic")]
+pub(crate) unsafe fn intra_partition_memory_grow<M: Memory>(_mem: &mut M, address: usize) {
+    use crate::memory::ic::allocate_wasm_memory;
+
+    // Allocate the memory without keeping the usual memory reserve.
+    // This is because the partition may have been allocated in a moment
+    // where the reserve was granted. Such a partition remains available for
+    // subsequent incremental allocations even when the reserve is reactivated.        
+    allocate_wasm_memory(Bytes(address));
+}
+
+#[cfg(not(feature = "ic"))]
+pub(crate) unsafe fn intra_partition_memory_grow<M: Memory>(mem: &mut M, address: usize) {
+    // Only for test purposes
+    mem.grow_memory(address);
 }


### PR DESCRIPTION
This fixes a scenario on memory pressure on very large heaps (6 GB currently), related to incremental partition allocation:
1. The allocator keeps a memory reserve for critical operations such as for the GC and upgrades.
2. A partition may be virtually allocated in such an exception moment.
3. The critical operation completes and the reserve is again put back in force.
4. Now, the incremental intra-partition allocator still remains in this partition (in reserve space) and must be able to complete the partition before a new partition in lower sub-reserve space can be used.

The fix can be applied through usual EOP upgrade to a Motoko canister that might be stuck by this issue.