### PR TITLE
doc: migration guide tweaks

### DIFF
--- a/doc/md/12-base-core-migration.md
+++ b/doc/md/12-base-core-migration.md
@@ -102,12 +102,12 @@ Modules like `Random`, `Region`, `Time`, `Timer`, and `Stack` still exist in cor
 
 ## Data structure improvements
 
-The core package introduces a fundamental reorganization of data structures with a clear separation between mutable and immutable (purely functional) APIs. All data structures are now usable in stable memory.
+The `core` package brings significant changes to data structures, making a clear separation between mutable and immutable (purely functional) APIs. All data structures can now be stored directly in stable memory.
 
 | Structure         | Module               | Description                                                                                                                                                 |
 | ----------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **List**          | `List`               | Mutable list                                                                                                                                                |
-| **Map**           | `Map`                | Mutable map                                                                                                                                                 |
+| **List**          | `List`               | Mutable list (originally [`mo:vector`](https://mops.one/vector))                                                                                            |
+| **Map**           | `Map`                | Mutable map (originally [`mo:stableheapbtreemap`](https://mops.one/stableheapbtreemap))                                                                     |
 | **Queue**         | `Queue`              | Mutable queue
 | **Set**           | `Set`                | Mutable set                                                                                                                                                 |
 | **Array**         | `Array`              | Immutable array                                                                                                                                             |

--- a/doc/md/12-base-core-migration.md
+++ b/doc/md/12-base-core-migration.md
@@ -382,7 +382,7 @@ The `with migration` syntax follows this structure:
     // Conversion logic
   }
 )
-actor App {
+persistent actorApp {
   // New stable declarations
 };
 ```
@@ -393,7 +393,7 @@ It's also possible to use a function defined in an imported module:
 import { migrate } "Migration";
 
 (with migration = migrate)
-actor App {
+persistent actorApp {
   // New stable declarations
 };
 ```
@@ -407,7 +407,7 @@ This pattern ensures that existing stable data is preserved and converted to the
 ```motoko
 import Buffer "mo:base/Buffer";
 
-actor {
+persistent actor{
   type Item = Text;
 
   stable var items : [Item] = [];
@@ -447,7 +447,7 @@ import List "mo:core/List";
     list = List.fromArray(state.items);
   }
 )
-actor App {
+persistent actorApp {
   public type Item = Text; // `public` for migration
 
   stable let list = List.empty<Item>();
@@ -469,7 +469,7 @@ actor App {
 ```motoko
 import Deque "mo:base/Deque";
 
-actor {
+persistent actor{
   type Item = Text;
 
   stable var deque = Deque.empty<Item>();
@@ -542,7 +542,7 @@ import HashMap "mo:base/HashMap";
 import Text "mo:base/Text";
 import Iter "mo:base/Iter";
 
-actor {
+persistent actor{
   stable var mapEntries : [(Text, Nat)] = [];
   let map = HashMap.fromIter<Text, Nat>(mapEntries.vals(), 10, Text.equal, Text.hash);
 
@@ -586,7 +586,7 @@ import Iter "mo:core/Iter";
     map = Map.fromIter(state.mapEntries.vals(), Text.compare);
   }
 )
-actor {
+persistent actor{
   stable let map = Map.empty<Text, Nat>();
 
   public func update(key : Text, value : Nat) : async () {
@@ -612,7 +612,7 @@ import OrderedMap "mo:base/OrderedMap";
 import Text "mo:base/Text";
 import Iter "mo:base/Iter";
 
-actor {
+persistent actor{
   let textMap = OrderedMap.Make<Text>(Text.compare);
   stable var map = textMap.empty<Nat>();
 
@@ -654,7 +654,7 @@ import Iter "mo:core/Iter";
     { map };
   }
 )
-actor {
+persistent actor{
   stable let map = Map.empty<Text, Nat>();
 
   public func update(key : Text, value : Nat) : async () {
@@ -680,7 +680,7 @@ import OrderedSet "mo:base/OrderedSet";
 import Text "mo:base/Text";
 import Iter "mo:base/Iter";
 
-actor {
+persistent actor{
   type Item = Text;
 
   let textSet = OrderedSet.Make<Item>(Text.compare);
@@ -724,7 +724,7 @@ import Iter "mo:core/Iter";
     { set };
   }
 )
-actor App {
+persistent actorApp {
   public type Item = Text; // `public` for migration
 
   stable let set = Set.empty<Item>();
@@ -752,7 +752,7 @@ import Trie "mo:base/Trie";
 import Text "mo:base/Text";
 import Iter "mo:base/Iter";
 
-actor {
+persistent actor{
   type Key = Text;
   type Value = Nat;
 
@@ -795,7 +795,7 @@ import Iter "mo:core/Iter";
     map = Map.fromIter(Trie.iter(state.trie), Text.compare);
   }
 )
-actor {
+persistent actor{
   stable let map = Map.empty<Text, Nat>();
 
   public func update(key : Text, value : Nat) : async () {
@@ -821,7 +821,7 @@ import TrieMap "mo:base/TrieMap";
 import Text "mo:base/Text";
 import Iter "mo:base/Iter";
 
-actor {
+persistent actor{
   stable var mapEntries : [(Text, Nat)] = [];
   let map = TrieMap.fromEntries<Text, Nat>(mapEntries.vals(), Text.equal, Text.hash);
 
@@ -865,7 +865,7 @@ import Iter "mo:core/Iter";
     map = Map.fromIter(state.mapEntries.values(), Text.compare);
   }
 )
-actor {
+persistent actor{
   stable let map = Map.empty<Text, Nat>();
 
   public func update(key : Text, value : Nat) : async () {
@@ -890,7 +890,7 @@ actor {
 import TrieSet "mo:base/TrieSet";
 import Text "mo:base/Text";
 
-actor {
+persistent actor{
   type Item = Text;
 
   stable var set : TrieSet.Set<Item> = TrieSet.empty<Item>();
@@ -930,7 +930,7 @@ import TrieSet "mo:base/TrieSet";
     set = Set.fromIter(TrieSet.toArray(state.set).vals(), Text.compare);
   }
 )
-actor App {
+persistent actorApp {
   public type Item = Text; // `public` for migration
 
   stable let set = Set.empty<Item>();

--- a/doc/md/12-base-core-migration.md
+++ b/doc/md/12-base-core-migration.md
@@ -65,7 +65,7 @@ The following modules are **new** in the `core` package:
 
 ### 2. Renamed modules
 
-| Base module                    | Core module        | Notes                                               |
+| Base package                   | Core package       | Notes                                               |
 | ------------------------------ | ------------------ | --------------------------------------------------- |
 | `ExperimentalCycles`           | `Cycles`           | Stabilized module for cycle management              |
 | `ExperimentalInternetComputer` | `InternetComputer` | Stabilized low-level ICP interface                  |
@@ -75,7 +75,7 @@ The following modules are **new** in the `core` package:
 | `OrderedSet`                   | `pure/Set`         | Ordered set moved to `pure/` namespace              |
 
 :::info
-The `pure/` namespace contains immutable (purely functional) data structures where operations return new instances rather than modifying existing ones. This naming follows functional programming conventions and makes the distinction between mutable and immutable data structures explicit.
+The `pure/` namespace contains immutable (purely functional) data structures where operations return new values rather than modifying in place. The namespace makes it clear which data structures are mutable and which are immutable.
 :::
 
 ### 3. Removed modules
@@ -104,19 +104,19 @@ Modules like `Random`, `Region`, `Time`, `Timer`, and `Stack` still exist in cor
 
 The `core` package brings significant changes to data structures, making a clear separation between mutable and immutable (purely functional) APIs. All data structures can now be stored directly in stable memory.
 
-| Structure         | Module               | Description                                                                                                                                                 |
-| ----------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **List**          | `List`               | Mutable list (originally [`mo:vector`](https://mops.one/vector))                                                                                            |
-| **Map**           | `Map`                | Mutable map (originally [`mo:stableheapbtreemap`](https://mops.one/stableheapbtreemap))                                                                     |
-| **Queue**         | `Queue`              | Mutable queue
-| **Set**           | `Set`                | Mutable set                                                                                                                                                 |
-| **Array**         | `Array`              | Immutable array                                                                                                                                             |
-| **VarArray**      | `VarArray`           | Mutable array                                                                                                                                               |
-| **List**          | `pure/List`          | Immutable list (originally `mo:base/List`)                                                                                                                  |
-| **Map**           | `pure/Map`           | Immutable map (originally `mo:base/OrderedMap`)                                                                                                             |
-| **Set**           | `pure/Set`           | Immutable set (originally `mo:base/OrderedSet`)                                                                                                             |
-| **Queue**         | `pure/Queue`         | Immutable queue  (orginally `mo:base/Deque`)                                                                                                                                              |
-| **RealTimeQueue** | `pure/RealTimeQueue` | Real-time queue with [constant-time operations](https://drops.dagstuhl.de/storage/00lipics/lipics-vol268-itp2023/LIPIcs.ITP.2023.29/LIPIcs.ITP.2023.29.pdf) |
+| Data Structure         | Description                                                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **List**               | Mutable list (originally [`mo:vector`](https://mops.one/vector))                                                                                            |
+| **Map**                | Mutable map (originally [`mo:stableheapbtreemap`](https://mops.one/stableheapbtreemap))                                                                     |
+| **Queue**              | Mutable queue
+| **Set**                | Mutable set                                                                                                                                                 |
+| **Array**              | Immutable array                                                                                                                                             |
+| **VarArray**           | Mutable array                                                                                                                                               |
+| **pure/List**          | Immutable list (originally `mo:base/List`)                                                                                                                  |
+| **pure/Map**           | Immutable map (originally `mo:base/OrderedMap`)                                                                                                             |
+| **pure/Set**           | Immutable set (originally `mo:base/OrderedSet`)                                                                                                             |
+| **pure/Queue**         | Immutable queue  (orginally `mo:base/Deque`)                                                                                                                                              |
+| **pure/RealTimeQueue** | Immutable queue with [constant-time operations](https://drops.dagstuhl.de/storage/00lipics/lipics-vol268-itp2023/LIPIcs.ITP.2023.29/LIPIcs.ITP.2023.29.pdf) |
 
 ## Interface changes by module
 

--- a/doc/md/12-base-core-migration.md
+++ b/doc/md/12-base-core-migration.md
@@ -38,7 +38,7 @@ When updating to the `core` package:
 - `range()` functions in the `core` library are now exclusive rather than inclusive! Keep this in mind when replacing `Iter.range()` with `Nat.range()`.
 - Functions previously named `vals()` are renamed to `values()`. This also applies to fields. For example, `array.vals()` can be replaced with `array.values()`.
 - Hash-based data structures are no longer included in the standard library. It is encouraged to use ordered maps and sets for improved security.
-In some cases, it won't be possible to fully migrate to `core` due to removal of some features in `base`. In these cases, you can continue using both packages side-by-side or search for [Mops packages](https://mops.one/) built by the community.
+- In some cases, it won't be possible to fully migrate to `core` due to removal of some features in `base`. In these cases, you can continue using both packages side-by-side or search for [Mops packages](https://mops.one/) built by the community.
 
 For details on function signatures, please refer to the official [documentation](https://internetcomputer.org/docs/motoko/core/).
 

--- a/doc/md/12-base-core-migration.md
+++ b/doc/md/12-base-core-migration.md
@@ -387,6 +387,17 @@ actor App {
 };
 ```
 
+It's also possible to use a function defined in an imported module:
+
+```motoko
+import { migrate } "Migration";
+
+(with migration = migrate)
+actor App {
+  // New stable declarations
+};
+```
+
 This pattern ensures that existing stable data is preserved and converted to the new format during canister upgrades.
 
 ### `Buffer`

--- a/doc/md/12-base-core-migration.md
+++ b/doc/md/12-base-core-migration.md
@@ -373,9 +373,13 @@ The `with migration` syntax follows this structure:
 ```motoko
 (
   with migration = func(
-    state : { /* old stable state types */ }
-  ) : { /* new stable state types */ } = {
-    /* conversion logic */
+    state : {
+      // Original state types
+    }
+  ) : {
+    // New state types
+  } = {
+    // Conversion logic
   }
 )
 actor App {


### PR DESCRIPTION
Miscellaneous improvements to the `base` -> `core` migration guide.