### PR TITLE
Update `core` migration guide

### DIFF
--- a/doc/md/12-base-core-migration.md
+++ b/doc/md/12-base-core-migration.md
@@ -89,7 +89,7 @@ The following modules have been **removed** in the core package:
 - `HashMap` - Use `Map` or `pure/Map`
 - `Heap` - Use `Map` or `Set` instead
 - `IterType` - Merged into `Types` module
-- `None`
+- `None` - Use `switch x {}` in place of `None.impossible(x)`
 - `Prelude` - Merged into `Debug` and `Runtime`
 - `RBTree` - Use `Map` instead
 - `Trie` - Use `Map` instead

--- a/doc/md/12-base-core-migration.md
+++ b/doc/md/12-base-core-migration.md
@@ -87,12 +87,12 @@ The following modules have been **removed** in the core package:
 - `ExperimentalStableMemory` - Deprecated
 - `Hash` - Vulnerable to hash collision attacks
 - `HashMap` - Use `Map` or `pure/Map`
-- `Heap`
+- `Heap` - Use `Map` or `Set` instead
 - `IterType` - Merged into `Types` module
 - `None`
 - `Prelude` - Merged into `Debug` and `Runtime`
-- `RBTree`
-- `Trie`
+- `RBTree` - Use `Map` instead
+- `Trie` - Use `Map` instead
 - `TrieMap` - Use `Map` or `pure/Map` instead
 - `TrieSet` - Use `Set` or `pure/Set` instead
 


### PR DESCRIPTION
Adds information for migrating from the `Heap`, `None`, `RBTree`, and `Trie` modules.