### PR TITLE
feat: selectively suppress warning on dropped fields in migration function using named types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,27 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * Allow suppression of migration warnings `M0206` and `M0207` using named field types (#5466):
+
+    For example:
+
+    ```motoko
+    (with migration = func (_ : {f : ()}) : {} = {}) // warn on dropped field `f`
+    actor a { };
+    ```
+    issues the warning `M0206` that field `f` is being dropped during migration.
+
+    The same code, naming the type of field `f` with `nowarn`, silences the warning:
+
+    ```motoko
+    (with migration = func (_ : {f : (nowarn: ())}) : {} = {}) // no-warning, named type for `f`
+    actor a { };
+    ```
+
+    Any name, not just `nowarn`, will suppress the warning.
+
+
 ## 0.16.1 (2025-08-25)
 
 * motoko (`moc`)

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -3141,7 +3141,7 @@ and check_migration env (stab_tfs : T.field list) exp_opt =
    (* This may indicate unintentional data loss. *)
    let is_named typ = T.(match typ with
         | Mut (Named _)
-        | Named (_, _) -> true
+        | Named _ -> true
         | _ -> false)
    in
    List.iter (fun T.{lab;typ;src} ->

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -3139,6 +3139,11 @@ and check_migration env (stab_tfs : T.field list) exp_opt =
      rng_tfs;
    (* Warn about any field in domain, not in range, and declared stable in actor *)
    (* This may indicate unintentional data loss. *)
+   let is_named typ = T.(match typ with
+        | Mut (Named _)
+        | Named (_, _) -> true
+        | _ -> false)
+   in
    List.iter (fun T.{lab;typ;src} ->
      match typ with
      | T.Typ c -> ()
@@ -3148,20 +3153,22 @@ and check_migration env (stab_tfs : T.field list) exp_opt =
        | None ->
          if List.mem lab stab_ids then
            (* re-initialized *)
-           warn env focus "M0206"
-             "migration expression consumes field `%s` of type%a\nbut does not produce it, yet the field is declared in the actor.\n%s\n%s"
-             lab
-             display_typ_expand typ
-             "The declaration in the actor will be reinitialized, discarding its consumed value."
-             "If reinitialization is unintended, and you want to preserve the consumed value, either remove this field from the parameter of the migration function or add it to the result of the migration function."
-         else
-           (* dropped *)
-           warn env focus "M0207"
-             "migration expression consumes field `%s` of type%a\nbut does not produce it. The field is not declared in the actor.\n%s\n%s"
-             lab
-             display_typ_expand typ
-             "This field will be removed from the actor, discarding its consumed value."
-             "If this removal is unintended, declare the field in the actor and either remove the field from the parameter of the migration function or add it to the result of the migration function."
+           (if (not (is_named typ)) then
+             warn env focus "M0206"
+               "migration expression consumes field `%s` of type%a\nbut does not produce it, yet the field is declared in the actor.\n%s\n%s"
+               lab
+               display_typ_expand typ
+               "The declaration in the actor will be reinitialized, discarding its consumed value."
+               "If reinitialization is unintended, and you want to preserve the consumed value, either remove this field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.")
+        else
+           (if (not (is_named typ)) then
+             (* dropped *)
+             warn env focus "M0207"
+               "migration expression consumes field `%s` of type%a\nbut does not produce it. The field is not declared in the actor.\n%s\n%s"
+               lab
+               display_typ_expand typ
+               "This field will be removed from the actor, discarding its consumed value."
+               "If this removal is unintended, declare the field in the actor and either remove the field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.")
      )
      dom_tfs;
    (* Warn the user about unrecognised attributes. *)

--- a/test/fail/migration-bad.mo
+++ b/test/fail/migration-bad.mo
@@ -50,3 +50,4 @@ module k {
 (with migration = func ({}) : {}{{}};) // error, unexpected object
 object l {
 };
+

--- a/test/fail/migration-silent-drop.mo
+++ b/test/fail/migration-silent-drop.mo
@@ -1,0 +1,14 @@
+// test warning suppression
+
+(with migration = func ({f = _ : ()}) : {} = {}) // warnon dropped field
+actor a1 { };
+
+(with migration = func ({f = _ : (nowarn: ()) }) : {} = {}) // no-warning, named type
+actor a2 { };
+
+(with migration = func ({f = _ : () }) : {} = {}) // warn on re-initialized field
+actor b1 { stable let f = (); f };
+
+(with migration = func ({f = _ : (nowarn: ()) }) : {} = {}) // no-warning, named type
+actor b2 { stable let f = (); f };
+

--- a/test/fail/migration-silent-drop.mo
+++ b/test/fail/migration-silent-drop.mo
@@ -1,14 +1,29 @@
 // test warning suppression
 
-(with migration = func ({f = _ : ()}) : {} = {}) // warnon dropped field
+(with migration = func (_ : {f : ()}) : {} = {}) // warn on dropped field
 actor a1 { };
 
-(with migration = func ({f = _ : (nowarn: ()) }) : {} = {}) // no-warning, named type
+(with migration = func (_ : {f : (nowarn: ())}) : {} = {}) // no-warning, named type
 actor a2 { };
 
-(with migration = func ({f = _ : () }) : {} = {}) // warn on re-initialized field
+(with migration = func (_ : {f : ()}) : {} = {}) // warn on re-initialized field
 actor b1 { stable let f = (); f };
 
-(with migration = func ({f = _ : (nowarn: ()) }) : {} = {}) // no-warning, named type
+(with migration = func (_ : {f : (nowarn: ())}) : {} = {}) // no-warning, named type
 actor b2 { stable let f = (); f };
+
+
+(with migration = func (_ : {var f : ()}) : {} = {}) // warn on dropped field
+actor c1 { };
+
+(with migration = func (_ : {var f : (nowarn: ())}) : {} = {}) // no-warning, named type
+actor c2 { };
+
+(with migration = func (_ : {var f : ()}) : {} = {}) // warn on re-initialized field
+actor c3 { stable let f = (); f };
+
+(with migration = func (_ : {var f : (nowarn: ())}) : {} = {}) // no-warning, named type
+actor c4 { stable let f = (); f };
+
+
 

--- a/test/fail/ok/migration-bad.tc.ok
+++ b/test/fail/ok/migration-bad.tc.ok
@@ -14,7 +14,7 @@ migration-bad.mo:19.7-19.44: warning [M0207], migration expression consumes fiel
   () -> ()
 but does not produce it. The field is not declared in the actor.
 This field will be removed from the actor, discarding its consumed value.
-If this removal is unintended, declare the field in the actor and either remove the field from the parameter of the migration function or add it to the result of the migration function.
+If this removal is unintended, declare the field in the actor and either remove the field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.
 migration-bad.mo:23.7-23.57: type error [M0201], expected stable type, but migration expression produces non-stable type
   {f : () -> ()}
 migration-bad.mo:23.7-23.57: type error [M0202], expected object type, but migration expression consumes non-object type

--- a/test/fail/ok/migration-silent-drop.tc.ok
+++ b/test/fail/ok/migration-silent-drop.tc.ok
@@ -1,0 +1,10 @@
+migration-silent-drop.mo:3.7-3.48: warning [M0207], migration expression consumes field `f` of type
+  ()
+but does not produce it. The field is not declared in the actor.
+This field will be removed from the actor, discarding its consumed value.
+If this removal is unintended, declare the field in the actor and either remove the field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.
+migration-silent-drop.mo:9.7-9.49: warning [M0206], migration expression consumes field `f` of type
+  ()
+but does not produce it, yet the field is declared in the actor.
+The declaration in the actor will be reinitialized, discarding its consumed value.
+If reinitialization is unintended, and you want to preserve the consumed value, either remove this field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.

--- a/test/fail/ok/migration-silent-drop.tc.ok
+++ b/test/fail/ok/migration-silent-drop.tc.ok
@@ -3,8 +3,18 @@ migration-silent-drop.mo:3.7-3.48: warning [M0207], migration expression consume
 but does not produce it. The field is not declared in the actor.
 This field will be removed from the actor, discarding its consumed value.
 If this removal is unintended, declare the field in the actor and either remove the field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.
-migration-silent-drop.mo:9.7-9.49: warning [M0206], migration expression consumes field `f` of type
+migration-silent-drop.mo:9.7-9.48: warning [M0206], migration expression consumes field `f` of type
   ()
+but does not produce it, yet the field is declared in the actor.
+The declaration in the actor will be reinitialized, discarding its consumed value.
+If reinitialization is unintended, and you want to preserve the consumed value, either remove this field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.
+migration-silent-drop.mo:16.7-16.52: warning [M0207], migration expression consumes field `f` of type
+  var ()
+but does not produce it. The field is not declared in the actor.
+This field will be removed from the actor, discarding its consumed value.
+If this removal is unintended, declare the field in the actor and either remove the field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.
+migration-silent-drop.mo:22.7-22.52: warning [M0206], migration expression consumes field `f` of type
+  var ()
 but does not produce it, yet the field is declared in the actor.
 The declaration in the actor will be reinitialized, discarding its consumed value.
 If reinitialization is unintended, and you want to preserve the consumed value, either remove this field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.

--- a/test/fail/ok/migration-warn.tc.ok
+++ b/test/fail/ok/migration-warn.tc.ok
@@ -2,4 +2,4 @@ migration-warn.mo:4.7-8.5: warning [M0206], migration expression consumes field 
   Nat
 but does not produce it, yet the field is declared in the actor.
 The declaration in the actor will be reinitialized, discarding its consumed value.
-If reinitialization is unintended, and you want to preserve the consumed value, either remove this field from the parameter of the migration function or add it to the result of the migration function.
+If reinitialization is unintended, and you want to preserve the consumed value, either remove this field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.

--- a/test/fail/ok/migration.tc.ok
+++ b/test/fail/ok/migration.tc.ok
@@ -21,4 +21,4 @@ migration.mo:3.7-13.7: warning [M0207], migration expression consumes field `uns
   () -> ()
 but does not produce it. The field is not declared in the actor.
 This field will be removed from the actor, discarding its consumed value.
-If this removal is unintended, declare the field in the actor and either remove the field from the parameter of the migration function or add it to the result of the migration function.
+If this removal is unintended, declare the field in the actor and either remove the field from the parameter of the migration function or add it to the result of the migration function. To suppress this warning, use a named type for the field.


### PR DESCRIPTION
closes https://github.com/dfinity/motoko/issues/5301


NB: this is probably better than just disabling these warnings entirely since it forces users to consider each field on a case by case basis.
