### PR TITLE
fix: disable `base` tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -260,7 +260,9 @@
 
       common-constituents = rec {
         samples = import ./nix/samples.nix { inherit pkgs; inherit (debugMoPackages) moc; };
-        base-tests = import ./nix/base-tests.nix { inherit pkgs; inherit (debugMoPackages) moc; };
+        # TODO: Re-enable base tests once we recalibrate them so they
+        # don't OOM anymore.
+        # base-tests = import ./nix/base-tests.nix { inherit pkgs; inherit (debugMoPackages) moc; };
         base-doc = import ./nix/base-doc.nix { inherit pkgs; inherit (debugMoPackages) mo-doc; };
         report-site = import ./nix/report-site.nix { inherit pkgs base-doc docs; inherit (tests) coverage; };
 


### PR DESCRIPTION
This PR disables `base` tests because they allocate too much memory and they OOM the GitHub linux runners. We re-enable after the `base` tests have been re-calibrated to use less memory.

