### PR TITLE
experiment: add layout of stable closures for graphcopy serialization

### DIFF
--- a/rts/motoko-rts/src/stabilization/layout.rs
+++ b/rts/motoko-rts/src/stabilization/layout.rs
@@ -31,16 +31,16 @@ use crate::{
     types::{
         base_array_tag, size_of, Tag, Value, TAG_ARRAY_I, TAG_ARRAY_M, TAG_ARRAY_S,
         TAG_ARRAY_SLICE_MIN, TAG_ARRAY_T, TAG_BIGINT, TAG_BITS64_F, TAG_BITS64_S, TAG_BITS64_U,
-        TAG_BLOB_A, TAG_BLOB_B, TAG_BLOB_P, TAG_BLOB_T, TAG_CONCAT, TAG_MUTBOX, TAG_OBJECT,
-        TAG_REGION, TAG_SOME, TAG_VARIANT, TAG_CLOSURE, TRUE_VALUE,
+        TAG_BLOB_A, TAG_BLOB_B, TAG_BLOB_P, TAG_BLOB_T, TAG_CLOSURE, TAG_CONCAT, TAG_MUTBOX,
+        TAG_OBJECT, TAG_REGION, TAG_SOME, TAG_VARIANT, TRUE_VALUE,
     },
 };
 
 use self::{
     stable_array::StableArray, stable_bigint::StableBigInt, stable_bits64::StableBits64,
-    stable_blob::StableBlob, stable_concat::StableConcat, stable_mutbox::StableMutBox,
-    stable_object::StableObject, stable_region::StableRegion, stable_some::StableSome,
-    stable_variant::StableVariant, stable_closure::StableClosure
+    stable_blob::StableBlob, stable_closure::StableClosure, stable_concat::StableConcat,
+    stable_mutbox::StableMutBox, stable_object::StableObject, stable_region::StableRegion,
+    stable_some::StableSome, stable_variant::StableVariant,
 };
 
 use super::{
@@ -55,13 +55,13 @@ mod stable_array;
 mod stable_bigint;
 mod stable_bits64;
 mod stable_blob;
+mod stable_closure;
 mod stable_concat;
 mod stable_mutbox;
 mod stable_object;
 mod stable_region;
 mod stable_some;
 mod stable_variant;
-mod stable_closure;
 
 /// Different kinds of objects used in the stable format.
 #[repr(u64)]
@@ -453,6 +453,5 @@ pub unsafe fn deserialize<M: Memory>(
         StableObjectKind::Closure => {
             StableClosure::deserialize(main_memory, stable_memory, stable_object, object_kind)
         }
-
     }
 }

--- a/rts/motoko-rts/src/stabilization/layout/stable_closure.rs
+++ b/rts/motoko-rts/src/stabilization/layout/stable_closure.rs
@@ -1,57 +1,131 @@
 use crate::{
-    stabilization::serialization::stable_memory_stream::StableMemoryStream,
-    types::{Value, Closure, TAG_CLOSURE},
+    memory::Memory,
+    stabilization::{
+        deserialization::stable_memory_access::StableMemoryAccess,
+        layout::StableObjectKind,
+        serialization::{
+            stable_memory_stream::{ScanStream, StableMemoryStream, WriteStream},
+            SerializationContext,
+        },
+    },
+    types::{size_of, Closure, Value, Words, TAG_CLOSURE},
 };
 
-use super::{Serializer, StableObjectKind, StableValue, StaticScanner};
+use super::{Serializer, StableToSpace, StableValue, StaticScanner};
 
 #[repr(C)]
 pub struct StableClosure {
-    funid: u64,
-    size: u64,
-    hash: StableValue,
+    function_id: u64, // Stable function id.
+    size: u64,        // Number of captured variables.
+                      // Dynamically sized body with `size` fields, each of `StableValue` being a captured variable.
 }
 
-impl StaticScanner<StableValue> for StableClosure {
-    fn update_pointers<C, F: Fn(&mut C, StableValue) -> StableValue>(
-        &mut self,
-        context: &mut C,
-        translate: &F,
-    ) -> bool {
-        self.hash = translate(context, self.hash);
-        true
-    }
-}
+impl StaticScanner<StableValue> for StableClosure {}
 
 impl Serializer<Closure> for StableClosure {
     unsafe fn serialize_static_part(
         _stable_memory: &mut StableMemoryStream,
         main_object: *mut Closure,
     ) -> Self {
-        debug_assert_eq!(main_object.funid(), usize::MAX);
-        debug_assert_eq!(main_object.size(), 1);
+        debug_assert!(!(*main_object).funid == usize::MAX);
         StableClosure {
-	    funid: (*main_object).funid as u64,
-            size: (*main_object).size as u64,
-            hash: StableValue::serialize(*(main_object.payload_addr())),
+            function_id: (*main_object).funid as u64,
+            size: main_object.size() as u64,
         }
+    }
+
+    unsafe fn serialize_dynamic_part(
+        stable_memory: &mut StableMemoryStream,
+        main_object: *mut Closure,
+    ) {
+        let closure_size = main_object.size();
+        for index in 0..closure_size {
+            let main_captured = main_object.get(index);
+            let stable_captured = StableValue::serialize(main_captured);
+            stable_memory.write(&stable_captured);
+        }
+    }
+
+    fn scan_serialized_dynamic<
+        'a,
+        M,
+        F: Fn(&mut SerializationContext<'a, M>, StableValue) -> StableValue,
+    >(
+        &self,
+        context: &mut SerializationContext<'a, M>,
+        translate: &F,
+    ) {
+        for _ in 0..self.size {
+            let old_value = context.serialization.to_space().read::<StableValue>();
+            let new_value = translate(context, old_value);
+            context.serialization.to_space().update(&new_value);
+        }
+    }
+
+    unsafe fn allocate_deserialized<M: Memory>(
+        &self,
+        main_memory: &mut M,
+        object_kind: StableObjectKind,
+    ) -> Value {
+        debug_assert_eq!(object_kind, StableObjectKind::Closure);
+        let total_size = size_of::<Closure>() + Words(self.size as usize);
+        main_memory.alloc_words(total_size)
     }
 
     unsafe fn deserialize_static_part(
         &self,
-        target_closure: *mut Closure,
+        target_object: *mut Closure,
         object_kind: StableObjectKind,
     ) {
         debug_assert_eq!(object_kind, StableObjectKind::Closure);
-        debug_assert_eq!(self.funid, u64::MAX);
-        debug_assert_eq!(self.size, 1);
-        (*target_closure).header.tag = TAG_CLOSURE;
-        (*target_closure)
+        debug_assert!(self.function_id == u64::MAX);
+        (*target_object).header.tag = TAG_CLOSURE;
+        (*target_object)
             .header
-            .init_forward(Value::from_ptr(target_closure as usize));
-        (*target_closure).funid = self.funid as usize;
-        (*target_closure).size = self.size as usize;
-	let address = target_closure.payload_addr();
-        *address = self.hash.deserialize();
+            .init_forward(Value::from_ptr(target_object as usize));
+        (*target_object).funid = self.function_id as usize;
+        (*target_object).size = self.size as usize;
+    }
+
+    unsafe fn deserialize_dynamic_part<M: Memory>(
+        &self,
+        _main_memory: &mut M,
+        stable_memory: &StableMemoryAccess,
+        stable_object: StableValue,
+        target_object: *mut Closure,
+    ) {
+        let stable_address = stable_object.payload_address();
+        for index in 0..self.size {
+            let field_address = stable_address
+                + size_of::<StableClosure>().to_bytes().as_usize() as u64
+                + (index * size_of::<StableValue>().to_bytes().as_usize() as u64);
+            let field = stable_memory.read::<StableValue>(field_address);
+            let target_field_address = target_object.payload_addr().add(index as usize);
+            *target_field_address = field.deserialize();
+        }
     }
 }
+
+/*
+// Wrappers are needed for RTS unit testing.
+#[cfg(feature = "ic")]
+fn is_flexible_function_id(function_id: isize) -> bool {
+    crate::persistence::stable_functions::is_flexible_function_id(function_id)
+}
+
+#[cfg(not(feature = "ic"))]
+fn is_flexible_function_id(_function_id: isize) -> bool {
+    true
+}
+
+/// Resolve closure size (number of captured variables) during serialization.
+/// This requires a look up in the hash blob, which may however already have been
+/// serialized to stable memory.
+fn get_closure_size(stable_memory: &StableMemoryStream, main_object: *mut Closure) -> usize {
+    // Do not call tag as it resolves the forwarding pointer.
+    unsafe {
+        let main_hash_blob = (*main_object).hash_blob;
+        size_by_hash_blob(stable_memory, main_hash_blob)
+    }
+}
+*/

--- a/rts/motoko-rts/src/stabilization/serialization.rs
+++ b/rts/motoko-rts/src/stabilization/serialization.rs
@@ -101,7 +101,10 @@ impl Serialization {
     }
 
     fn has_non_stable_type(old_field: Value) -> bool {
-        unsafe { old_field.tag() == TAG_CLOSURE && (*old_field.as_closure()).funid != usize::MAX /* -1 */}
+        unsafe {
+            old_field.tag() == TAG_CLOSURE && (*old_field.as_closure()).funid != usize::MAX
+            /* -1 */
+        }
     }
 
     pub fn pending_array_scanning(&self) -> bool {

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -857,11 +857,11 @@ impl Closure {
         (*self).size
     }
 
-    #[enhanced_orthogonal_persistence]
-    pub(crate) unsafe fn funid(self: *mut Self) -> usize {
-        (*self).funid
+    #[allow(unused)]
+    pub(crate) unsafe fn get(self: *mut Self, index: usize) -> Value {
+        debug_assert!(index < self.size());
+        *self.payload_addr().add(index)
     }
-
 }
 
 #[repr(C)] // See the note at the beginning of this module

--- a/test/run-drun/ok/stabilize-func.drun.ok
+++ b/test/run-drun/ok/stabilize-func.drun.ok
@@ -8,20 +8,20 @@ ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 debug.print: #two({key = 1; name = "TEST TEST TEST"})
-ingress Err: IC0504: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister violated contract: function invocation does not match its signature.
-If you are running this canister in a test environment (e.g., dfx), make sure the test environment is up to date. Otherwise, this is likely an error with the compiler/CDK toolchain being used to build the canister. Please report the error to IC devs on the forum: https://forum.dfinity.org and include which language/CDK was used to create the canister.
+debug.print: #two({key = 1; name = "TEST TEST TEST"})
+ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 debug.print: #two({key = 1; name = "TEST TEST TEST TEST"})
-ingress Err: IC0504: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister violated contract: function invocation does not match its signature.
-If you are running this canister in a test environment (e.g., dfx), make sure the test environment is up to date. Otherwise, this is likely an error with the compiler/CDK toolchain being used to build the canister. Please report the error to IC devs on the forum: https://forum.dfinity.org and include which language/CDK was used to create the canister.
+debug.print: #two({key = 1; name = "TEST TEST TEST TEST"})
+ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 debug.print: #two({key = 1; name = "TEST TEST TEST TEST TEST"})
-ingress Err: IC0504: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister violated contract: function invocation does not match its signature.
-If you are running this canister in a test environment (e.g., dfx), make sure the test environment is up to date. Otherwise, this is likely an error with the compiler/CDK toolchain being used to build the canister. Please report the error to IC devs on the forum: https://forum.dfinity.org and include which language/CDK was used to create the canister.
+debug.print: #two({key = 1; name = "TEST TEST TEST TEST TEST"})
+ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 ingress Err: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'RTS error: Memory-incompatible program upgrade'.
 Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://internetcomputer.org/docs/current/references/execution-errors#trapped-explicitly


### PR DESCRIPTION
Builds on #5413 

Add stable_closure serialization for subset of closures that are stable (funid = -1).

Implementation adapted from #5451