### PR TITLE
feat: Warnings as Errors selectively

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,10 @@
     Multiple warnings can be disabled or enabled by comma-separating the message codes, e.g. `-A M0217,M0218`.
     Both flags can be used multiple times.
 
+  * Added `-E` flag to treat specified warnings as errors given their message codes (#5502).
+
+  * Added `--warn-help` flag to show available warning codes, current lint level (**A**llowed, **W**arn or **E**rror), and descriptions (#5502).
+
 ## 0.16.2 (2025-09-12)
 
 * motoko (`moc`)

--- a/doc/md/15-compiler-ref.md
+++ b/doc/md/15-compiler-ref.md
@@ -45,6 +45,8 @@ You can use the following options with the `moc` command.
 | `-Werror`                                 | Treat warnings as errors.                                                                                                                             |
 | `-A <codes>`                              | Disable (Allow) comma-separated warning codes, e.g. `-A M0194,M0223`                                                                                  |
 | `-W <codes>`                              | Enable (Warn) comma-separated warning codes, e.g. `-W M0223`                                                                                          |
+| `-E <codes>`                              | Treat as error comma-separated warning codes, e.g. `-E M0217`                                                                                         |
+| `--warn-help`                             | Show available warning codes, current lint level, and descriptions                                                                                    |
 | `--incremental-gc`                        | Use incremental GC (default, works with both enhanced orthogonal persistence and legacy/classical persistence).                                       |
 | `--idl`                                   | Compile binary and emit Candid IDL specification to `.did` file.                                                                                      |
 | `-i`                                      | Runs the compiler in an interactive read–eval–print loop (REPL) shell so you can evaluate program execution (implies -r).                             |

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -47,7 +47,7 @@ let modify_warning_levels level s =
   let codes = String.split_on_char ',' s in
   codes |> List.iter (fun code ->
     if validate_warning_code code then
-      Mo_config.Flags.set_warning_level code level
+      Flags.set_warning_level code level
     else begin
       eprintf "moc: invalid warning code: %s. Run 'moc --warn-help' to see available warning codes." code; exit 1
     end)

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -39,17 +39,17 @@ let valid_metadata_names =
 (* suppress documentation *)
 let _UNDOCUMENTED_ doc = "" (* TODO: enable with developer env var? *)
 
-let validate_message_code code =
+let validate_warning_code code =
   code <> "" &&
-  List.exists (fun (c, _) -> String.equal c code) Error_codes.error_codes
+  List.exists (fun (c, _, _) -> String.equal c code) Error_codes.warning_codes
 
-let modify_disabled_warning_codes op s =
+let modify_warning_levels level s =
   let codes = String.split_on_char ',' s in
   codes |> List.iter (fun code ->
-    if validate_message_code code then
-      Flags.disabled_warning_codes := op code !Flags.disabled_warning_codes
+    if validate_warning_code code then
+      Mo_config.Flags.set_warning_level code level
     else begin
-      eprintf "moc: invalid message code: %s" code; exit 1
+      eprintf "moc: invalid warning code: %s. Run 'moc --warn-help' to see available warning codes." code; exit 1
     end)
 
 let argspec = [
@@ -80,10 +80,26 @@ let argspec = [
   "-p", Arg.Set_int Flags.print_depth, "<n>  set print depth";
   "--hide-warnings", Arg.Clear Flags.print_warnings, " hide warnings";
   "-Werror", Arg.Set Flags.warnings_are_errors, " treat warnings as errors";
-  "-A", Arg.String (modify_disabled_warning_codes Flags.S.add),
-    "<codes>  disable (allow) comma-separated warning codes, e.g. -A M0194,M0223";
-  "-W", Arg.String (modify_disabled_warning_codes Flags.S.remove),
+  "-A", Arg.String (modify_warning_levels Flags.Allow),
+    "<codes>  disable (allow) comma-separated warning codes, e.g. -A M0194,M0217";
+  "-W", Arg.String (modify_warning_levels Flags.Warn),
     "<codes>  enable (warn) comma-separated warning codes, e.g. -W M0223";
+  "-E", Arg.String (modify_warning_levels Flags.Error),
+    "<codes>  treat as error comma-separated warning codes, e.g. -E M0217";
+  "--warn-help",
+    Arg.Unit (fun () ->
+      let string_of_level = function
+        | Flags.Allow -> "A"
+        | Flags.Warn -> "W"
+        | Flags.Error -> "E"
+      in
+      List.iter (fun (code, _, desc) ->
+        let lvl = Flags.get_warning_level code in
+        printf "%s (%s) %s\n" code (string_of_level lvl) desc
+      ) Error_codes.warning_codes;
+      printf "\nLegend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)\n";
+      exit 0),
+    " show available warning codes, current lint level, and descriptions";
   ]
 
   @ Args.error_args
@@ -357,7 +373,7 @@ let process_files files : unit =
          exit 1)
     end
   | Explain ->
-     match List.find_opt (fun (c, _) -> String.equal c !explain_code) Error_codes.error_codes with
+     match Error_codes.try_find_explanation !explain_code with
      | Some (_, Some(explanation)) ->
         printf "%s" explanation
      | Some (_, None) ->

--- a/src/lang_utils/diag.ml
+++ b/src/lang_utils/diag.ml
@@ -83,7 +83,7 @@ let is_warning_as_error msg =
 let print_message msg =
   let msg =
     if is_warning_as_error msg
-    then {msg with sev = Error}
+    then { msg with sev = Error }
     else msg
   in
   if msg.sev <> Error && not !Flags.print_warnings

--- a/src/lang_utils/diag.ml
+++ b/src/lang_utils/diag.ml
@@ -53,8 +53,13 @@ let rec fold : ('a -> 'b -> 'a result) -> 'a -> 'b list -> 'a result = fun f acc
 
 type msg_store = messages ref
 let add_msg s m = 
-  if m.sev = Warning && Flags.is_warning_disabled m.code then () else
-  s := m :: !s
+  if m.sev = Warning then
+    match Flags.get_warning_level m.code with
+    | Flags.Allow -> ()
+    | Flags.Warn -> s := m :: !s
+    | Flags.Error -> s := {m with sev = Error} :: !s
+  else
+    s := m :: !s
 let add_msgs s ms = List.iter (add_msg s) (List.rev ms)
 let get_msgs s = List.rev !s
 

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -8,7 +8,6 @@ let error_codes : (string * string option) list =
     "M0002", None; (* Lexer errors *)
     "M0003", Some([%blob "lang_utils/error_codes/M0003.md"]); (* Self-import *)
     "M0004", None; (* IDL file doesn't define a service *)
-    "M0005", None; (* Case mismatch between import and filename *)
     "M0006", None; (* Failed to parse import URL *)
     "M0007", None; (* Failed to parse actor alias *)
     "M0008", None; (* Actor import without IDL path *)
@@ -64,8 +63,6 @@ let error_codes : (string * string option) list =
     "M0058", None; (* No type can be inferred for actor reference *)
     "M0059", None; (* Operator is not defined for operand type *)
     "M0060", None; (* Operator is not defined for operand types *)
-    "M0061", None; (* Comparing abstract type to itself at supertype *)
-    "M0062", None; (* Comparing incompatible type at common supertype *)
     "M0063", None; (* Show is not defined for operand type *)
     "M0064", None; (* Misplaced '!' without enclosing do block *)
     "M0065", None; (* Expected option type before '!' *)
@@ -77,14 +74,12 @@ let error_codes : (string * string option) list =
     "M0071", None; (* Cannot infer type of forward field reference *)
     "M0072", None; (* Field does not exist in type *)
     "M0073", None; (* Expected mutable assignment target *)
-    "M0074", None; (* Array elements have inconsistent types *)
     "M0075", None; (* Expected array type *)
     "M0076", None; (* Shared functions are not supported *)
     "M0077", None; (* Shared function is only allowed as a public field of an actor *)
     "M0078", None; (* Shared function with () result type has unexpected body *)
     "M0079", None; (* Shared function with async result type has non-async body *)
     (* "M0080" DEFUNCT Local class type is contained in inferred block type *)
-    "M0081", None; (* If branches have inconsistent types *)
     "M0082", None; (* Expected iterable type *)
     "M0083", None; (* Unbound label *)
     "M0084", None; (* Cannot infer return type *)
@@ -92,7 +87,6 @@ let error_codes : (string * string option) list =
     "M0086", None; (* Async expressions are not supported *)
     "M0087", None; (* Ill-scoped await *)
     "M0088", None; (* Expected async type *)
-    "M0089", None; (* Redundant ignore *)
     "M0090", None; (* Actor reference must have an actor type *)
     "M0091", None; (* Mutable array expression cannot produce expected type *)
     "M0092", None; (* Async cannot produce scope *)
@@ -104,7 +98,6 @@ let error_codes : (string * string option) list =
     "M0098", None; (* Cannot instantiate function type *)
     "M0099", None; (* Shared function argument contains abstract type *)
     "M0100", None; (* Shared function call result contains abstract type *)
-    "M0101", None; (* Switch with inconsistent branch types *)
     "M0102", None; (* Cannot infer type of wildcard *)
     "M0103", None; (* Cannot infer type of variable *)
     (* "M0104" DEFUNCT Pattern branches have incompatible types *)
@@ -131,25 +124,20 @@ let error_codes : (string * string option) list =
     "M0125", None; (* Public actor field needs to be a manifest function *)
     "M0126", None; (* Shared function cannot be private *)
     "M0127", None; (* System function with wrong type *)
-    "M0128", None; (* Function with system function name but wrong visibility *)
     "M0129", None; (* Unexpected system method name *)
     "M0130", None; (* Misplaced system visibility *)
     "M0131", None; (* Expected stable type *)
     "M0132", None; (* Misplaced stability declaration *)
     "M0133", None; (* Misplaced stability modifier *)
     "M0134", None; (* Class body type mismatch *)
-    "M0135", None; (* Actor class has non-async return type *)
     "M0136", None; (* Empty block type mismatch *)
     "M0137", Some([%blob "lang_utils/error_codes/M0137.md"]); (* Type definition references type parameter from outer scope *)
     "M0138", None; (* Actor classes are not supported *)
     "M0139", None; (* Inner actor classes are not supported *)
     "M0140", None; (* Actor classes with type parameters are not supported *)
     "M0141", Some([%blob "lang_utils/error_codes/M0141.md"]); (* An actor or actor class must be the only non-imported declaration in a program *)
-    "M0142", None; (* An imported library should be a module or named actor class *)
     "M0143", None; (* Imported actor class cannot be anonymous *)
     "M0144", None; (* Expected a module or actor class *)
-    "M0145", None; (* Pattern does not cover value *)
-    "M0146", None; (* Pattern is never matched *)
     (* "M0147" DEFUNCT Object syntax is deprecated in this position *)
     (* "M0148" DEFUNCT Block syntax is deprecated in this position *)
     "M0149", Some([%blob "lang_utils/error_codes/M0149.md"]); (* Expected mutable 'var' field, found immutable field *)
@@ -157,8 +145,6 @@ let error_codes : (string * string option) list =
     "M0151", Some([%blob "lang_utils/error_codes/M0151.md"]); (* missing field in object literal *)
     (* "M0152" DEFUNCT Word field deprecation *)
     "M0153", Some([%blob "lang_utils/error_codes/M0153.md"]); (* IDL types not expressible in Motoko *)
-    "M0154", Some([%blob "lang_utils/error_codes/M0154.md"]); (* Deprecation annotation *)
-    "M0155", Some([%blob "lang_utils/error_codes/M0155.md"]); (* Inferred type Nat for subtraction *)
     "M0156", Some([%blob "lang_utils/error_codes/M0156.md"]); (* block contains expansive type definitions *)
     "M0157", Some([%blob "lang_utils/error_codes/M0157.md"]); (* block contains non-productive type definitions *)
     "M0158", Some([%blob "lang_utils/error_codes/M0158.md"]); (* a public class cannot be anonymous, please provide a name *)
@@ -169,8 +155,6 @@ let error_codes : (string * string option) list =
     (* "M0163" DEFUNCT Cannot import a Candid service constructor *)
     "M0164", None; (* Unknown record or variant label in textual representation *)
     "M0165", None; (* Odd expected type *)
-    "M0166", None; (* Type intersection results in abstract type *)
-    "M0167", None; (* Type union results in bottom type *)
     "M0168", None; (* Type union or intersection on forward types *)
     "M0169", None; (* Stable variable will be discarded. This may cause data loss. *)
     "M0170", None; (* Stable variable must subtype *)
@@ -193,43 +177,27 @@ let error_codes : (string * string option) list =
     "M0187", None; (* Send capability required (calling composite from non-composite) *)
     "M0188", None; (* Send capability required (calling shared from query) *)
     "M0189", None; (* Different set of bindings in pattern alternatives *)
-    "M0190", None; (* Types inconsistent for alternative pattern variables, losing information *)
-    "M0191", None; (* Code requires Wasm features ... to execute *)
     "M0192", None; (* Object/Actor/Module body type mismatch *)
     "M0193", None; (* Can't declare actor class to have `async*` result *)
-    "M0194", Some([%blob "lang_utils/error_codes/M0194.md"]); (* Unused identifier warning *)
-    "M0195", Some([%blob "lang_utils/error_codes/M0195.md"]); (* warn that `system` capability is implicitly supplied *)
     "M0196", None; (* `system` capability supplied but not required *)
     "M0197", Some([%blob "lang_utils/error_codes/M0197.md"]); (* `system` capability required *)
-    "M0198", Some([%blob "lang_utils/error_codes/M0198.md"]); (* Unused field pattern warning *)
-    "M0199", Some([%blob "lang_utils/error_codes/M0199.md"]); (* Deprecate experimental stable memory *)
     "M0200", Some([%blob "lang_utils/error_codes/M0200.md"]); (* Cannot determine subtyping or equality *)
     "M0201", None; (* Migration produces/consumes non-stable object *)
     "M0202", None; (* Migration produces/consume non-object type *)
     "M0203", None; (* Migration expression is not a function *)
     "M0204", None; (* Migration produces field of wrong type *)
     "M0205", None; (* Migration produces unexpected field *)
-    "M0206", None; (* Migration consumes, but does not produce, a declared field *)
-    "M0207", None; (* Migration consumes, but does not produce, an un-declared field *)
     "M0208", None; (* Missing field migration*)
     "M0209", None; (* Misplaced migration expression on module/object *)
-    "M0210", None; (* Parenthetical note must be applied to a message send *)
-    "M0211", None; (* Parenthetical note has no attributes *)
-    "M0212", Some([%blob "lang_utils/error_codes/M0212.md"]); (* Unrecognised attribute in parenthetical note *)
     "M0213", None; (* Parenthetical note on shared functions is disallowed *)
     "M0214", None; (* Expected type of field in parenthetical note differs from inferred *)
-    "M0215", None; (* Field is lost in record used at supertype *)
     "M0216", None; (* Stable variable must stable subtype *)
-    
     "M0219", None; (* Missing `transient` *)
     "M0220", None; (* Missing `persistent` *)
     "M0221", None; (* Failed to determine type for type pattern field *)
-    "M0222", None; (* Ignored `async*` *)
   ]
-(* TODO: move the lint level + map to here from Flags *)
-(* TODO: Remove warning codes from errors above, no duplication! *)
-(* TODO: Check if all warnings are accounted for below *)
-(* TODO: Make sure the warnings that are used as errors have their default lint level in the config in Flags *)
+
+(** Message codes that can be both used as warnings and errors *)
 let warning_codes = [
   "M0005", None, "Case mismatch between import and filename";
   "M0061", None, "Comparing abstract type to itself at supertype";
@@ -241,23 +209,23 @@ let warning_codes = [
   "M0128", None, "Function with system function name but wrong visibility";
   "M0135", None, "Actor class has non-async return type";
   "M0142", None, "An imported library should be a module or named actor class";
-  "M0145", None, "Pattern does not cover value";
+  "M0145", None, "Pattern does not cover value"; (* Warn or Error *)
   "M0146", None, "Pattern is never matched";
-  "M0154", None, "Deprecation annotation";
-  "M0155", None, "Inferred type Nat for subtraction";
+  "M0154", Some([%blob "lang_utils/error_codes/M0154.md"]), "Deprecation annotation";
+  "M0155", Some([%blob "lang_utils/error_codes/M0155.md"]), "Inferred type Nat for subtraction";
   "M0166", None, "Type intersection results in abstract type";
   "M0167", None, "Type union results in bottom type";
   "M0190", None, "Types inconsistent for alternative pattern variables, losing information";
   "M0191", None, "Code requires Wasm features ... to execute";
-  "M0194", None, "Unused identifier warning";
-  "M0195", None, "warn that `system` capability is implicitly supplied";
-  "M0198", None, "Unused field pattern warning";
-  "M0199", None, "Deprecate experimental stable memory";
+  "M0194", Some([%blob "lang_utils/error_codes/M0194.md"]), "Unused identifier warning";
+  "M0195", Some([%blob "lang_utils/error_codes/M0195.md"]), "warn that `system` capability is implicitly supplied";
+  "M0198", Some([%blob "lang_utils/error_codes/M0198.md"]), "Unused field pattern warning";
+  "M0199", Some([%blob "lang_utils/error_codes/M0199.md"]), "Deprecate experimental stable memory"; (* Warn or Error *)
   "M0206", None, "Migration consumes, but does not produce, a declared field";
   "M0207", None, "Migration consumes, but does not produce, an un-declared field";
   "M0210", None, "Parenthetical note must be applied to a message send";
   "M0211", None, "Parenthetical note has no attributes";
-  "M0212", None, "Unrecognised attribute in parenthetical note";
+  "M0212", Some([%blob "lang_utils/error_codes/M0212.md"]), "Unrecognised attribute in parenthetical note";
   "M0215", None, "Field is lost in record used at supertype";
   "M0217", None, "Redundant `persistent`";
   "M0218", None, "Redundant `stable`";

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -220,10 +220,53 @@ let error_codes : (string * string option) list =
     "M0214", None; (* Expected type of field in parenthetical note differs from inferred *)
     "M0215", None; (* Field is lost in record used at supertype *)
     "M0216", None; (* Stable variable must stable subtype *)
-    "M0217", None; (* Redundant `persistent` *)
-    "M0218", None; (* Redundant `stable` *)
+    
     "M0219", None; (* Missing `transient` *)
     "M0220", None; (* Missing `persistent` *)
     "M0221", None; (* Failed to determine type for type pattern field *)
     "M0222", None; (* Ignored `async*` *)
   ]
+(* TODO: move the lint level + map to here from Flags *)
+(* TODO: Remove warning codes from errors above, no duplication! *)
+(* TODO: Check if all warnings are accounted for below *)
+(* TODO: Make sure the warnings that are used as errors have their default lint level in the config in Flags *)
+let warning_codes = [
+  "M0005", None, "Case mismatch between import and filename";
+  "M0061", None, "Comparing abstract type to itself at supertype";
+  "M0062", None, "Comparing incompatible type at common supertype";
+  "M0074", None, "Array elements have inconsistent types";
+  "M0081", None, "If branches have inconsistent types";
+  "M0089", None, "Redundant ignore";
+  "M0101", None, "Switch with inconsistent branch types";
+  "M0128", None, "Function with system function name but wrong visibility";
+  "M0135", None, "Actor class has non-async return type";
+  "M0142", None, "An imported library should be a module or named actor class";
+  "M0145", None, "Pattern does not cover value";
+  "M0146", None, "Pattern is never matched";
+  "M0154", None, "Deprecation annotation";
+  "M0155", None, "Inferred type Nat for subtraction";
+  "M0166", None, "Type intersection results in abstract type";
+  "M0167", None, "Type union results in bottom type";
+  "M0190", None, "Types inconsistent for alternative pattern variables, losing information";
+  "M0191", None, "Code requires Wasm features ... to execute";
+  "M0194", None, "Unused identifier warning";
+  "M0195", None, "warn that `system` capability is implicitly supplied";
+  "M0198", None, "Unused field pattern warning";
+  "M0199", None, "Deprecate experimental stable memory";
+  "M0206", None, "Migration consumes, but does not produce, a declared field";
+  "M0207", None, "Migration consumes, but does not produce, an un-declared field";
+  "M0210", None, "Parenthetical note must be applied to a message send";
+  "M0211", None, "Parenthetical note has no attributes";
+  "M0212", None, "Unrecognised attribute in parenthetical note";
+  "M0215", None, "Field is lost in record used at supertype";
+  "M0217", None, "Redundant `persistent`";
+  "M0218", None, "Redundant `stable`";
+  "M0222", None, "Ignored `async*`";
+]
+
+let try_find_explanation code =
+  match List.find_opt (fun (c, _) -> String.equal c code) error_codes with
+  | None ->
+    List.find_opt (fun (c, _, _) -> String.equal c code) warning_codes
+    |> Option.map (fun (c, e, _ ) -> (c, e))
+  | o -> o

--- a/src/lang_utils/error_codes.mli
+++ b/src/lang_utils/error_codes.mli
@@ -1,1 +1,3 @@
 val error_codes : (string * string option) list
+val warning_codes : (string * string option * string) list
+val try_find_explanation : string -> (string * string option) option

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -89,3 +89,5 @@ let get_warning_level (code : string) : lint_level =
   match M.find_opt code !warning_levels with
   | None -> Warn
   | Some level -> level
+
+let is_warning_disabled code = get_warning_level code = Allow

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -13,6 +13,9 @@ type instruction_limits = {
 }
 
 type actors = LegacyActors | RequirePersistentActors | DefaultPersistentActors
+
+type lint_level = Allow | Warn | Error
+
 let ai_errors = ref false
 let trace = ref false
 let verbose = ref false
@@ -76,7 +79,13 @@ let stable_memory_access_limit = ref stable_memory_access_limit_default
 let experimental_stable_memory_default = 0 (* _ < 0: error; _ = 0: warn, _ > 0: allow *)
 let experimental_stable_memory = ref experimental_stable_memory_default
 let typechecker_combine_srcs = ref false (* useful for the language server *)
-let default_disabled_warning_codes = S.empty
-let disabled_warning_codes : S.t ref = ref default_disabled_warning_codes
 
-let is_warning_disabled code = S.mem code !disabled_warning_codes
+let warning_levels : lint_level M.t ref = ref M.empty
+
+let set_warning_level (code : string) (level : lint_level) : unit =
+  warning_levels := M.add code level !warning_levels
+
+let get_warning_level (code : string) : lint_level =
+  match M.find_opt code !warning_levels with
+  | None -> Warn
+  | Some level -> level

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -80,12 +80,12 @@ let experimental_stable_memory_default = 0 (* _ < 0: error; _ = 0: warn, _ > 0: 
 let experimental_stable_memory = ref experimental_stable_memory_default
 let typechecker_combine_srcs = ref false (* useful for the language server *)
 
-let warning_levels : lint_level M.t ref = ref M.empty
+let warning_levels = ref M.empty
 
-let set_warning_level (code : string) (level : lint_level) : unit =
+let set_warning_level code level =
   warning_levels := M.add code level !warning_levels
 
-let get_warning_level (code : string) : lint_level =
+let get_warning_level code =
   match M.find_opt code !warning_levels with
   | None -> Warn
   | Some level -> level

--- a/test/fail/ok/warn-help.tc.ok
+++ b/test/fail/ok/warn-help.tc.ok
@@ -1,0 +1,33 @@
+M0005 (W) Case mismatch between import and filename
+M0061 (W) Comparing abstract type to itself at supertype
+M0062 (W) Comparing incompatible type at common supertype
+M0074 (W) Array elements have inconsistent types
+M0081 (W) If branches have inconsistent types
+M0089 (E) Redundant ignore
+M0101 (W) Switch with inconsistent branch types
+M0128 (W) Function with system function name but wrong visibility
+M0135 (W) Actor class has non-async return type
+M0142 (W) An imported library should be a module or named actor class
+M0145 (W) Pattern does not cover value
+M0146 (W) Pattern is never matched
+M0154 (W) Deprecation annotation
+M0155 (W) Inferred type Nat for subtraction
+M0166 (W) Type intersection results in abstract type
+M0167 (W) Type union results in bottom type
+M0190 (W) Types inconsistent for alternative pattern variables, losing information
+M0191 (W) Code requires Wasm features ... to execute
+M0194 (E) Unused identifier warning
+M0195 (W) warn that `system` capability is implicitly supplied
+M0198 (W) Unused field pattern warning
+M0199 (W) Deprecate experimental stable memory
+M0206 (W) Migration consumes, but does not produce, a declared field
+M0207 (W) Migration consumes, but does not produce, an un-declared field
+M0210 (W) Parenthetical note must be applied to a message send
+M0211 (W) Parenthetical note has no attributes
+M0212 (W) Unrecognised attribute in parenthetical note
+M0215 (W) Field is lost in record used at supertype
+M0217 (W) Redundant `persistent`
+M0218 (A) Redundant `stable`
+M0222 (A) Ignored `async*`
+
+Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/fail/ok/warn-help.tc.ok
+++ b/test/fail/ok/warn-help.tc.ok
@@ -29,5 +29,6 @@ M0215 (W) Field is lost in record used at supertype
 M0217 (W) Redundant `persistent`
 M0218 (A) Redundant `stable`
 M0222 (A) Ignored `async*`
+M0223 (A) Redundant type instantiation
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/fail/ok/warnings-as-errors.tc.ok
+++ b/test/fail/ok/warnings-as-errors.tc.ok
@@ -1,0 +1,2 @@
+warnings-as-errors.mo:4.1-4.15: type error [M0089], redundant ignore, operand already has type ()
+warnings-as-errors.mo:3.11-3.12: type error [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)

--- a/test/fail/ok/warnings-as-errors.tc.ret.ok
+++ b/test/fail/ok/warnings-as-errors.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/warn-help.mo
+++ b/test/fail/warn-help.mo
@@ -1,0 +1,5 @@
+//MOC-FLAG -E=M0194,M0089,M0222,M0155
+// NOTE:     ^ this format is necessary because of the way the flags are parsed in run.sh
+//MOC-FLAG -A M0218,M0222
+//MOC-FLAG -W M0155
+//MOC-FLAG --warn-help

--- a/test/fail/warnings-as-errors.mo
+++ b/test/fail/warnings-as-errors.mo
@@ -1,0 +1,4 @@
+//MOC-FLAG -E=M0194,M0089
+// NOTE:     ^ this format is necessary because of the way the flags are parsed in run.sh
+func main(x : Int) {};
+ignore main(1);


### PR DESCRIPTION
- Adds `-E` moc flag to complement `-A` and `-W`, can be used to treat selected warnings as errors (set their lint level to error). Only warnings can be modified. Messages raised as `error` are left untouched. This is important note, because some warning codes are used as `error`. These instances won't be affected. Only when calling with `warn` can the configuration be used to change the severity of the message.
- Adds `--warn-help` flag that lists all configurable warnings with their current lint level and their brief description