### PR TITLE
chore: avoid release workflow on push tag to non-master branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin master
-          if git merge-base --is-ancestor "${GITHUB_SHA}" "origin/kamil/avoid-release-on-tag-not-master"; then
+          if git merge-base --is-ancestor "${GITHUB_SHA}" "origin/master"; then
             echo "Tag commit ${GITHUB_SHA} is reachable from master."
           else
             echo "Error: Tag commit ${GITHUB_SHA} is not on master. Aborting workflow."


### PR DESCRIPTION
Fails the release workflow on push tag event when the commit is not on the master branch.
The full release workflow should only be triggered from the master branch, but it is sometimes triggered when creating a prerelease which can push a new tag.
This fix is not ideal as the workflow is still triggered but it prevents accidentally triggering a full release not from master.