### PR TITLE
experiment: refine contextual dot notation to ignore non-functional object fields of the receiver object

### DIFF
--- a/test/fail/ok/contextual-dot-biased.tc.ok
+++ b/test/fail/ok/contextual-dot-biased.tc.ok
@@ -1,0 +1,3 @@
+contextual-dot-biased.mo:23.12-23.17: type error [M0072], field other does exist in type:
+  {var other : Nat; var size : Nat} but is not a function
+Hint: If you're trying to use a contextual call you need to import the corresponding module.

--- a/test/fail/ok/contextual-dot-biased.tc.ret.ok
+++ b/test/fail/ok/contextual-dot-biased.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1


### PR DESCRIPTION
… same name