### PR TITLE
chore: reduce the Mergify dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
-          echo ${{ github.event.pull_request.number }}
+          echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.html_url }}
+          sleep 3
           gh pr view ${{ github.event.pull_request.number }}
-          gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
+          gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
           $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,7 @@ jobs:
         run: echo "Main tests completed successfully."
 
   autoclose:
+    if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'autoclose')
     needs: [verify-common-gc, verify-main-tests]
     runs-on: ubuntu-latest
     steps:
@@ -151,7 +152,6 @@ jobs:
       - name: Automatically closing successful trials
         env:
           GH_TOKEN: ${{ github.token }}
-        if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
           gh pr close ${{ github.event.pull_request.number }} --delete-branch --comment "CI looks good, this dependency bump would not cause problems, hence closing this trial PR."
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,8 +155,5 @@ jobs:
         run: |
           echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.state }} ${{ github.event.pull_request.html_url }}
           sleep 3
-          gh pr view ${{ github.event.pull_request.number }}
-          gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
-          $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') \
-          && (gh pr close ${{ github.event.pull_request.number }} --delete-branch --comment "CI looks good, this dependency bump would not cause problems, hence closing this trial PR." \
-              && gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose")
+          gh pr close ${{ github.event.pull_request.number }} --delete-branch --comment "CI looks good, this dependency bump would not cause problems, hence closing this trial PR."
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,10 +151,10 @@ jobs:
       - name: Automatically closing successful trials
         env:
           GH_TOKEN: ${{ github.token }}
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
+        if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
           echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.state }} ${{ github.event.pull_request.html_url }}
           sleep 3
           gh pr view ${{ github.event.pull_request.number }}
           gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
-          $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE
+          $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') && gh pr edit ${{ github.event.pull_request.number }} --add-label testing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,11 +86,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         if: matrix.os == 'ubuntu-24-large' && matrix.build_type == 'release' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
-        run: gh pr view
-
-        # gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length'
-
-        # $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE
+        run: |
+          gh pr view
+          gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' # | jq -n '[inputs] | length'
+          $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE
 
     #steps:
     #  - name: Automatically closing successful trials

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,4 +162,4 @@ jobs:
               && gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose")
 
 
-# delete_head_branch, remove 'autoclose'
+# delete_head_branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Automatically closing successful trials
         env:
           GH_TOKEN: ${{ github.token }}
-        if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'autoclose')
+        if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'testing')
         run: |
           echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.state }} ${{ github.event.pull_request.html_url }}
           sleep 3
@@ -159,7 +159,7 @@ jobs:
           gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
           $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') \
           && (gh pr comment ${{ github.event.pull_request.number }} --body "CI looks good, this dependency bump would not cause problems, hence closing this trial PR." \
-              && gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose")
+              && gh pr edit ${{ github.event.pull_request.number }} --remove-label "testing")
 
 
 # delete_head_branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
 
   # cleanups:
       - name: Automatically closing successful trials
-        if: matrix.os == 'ubuntu-24-large' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'autoclose')
+        if: matrix.os == 'ubuntu-24-large' && matrix.build_type == 'release' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: gh pr view
 
         # gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
-          echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.status }} ${{ github.event.pull_request.html_url }}
+          echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.state }} ${{ github.event.pull_request.html_url }}
           sleep 3
           gh pr view ${{ github.event.pull_request.number }}
           gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,10 +151,15 @@ jobs:
       - name: Automatically closing successful trials
         env:
           GH_TOKEN: ${{ github.token }}
-        if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
+        if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
           echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.state }} ${{ github.event.pull_request.html_url }}
           sleep 3
           gh pr view ${{ github.event.pull_request.number }}
           gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
-          $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') && gh pr comment ${{ github.event.pull_request.number }} --body "CI looks good, this dependency bump would not cause problems, hence closing this trial PR."
+          $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') \
+          && (gh pr comment ${{ github.event.pull_request.number }} --body "CI looks good, this dependency bump would not cause problems, hence closing this trial PR." \
+              && gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose")
+
+
+# delete_head_branch, remove 'autoclose'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
-          echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.state }} ${{ github.event.pull_request.html_url }}
           gh pr close ${{ github.event.pull_request.number }} --delete-branch --comment "CI looks good, this dependency bump would not cause problems, hence closing this trial PR."
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,3 +164,16 @@ jobs:
     steps:
       - name: Main tests passed
         run: echo "Main tests completed successfully."
+
+  autoclose:
+    needs: [verify-common-gc, verify-main-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatically closing successful trials XXXX
+        env:
+          GH_TOKEN: ${{ github.token }}
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
+        run: |
+          gh pr view
+          gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
+          $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,7 @@ jobs:
     needs: [verify-common-gc, verify-main-tests]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
       - name: Automatically closing successful trials XXXX
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,4 +157,4 @@ jobs:
           sleep 3
           gh pr view ${{ github.event.pull_request.number }}
           gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
-          $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') && gh pr edit ${{ github.event.pull_request.number }} --add-label testing
+          $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') && gh pr comment ${{ github.event.pull_request.number }} --body "CI looks good, this dependency bump would not cause problems, hence closing this trial PR."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,30 +80,6 @@ jobs:
           is_fork: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           token: ${{ steps.app-token.outputs.token }}
 
-
-  # cleanups:
-      - name: Automatically closing successful trials
-        env:
-          GH_TOKEN: ${{ github.token }}
-        if: matrix.os == 'ubuntu-24-large' && matrix.build_type == 'release' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
-        run: |
-          gh pr view
-          gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
-          $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE
-
-    #steps:
-    #  - name: Automatically closing successful trials
-    #  
-    #  - name: Clean up automerge tags
-    #conditions:
-    #  - closed
-    #actions:
-    #  label:
-    #    remove:
-    #      - automerge-squash
-    #      - autoclose
-
-
   reports:
     if: github.ref == 'refs/heads/master'
     needs: [tests]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Automatically closing successful trials
         env:
           GH_TOKEN: ${{ github.token }}
-        if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'testing')
+        if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
           echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.state }} ${{ github.event.pull_request.html_url }}
           sleep 3
@@ -159,7 +159,5 @@ jobs:
           gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
           $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') \
           && (gh pr comment ${{ github.event.pull_request.number }} --body "CI looks good, this dependency bump would not cause problems, hence closing this trial PR." \
-              && gh pr edit ${{ github.event.pull_request.number }} --remove-label "testing")
-
-
-# delete_head_branch
+              && gh pr close ${{ github.event.pull_request.number }} --delete-branch
+              && gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: update_flake_lock_action_daily
+          ref: 'master'
       - name: Automatically closing successful trials XXXX
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,8 @@ jobs:
 
   # cleanups:
       - name: Automatically closing successful trials
+        env:
+          GH_TOKEN: ${{ github.token }}
         if: matrix.os == 'ubuntu-24-large' && matrix.build_type == 'release' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: gh pr view
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,7 +175,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
-          echo ${{ github.event.pull_request }}
-          gh pr view
+          echo ${{ github.event.pull_request.number }}
+          gh pr view ${{ github.event.pull_request.number }}
           gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
           $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: 'master'
-      - name: Automatically closing successful trials XXXX
+      - name: Automatically closing successful trials
         env:
           GH_TOKEN: ${{ github.token }}
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
@@ -157,4 +157,4 @@ jobs:
           sleep 3
           gh pr view ${{ github.event.pull_request.number }}
           gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
-          $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE
+          $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
         if: matrix.os == 'ubuntu-24-large' && matrix.build_type == 'release' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
           gh pr view
-          gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' # | jq -n '[inputs] | length'
+          gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state'
           $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE
 
     #steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,5 @@ jobs:
           gh pr view ${{ github.event.pull_request.number }}
           gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
           $(gh pr checks  ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') \
-          && (gh pr comment ${{ github.event.pull_request.number }} --body "CI looks good, this dependency bump would not cause problems, hence closing this trial PR." \
-              && gh pr close ${{ github.event.pull_request.number }} --delete-branch
+          && (gh pr close ${{ github.event.pull_request.number }} --delete-branch --comment "CI looks good, this dependency bump would not cause problems, hence closing this trial PR." \
               && gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,6 +175,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
+          echo ${{ github.event.pull_request }}
           gh pr view
           gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
           $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,29 @@ jobs:
           is_fork: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           token: ${{ steps.app-token.outputs.token }}
 
+
+  # cleanups:
+      - name: Automatically closing successful trials
+        if: matrix.os == 'ubuntu-24-large' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'autoclose')
+        run: gh pr view
+
+        # gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length'
+
+        # $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE
+
+    #steps:
+    #  - name: Automatically closing successful trials
+    #  
+    #  - name: Clean up automerge tags
+    #conditions:
+    #  - closed
+    #actions:
+    #  label:
+    #    remove:
+    #      - automerge-squash
+    #      - autoclose
+
+
   reports:
     if: github.ref == 'refs/heads/master'
     needs: [tests]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
         if: matrix.os == 'ubuntu-24-large' && matrix.build_type == 'release' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
           gh pr view
-          gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state'
+          gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat
           $(gh pr checks -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | jq -n '[inputs] | length==2') || echo NICE
 
     #steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
-          echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.html_url }}
+          echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.status }} ${{ github.event.pull_request.html_url }}
           sleep 3
           gh pr view ${{ github.event.pull_request.number }}
           gh pr checks ${{ github.event.pull_request.number }} -q '.[] | select(.state=="SUCCESS" and (.name=="verify-common-gc" or .name=="verify-main-tests"))' --json='name,state' | cat

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: update_flake_lock_action_daily
       - name: Automatically closing successful trials XXXX
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,6 +154,5 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'autoclose')
         run: |
           echo ${{ github.event.pull_request.number }} ${{ github.event.pull_request.state }} ${{ github.event.pull_request.html_url }}
-          sleep 3
           gh pr close ${{ github.event.pull_request.number }} --delete-branch --comment "CI looks good, this dependency bump would not cause problems, hence closing this trial PR."
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "autoclose"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,7 +39,6 @@ pull_request_rules:
       label:
         remove:
           - automerge-squash
-          - autoclose
   - name: Auto-approve auto-PRs
     conditions:
       - author=pr-automation-bot-public[bot]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,16 +32,6 @@ pull_request_rules:
     actions:
       delete_head_branch: {}
       queue:
-  - name: Automatically closing successful trials
-    conditions:
-      - status-success=verify-common-gc
-      - status-success=verify-main-tests
-      - base=master
-      - label=autoclose
-    actions:
-      close:
-        message: CI looks good, this dependency bump would not cause problems, hence closing this trial PR.
-      delete_head_branch: {}
   - name: Clean up automerge tags
     conditions:
       - closed

--- a/Building.md
+++ b/Building.md
@@ -204,7 +204,7 @@ git push --set-upstream origin $USER/$NEXT_MOC_VERSION
 
 Create a PR from this commit:
 - Make sure the **PR title** is the same as the **commit message**.
-- Label the PR with `release` (to mark it as a release PR) and enable auto-merge on it. It will get merged into `master` without additional approval (???), but it will take some time as the title (version number) enters into the `nix` dependency tracking.
+- Label the PR with `release` (to mark it as a release PR) and enable auto-merge on it. It will not get merged into `master` without additional approval, and it may take some time as the title (version number) enters into the `nix` dependency tracking.
 
 To create the PR, you can use `gh` CLI:
 ```bash

--- a/Building.md
+++ b/Building.md
@@ -168,7 +168,7 @@ echo "Last version: $LAST_MOC_VERSION"
 echo "Next version: $NEXT_MOC_VERSION"
 ```
 
-Run the following command to create the release PR:
+Run the following command pipeline to create the release PR:
 
 ```bash
 (test -n "$NEXT_MOC_VERSION" || (echo "NEXT_MOC_VERSION is not set" && false)) && \
@@ -176,7 +176,8 @@ git switch -c $USER/$NEXT_MOC_VERSION && \
 git add Changelog.md && \
 git commit -m "chore: Releasing $NEXT_MOC_VERSION" && \
 git push --set-upstream origin $USER/$NEXT_MOC_VERSION && \
-gh pr create --title "chore: Releasing $NEXT_MOC_VERSION" --label "release,automerge-squash" --base master --head $USER/$NEXT_MOC_VERSION --body ""
+gh pr create --title "chore: Releasing $NEXT_MOC_VERSION" --label "release" --base master --head $USER/$NEXT_MOC_VERSION --body "" && \
+gh pr merge --auto
 ```
 
 <details>
@@ -203,11 +204,11 @@ git push --set-upstream origin $USER/$NEXT_MOC_VERSION
 
 Create a PR from this commit:
 - Make sure the **PR title** is the same as the **commit message**.
-- Label the PR with `release` (to mark it as a release PR) and `automerge-squash`. Mergify will merge it into `master` without additional approval, but it will take some time as the title (version number) enters into the `nix` dependency tracking.
+- Label the PR with `release` (to mark it as a release PR) and enable auto-merge on it. It will get merged into `master` without additional approval (???), but it will take some time as the title (version number) enters into the `nix` dependency tracking.
 
 To create the PR, you can use `gh` CLI:
 ```bash
-gh pr create --title "chore: Releasing $NEXT_MOC_VERSION" --label "release,automerge-squash" --base master --head $USER/$NEXT_MOC_VERSION --body ""
+gh pr create --title "chore: Releasing $NEXT_MOC_VERSION" --label "release" --base master --head $USER/$NEXT_MOC_VERSION --body "" && gh pr merge --auto
 ```
 </details>
 

--- a/CI.md
+++ b/CI.md
@@ -80,7 +80,7 @@ This can be done before approvals are in and/or CI has turned green, and will
 reliably be acted on once requirements are fulfilled.
 
 **Implementation:**
-Use the "Enable auto-merge (squash)" button of the GitHub PR weeb page.
+Use the "Enable auto-merge (squash)" button of the GitHub PR web page.
 Alternatively from the CLI `gh pr merge --auto` will do. Note that you have to update
 the PR with `master` first, so that the tests can run on the most recent codebase.
 From the command line issue `gh pr update-branch` to that effect.

--- a/CI.md
+++ b/CI.md
@@ -9,12 +9,7 @@ This document distinguishes use-cases (requirements, goals) from
 implementations, to allow evaluating alternative implementations.
 
 The implementation is currently a careful choreography between Github, Github
-Actions, Hydra, the cachix nix cache, the internal nix cache and mergify.
-
-This file describes both the  pre-open-source setup (**internal**) which will
-gradually be updated or removed as we move away from the internal CI setup
-towards the open setup (**external**).
-
+Actions, and the cachix nix cache.
 
 Knowing if it is broken
 -----------------------
@@ -85,9 +80,10 @@ This can be done before approvals are in and/or CI has turned green, and will
 reliably be acted on once requirements are fulfilled.
 
 **Implementation:**
-Mergify reacts to the `automerge-squash` label. Once approved and CI passes, it
-merges master into the branch (using normal merge, which is important for
-stashed PRs) and then squash-merges the PR.
+Use the "Enable auto-merge (squash)" button of the GitHub PR weeb page.
+Alternatively from the CLI `gh pr merge --auto` will do. Note that you have to update
+the PR with `master` first, so that the tests can run on the most recent codebase.
+From the command line issue `gh pr update-branch` to that effect.
 
 Render and provide various reports
 ----------------------------------

--- a/CI.md
+++ b/CI.md
@@ -9,7 +9,7 @@ This document distinguishes use-cases (requirements, goals) from
 implementations, to allow evaluating alternative implementations.
 
 The implementation is currently a careful choreography between Github, Github
-Actions, and the cachix nix cache.
+Actions, and the Cachix nix cache.
 
 Knowing if it is broken
 -----------------------

--- a/CI.md
+++ b/CI.md
@@ -135,19 +135,19 @@ Dependencies are updated automatically
 --------------------------------------
 
 **Use-case:**
-Several dependencies, as pinned by `nix/souces.json`, should be updated without
+Several dependencies, as pinned by `flake.nix`, should be updated without
 human intervention. Some dependencies are updated daily, others weekly. For
 some dependency, it should only be _tested_ if it builds, but not merged.
 
 **Implementation:**
  * Multiple files (with different settings) in `.github/workflows/` use
-   [niv-updater-action](https://github.com/knl/niv-updater-action) to create
+   flake-updater to create
    pull requests with the version bumps, as `dfinity-bot`, setting
    `automerge-squash` or `autoclose`.
- * Mergify automatically approves PRs from `dfinity-bot`.
- * Once CI passes, mergify merges or closes PRs, as per label.
+ * (obsolete) Mergify automatically approves PRs from `dfinity-bot`.
+ * Once CI passes, the `test.yml` GitHub action merges or closes PRs, as per label.
 
-Updates to the Changelog require no review
+(obsolete) Updates to the Changelog require no review
 ------------------------------------------
 
 **Use-case:**


### PR DESCRIPTION
It should be possible to instead use GitHub actions and the `gh` tool to
emulate the subset of functionality that we use Mergify for.

As communicated to the team:
> I have activated the “Enable auto-merge (squash)” button on PRs (with the PR description as the default commit message) and tested it myself successfully for #5533. Please start using it and report back if you find something odd. We plan to phase-out Mergify this month and I’ll prepare a PR to remove all mentions to it, as GH seems to provide the same functionality that we need.

TODO:
- [ ] remove `.mergify.yml`
- [ ] compensate for `automerge-squash` in `.github/workflows/update-flake-lock.yml`
- [x] work around `autoclose` in scheduled weekly runs
  - [ ] check `base=master` (previously in `.mergify.yml`)
  - [x] predicate this not on the step, but the top-level
- [ ] can we emulate approvals previously given by Mergify?
- [x] Clean `CI.md`
- [ ] Communicate the elimination to the IT team

Out of an abundance of caution I'll do the remaining work on a follow-up PR.