### PR TITLE
Revert "fix: fixes a bug with contextual dot and a tuple receiver (#5547)"

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2578,15 +2578,6 @@ and infer_call env exp1 inst (parenthesized, ref_exp2) at t_expect_opt =
     | None -> t_arg, []
     | Some(e, t) -> begin
       match T.normalize t_arg with
-      (* This solves an edge-case when using a tuple type as the Self/receiver type.
-         Given
-           f : t' -> t_res
-           x : t
-         Then
-           x.f() : t_res
-         When
-           t <: t' *)
-      | t' when exp2.it = TupE [] -> T.unit, [(t, t')]
       | T.Tup([t'; t2]) -> t2, [(t, t')]
       | T.Tup(t'::ts) -> T.Tup(ts), [(t, t')]
       | t' -> T.unit, [(t, t')]

--- a/test/fail/ok/implicit-import-hint-dot.tc.ok
+++ b/test/fail/ok/implicit-import-hint-dot.tc.ok
@@ -2,14 +2,13 @@ implicit-import-hint-dot.mo:13.3-13.12: type error [M0098], cannot implicitly in
   <K, V>(map : Map<K, V>, compare : (implicit : (K, K) -> Order), key : K) ->
     ?V
 to argument of type
-  ()
+  (compare : (implicit : (K, K) -> Order), key : K)
 to produce result of type
   ()
 because no instantiation of K, V makes
   ?V  <:  ()
 and
-  {var root : Node<Text, Text>; var size_ : Nat}  <: 
-    (map : Map<K, V>, compare : (implicit : (K, K) -> Order), key : K)
+  {var root : Node<Text, Text>; var size_ : Nat}  <:  (map : Map<K, V>)
 implicit-import-hint-dot.mo:17.12-17.26: type error [M0230], Cannot determine implicit argument `compare` of type
   (Text, Text) -> Order
 Hint: Did you mean to import `core-stub/src/Text.mo.compare`?

--- a/test/run/contextual-dot.mo
+++ b/test/run/contextual-dot.mo
@@ -36,11 +36,6 @@ module NatExt {
   public func twice(self : Nat) : Nat { self * 2 };
 };
 
-module M {
-  public type Self = (Nat, Nat);
-  public func f(_s : Self) {};
-};
-
 module Main {
   public func vec() {
     let x = { x = 10; y = 20 };
@@ -81,11 +76,6 @@ module Main {
     let xs : [var (Nat, Text)] = [var];
     assert xs.append((3, "hello")).size() == 0
   };
-
-  public func tupleIssue2() {
-    let s : M.Self = (0, 0);
-    s.f()
-  };
 };
 
 Main.vec();
@@ -93,4 +83,3 @@ Main.immutableArray();
 Main.mutableArray();
 Main.nat();
 Main.overlappingSelf();
-Main.tupleIssue2();


### PR DESCRIPTION
This reverts commit 69f0aa8bf95271b49d808a9aa28a4615737e8b7c.

Causes regressions when interacting with functions accepting implicits.