### PR TITLE
bug: implicit single arg as many

### DIFF
--- a/test/fail/implicit-single-arg-as-many.mo
+++ b/test/fail/implicit-single-arg-as-many.mo
@@ -1,0 +1,14 @@
+module M {
+  public func withImplicit(_ : Int, _ : (implicit : Text), _ : Nat) {};
+  public func withoutImplicit(_ : Int, _ : Text, _ : Nat) {};
+};
+let arg = (1 : Int, "abc", 2);
+
+func singleArgAsMany1() {
+  let _ = M.withoutImplicit(arg);
+  let _ = M.withImplicit(arg);
+};
+func singleArgAsMany2() {
+  let _ = M.withoutImplicit arg;
+  let _ = M.withImplicit arg;
+};

--- a/test/fail/ok/implicit-single-arg-as-many.tc.ok
+++ b/test/fail/ok/implicit-single-arg-as-many.tc.ok
@@ -1,0 +1,2 @@
+implicit-single-arg-as-many.mo:9.11-9.30: type error [M0232], cannot infer type of implicit argument
+implicit-single-arg-as-many.mo:13.11-13.29: type error [M0232], cannot infer type of implicit argument

--- a/test/fail/ok/implicit-single-arg-as-many.tc.ret.ok
+++ b/test/fail/ok/implicit-single-arg-as-many.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1


### PR DESCRIPTION
Hmm, nice find!

Maybe the fix is to insert holes only if the number of actual arguments is exactly the number of non-implicits in the type, not just less than the number of arguments in the type.