### PR TITLE
experiment: improve type inference errors

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2574,16 +2574,21 @@ and infer_call env exp1 inst (parenthesized, ref_exp2) at t_expect_opt =
           "this looks like an unintended function call, perhaps a missing ';'?";
       T.as_func_sub T.Local n T.Non
   in
-  let t_arg, extra_subtype_problems = match ctx_dot with
-    | None -> t_arg, []
+  let t1, t_arg, extra_subtype_problems = match ctx_dot with
+    | None -> t1, t_arg, []
     | Some(e, t) -> begin
       match T.normalize t_arg with
-      | T.Tup([t'; t2]) -> t2, [(t, t')]
-      | T.Tup(t'::ts) -> T.Tup(ts), [(t, t')]
-      | t' -> T.unit, [(t, t')]
+      | T.Tup([t'; t2]) ->
+         T.Func(sort, T.Returns, tbs, [t2], [t_ret]),
+         t2, [(t, t')]
+      | T.Tup(t'::ts) ->
+         T.Func(sort, T.Returns, tbs, ts, [t_ret]),
+         T.Tup(ts), [(t, t')]
+      | t' ->
+         T.Func(sort, T.Returns, tbs, [], [t_ret]),
+         T.unit, [(t, t')]
     end
   in
-  let display_t1 = T.Func(sort, T.Returns (*HACK *), tbs, T.as_seq t_arg, T.as_seq t_ret) in
   let exp2 =
     let es = match exp2.it with
       | TupE es when not parenthesized -> es
@@ -2612,11 +2617,11 @@ and infer_call env exp1 inst (parenthesized, ref_exp2) at t_expect_opt =
       if not env.pre then check_exp_strong env t_arg' exp2
       else if typs <> [] && Flags.is_warning_enabled "M0223" &&
         is_redundant_instantiation ts env (fun env' ->
-          infer_call_instantiation env' display_t1 tbs t_arg t_ret exp2 at t_expect_opt extra_subtype_problems) then
+          infer_call_instantiation env' t1 tbs t_arg t_ret exp2 at t_expect_opt extra_subtype_problems) then
             warn env inst.at "M0223" "redundant type instantiation";
       ts, t_arg', t_ret'
     | _::_, None -> (* implicit, infer *)
-      infer_call_instantiation env display_t1 tbs t_arg t_ret exp2 at t_expect_opt extra_subtype_problems
+      infer_call_instantiation env t1 tbs t_arg t_ret exp2 at t_expect_opt extra_subtype_problems
   in
   inst.note <- ts;
   if not env.pre then begin

--- a/test/fail/inf-error.mo
+++ b/test/fail/inf-error.mo
@@ -34,8 +34,7 @@ persistent actor {
 
    let peopleMap = Map.empty<Nat, Text>();
    public shared query func test() : async () {
-      let person0 = peopleMap.get(Nat.compare, 1);
-      let person1 = peopleMap.get(Nat.compare, 1);
-      let person2 = peopleMap.get(Nat.compare, "test");
+      let person0 = peopleMap.get(Nat.compare, 1); // ok
+      let person2 = peopleMap.get(Nat.compare, "test"); // bad
    };
 }

--- a/test/fail/inf-error.mo
+++ b/test/fail/inf-error.mo
@@ -1,0 +1,41 @@
+    type Order = {
+       #less; #equal; #greater;
+    };
+
+    module Nat {
+      public func compare(n : Nat, m : Nat) : Order { #equal };
+    };
+
+    module Map {
+      public type Map<K,V> = {map : [(K, [var V])]};
+      public type Self<K, V> = Map<K, V>;
+      public func empty<K, V>() : Map<K,V> = {map= []};
+      public func get<K, V>(
+         map : Map<K, V>,
+	 compare: (implicit : (K, K) -> Order),
+  	 n : K,
+	 ) : ?V {
+	 ?(map.map[0].1[0])
+      };
+
+      public func set<K, V>(
+         map : Map<K, V>,
+	 compare: (implicit : (K, K) -> Order),
+  	 n : K,
+	 v : V
+	 ) : Map<K, V> {
+	 map
+      };
+
+
+   };
+
+persistent actor {
+
+   let peopleMap = Map.empty<Nat, Text>();
+   public shared query func test() : async () {
+      let person0 = peopleMap.get(Nat.compare, 1);
+      let person1 = peopleMap.get(Nat.compare, 1);
+      let person2 = peopleMap.get(Nat.compare, "test");
+   };
+}

--- a/test/fail/ok/implicit-import-hint-dot.tc.ok
+++ b/test/fail/ok/implicit-import-hint-dot.tc.ok
@@ -1,6 +1,7 @@
 implicit-import-hint-dot.mo:13.3-13.12: type error [M0098], cannot implicitly instantiate function of type
-  <K, V>(map : Map<K, V>, compare : (implicit : (K, K) -> Order), key : K) ->
-    ?V
+  <K, V>(compare : (implicit : (K, K) -> Order), key : K) -> ?V
+with parameters
+  (compare : (implicit : (K, K) -> Order), key : K)
 to argument of type
   (compare : (implicit : (K, K) -> Order), key : K)
 to produce result of type

--- a/test/fail/ok/inf-error.tc.ok
+++ b/test/fail/ok/inf-error.tc.ok
@@ -1,0 +1,10 @@
+inf-error.mo:38.21-38.55: type error [M0098], cannot implicitly instantiate function of type
+  <K, V>(map : Map<K, V>, compare : (implicit : (K, K) -> Order), n : K) ->
+    ?V
+to argument of type
+  ((n : Nat, m : Nat) -> Order, Text)
+because implicit instantiation of type parameter K is over-constrained with
+  Any  <:  K  <:  Nat
+where
+  Any  </:  Nat
+so that no valid instantiation exists

--- a/test/fail/ok/inf-error.tc.ok
+++ b/test/fail/ok/inf-error.tc.ok
@@ -1,6 +1,7 @@
 inf-error.mo:38.21-38.55: type error [M0098], cannot implicitly instantiate function of type
-  <K, V>(map : Map<K, V>, compare : (implicit : (K, K) -> Order), n : K) ->
-    ?V
+  <K, V>(compare : (implicit : (K, K) -> Order), n : K) -> ?V
+with parameters
+  (compare : (implicit : (K, K) -> Order), n : K)
 to argument of type
   ((n : Nat, m : Nat) -> Order, Text)
 because implicit instantiation of type parameter K is over-constrained with

--- a/test/fail/ok/inf-error.tc.ret.ok
+++ b/test/fail/ok/inf-error.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/inference.tc.ok
+++ b/test/fail/ok/inference.tc.ok
@@ -8,6 +8,8 @@ cannot produce expected type
   Any -> Any
 inference.mo:67.1-67.40: type error [M0098], cannot implicitly instantiate function of type
   <T>(f : T -> T) -> ()
+with parameters
+  (f : T -> T)
 to argument of type
   (x : None) -> Any
 to produce result of type
@@ -20,6 +22,8 @@ so that no valid instantiation exists
 inference.mo:87.20-87.27: warning [M0146], this pattern is never matched
 inference.mo:94.8-94.20: type error [M0098], cannot implicitly instantiate function of type
   <T <: U, U>(x : T, y : T) -> (U, U)
+with parameters
+  (x : T, y : T)
 to argument of type
   (Nat, Nat)
 to produce result of type
@@ -29,6 +33,8 @@ because type parameter T has an open bound
 mentioning another type parameter, so that explicit type instantiation is required due to limitation of inference
 inference.mo:95.8-95.26: type error [M0098], cannot implicitly instantiate function of type
   <T <: U, U>(x : T, y : T) -> (U, U)
+with parameters
+  (x : T, y : T)
 to argument of type
   (Nat, Int)
 to produce result of type
@@ -38,6 +44,8 @@ because type parameter T has an open bound
 mentioning another type parameter, so that explicit type instantiation is required due to limitation of inference
 inference.mo:96.8-96.23: type error [M0098], cannot implicitly instantiate function of type
   <T <: U, U>(x : T, y : T) -> (U, U)
+with parameters
+  (x : T, y : T)
 to argument of type
   (Nat, Bool)
 to produce result of type
@@ -47,6 +55,8 @@ because type parameter T has an open bound
 mentioning another type parameter, so that explicit type instantiation is required due to limitation of inference
 inference.mo:111.8-111.17: type error [M0098], cannot implicitly instantiate function of type
   <T <: Int>(x : T) -> T
+with parameters
+  (x : T)
 to argument of type
   Bool
 to produce result of type
@@ -58,6 +68,8 @@ where
 so that no valid instantiation exists
 inference.mo:112.1-112.10: type error [M0098], cannot implicitly instantiate function of type
   <T <: Int>(x : T) -> T
+with parameters
+  (x : T)
 to argument of type
   Bool
 to produce result of type
@@ -69,6 +81,8 @@ where
 so that no valid instantiation exists
 inference.mo:116.1-116.27: type error [M0098], cannot implicitly instantiate function of type
   <T>(f : <U>T -> U) -> ()
+with parameters
+  (f : <U>T -> U)
 to argument of type
   <V>(x : V) -> V
 to produce result of type
@@ -77,6 +91,8 @@ because no instantiation of T makes
   <V>(x : V) -> V  <:  (f : <U>T -> U)
 inference.mo:118.1-118.31: type error [M0098], cannot implicitly instantiate function of type
   <T>(f : <U>U -> T) -> ()
+with parameters
+  (f : <U>U -> T)
 to argument of type
   <V>(x : V) -> V
 to produce result of type
@@ -85,6 +101,8 @@ because no instantiation of T makes
   <V>(x : V) -> V  <:  (f : <U>U -> T)
 inference.mo:127.8-127.20: type error [M0098], cannot implicitly instantiate function of type
   <T>(x : [T]) -> T
+with parameters
+  (x : [T])
 to argument of type
   [var Nat]
 to produce result of type
@@ -93,6 +111,8 @@ because no instantiation of T makes
   [var Nat]  <:  (x : [T])
 inference.mo:130.1-130.13: type error [M0098], cannot implicitly instantiate function of type
   <T>(x : [var T]) -> T
+with parameters
+  (x : [var T])
 to argument of type
   [Nat]
 to produce result of type
@@ -103,6 +123,8 @@ and
   [Nat]  <:  (x : [var T])
 inference.mo:132.1-132.17: type error [M0098], cannot implicitly instantiate function of type
   <T>(x : [var T]) -> T
+with parameters
+  (x : [var T])
 to argument of type
   [var Nat]
 to produce result of type
@@ -114,6 +136,8 @@ where
 so that no valid instantiation exists
 inference.mo:137.4-137.8: type error [M0098], cannot implicitly instantiate function of type
   <U <: {}>(y : U) -> ()
+with parameters
+  (y : U)
 to argument of type
   T
 to produce result of type
@@ -125,6 +149,8 @@ where
 so that no valid instantiation exists
 inference.mo:152.11-152.15: type error [M0098], cannot implicitly instantiate function of type
   <U <: T>(y : U) -> U
+with parameters
+  (y : U)
 to argument of type
   T
 to produce result of type
@@ -136,6 +162,8 @@ where
 so that no valid instantiation exists
 inference.mo:172.8-172.54: type error [M0098], cannot implicitly instantiate function of type
   <T>(b : Bool, x : [var T], y : [var T]) -> [var T]
+with parameters
+  (b : Bool, x : [var T], y : [var T])
 to argument of type
   (Bool, [var Nat], [var Int])
 to produce result of type
@@ -147,6 +175,8 @@ where
 so that no valid instantiation exists
 inference.mo:177.8-177.44: type error [M0098], cannot implicitly instantiate function of type
   <T>(o : {x : T}) -> T
+with parameters
+  (o : {x : T})
 to argument of type
   {type x = Nat}
 to produce result of type

--- a/test/fail/ok/invariant-inference.tc.ok
+++ b/test/fail/ok/invariant-inference.tc.ok
@@ -1,5 +1,7 @@
 invariant-inference.mo:5.11-5.32: type error [M0098], cannot implicitly instantiate function of type
   <T>(len : Nat, x : T) -> [var T]
+with parameters
+  (len : Nat, x : T)
 to argument of type
   (Nat, Nat)
 because implicit instantiation of type parameter T is under-constrained with

--- a/test/fail/ok/lambdas-invariant.tc.ok
+++ b/test/fail/ok/lambdas-invariant.tc.ok
@@ -1,5 +1,7 @@
 lambdas-invariant.mo:27.11-27.39: type error [M0098], cannot implicitly instantiate function of type
   <T, U>([var T], T -> U) -> [var U]
+with parameters
+  ([var Nat], Nat -> U)
 to argument of type
   ([var Nat], Nat -> U)
 because implicit instantiation of type parameter U is under-constrained with
@@ -9,6 +11,8 @@ where
 so that explicit type instantiation is required
 lambdas-invariant.mo:30.11-30.45: type error [M0098], cannot implicitly instantiate function of type
   <T, U>([var T], T -> U) -> [var U]
+with parameters
+  ([var Nat], Nat -> U)
 to argument of type
   ([var Nat], Nat -> U)
 because implicit instantiation of type parameter U is under-constrained with
@@ -18,6 +22,8 @@ where
 so that explicit type instantiation is required
 lambdas-invariant.mo:33.11-33.42: type error [M0098], cannot implicitly instantiate function of type
   <T, U>([var T], T -> U) -> [var U]
+with parameters
+  ([var Nat], Nat -> U)
 to argument of type
   ([var Nat], Nat -> U)
 because implicit instantiation of type parameter U is under-constrained with
@@ -27,6 +33,8 @@ where
 so that explicit type instantiation is required
 lambdas-invariant.mo:36.11-36.56: type error [M0098], cannot implicitly instantiate function of type
   <T, U>([var T], T -> U) -> [var U]
+with parameters
+  ([var Nat], Nat -> U)
 to argument of type
   ([var Nat], Nat -> U)
 because implicit instantiation of type parameter U is under-constrained with
@@ -36,6 +44,8 @@ where
 so that explicit type instantiation is required
 lambdas-invariant.mo:39.11-39.41: type error [M0098], cannot implicitly instantiate function of type
   <T, U>([var T], T -> U) -> [var U]
+with parameters
+  ([var Nat], Nat -> U)
 to argument of type
   ([var Nat], Nat -> U)
 because implicit instantiation of type parameter U is under-constrained with
@@ -45,6 +55,8 @@ where
 so that explicit type instantiation is required
 lambdas-invariant.mo:42.11-42.43: type error [M0098], cannot implicitly instantiate function of type
   <T, U>([var T], T -> U) -> [var U]
+with parameters
+  ([var Nat], Nat -> U)
 to argument of type
   ([var Nat], Nat -> U)
 because implicit instantiation of type parameter U is under-constrained with
@@ -54,6 +66,8 @@ where
 so that explicit type instantiation is required
 lambdas-invariant.mo:45.11-45.43: type error [M0098], cannot implicitly instantiate function of type
   <T, U>([var T], T -> U) -> [var U]
+with parameters
+  ([var Nat], Nat -> U)
 to argument of type
   ([var Nat], Nat -> U)
 because implicit instantiation of type parameter U is under-constrained with
@@ -63,6 +77,8 @@ where
 so that explicit type instantiation is required
 lambdas-invariant.mo:58.11-58.39: type error [M0098], cannot implicitly instantiate function of type
   <T, U>([var T], T -> U) -> [var U]
+with parameters
+  ([var Nat], Nat -> U)
 to argument of type
   ([var Nat], Nat -> U)
 because implicit instantiation of type parameter U is under-constrained with
@@ -72,6 +88,8 @@ where
 so that explicit type instantiation is required
 lambdas-invariant.mo:62.11-62.39: type error [M0098], cannot implicitly instantiate function of type
   <T, U>([var T], T -> U) -> [var U]
+with parameters
+  ([var Nat], Nat -> U)
 to argument of type
   ([var Nat], Nat -> U)
 because implicit instantiation of type parameter U is under-constrained with

--- a/test/fail/ok/lambdas-open-types-in-deferred.tc.ok
+++ b/test/fail/ok/lambdas-open-types-in-deferred.tc.ok
@@ -1,10 +1,14 @@
 lambdas-open-types-in-deferred.mo:4.11-4.30: type error [M0098], cannot implicitly instantiate function of type
   <T, I>(t : T, f : I -> T) -> ()
+with parameters
+  (t : T, f : I -> T)
 to argument of type
   (Nat, f : I -> T)
 because cannot infer I
 lambdas-open-types-in-deferred.mo:8.11-11.5: type error [M0098], cannot implicitly instantiate function of type
   <T, I>(t : T, f : I -> T) -> ()
+with parameters
+  (t : T, f : I -> T)
 to argument of type
   (Nat, f : I -> T)
 because cannot infer I

--- a/test/fail/ok/lambdas-open-types.tc.ok
+++ b/test/fail/ok/lambdas-open-types.tc.ok
@@ -1,5 +1,7 @@
 lambdas-open-types.mo:6.9-6.37: type error [M0098], cannot implicitly instantiate function of type
   <T, U>(_ar : [var T], _f : T -> U) -> [var U]
+with parameters
+  (_ar : [var T], _f : T -> U)
 to argument of type
   ([Nat], _f : T -> U)
 because no instantiation of T, U makes

--- a/test/fail/ok/pretty-inference.tc.ok
+++ b/test/fail/ok/pretty-inference.tc.ok
@@ -1,5 +1,7 @@
 pretty-inference.mo:13.1-13.5: type error [M0098], cannot implicitly instantiate function of type
   <T <: ()>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   Nat
 to produce result of type
@@ -11,6 +13,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:15.1-15.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: ()>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   (Nat, Bool)
 to produce result of type
@@ -22,6 +26,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:17.1-17.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: ()>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   ((Nat, Bool), (Nat, Bool))
 to produce result of type
@@ -33,6 +39,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:19.1-19.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: ()>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool)))
 to produce result of type
@@ -44,6 +52,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:21.1-21.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: ()>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   ((((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))),
    (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))))
@@ -60,6 +70,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:23.1-23.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: ()>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   (((((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))),
     (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool)))),
@@ -82,6 +94,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:28.1-28.5: type error [M0098], cannot implicitly instantiate function of type
   <T <: C<C<C<C<Nat>>>>>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   Nat
 to produce result of type
@@ -93,6 +107,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:30.1-30.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: C<C<C<C<Nat>>>>>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   (Nat, Bool)
 to produce result of type
@@ -104,6 +120,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:32.1-32.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: C<C<C<C<Nat>>>>>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   ((Nat, Bool), (Nat, Bool))
 to produce result of type
@@ -115,6 +133,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:34.1-34.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: C<C<C<C<Nat>>>>>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool)))
 to produce result of type
@@ -128,6 +148,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:36.1-36.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: C<C<C<C<Nat>>>>>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   ((((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))),
    (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))))
@@ -144,6 +166,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:38.1-38.6: type error [M0098], cannot implicitly instantiate function of type
   <T <: C<C<C<C<Nat>>>>>(x : T) -> ()
+with parameters
+  (x : T)
 to argument of type
   (((((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))),
     (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool)))),
@@ -166,6 +190,8 @@ where
 so that no valid instantiation exists
 pretty-inference.mo:42.1-42.7: type error [M0098], cannot implicitly instantiate function of type
   <T, U>(x : T, u : U) -> Nat
+with parameters
+  (x : T, u : U)
 to argument of type
   (Nat, Nat)
 to produce result of type
@@ -178,6 +204,8 @@ and
   Nat  <:  (x : T)
 pretty-inference.mo:44.1-44.9: type error [M0098], cannot implicitly instantiate function of type
   <T, U>(x : T, u : U) -> Nat
+with parameters
+  (x : T, u : U)
 to argument of type
   ((Nat, Bool), (Nat, Bool))
 to produce result of type
@@ -190,6 +218,8 @@ and
   (Nat, Bool)  <:  (x : T)
 pretty-inference.mo:46.1-46.9: type error [M0098], cannot implicitly instantiate function of type
   <T, U>(x : T, u : U) -> Nat
+with parameters
+  (x : T, u : U)
 to argument of type
   (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool)))
 to produce result of type
@@ -202,6 +232,8 @@ and
   ((Nat, Bool), (Nat, Bool))  <:  (x : T)
 pretty-inference.mo:48.1-48.9: type error [M0098], cannot implicitly instantiate function of type
   <T, U>(x : T, u : U) -> Nat
+with parameters
+  (x : T, u : U)
 to argument of type
   ((((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))),
    (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))))
@@ -215,6 +247,8 @@ and
   (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool)))  <:  (x : T)
 pretty-inference.mo:50.1-50.9: type error [M0098], cannot implicitly instantiate function of type
   <T, U>(x : T, u : U) -> Nat
+with parameters
+  (x : T, u : U)
 to argument of type
   (((((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))),
     (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool)))),
@@ -234,6 +268,8 @@ and
     (x : T)
 pretty-inference.mo:52.1-52.9: type error [M0098], cannot implicitly instantiate function of type
   <T, U>(x : T, u : U) -> Nat
+with parameters
+  (x : T, u : U)
 to argument of type
   ((((((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool))),
      (((Nat, Bool), (Nat, Bool)), ((Nat, Bool), (Nat, Bool)))),

--- a/test/fail/ok/pretty_scoped.tc.ok
+++ b/test/fail/ok/pretty_scoped.tc.ok
@@ -1,5 +1,7 @@
 pretty_scoped.mo:2.1-2.38: type error [M0098], cannot implicitly instantiate function of type
   <A>(g : A -> async ()) -> ()
+with parameters
+  (g : A -> async ())
 to argument of type
   ()
 to produce result of type
@@ -8,6 +10,8 @@ because no instantiation of A makes
   ()  <:  (g : A -> async ())
 pretty_scoped.mo:4.1-4.45: type error [M0098], cannot implicitly instantiate function of type
   <A, B>(g : (A, B) -> async ()) -> ()
+with parameters
+  (g : (A, B) -> async ())
 to argument of type
   ()
 to produce result of type
@@ -16,6 +20,8 @@ because no instantiation of A, B makes
   ()  <:  (g : (A, B) -> async ())
 pretty_scoped.mo:6.1-6.50: type error [M0098], cannot implicitly instantiate function of type
   <A, B, C>(g : (A, B, C) -> async ()) -> ()
+with parameters
+  (g : (A, B, C) -> async ())
 to argument of type
   ()
 to produce result of type
@@ -24,6 +30,8 @@ because no instantiation of A, B, C makes
   ()  <:  (g : (A, B, C) -> async ())
 pretty_scoped.mo:8.1-8.55: type error [M0098], cannot implicitly instantiate function of type
   <A, B, C>(g : <D>(A, B, C, D) -> async ()) -> ()
+with parameters
+  (g : <D>(A, B, C, D) -> async ())
 to argument of type
   ()
 to produce result of type
@@ -32,6 +40,8 @@ because no instantiation of A, B, C makes
   ()  <:  (g : <D>(A, B, C, D) -> async ())
 pretty_scoped.mo:10.1-10.69: type error [M0098], cannot implicitly instantiate function of type
   <A, B, C>(g : <D <: C, E <: D>(A, B, C, D, E) -> async ()) -> ()
+with parameters
+  (g : <D <: C, E <: D>(A, B, C, D, E) -> async ())
 to argument of type
   ()
 because no instantiation of A, B, C makes

--- a/test/fail/ok/variance.tc.ok
+++ b/test/fail/ok/variance.tc.ok
@@ -36,6 +36,8 @@ cannot produce expected type
   {get : () -> ?Any; put : (i : Any) -> ()}
 variance.mo:84.15-84.20: type error [M0098], cannot implicitly instantiate function of type
   <A>() -> Inv<A>
+with parameters
+  ()
 to argument of type
   ()
 because implicit instantiation of type parameter A is under-constrained with


### PR DESCRIPTION
* suppress reporting expected receiver when generic and dotted.
* report instantiated parameter types as well.


TODO: maybe don't show the full generic type at all, just the open domain (and range).