### PR TITLE
fix: only report dot-context hint with an actual suggestion

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2593,9 +2593,7 @@ and infer_callee env exp =
     | Error (t1, mk_e) ->
       match contextual_dot env id t1 with
       | Error [] ->
-         let e = mk_e () in
-         let sug = "\nHint: If you're trying to use a contextual call you need to import the corresponding module." in
-         Diag.add_msg env.msgs Diag.{ e with text = e.text ^ sug }; raise Recover
+         Diag.add_msg env.msgs (mk_e ()); raise Recover
       | Error suggestions ->
          let e = mk_e () in
          let sug = Format.sprintf "\nHint: Did you mean to import %s?" (String.concat " or " suggestions) in

--- a/test/fail/ok/contextual-dot-biased.tc.ok
+++ b/test/fail/ok/contextual-dot-biased.tc.ok
@@ -3,4 +3,3 @@ contextual-dot-biased.mo:23.12-23.17: type error [M0234], field other does exist
 but is not a function.
 
 Did you mean field other?
-Hint: If you're trying to use a contextual call you need to import the corresponding module.

--- a/test/fail/ok/contextual-dot.tc.ok
+++ b/test/fail/ok/contextual-dot.tc.ok
@@ -3,4 +3,3 @@ contextual-dot.mo:6.13-6.18: type error [M0072], field first does not exist in t
 Hint: Did you mean to import lib/Array.mo?
 contextual-dot.mo:10.13-10.17: type error [M0072], field last does not exist in type:
   [Nat]
-Hint: If you're trying to use a contextual call you need to import the corresponding module.


### PR DESCRIPTION
This hint is more misleading than helpful when we can't actually suggest a possible import.