### PR TITLE
chore: clean up `test.yml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,7 +200,6 @@ jobs:
           && [ $(gh pr diff $PR --name-only) == "doc/docusaurus/package-lock.json" ] \
           && gh pr review $PR --approve --body 'A change to `doc/docusaurus/package-lock.json`? I can handle that!'
           ### Handles open PRs filed by the GH automation bot that carry the `automerge-squash` label. The single changed file must be `flake.lock`. If so, the PR gets approved with a comment, auto-merge activated and the label removed.
-          echo ${{ github.event.pull_request.user.login }}
           ${{ github.event.pull_request.user.login == 'pr-automation-bot-public[bot]' && contains(github.event.pull_request.labels.*.name, 'automerge-squash') }} \
           && [ $(gh pr diff $PR --name-only) == "flake.lock" ] \
           && gh pr review $PR --approve --body 'A change to `flake.lock`? I can handle that!' \


### PR DESCRIPTION
The `flake.lock` approval worked, now cleaning up:
``` shell
  true \
  && [ $(gh pr diff $PR --name-only) == "flake.lock" ] \
  && gh pr review $PR --approve --body 'A change to `flake.lock`? I can handle that!' \
  && gh pr merge $PR --squash --auto \
  && gh pr edit $PR --remove-label 'automerge-squash'
```
This is an afterburner to #5594.