### PR TITLE
feat: relaxes grammar to allow un-parenthesized unary operator patterns

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -300,6 +300,7 @@
     '_'
     <id>
     <lit>
+    <unop> <lit>
     '(' <list(<pat_bin>, ',')> ')'
 
 <pat_nullary> ::= 
@@ -311,7 +312,6 @@
     '#' <id>
     '#' <id> <pat_nullary>
     '?' <pat_un>
-    <unop> <lit>
 
 <pat_bin> ::= 
     <pat_un>

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -896,6 +896,13 @@ pat_plain :
     { VarP(x) @! at $sloc }
   | l=lit
     { LitP(ref l) @! at $sloc }
+  | op=unop l=lit
+    { match op, l with
+      | (PosOp | NegOp), PreLit (s, (Type.(Nat | Float) as typ)) ->
+        let signed = match op with NegOp -> "-" ^ s | _ -> "+" ^ s in
+        LitP(ref (PreLit (signed, Type.(if typ = Nat then Int else typ)))) @! at $sloc
+      | _ -> SignP(op, ref l) @! at $sloc
+    }
   | LPAR ps=seplist(pat_bin, COMMA) RPAR
     { (match ps with [p] -> ParP(p) | _ -> TupP(ps)) @! at $sloc }
 
@@ -914,13 +921,6 @@ pat_un :
     { TagP(x, p) @! at $sloc }
   | QUEST p=pat_un
     { OptP(p) @! at $sloc }
-  | op=unop l=lit
-    { match op, l with
-      | (PosOp | NegOp), PreLit (s, (Type.(Nat | Float) as typ)) ->
-        let signed = match op with NegOp -> "-" ^ s | _ -> "+" ^ s in
-        LitP(ref (PreLit (signed, Type.(if typ = Nat then Int else typ)))) @! at $sloc
-      | _ -> SignP(op, ref l) @! at $sloc
-    }
 
 pat_bin :
   | p=pat_un

--- a/test/run/ok/pat-subtyping.tc.ok
+++ b/test/run/ok/pat-subtyping.tc.ok
@@ -1,5 +1,5 @@
 pat-subtyping.mo:7.8-7.9: warning [M0146], this pattern is never matched
-pat-subtyping.mo:8.8-8.12: warning [M0146], this pattern is never matched
+pat-subtyping.mo:8.8-8.10: warning [M0146], this pattern is never matched
 pat-subtyping.mo:11.8-11.17: warning [M0146], this pattern is never matched
 pat-subtyping.mo:12.8-12.17: warning [M0146], this pattern is never matched
 pat-subtyping.mo:19.8-19.25: warning [M0146], this pattern is never matched

--- a/test/run/pat-subtyping.mo
+++ b/test/run/pat-subtyping.mo
@@ -5,7 +5,7 @@ if false {
 
 switch (magic ()) {
   case 1 {};  // redundant
-  case (-1) {};  // redundant
+  case -1 {};  // redundant
 };
 switch (magic ()) {
   case (1 : Nat) {};  // redundant

--- a/test/run/switch.mo
+++ b/test/run/switch.mo
@@ -7,10 +7,10 @@ let x1 = switch 2 {
 assert (x1 == 1);
 
 let x2 : Int = switch (-3) {
-  case (0) 0;
-  case (-1) 2;
-  case (-3) 1;
-  case (x) x;
+  case 0 0;
+  case -1 2;
+  case -3 1;
+  case x x;
 };
 assert (x2 == 1);
 


### PR DESCRIPTION
As there's no ambiguity arising from this, I think it's consistent and more convenient to group unary operator patterns (like `case -1`) with the other literals.