### PR TITLE
chore: fix GH action failure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -259,7 +259,7 @@
         # Platform-specific release files.
         release-files-ubuntu-latest = import ./nix/release-files-ubuntu-latest.nix { inherit self pkgs; };
         "release-files-ubuntu-24.04-arm" = import ./nix/release-files-ubuntu-24.04-arm.nix { inherit self pkgs; };
-        release-files-macos-intel = import ./nix/release-files-macos-15-intel.nix { inherit self pkgs; };
+        release-files-macos-15-intel = import ./nix/release-files-macos-15-intel.nix { inherit self pkgs; };
         release-files-macos-latest = import ./nix/release-files-macos-latest.nix { inherit self pkgs; };
 
         # Common tests version - includes non-GC, non-release/debug specific tests.


### PR DESCRIPTION
The GH action expects accordingly named derivations in the `flake.nix`.

Synchronise them to be `release-files-macos-15-intel`.

See https://github.com/dfinity/motoko/pull/5656/files#r2545618146 for the failure.