### PR TITLE
doc: implicit parameters

### DIFF
--- a/doc/md/16-language-manual.md
+++ b/doc/md/16-language-manual.md
@@ -584,7 +584,6 @@ The syntax of a pattern is as follows:
 ```
 
 `implicit` patterns may only appear in function or class argument positions to declare implicit parameters that can be omitted at calls.
-<!-- what about mixins? -->
 The pattern `implict <id> : <typ>` is sugar for `<id> : (implicit <id> : <typ>)`.
 The named implicit pattern `implict <id> : <typ> = <pat>` is sugar for `<pat> : (implicit <id> : <typ>)`.
 The wildcard implicit pattern `implicit _ : <typ> = <pat>` is sugar for `<pat> : (implicit _ : <typ>)`.


### PR DESCRIPTION
Revised doc for dedicated `implicit (<id>| _) <typ>` syntax (including wildcard patterns for now).

Matches #5659  