### PR TITLE
chore: simplify building `%.js` targets

### DIFF
--- a/nix/moc.js.nix
+++ b/nix/moc.js.nix
@@ -15,7 +15,7 @@ let
       '' + pkgs.lib.optionalString (rts != null) ''
         ./rts/gen.sh ${rts}/rts/
       '' + ''
-        make DUNE_OPTS="--profile=release" ${n}.js
+        make ${n}.js
         terser ${n}.js -o ${n}.min.js -c -m
       '';
       installPhase = ''

--- a/src/Makefile
+++ b/src/Makefile
@@ -49,17 +49,17 @@ mo-doc: $(SOURCE_ID)
 	@ln -fs $(MO_DOC_TARGET) $@
 
 moc.js: $(SOURCE_ID)
-	dune build $(DUNE_OPTS) --profile=release $(MOC_JS_TARGET)
+	dune build $(DUNE_OPTS) $(MOC_JS_TARGET)
 	@ln -fs $(MOC_JS_TARGET) $@
 	ls -al $(MOC_JS_TARGET)
 
 moc_interpreter.js: $(SOURCE_ID)
-	dune build $(DUNE_OPTS) --profile=release $(MOC_INTERPRETER_TARGET)
+	dune build $(DUNE_OPTS) $(MOC_INTERPRETER_TARGET)
 	@ln -fs $(MOC_INTERPRETER_TARGET) $@
 	ls -al $(MOC_INTERPRETER_TARGET)
 
 didc.js: $(SOURCE_ID)
-	dune build $(DUNE_OPTS) --profile=release $(DIDC_JS_TARGET)
+	dune build $(DUNE_OPTS) $(DIDC_JS_TARGET)
 	@ln -fs $(DIDC_JS_TARGET) $@
 	ls -al $(DIDC_JS_TARGET)
 

--- a/src/js/dune
+++ b/src/js/dune
@@ -35,4 +35,3 @@
  (libraries lib idllib lang_utils)
  (preprocess (pps js_of_ocaml-ppx))
 )
-


### PR DESCRIPTION
No functionality change; now respects `--profile=debug` when passed though `DUNE_OPTS`.
Before it would always build in release mode.

This might help debugging the `jsoo`-v6.0.1 related crash.
