### PR TITLE
chore: fix `reports` creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,6 @@ jobs:
       - uses: cachix/cachix-action@v16
         with:
           name: ic-hs-test
-          authToken: ${{ inputs.cachix-auth-token }}
       - uses: nixbuild/nixbuild-action@v24
         with:
           nixbuild_token: ${{ secrets.NIXBUILD_TOKEN }}


### PR DESCRIPTION
This was only triggered on `master`, so it regressed:
https://github.com/dfinity/motoko/actions/runs/19743469155/job/56572868022

This PR attempts to fix the slight fallout from #5032.