### PR TITLE
feat: Explanation for migration stable sub

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -3856,15 +3856,22 @@ and check_migration env (stab_tfs : T.field list) exp_opt =
    in
    List.iter
      (fun tf ->
-       match T.lookup_val_field_opt tf.T.lab rng_tfs with
-       | None -> ()
-       | Some typ ->
-         if not (T.stable_sub ~src_fields:env.srcs (T.as_immut typ) (T.as_immut tf.T.typ)) then
-           local_error env focus "M0204"
-             "migration expression produces field `%s` of type%a\n, not the expected type%a"
-              tf.T.lab
-              display_typ_expand typ
-              display_typ_expand tf.T.typ) stab_tfs;
+      match T.lookup_val_field_opt tf.T.lab rng_tfs with
+      | None -> ()
+      | Some typ ->
+        let context = [T.StableVariable tf.T.lab] in
+        let imm_typ = T.as_immut typ in
+        let imm_expected = T.as_immut tf.T.typ in
+        match T.stable_sub_explained ~src_fields:env.srcs context imm_typ imm_expected with
+        | T.Compatible -> ()
+        | T.Incompatible explanation ->
+          local_error env focus "M0204"
+            "migration expression produces field `%s` of type%a\n, not the expected type%a\nbecause: %s"
+            tf.T.lab
+            display_typ_expand typ
+            display_typ_expand tf.T.typ
+            (T.string_of_explanation explanation)
+    ) stab_tfs;
    (* Construct the pre signature *)
    let pre_tfs = List.sort T.compare_field
       dom_tfs @

--- a/test/fail/ok/migration-bad.tc.ok
+++ b/test/fail/ok/migration-bad.tc.ok
@@ -23,6 +23,9 @@ migration-bad.mo:23.7-23.57: type error [M0204], migration expression produces f
   () -> ()
 , not the expected type
   Any
+because: Converting 
+  () -> ()
+ to `Any` is disallowed as it leads to data loss: f
 migration-bad.mo:28.41-28.43: type error [M0136], empty block cannot produce expected type
   {} -> {}
 migration-bad.mo:28.19-28.47: type error [M0014], non-static expression in library, module or migration expression

--- a/test/fail/ok/migration.tc.ok
+++ b/test/fail/ok/migration.tc.ok
@@ -8,6 +8,11 @@ migration.mo:3.7-13.7: type error [M0204], migration expression produces field `
   var Text
 , not the expected type
   var [var (Nat, Text)]
+because: The type 
+  Text
+ is not compatible with type 
+  [var (Nat, Text)]
+ of three
 migration.mo:3.7-13.7: type error [M0205], migration expression produces unexpected field `unstable2` of type
   () -> ()
 


### PR DESCRIPTION
Provide an explanation for expressions like
```
type error [M0204], migration expression produces field `attachments` of type
  var Map<Text, Attachment>
, not the expected type
  var Map<Text, Attachment>
```