### PR TITLE
experiment: Try pretty-printing a diff when subtyping fails

### DIFF
--- a/src/mo_types/type.mli
+++ b/src/mo_types/type.mli
@@ -249,7 +249,7 @@ and explanation =
   | MissingTag of context * lab * typ
   | UnexpectedTag of context * lab * typ
   | MissingField of context * lab * typ
-  | UnexpectedField of context * lab * typ
+  | UnexpectedField of context * context * field * typ
   | FewerItems of context * string
   | MoreItems of context * string
   | PromotionToAny of context * typ
@@ -264,7 +264,8 @@ and context_item =
   | NamedType of name
   | StableVariable of lab
   | Field of lab
-and context = context_item list
+  | ArrayItem
+  and context = context_item list
 
 exception Undecided (* raised if termination depth exceeded  *)
 

--- a/test/fail/import-main-in-migration.mo
+++ b/test/fail/import-main-in-migration.mo
@@ -1,0 +1,3 @@
+type Type = { };
+actor {
+}

--- a/test/fail/import-main-in-migration/migration.mo
+++ b/test/fail/import-main-in-migration/migration.mo
@@ -1,0 +1,5 @@
+import Main "../import-main-in-migration";
+
+module {
+  public func run({}) : Main.Type { {} }
+}

--- a/test/fail/migration-forgot-field.mo
+++ b/test/fail/migration-forgot-field.mo
@@ -1,0 +1,10 @@
+type Data = { a : Nat }; // forgot about field b
+type OldActor = { data : [Data] };
+type NewActor = { data : [Data] };
+(
+  with migration = func(r : OldActor) : NewActor { r }
+)
+persistent actor {
+  type Data = { a : Nat; b : Text };
+  let data : [Data] = [{ a = 0; b = "" }];
+};

--- a/test/fail/ok/migration-forgot-field.tc.ok
+++ b/test/fail/ok/migration-forgot-field.tc.ok
@@ -1,0 +1,8 @@
+migration-forgot-field.mo:5.8-5.55: type error [M0204], migration expression produces field `data` of type
+  [Data]
+, not the expected type
+  [Data]
+because: Unsupported additional field `b`. Type
+  [Data = {... b : Text ...}]
+ is not compatible with
+  [Data = { ... }]

--- a/test/fail/ok/migration-forgot-field.tc.ret.ok
+++ b/test/fail/ok/migration-forgot-field.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1


### PR DESCRIPTION
Idea / Specification 

```
type
  [Data = {... b : Text ...}]
 is not compatible with
  [Data = { ... }]
```

Print both types focusing on incompatible path found during subtype check.
It should print type aliases plus their normalized form.
It should skip most of the compatible fields to focus on the difference, but it should include some of the correct fields to keeps the surrounding (best to keep the 2 surrounding fields from the source, but what if they are sorted?)