### PR TITLE
chore: run `nix fmt`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -157,15 +157,15 @@
         # Make pocket-ic available during tests.
         checkInputs = [ pkgs.pocket-ic.server pkgs.cacert ];
         nativeCheckInputs = [ pkgs.pocket-ic.server ];
-        
+
         POCKET_IC_BIN = "${pkgs.pocket-ic.server}/bin/pocket-ic-server";
         SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-        
+
         doCheck = true;
       };
 
-      tests = import ./nix/tests.nix { 
-        inherit pkgs llvmEnv esm commonBuildInputs debugMoPackages test-runner; 
+      tests = import ./nix/tests.nix {
+        inherit pkgs llvmEnv esm commonBuildInputs debugMoPackages test-runner;
       };
 
       filterTests = type:
@@ -181,7 +181,8 @@
                 matchRelease == null &&
                 matchGC == null &&
                 matchPerf == null;
-            in {
+            in
+            {
               debug = matchDebug != null;
               release = matchRelease != null;
               gc = matchGC != null;
@@ -251,13 +252,13 @@
         # Common tests version - includes non-GC, non-release/debug specific tests.
         common-tests = pkgs.releaseTools.aggregate {
           name = "common-tests";
-          constituents = filterTests "common";  # Only include common tests.
+          constituents = filterTests "common"; # Only include common tests.
         };
 
         # GC tests version - only includes GC tests.
         gc-tests = pkgs.releaseTools.aggregate {
           name = "gc-tests";
-          constituents = filterTests "gc";  # Only include GC tests.
+          constituents = filterTests "gc"; # Only include GC tests.
         };
 
         # Release version - excludes debug tests.

--- a/nix/pocket-ic.nix
+++ b/nix/pocket-ic.nix
@@ -1,4 +1,5 @@
-pkgs: let
+pkgs:
+let
   # Map Nix system to binary name (note: Nix uses aarch64, binaries use arm64)
   binaryName = {
     "x86_64-linux" = "pocket-ic-x86_64-linux";
@@ -25,15 +26,15 @@ pkgs: let
 
   server = pkgs.stdenv.mkDerivation rec {
     name = "pocket-ic-server";
-    
+
     src = pkgs.fetchurl {
       url = "${baseUrl}/${binaryName}.gz";
       sha256 = sha256Map.${binaryName};
-      name = "pocket-ic-server.gz"; 
+      name = "pocket-ic-server.gz";
     };
-    
-    dontUnpack = true; 
-    
+
+    dontUnpack = true;
+
     nativeBuildInputs = [ pkgs.gzip ]
       ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.autoPatchelfHook;
 
@@ -42,7 +43,7 @@ pkgs: let
       pkgs.zlib
       pkgs.openssl
     ];
-    
+
     installPhase = ''
       mkdir -p $out/bin
       
@@ -54,6 +55,7 @@ pkgs: let
     '';
   };
 
-in {
+in
+{
   inherit server;
 }

--- a/nix/release-files-common.nix
+++ b/nix/release-files-common.nix
@@ -23,4 +23,4 @@ in
       } ''
       cp -v ${drv}/bin/*.min.js $out
     '';
-} 
+}

--- a/nix/release-files-macos-15-intel.nix
+++ b/nix/release-files-macos-15-intel.nix
@@ -6,4 +6,4 @@ in
 pkgs.runCommandNoCC "motoko-release-${common.releaseVersion}" { } ''
   mkdir $out
   cp ${common.as_tarball "Darwin-x86_64" (with packages.release; [ mo-doc moc ])} $out/motoko-Darwin-x86_64-${common.releaseVersion}.tar.gz
-'' 
+''

--- a/nix/release-files-macos-latest.nix
+++ b/nix/release-files-macos-latest.nix
@@ -6,4 +6,4 @@ in
 pkgs.runCommandNoCC "motoko-release-${common.releaseVersion}" { } ''
   mkdir $out
   cp ${common.as_tarball "Darwin-arm64" (with packages.release; [ mo-doc moc ])} $out/motoko-Darwin-arm64-${common.releaseVersion}.tar.gz
-'' 
+''

--- a/nix/release-files-ubuntu-24.04-arm.nix
+++ b/nix/release-files-ubuntu-24.04-arm.nix
@@ -6,4 +6,4 @@ in
 pkgs.runCommandNoCC "motoko-release-${common.releaseVersion}" { } ''
   mkdir $out
   cp ${common.as_tarball "Linux-aarch64" (with packages.release; [ mo-doc moc ])} $out/motoko-Linux-aarch64-${common.releaseVersion}.tar.gz
-'' 
+''

--- a/nix/release-files-ubuntu-latest.nix
+++ b/nix/release-files-ubuntu-latest.nix
@@ -10,4 +10,4 @@ pkgs.runCommandNoCC "motoko-release-${common.releaseVersion}" { } ''
   cp ${common.as_js "moc-interpreter" packages.js.moc_interpreter} $out/moc-interpreter-${common.releaseVersion}.js
   tar --exclude=.github -C ${pkgs.sources.motoko-base-src} -czvf $out/motoko-base-library.tar.gz .
   tar --exclude=.github -C ${pkgs.sources.motoko-core-src} -czvf $out/motoko-core.tar.gz .
-'' 
+''

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -146,7 +146,7 @@ let
     # test directory to be run by src/pipeline/test_field_srcs.ml. We create src
     # and test (the latter only with the wanted subdirectories) so that the dune
     # rule will be able to copy.
-    src = pkgs.runCommand "project-sources" {} ''
+    src = pkgs.runCommand "project-sources" { } ''
       mkdir -p $out/src $out/test
       cp -r ${../src}/* $out/src
       cp -r ${../test}/{run,run-drun,perf,bench} $out/test


### PR DESCRIPTION
Ran `nix fmt` to format to Nix code.

Future work: run this on CI to ensure consistently formatted Nix code.