### PR TITLE
experiment: error on dropped fields

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -3720,7 +3720,7 @@ and infer_obj env obj_sort exp_opt dec_fields at : T.typ =
   let _, scope = infer_block env decs at false in
   let t = object_of_scope env s dec_fields scope at in
   leave_scope env (private_identifiers scope.Scope.val_env) initial_usage;
-  let (_, fs) = T.as_obj t in
+  let (_, fs, _) = T.as_obj' t in
   if not env.pre then begin
     if s = T.Actor || s = T.Mixin then begin
       List.iter (fun T.{lab; typ; _} ->

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -628,7 +628,9 @@ let is_var = function Var _ -> true | _ -> false
 let invalid s = raise (Invalid_argument ("Type." ^ s))
 
 let as_prim p = function Prim p' when p = p' -> () | _ -> invalid "as_prim"
-let as_obj = function Obj (s, fs, _) -> s, fs | _ -> invalid "as_obj"
+let as_obj = function Obj (s, fs, []) -> s, fs
+                    | Obj (s, fs, _::_) -> invalid "as_obj (unexpected typ fields)"
+                    | _ -> invalid "as_obj"
 let as_obj' = function Obj (s, fs, tfs) -> s, fs, tfs | _ -> invalid "as_obj'"
 let as_array = function Array t -> t | _ -> invalid "as_array"
 let as_opt = function Opt t -> t | _ -> invalid "as_opt"


### PR DESCRIPTION
The rewrite Type.as_obj succeeds even when dropping type fields. 
Let's make it fail when the type fields are non-empty, to see if it flushes out any bugs.