### PR TITLE
chore: In `--error-format` options replace 'classic' with 'plain'

### DIFF
--- a/src/lang_utils/diag.ml
+++ b/src/lang_utils/diag.ml
@@ -118,7 +118,7 @@ let print_message msg =
   if msg.sev <> Error && not !Flags.print_warnings
   then ()
   else match !Flags.error_format with
-  | Flags.Classic -> Printf.eprintf "%s%!" (string_of_message msg)
+  | Flags.Plain -> Printf.eprintf "%s%!" (string_of_message msg)
   | Flags.Json -> Printf.printf "%s\n%!" (json_string_of_message msg)
 
 let print_messages = List.iter print_message

--- a/src/mo_config/args.ml
+++ b/src/mo_config/args.ml
@@ -29,10 +29,10 @@ let package_args = [
 let error_args = [
   "--error-detail", Arg.Set_int Flags.error_detail, "<n>  set error message detail for syntax errors, n in [0..3] (default 2)";
   "--error-recovery", Arg.Set Flags.error_recovery, " report multiple syntax errors";
-  "--error-format",     Arg.Symbol (["classic"; "json"], fun s ->
+  "--error-format",     Arg.Symbol (["plain"; "json"], fun s ->
       Flags.error_format := (match s with
         | "json" -> Flags.Json
-        | _ -> Flags.Classic)),
+        | _ -> Flags.Plain)),
     " set error output format"
   (* TODO move --hide-warnings here? *)
   ]

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -14,11 +14,11 @@ type instruction_limits = {
 
 type actors = LegacyActors | RequirePersistentActors | DefaultPersistentActors
 
-type error_format = Classic | Json
+type error_format = Plain | Json
 
 type lint_level = Allow | Warn | Error
 
-let error_format = ref Classic
+let error_format = ref Plain
 let ai_errors = ref false
 let trace = ref false
 let verbose = ref false


### PR DESCRIPTION
Changed the error format from 'classic' to 'plain'. Better describes the format to be a plain text than a vague 'classic'