### PR TITLE
fix: removes accidental unused warnings in test/fail

### DIFF
--- a/test/fail/M0128.mo
+++ b/test/fail/M0128.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 actor {
   func preupgrade(foo : Bool) {}
 }

--- a/test/fail/bad-import-decs.mo
+++ b/test/fail/bad-import-decs.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 import C "lib/decs"; // bad actor import
 
 actor {

--- a/test/fail/base-and-core.mo
+++ b/test/fail/base-and-core.mo
@@ -1,4 +1,5 @@
 //MOC-FLAG --package base base-and-core/base --package core base-and-core/core --implicit-package core
+//MOC-FLAG -A=M0194
 import A "mo:base/Array";
 import B "mo:core/Array";
 

--- a/test/fail/branch-before-define.mo
+++ b/test/fail/branch-before-define.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 import Prim "mo:⛔";
 
 func f():() -> Int {

--- a/test/fail/caffeine-deprecated-off.mo
+++ b/test/fail/caffeine-deprecated-off.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194,M0198
 module A {
   /// @deprecated M0235
   public let foo = 5;

--- a/test/fail/caffeine-deprecated-on.mo
+++ b/test/fail/caffeine-deprecated-on.mo
@@ -1,4 +1,5 @@
 //MOC-FLAG -W M0235
+//MOC-FLAG -A=M0194,M0198
 module A {
   /// @deprecated M0235
   public let foo = 5;

--- a/test/fail/contextual-dot-suggest.mo
+++ b/test/fail/contextual-dot-suggest.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 //MOC-FLAG -W M0236
 // test suggestion of contextual dot notation,
 // excluding binary equals and compare(XXX)

--- a/test/fail/ho-variant.mo
+++ b/test/fail/ho-variant.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 
 type Term = {
  #id : Text;
@@ -45,4 +46,3 @@ func eval (env : Text -> Val, e:Term) : Val {
    }
  };
 };
-

--- a/test/fail/implicit-example.mo
+++ b/test/fail/implicit-example.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 // test legacy syntax works too
 import {debugPrint} "mo:prim";
 

--- a/test/fail/issue-1411.mo
+++ b/test/fail/issue-1411.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 import M "lib/M";
 
 let Z1 : M.F = M.F();

--- a/test/fail/issue-5336.mo
+++ b/test/fail/issue-5336.mo
@@ -1,4 +1,6 @@
 //MOC-FLAG --require-persistent-actors
+//MOC-FLAG -A=M0194
+
 import Actor "issue-5336/actor";
 
 persistent actor class Main() {};

--- a/test/fail/issue-5336a.mo
+++ b/test/fail/issue-5336a.mo
@@ -1,4 +1,5 @@
 //MOC-FLAG --default-persistent-actors
+//MOC-FLAG -A=M0194
 import Actor "issue-5336a/actor";
 
 persistent actor class Main() {};

--- a/test/fail/issue-5336b.mo
+++ b/test/fail/issue-5336b.mo
@@ -1,4 +1,5 @@
 //MOC-FLAG --default-persistent-actors
+//MOC-FLAG -A=M0194
 import Actor "issue-5336b/actor";
 
 actor class Main() {};

--- a/test/fail/obj-with.mo
+++ b/test/fail/obj-with.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 import Prim "mo:⛔";
 
 // syntax
@@ -8,4 +9,3 @@ let ba_semi = { b with a = 8; };
 
 let bac = { b with a = 8; c = true };
 let bac_semi = { b with a = 8; c = true; };
-

--- a/test/fail/ok/M0128.tc.ok
+++ b/test/fail/ok/M0128.tc.ok
@@ -1,3 +1,1 @@
-M0128.mo:2.8-2.18: warning [M0128], this function has the name of a system method, but is declared without system visibility and will not be called by the system
-M0128.mo:2.8-2.18: warning [M0194], unused identifier preupgrade (delete or rename to wildcard `_` or `_preupgrade`)
-M0128.mo:2.19-2.22: warning [M0194], unused identifier foo (delete or rename to wildcard `_` or `_foo`)
+M0128.mo:3.8-3.18: warning [M0128], this function has the name of a system method, but is declared without system visibility and will not be called by the system

--- a/test/fail/ok/bad-import-decs.tc.ok
+++ b/test/fail/ok/bad-import-decs.tc.ok
@@ -1,2 +1,1 @@
 lib/decs.mo:0.1: warning [M0142], deprecated syntax: an imported library should be a module or named actor class
-bad-import-decs.mo:1.8-1.9: warning [M0194], unused identifier C (delete or rename to wildcard `_` or `_C`)

--- a/test/fail/ok/base-and-core.tc.ok
+++ b/test/fail/ok/base-and-core.tc.ok
@@ -1,2 +1,0 @@
-base-and-core.mo:2.8-2.9: warning [M0194], unused identifier A (delete or rename to wildcard `_` or `_A`)
-base-and-core.mo:3.8-3.9: warning [M0194], unused identifier B (delete or rename to wildcard `_` or `_B`)

--- a/test/fail/ok/branch-before-define.tc.ok
+++ b/test/fail/ok/branch-before-define.tc.ok
@@ -1,2 +1,1 @@
-branch-before-define.mo:18.5-18.10: warning [M0194], unused identifier wrong (delete or rename to wildcard `_` or `_wrong`)
-branch-before-define.mo:7.7-7.40: definedness error [M0016], cannot use g before x has been defined
+branch-before-define.mo:8.7-8.40: definedness error [M0016], cannot use g before x has been defined

--- a/test/fail/ok/caffeine-deprecated-off.tc.ok
+++ b/test/fail/ok/caffeine-deprecated-off.tc.ok
@@ -1,2 +1,0 @@
-caffeine-deprecated-off.mo:23.11-23.12: warning [M0198], unused field f in object pattern (delete or rewrite as `f = _`)
-caffeine-deprecated-off.mo:24.15-24.16: warning [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)

--- a/test/fail/ok/caffeine-deprecated-on.tc.ok
+++ b/test/fail/ok/caffeine-deprecated-on.tc.ok
@@ -1,10 +1,8 @@
-caffeine-deprecated-on.mo:15.9-15.14: warning [M0235], field foo is deprecated for caffeine
 caffeine-deprecated-on.mo:16.9-16.14: warning [M0235], field foo is deprecated for caffeine
-caffeine-deprecated-on.mo:18.8-18.11: warning [M0235], field f is deprecated for caffeine
+caffeine-deprecated-on.mo:17.9-17.14: warning [M0235], field foo is deprecated for caffeine
 caffeine-deprecated-on.mo:19.8-19.11: warning [M0235], field f is deprecated for caffeine
 caffeine-deprecated-on.mo:20.8-20.11: warning [M0235], field f is deprecated for caffeine
-caffeine-deprecated-on.mo:22.13-22.16: warning [M0235], type field T is deprecated for caffeine
-caffeine-deprecated-on.mo:24.11-24.12: warning [M0235], field f is deprecated for caffeine
-caffeine-deprecated-on.mo:25.11-25.16: warning [M0235], field f is deprecated for caffeine
-caffeine-deprecated-on.mo:24.11-24.12: warning [M0198], unused field f in object pattern (delete or rewrite as `f = _`)
-caffeine-deprecated-on.mo:25.15-25.16: warning [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)
+caffeine-deprecated-on.mo:21.8-21.11: warning [M0235], field f is deprecated for caffeine
+caffeine-deprecated-on.mo:23.13-23.16: warning [M0235], type field T is deprecated for caffeine
+caffeine-deprecated-on.mo:25.11-25.12: warning [M0235], field f is deprecated for caffeine
+caffeine-deprecated-on.mo:26.11-26.16: warning [M0235], field f is deprecated for caffeine

--- a/test/fail/ok/contextual-dot-suggest.tc.ok
+++ b/test/fail/ok/contextual-dot-suggest.tc.ok
@@ -1,11 +1,7 @@
-contextual-dot-suggest.mo:81.10-81.25: warning [M0236], You can use the dot notation `(#odd).equal(...)` here
-contextual-dot-suggest.mo:82.10-82.39: warning [M0236], You can use the dot notation `(#odd).compare(...)` here
-contextual-dot-suggest.mo:85.10-85.44: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
-contextual-dot-suggest.mo:86.10-86.31: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
-contextual-dot-suggest.mo:87.10-87.29: warning [M0236], You can use the dot notation `peopleMap.size(...)` here
-contextual-dot-suggest.mo:89.18-89.38: warning [M0236], You can use the dot notation `peopleMap.clone(...)` here
-contextual-dot-suggest.mo:89.10-89.55: warning [M0236], You can use the dot notation `Map.clone(peopleMap).get(...)` here
-contextual-dot-suggest.mo:25.23-25.27: warning [M0194], unused identifier self (delete or rename to wildcard `_` or `_self`)
-contextual-dot-suggest.mo:26.21-26.25: warning [M0194], unused identifier self (delete or rename to wildcard `_` or `_self`)
-contextual-dot-suggest.mo:45.5-45.9: warning [M0194], unused identifier self (delete or rename to wildcard `_` or `_self`)
-contextual-dot-suggest.mo:63.26-63.30: warning [M0194], unused identifier self (delete or rename to wildcard `_` or `_self`)
+contextual-dot-suggest.mo:82.10-82.25: warning [M0236], You can use the dot notation `(#odd).equal(...)` here
+contextual-dot-suggest.mo:83.10-83.39: warning [M0236], You can use the dot notation `(#odd).compare(...)` here
+contextual-dot-suggest.mo:86.10-86.44: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
+contextual-dot-suggest.mo:87.10-87.31: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
+contextual-dot-suggest.mo:88.10-88.29: warning [M0236], You can use the dot notation `peopleMap.size(...)` here
+contextual-dot-suggest.mo:90.18-90.38: warning [M0236], You can use the dot notation `peopleMap.clone(...)` here
+contextual-dot-suggest.mo:90.10-90.55: warning [M0236], You can use the dot notation `Map.clone(peopleMap).get(...)` here

--- a/test/fail/ok/ho-variant.tc.ok
+++ b/test/fail/ok/ho-variant.tc.ok
@@ -1,5 +1,0 @@
-ho-variant.mo:19.5-19.6: warning [M0194], unused identifier a (delete or rename to wildcard `_` or `_a`)
-ho-variant.mo:21.5-21.7: warning [M0194], unused identifier x0 (delete or rename to wildcard `_` or `_x0`)
-ho-variant.mo:22.5-22.7: warning [M0194], unused identifier x1 (delete or rename to wildcard `_` or `_x1`)
-ho-variant.mo:23.5-23.7: warning [M0194], unused identifier x2 (delete or rename to wildcard `_` or `_x2`)
-ho-variant.mo:26.5-26.6: warning [M0194], unused identifier z (delete or rename to wildcard `_` or `_z`)

--- a/test/fail/ok/implicit-example.tc.ok
+++ b/test/fail/ok/implicit-example.tc.ok
@@ -1,1 +1,0 @@
-implicit-example.mo:46.7-46.8: warning [M0194], unused identifier p (delete or rename to wildcard `_` or `_p`)

--- a/test/fail/ok/issue-1411.tc.ok
+++ b/test/fail/ok/issue-1411.tc.ok
@@ -1,2 +1,0 @@
-issue-1411.mo:6.5-6.7: warning [M0194], unused identifier x1 (delete or rename to wildcard `_` or `_x1`)
-issue-1411.mo:11.5-11.7: warning [M0194], unused identifier x2 (delete or rename to wildcard `_` or `_x2`)

--- a/test/fail/ok/issue-5336.tc.ok
+++ b/test/fail/ok/issue-5336.tc.ok
@@ -1,1 +1,0 @@
-issue-5336.mo:2.8-2.13: warning [M0194], unused identifier Actor (delete or rename to wildcard `_` or `_Actor`)

--- a/test/fail/ok/issue-5336a.tc.ok
+++ b/test/fail/ok/issue-5336a.tc.ok
@@ -1,3 +1,2 @@
 issue-5336a/actor.mo:1.1-1.11: warning [M0217], with flag --default-persistent-actors, the `persistent` keyword is redundant and can be removed
-issue-5336a.mo:4.1-4.11: warning [M0217], with flag --default-persistent-actors, the `persistent` keyword is redundant and can be removed
-issue-5336a.mo:2.8-2.13: warning [M0194], unused identifier Actor (delete or rename to wildcard `_` or `_Actor`)
+issue-5336a.mo:5.1-5.11: warning [M0217], with flag --default-persistent-actors, the `persistent` keyword is redundant and can be removed

--- a/test/fail/ok/issue-5336b.tc.ok
+++ b/test/fail/ok/issue-5336b.tc.ok
@@ -1,1 +1,0 @@
-issue-5336b.mo:2.8-2.13: warning [M0194], unused identifier Actor (delete or rename to wildcard `_` or `_Actor`)

--- a/test/fail/ok/obj-with.tc.ok
+++ b/test/fail/ok/obj-with.tc.ok
@@ -1,5 +1,0 @@
-obj-with.mo:1.8-1.12: warning [M0194], unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)
-obj-with.mo:6.5-6.7: warning [M0194], unused identifier ba (delete or rename to wildcard `_` or `_ba`)
-obj-with.mo:7.5-7.12: warning [M0194], unused identifier ba_semi (delete or rename to wildcard `_` or `_ba_semi`)
-obj-with.mo:9.5-9.8: warning [M0194], unused identifier bac (delete or rename to wildcard `_` or `_bac`)
-obj-with.mo:10.5-10.13: warning [M0194], unused identifier bac_semi (delete or rename to wildcard `_` or `_bac_semi`)

--- a/test/fail/ok/redundant-ignore.tc.ok
+++ b/test/fail/ok/redundant-ignore.tc.ok
@@ -1,8 +1,7 @@
-redundant-ignore.mo:3.1-3.9: warning [M0239], Avoid binding a unit `()` result; remove `let` and keep the expression
-redundant-ignore.mo:4.1-4.10: warning [M0089], redundant ignore, operand already has type ()
-redundant-ignore.mo:5.1-5.11: warning [M0089], redundant ignore, operand already has type ()
-redundant-ignore.mo:6.1-6.9: warning [M0089], redundant ignore, operand already has type ()
-redundant-ignore.mo:11.3-11.12: warning [M0089], redundant ignore, operand already has type ()
-redundant-ignore.mo:12.3-12.13: warning [M0089], redundant ignore, operand already has type ()
-redundant-ignore.mo:13.3-13.11: warning [M0089], redundant ignore, operand already has type ()
-redundant-ignore.mo:10.6-10.7: warning [M0194], unused identifier g (delete or rename to wildcard `_` or `_g`)
+redundant-ignore.mo:4.1-4.9: warning [M0239], Avoid binding a unit `()` result; remove `let` and keep the expression
+redundant-ignore.mo:5.1-5.10: warning [M0089], redundant ignore, operand already has type ()
+redundant-ignore.mo:6.1-6.11: warning [M0089], redundant ignore, operand already has type ()
+redundant-ignore.mo:7.1-7.9: warning [M0089], redundant ignore, operand already has type ()
+redundant-ignore.mo:12.3-12.12: warning [M0089], redundant ignore, operand already has type ()
+redundant-ignore.mo:13.3-13.13: warning [M0089], redundant ignore, operand already has type ()
+redundant-ignore.mo:14.3-14.11: warning [M0089], redundant ignore, operand already has type ()

--- a/test/fail/ok/return-before-define.tc.ok
+++ b/test/fail/ok/return-before-define.tc.ok
@@ -1,2 +1,1 @@
-return-before-define.mo:16.5-16.10: warning [M0194], unused identifier wrong (delete or rename to wildcard `_` or `_wrong`)
-return-before-define.mo:6.5-6.34: definedness error [M0016], cannot use g before x has been defined
+return-before-define.mo:7.5-7.34: definedness error [M0016], cannot use g before x has been defined

--- a/test/fail/ok/use-before-define.tc.ok
+++ b/test/fail/ok/use-before-define.tc.ok
@@ -1,2 +1,1 @@
-use-before-define.mo:4.5-4.6: warning [M0194], unused identifier y (delete or rename to wildcard `_` or `_y`)
-use-before-define.mo:4.1-4.12: definedness error [M0016], cannot use f before x has been defined
+use-before-define.mo:5.1-5.12: definedness error [M0016], cannot use f before x has been defined

--- a/test/fail/ok/use-before-define6.tc.ok
+++ b/test/fail/ok/use-before-define6.tc.ok
@@ -1,2 +1,1 @@
-use-before-define6.mo:3.9-3.13: warning [M0194], unused identifier bomb (delete or rename to wildcard `_` or `_bomb`)
-use-before-define6.mo:6.3-6.20: definedness error [M0016], cannot use g before g has been defined
+use-before-define6.mo:7.3-7.20: definedness error [M0016], cannot use g before g has been defined

--- a/test/fail/ok/usedefbug.tc.ok
+++ b/test/fail/ok/usedefbug.tc.ok
@@ -1,4 +1,1 @@
-usedefbug.mo:1.7-1.10: warning [M0194], unused identifier Bar (delete or rename to wildcard `_` or `_Bar`)
-usedefbug.mo:4.9-4.13: warning [M0194], unused identifier bomb (delete or rename to wildcard `_` or `_bomb`)
-usedefbug.mo:7.7-7.10: warning [M0194], unused identifier Bar (delete or rename to wildcard `_` or `_Bar`)
-usedefbug.mo:7.3-7.22: definedness error [M0016], cannot use g before g has been defined
+usedefbug.mo:8.3-8.22: definedness error [M0016], cannot use g before g has been defined

--- a/test/fail/redundant-ignore.mo
+++ b/test/fail/redundant-ignore.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 func f() {};
 
 let u = ();

--- a/test/fail/return-before-define.mo
+++ b/test/fail/return-before-define.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 import Prim "mo:⛔";
 
 func f():() -> Int {

--- a/test/fail/use-before-define.mo
+++ b/test/fail/use-before-define.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 import Prim "mo:⛔";
 
 func f():Int = x;

--- a/test/fail/use-before-define6.mo
+++ b/test/fail/use-before-define6.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0194
 class Bar () {
   class Foo(f1 : Int -> Int, f2 : Int -> Int) {
     let bomb = f1(666) + f2(666);

--- a/test/fail/usedefbug.mo
+++ b/test/fail/usedefbug.mo
@@ -1,6 +1,7 @@
+//MOC-FLAG -A=M0194
 class Bar () {
-  
-  private class Foo(f1:Int -> Int, f2:Int -> Int) { 
+
+  private class Foo(f1:Int -> Int, f2:Int -> Int) {
     let bomb = f1(666) + f2(666);
   };
 


### PR DESCRIPTION
Only preserve the unused warnings in the tests that want to actually exercise them

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5855 
- <kbd>&nbsp;1&nbsp;</kbd> #5848 👈 
<!-- GitButler Footer Boundary Bottom -->

