### PR TITLE
fix: perf fix in run.sh

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -125,10 +125,11 @@ function run () {
 
   $ECHO -n " [$ext]"
   $ECHO "$@" >& $out/$base.$ext
-  set -o pipefail
-  "$@" |& ${FILTER:-cat} > $out/$base.$ext
+  "$@" >& $out/$base.$ext
   local ret=$?
-  set +o pipefail
+  if [[ -n "${FILTER:-}" ]]; then
+    $FILTER < $out/$base.$ext > $out/$base.$ext.tmp && mv $out/$base.$ext.tmp $out/$base.$ext
+  fi
 
   if [ $ret != 0 ]
   then echo "Return code $ret" >> $out/$base.$ext.ret


### PR DESCRIPTION
[PR #5706](https://github.com/caffeinelabs/motoko/pull/5706)  introduced a perf regression for `run-drun` tests by making pocket-ic hang for 60s. This fixes that.

**Before**:
```
$ time EXTRA_MOC_ARGS="--enhanced-orthogonal-persistence" ./run.sh -d run-drun/blob-dedup-test.mo 
blob-dedup-test: [tc] [comp] [valid] [drun-run]
All tests passed.

real    1m3.796s
user    0m0.530s
sys     0m0.226s
```
**After**:
```
$ time EXTRA_MOC_ARGS="--enhanced-orthogonal-persistence" ./run.sh -d run-drun/blob-dedup-test.mo 
blob-dedup-test: [tc] [comp] [valid] [drun-run]
All tests passed.

real    0m3.236s
user    0m0.548s
sys     0m0.258s
```
