### PR TITLE
refactor: intro and use `NumType.one`

### DIFF
--- a/src/ir_passes/await.ml
+++ b/src/ir_passes/await.ml
@@ -685,7 +685,7 @@ and t_timer_throw context exp =
     (blockE
        [expD (primE
                 (OtherPrim "global_timer_set")
-                [Mo_values.Numerics.Nat64.of_int 1 |> nat64E])]
+                [nat64E Mo_values.Numerics.Nat64.one])]
        (tupE[]))
 
 and t_prog (prog, flavor) =

--- a/src/linking/linkModule.ml
+++ b/src/linking/linkModule.ml
@@ -800,7 +800,7 @@ let collect_got_imports (m : module_') : got_import list =
   let got_mem_name = Lib.Utf8.decode "GOT.mem" in
 
   let get_got_import (allow_normal_globals, global_index, imports) import : (bool * int32 * got_import list) =
-    let next_index = Int32.add global_index (Int32.of_int 1) in
+    let next_index = Int32.(add global_index one) in
     if import.it.module_name = got_func_name then
       let got_func = resolve_got_func global_index import m in
       (false, next_index, got_func :: imports)

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -352,23 +352,23 @@ and neutral (op : (binop, binop) Either.t) : exp -> bool =
       let open Numerics in
       (match contents with
        | NatLit n | IntLit n when add_like op && Int.(eq n zero) -> true
-       | NatLit n | IntLit n when mul_like op && Int.(of_int 1 |> eq n) -> true
+       | NatLit n | IntLit n when mul_like op && Int.(eq n one) -> true
        | Nat8Lit n when add_like op && Nat8.(eq n zero) -> true
-       | Nat8Lit n when mul_like op && Nat8.(of_int 1 |> eq n) -> true
+       | Nat8Lit n when mul_like op && Nat8.(eq n one) -> true
        | Int8Lit n when add_like op && Int_8.(eq n zero) -> true
-       | Int8Lit n when mul_like op && Int_8.(of_int 1 |> eq n) -> true
+       | Int8Lit n when mul_like op && Int_8.(eq n one) -> true
        | Nat16Lit n when add_like op && Nat16.(eq n zero) -> true
-       | Nat16Lit n when mul_like op && Nat16.(of_int 1 |> eq n) -> true
+       | Nat16Lit n when mul_like op && Nat16.(eq n one) -> true
        | Int16Lit n when add_like op && Int_16.(eq n zero) -> true
-       | Int16Lit n when mul_like op && Int_16.(of_int 1 |> eq n) -> true
+       | Int16Lit n when mul_like op && Int_16.(eq n one) -> true
        | Nat32Lit n when add_like op && Nat32.(eq n zero) -> true
-       | Nat32Lit n when mul_like op && Nat32.(of_int 1 |> eq n) -> true
+       | Nat32Lit n when mul_like op && Nat32.(eq n one) -> true
        | Int32Lit n when add_like op && Int_32.(eq n zero) -> true
-       | Int32Lit n when mul_like op && Int_32.(of_int 1 |> eq n) -> true
+       | Int32Lit n when mul_like op && Int_32.(eq n one) -> true
        | Nat64Lit n when add_like op && Nat64.(eq n zero) -> true
-       | Nat64Lit n when mul_like op && Nat64.(of_int 1 |> eq n) -> true
+       | Nat64Lit n when mul_like op && Nat64.(eq n one) -> true
        | Int64Lit n when add_like op && Int_64.(eq n zero) -> true
-       | Int64Lit n when mul_like op && Int_64.(of_int 1 |> eq n) -> true
+       | Int64Lit n when mul_like op && Int_64.(eq n one) -> true
        | _ -> false)
     | _ -> false in
   examine

--- a/src/mo_frontend/coverage.ml
+++ b/src/mo_frontend/coverage.ml
@@ -57,7 +57,7 @@ let max_expand = 2
 let pick_nat (type t) (module Num : Numerics.NumType with type t = t) to_val vs =
   let x = ref Num.zero in
   while ValSet.mem (to_val !x) vs do
-    x := Num.add (Num.of_int 1) !x
+    x := Num.(add one !x)
   done;
   Val (to_val !x)
 
@@ -65,7 +65,7 @@ let pick_int (type t) (module Num : Numerics.NumType with type t = t) to_val vs 
   let x = ref Num.zero in
   while ValSet.mem (to_val !x) vs do
     x := Num.neg !x;
-    if Num.ge !x Num.zero then x := Num.add (Num.of_int 1) !x
+    Num.(if ge !x zero then x := add one !x)
   done;
   Val (to_val !x)
 

--- a/src/mo_values/numerics.ml
+++ b/src/mo_values/numerics.ml
@@ -207,6 +207,7 @@ sig
   type t
   val signed : bool
   val zero : t
+  val one : t
   val abs : t -> t
   val neg : t -> t
   val add : t -> t -> t
@@ -241,6 +242,7 @@ struct
   type t = big_int
   let signed = true
   let zero = zero_big_int
+  let one = unit_big_int
   let sub = sub_big_int
   let abs = abs_big_int
   let neg = minus_big_int

--- a/src/mo_values/numerics.mli
+++ b/src/mo_values/numerics.mli
@@ -5,6 +5,7 @@ sig
   type t
   val signed : bool
   val zero : t
+  val one : t
   val abs : t -> t
   val neg : t -> t
   val add : t -> t -> t

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -191,14 +191,14 @@ let prim trap =
      fun _ v k ->
      let w, a = as_pair v
      in k (match w with
-           | Nat8  y -> Nat8  Nat8. (and_ y (shl (of_int 1) (as_nat8  a)))
-           | Nat16 y -> Nat16 Nat16.(and_ y (shl (of_int 1) (as_nat16 a)))
-           | Nat32 y -> Nat32 Nat32.(and_ y (shl (of_int 1) (as_nat32 a)))
-           | Nat64 y -> Nat64 Nat64.(and_ y (shl (of_int 1) (as_nat64 a)))
-           | Int8  y -> Int8  Int_8. (and_ y (shl (of_int 1) (as_int8  a)))
-           | Int16 y -> Int16 Int_16.(and_ y (shl (of_int 1) (as_int16 a)))
-           | Int32 y -> Int32 Int_32.(and_ y (shl (of_int 1) (as_int32 a)))
-           | Int64 y -> Int64 Int_64.(and_ y (shl (of_int 1) (as_int64 a)))
+           | Nat8  y -> Nat8  Nat8. (and_ y (shl one (as_nat8  a)))
+           | Nat16 y -> Nat16 Nat16.(and_ y (shl one (as_nat16 a)))
+           | Nat32 y -> Nat32 Nat32.(and_ y (shl one (as_nat32 a)))
+           | Nat64 y -> Nat64 Nat64.(and_ y (shl one (as_nat64 a)))
+           | Int8  y -> Int8  Int_8. (and_ y (shl one (as_int8  a)))
+           | Int16 y -> Int16 Int_16.(and_ y (shl one (as_int16 a)))
+           | Int32 y -> Int32 Int_32.(and_ y (shl one (as_int32 a)))
+           | Int64 y -> Int64 Int_64.(and_ y (shl one (as_int64 a)))
            | _ -> failwith "btst")
 
   | "lsh_Nat" -> fun _ v k ->


### PR DESCRIPTION
We didn't have it. [@crusso asked for it](https://github.com/caffeinelabs/motoko/pull/5706#discussion_r2789369017). I just added it.