### PR TITLE
fix: only add synthetic primary span if there are no others

### DIFF
--- a/src/lang_utils/diag.ml
+++ b/src/lang_utils/diag.ml
@@ -121,7 +121,13 @@ let fancy_of_message msg =
     if msg.spans = [] then
       [G.Diagnostic.Label.primaryf ~range:(range msg.at) ""]
     else
-      List.map mk_span msg.spans in
+      let spans = List.map mk_span msg.spans in
+      let primary_spans = List.filter (fun span -> span.prio = Primary) msg.spans in
+      if primary_spans = [] then
+        G.Diagnostic.Label.primaryf ~range:(range msg.at) "" :: spans
+      else
+        spans
+  in
   let severity = match msg.sev with
     | Error -> G.Diagnostic.Severity.Error
     | Warning -> G.Diagnostic.Severity.Warning

--- a/test/fail/ok/bad-type-comp.tc-human.ok
+++ b/test/fail/ok/bad-type-comp.tc-human.ok
@@ -22,8 +22,10 @@ because the type
 error[M0018]: duplicate type field name T in object type
     ┌─ bad-type-comp.mo:7:73
   7 │  ignore ((module { public type T = Null}) : module { type T = Null; type T = Null });
-    │                                                           -              - used more than once
-    │                                                           │
+    │                                                           -              ^
+    │                                                           │              │
+    │                                                           │              
+    │                                                           │              used more than once
     │                                                           first use of T
 error[M0029]: unbound type T
 Did you mean type Text?

--- a/test/fail/ok/duplicate-field.tc-human.ok
+++ b/test/fail/ok/duplicate-field.tc-human.ok
@@ -5,8 +5,10 @@ error[M0051]: duplicate definition for m in block
 error[M0018]: duplicate field name foo in object type
     ┌─ duplicate-field.mo:8:22
   8 │  type T = {foo : Int; foo: Bool}
-    │            ---        --- used more than once
-    │            │
+    │            ---        ^^^
+    │            │          │
+    │            │          
+    │            │          used more than once
     │            first use of foo
 error[M0018]: duplicate field name foo in object type
     ┌─ duplicate-field.mo:21:3
@@ -14,7 +16,10 @@ error[M0018]: duplicate field name foo in object type
     │    --- first use of foo
     ·  
  21 │    foo: Bool;
-    │    --- used more than once
+    │    ^^^
+    │    │
+    │    
+    │    used more than once
 error[M0019]: field names foo and nxnnbkddcv in object type have colliding hashes
     ┌─ duplicate-field.mo:26:22
  26 │  type T = {foo : Int; nxnnbkddcv: Bool}
@@ -26,8 +31,10 @@ error[M0019]: tag names foo and nxnnbkddcv in variant type have colliding hashes
 error[M0018]: duplicate field name foo in object
     ┌─ duplicate-field.mo:34:18
  34 │  ignore({foo = 5; foo = true});
-    │          ---      --- used more than once
-    │          │
+    │          ---      ^^^
+    │          │        │
+    │          │        
+    │          │        used more than once
     │          first use of foo
 error[M0019]: field names foo and nxnnbkddcv in object have colliding hashes
     ┌─ duplicate-field.mo:38:18

--- a/test/fail/ok/type-comp.tc-human.ok
+++ b/test/fail/ok/type-comp.tc-human.ok
@@ -1,8 +1,10 @@
 error[M0018]: duplicate type field name T in object type
     ┌─ type-comp.mo:3:42
   3 │    type MT = module { type T = Null; type T<A> = A }; // reject
-    │                            -              - used more than once
-    │                            │
+    │                            -              ^
+    │                            │              │
+    │                            │              
+    │                            │              used more than once
     │                            first use of T
 error[M0046]: type argument
   P2


### PR DESCRIPTION
Purely affects the human error format. Only add the “synthetic” span covering the original specified range when there are no other primary spans specified.