### PR TITLE
cleanup: removes code for anonymous implicits

### DIFF
--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -181,10 +181,9 @@ let break_label kind (id_opt : id option) =
 
 
 type id_ref = (string, mut' * exp option) Source.annotated_phrase
-and hole_sort = Named of string | Anon of int
 and exp = (exp', typ_note) Source.annotated_phrase
 and exp' =
-  | HoleE of hole_sort * exp ref
+  | HoleE of string * exp ref
   | PrimE of string                            (* primitive *)
   | VarE of id_ref                             (* variable *)
   | LitE of lit ref                            (* literal *)

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1486,26 +1486,19 @@ let module_ref_of_dot_module_exp (path : exp) =
   | DotE ({ it = ImplicitLibE module_path; _ }, _, _) -> Some module_path
   | _ -> None
 
-(** Searches for hole resolutions for [name] on a given [hole_sort] and [typ].
+type hole_error =
+  | HoleSuggestions of hole_candidate list * hole_candidate list * (env -> unit)
+  | HoleAmbiguous of (env -> unit)
+
+(** Searches for hole resolutions for [name] of a given [typ].
     Returns [Ok(candidate)] when a single resolution is
     found, [Error(file_paths)] when no resolution was found, but a
     matching module could be imported, and reports an ambiguity error
     when finding multiple resolutions.
  *)
-
-type hole_error =
-  | HoleSuggestions of hole_candidate list * hole_candidate list * (env -> unit)
-  | HoleAmbiguous of (env -> unit)
-
-let resolve_hole env at hole_sort typ =
-  let is_matching_lab lab =
-    match hole_sort with
-    | Named lab1 -> lab = lab1
-    | Anon _ -> not (Syntax.is_privileged lab) (* fix from 5659 *)
-  in
-
-  let is_matching_typ typ1 = T.sub typ1 typ
-  in
+let resolve_hole env at name typ =
+  let is_matching_lab lab = name = lab in
+  let is_matching_typ typ1 = T.sub typ1 typ in
   let has_matching_field_typ = function
     | T.{ lab; typ = Mut t; _ } -> None
     | T.{ lab = lab1; typ = typ1; src } ->
@@ -1562,24 +1555,20 @@ let resolve_hole env at hole_sort typ =
       if (candidate.region.left.file = at.left.file) then
         let call_region = Source.string_of_region at in
         let call_src = match Source.read_region at with Some s -> ": " ^ s | None -> "." in
-        match hole_sort with
-        | Anon _ -> ()
-        | Named id ->
-          let mod_desc, mid =
-            match candidate.path.it with
-            | DotE({ it = VarE {it = mid;_ }; _ }, _, _) ->
-              ("the existing", mid)
-            | VarE _ | _ ->
-              let mid = match Lib.String.chop_prefix id candidate.id with
-                | Some suffix when not (T.Env.mem suffix env.vals) ->
-                   suffix
-                | _ -> "<M>"
-              in
-              ("a new", mid)
+        let mod_desc, mid =
+          match candidate.path.it with
+          | DotE({ it = VarE {it = mid;_ }; _ }, _, _) ->
+            ("the existing", mid)
+          | VarE _ | _ ->
+            let mid = match Lib.String.chop_prefix name candidate.id with
+              | Some suffix when not (T.Env.mem suffix env.vals) -> suffix
+              | _ -> "<M>"
+            in
+            ("a new", mid)
           in
             info env candidate.region
              "Consider renaming `%s` to `%s.%s` in %s module `%s`. Then it can serve as an implicit argument `%s` in this call:\n%s%s"
-             (desc_of_candidate candidate) mid id mod_desc mid id call_region call_src)
+             (desc_of_candidate candidate) mid name mod_desc mid name call_region call_src)
       explicit_terms
   in
   (* All candidates are subtypes of the required type. The "greatest" of these types is the "closest" to the required type.
@@ -1601,9 +1590,7 @@ let resolve_hole env at hole_sort typ =
          if explicit_terms = [] then [] else
             [ "The other explicit candidates are: " ^ (String.concat ", " (List.map desc_of_candidate explicit_terms)) ]
        in
-       error env at "M0231" ~notes "ambiguous implicit argument %s of type %a."
-         (match hole_sort with Named n -> "named " ^ quote n | Anon i -> "at argument position " ^ Int.to_string i)
-         display_typ typ))
+       error env at "M0231" ~notes "ambiguous implicit argument %s of type %a." ("named " ^ quote name) display_typ typ))
 
 type ctx_dot_candidate =
   { module_ref : T.lab option; (* optional module reference : name (from `vals`) or path (from `libs`) *)
@@ -2471,10 +2458,6 @@ and check_exp' env0 t exp : T.typ =
   let env = {env0 with in_prog = false; in_actor = false; context = exp.it :: env0.context } in
   match exp.it, t with
   | HoleE (s, e), t ->
-    let desc = function
-      | Named id -> "`"^id^"`"
-      | Anon idx -> "at position " ^ (Int.to_string idx)
-    in
     begin match resolve_hole env exp.at s t with
     | Ok {path; _} ->
       e := path;
@@ -2491,17 +2474,14 @@ and check_exp' env0 t exp : T.typ =
         in
         let import_sug =
           if lib_terms = [] then
-            let desc = match s with Named id -> " named " ^ quote id | _ -> "" in
             Stdlib.Format.sprintf
-             "If you're trying to omit an implicit argument%s you need to have a matching declaration%s in scope."
-             desc desc
+             "If you're trying to omit an implicit argument named %s you need to have a matching declaration named %s in scope."
+             (quote s) (quote s)
           else Stdlib.Format.sprintf "Did you mean to import %s?" (String.concat " or " (List.filter_map import_suggestion_of_candidate lib_terms))
         in
         renaming_hints env;
         let notes = import_sug::explicit_sug in
-        local_error ~notes env exp.at "M0230" "Cannot determine implicit argument %s of type%a"
-          (desc s)
-          display_typ t
+        local_error ~notes env exp.at "M0230" "Cannot determine implicit argument %s of type%a" (quote s) display_typ t
       end;
       t
   end
@@ -2842,11 +2822,6 @@ and infer_callee env exp =
   | _ ->
      infer_exp_promote env exp, None
 and as_implicit = function
-(* disable wildcard patterns
-  | T.Named ("implicit", T.Named (arg_name, t)) ->
-    Some arg_name
-  | T.Named ("implicit", t) ->
-    Some "_" *)
   | T.Named (_inf_arg_name, (T.Named ("implicit", T.Named (arg_name, t)))) ->
     (* override inferred arg_name *)
     Some arg_name
@@ -2866,8 +2841,7 @@ and arity_with_implicits t_args =
 
 and insert_holes at ts es =
   let mk_hole pos hole_id =
-    let hole_sort = if hole_id = "" then Anon pos else Named hole_id in
-    {it = HoleE (hole_sort, ref {it = PrimE "hole"; at; note=empty_typ_note });
+    {it = HoleE (hole_id, ref {it = PrimE "hole"; at; note=empty_typ_note });
       at;
       note = empty_typ_note }
   in
@@ -2898,7 +2872,7 @@ and check_explicit_arguments env saturated_arity implicits_arity arg_typs syntax
              match as_implicit typ with
              | None -> acc
              | Some name ->
-                match resolve_hole env arg.at (match name with "_" -> Anon pos | id -> Named id) typ with
+                match resolve_hole env arg.at name typ with
                 | Error _ -> acc
                 | Ok {path;_} ->
                    match path.it, arg.it with


### PR DESCRIPTION
These were disabled by commenting out code. Let’s clean up

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5920 
- <kbd>&nbsp;2&nbsp;</kbd> #5921 
- <kbd>&nbsp;1&nbsp;</kbd> #5922 👈 
<!-- GitButler Footer Boundary Bottom -->

