### PR TITLE
fix: drop esm shim to unblock Node.js 22 upgrade

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -659,8 +659,7 @@ do
 
       if [ -e $out/$base.js ]
       then
-        export NODE_PATH=$NODE_PATH:$ESM
-        run node node -r esm $out/$base.js
+        run node node $out/$base.js
       fi
     fi
     ;;


### PR DESCRIPTION
## Summary
- Removes the abandoned `esm` npm package (v3.2.25, last updated 2019) from the IDL test runner
- The `esm` package monkey-patches Node.js internals removed in v21+, causing `TypeError: Function.prototype.apply was called on undefined` on both `nodejs_22` and `nodejs_24`
- Node.js 22+ has native ESM support with automatic module detection (stable since v22.7.0), so `export default` in `.js` files works without any shim

## Test plan
- [x] All 38 IDL tests pass locally with Node.js 22.20.0
- [ ] CI passes (`common-tests`, `test-idl`, `test-coverage`)

## Follow-up
- The `esm` flake input and `export ESM=...` in nix configs are now dead code and can be cleaned up separately

Made with [Cursor](https://cursor.com)