### PR TITLE
ci: dispatch motoko-release event to node-motoko on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,7 @@ jobs:
         with:
           app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
+          repositories: motoko,node-motoko
 
       - name: Upload Release Assets
         uses: svenstaro/upload-release-action@v2
@@ -176,3 +177,12 @@ jobs:
           body: ${{ needs.changelog.outputs.release_body || 'Draft release created for testing purposes' }}
           draft: ${{ github.event_name == 'workflow_dispatch' }}
           prerelease: ${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Notify node-motoko of new release
+        if: ${{ github.event_name == 'push' }}
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: caffeinelabs/node-motoko
+          event-type: motoko-release
+          client-payload: '{"version": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Summary

- Adds a `repository_dispatch` step at the end of the `publish` job in the release workflow that sends a `motoko-release` event (with the tag version) to `caffeinelabs/node-motoko` on tag pushes.
- Expands the GitHub App token scope to include both `motoko` and `node-motoko` repositories so the dispatch has write access.
- Skipped for `workflow_dispatch` (draft) releases — only real tag pushes trigger the notification.
