### PR TITLE
refactor: introduce `powf` RTS forwarder for `Float32` `PowOp` (`**`)

### DIFF
--- a/rts/Makefile
+++ b/rts/Makefile
@@ -275,6 +275,7 @@ EXPORTED_SYMBOLS=\
   atan \
   atan2 \
   pow \
+  powf \
   sin \
   cos \
   exp \

--- a/rts/motoko-rts/src/float.rs
+++ b/rts/motoko-rts/src/float.rs
@@ -44,6 +44,10 @@ pub fn pow(a: f64, b: f64) -> f64 {
     libm::pow(a, b)
 }
 #[no_mangle]
+pub fn powf(a: f32, b: f32) -> f32 {
+    libm::powf(a, b)
+}
+#[no_mangle]
 pub fn tan(a: f64) -> f64 {
     libm::tan(a)
 }

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -1168,6 +1168,7 @@ module RTS = struct
     E.add_func_import env "rts" "blob_iter" [I32Type] [I32Type];
     E.add_func_import env "rts" "blob_iter_next" [I32Type] [I32Type];
     E.add_func_import env "rts" "pow" [F64Type; F64Type] [F64Type];
+    E.add_func_import env "rts" "powf" [F32Type; F32Type] [F32Type];
     E.add_func_import env "rts" "sin" [F64Type] [F64Type];
     E.add_func_import env "rts" "cos" [F64Type] [F64Type];
     E.add_func_import env "rts" "tan" [F64Type] [F64Type];
@@ -11025,14 +11026,7 @@ let compile_binop env t op : SR.t * SR.t * G.t =
       (powInt64_shortcut (Word64.compile_unsigned_pow env))
   | Type.(Prim Nat),                          PowOp -> BigNum.compile_unsigned_pow env
   | Type.(Prim Float),                        PowOp -> E.call_import env "rts" "pow"
-  | Type.(Prim Float32),                      PowOp ->
-    (* promote both f32 args to f64, call rts pow, demote back *)
-    let set_b, get_b, _ = new_local_ env F32Type "f32_pow_b" in
-    set_b ^^
-    G.i (Convert (Wasm.Values.F64 F64Op.PromoteF32)) ^^
-    get_b ^^ G.i (Convert (Wasm.Values.F64 F64Op.PromoteF32)) ^^
-    E.call_import env "rts" "pow" ^^
-    G.i (Convert (Wasm.Values.F32 F32Op.DemoteF64))
+  | Type.(Prim Float32),                      PowOp -> E.call_import env "rts" "powf"
   | Type.(Prim (Nat64|Int64)),                AndOp -> G.i (Binary (Wasm.Values.I64 I64Op.And))
   | Type.(Prim (Nat8|Nat16|Nat32|Int8|Int16|Int32)),
                                               AndOp -> G.i (Binary (Wasm.Values.I32 I32Op.And))

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -1248,6 +1248,7 @@ module RTS = struct
     E.add_func_import env "rts" "blob_iter" [I64Type] [I64Type];
     E.add_func_import env "rts" "blob_iter_next" [I64Type] [I64Type];
     E.add_func_import env "rts" "pow" [F64Type; F64Type] [F64Type];
+    E.add_func_import env "rts" "powf" [F32Type; F32Type] [F32Type];
     E.add_func_import env "rts" "sin" [F64Type] [F64Type];
     E.add_func_import env "rts" "cos" [F64Type] [F64Type];
     E.add_func_import env "rts" "tan" [F64Type] [F64Type];
@@ -11389,14 +11390,7 @@ let compile_binop env t op : SR.t * SR.t * G.t =
       (powInt64_shortcut (Word64.compile_unsigned_pow env))
   | Type.(Prim Nat),                          PowOp -> BigNum.compile_unsigned_pow env
   | Type.(Prim Float),                        PowOp -> E.call_import env "rts" "pow"
-  | Type.(Prim Float32),                      PowOp ->
-    (* stack: [e1:f32, e2:f32]; promote both to f64, call pow, demote back *)
-    let set_b, get_b, _ = new_local_ env F32Type "f32_pow_b" in
-    set_b ^^
-    G.i (Convert (Wasm_exts.Values.F64 F64Op.PromoteF32)) ^^
-    get_b ^^ G.i (Convert (Wasm_exts.Values.F64 F64Op.PromoteF32)) ^^
-    E.call_import env "rts" "pow" ^^
-    G.i (Convert (Wasm_exts.Values.F32 F32Op.DemoteF64))
+  | Type.(Prim Float32),                      PowOp -> E.call_import env "rts" "powf"
   | Type.(Prim (Nat8|Nat16|Nat32|Nat64|Int8|Int16|Int32|Int64)),
                                               AndOp -> G.i (Binary (Wasm_exts.Values.I64 I64Op.And))
   | Type.(Prim (Nat8|Nat16|Nat32|Nat64|Int8|Int16|Int32|Int64)),


### PR DESCRIPTION
## Summary

- Wasm has no native f32 power instruction; the previous implementation promoted both `f32` operands to `f64`, called the `rts pow` import, then demoted back, requiring a temporary local
- Fix: add a single-precision `powf(f32, f32) -> f32` wrapper in the RTS (delegating to `libm::powf`) and export it via `EXPORTED_SYMBOLS`
- Use `call_import env "rts" "powf"` directly in both `compile_classical.ml` and `compile_enhanced.ml`, eliminating the promote/demote dance and the temporary local
- Analogous to the `fmodf` change for `Float32 ModOp` (#5950)

## Test plan

- [x] `**` already tested in `test/run/float32.mo` (lines 39, 43, 69, 72)
- [x] `make -C test/run float32.only` — all modes pass: `[tc] [run] [run-ir] [run-low] [comp] [valid] [wasm-run]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)