### PR TITLE
chore: multimigration v2 renaming of run to migration

### DIFF
--- a/doc/md/fundamentals/2-actors/8-enhanced-multi-migration.md
+++ b/doc/md/fundamentals/2-actors/8-enhanced-multi-migration.md
@@ -14,7 +14,7 @@ With enhanced multi-migration you:
 
 1. Create a `migrations/` directory alongside your actor source.
 2. Add one `.mo` file per migration, named with a timestamp prefix so they sort chronologically.
-3. Each migration module exports a `public func run({...}) : {...}` that transforms a subset of stable fields.
+3. Each migration module exports a `public func migration({...}) : {...}` that transforms a subset of stable fields.
 4. Pass `--enhanced-migration ./migrations` to `moc` when compiling.
 
 The compiler reads all migration modules in lexicographic order, checks that they compose correctly, and compiles them into the actor. At runtime, only migrations that have not yet been applied are executed — already-applied migrations are skipped automatically.
@@ -41,12 +41,12 @@ my-canister/
 
 ### Writing a migration module
 
-Each migration module must export a `public func run` that takes a record of input fields and returns a record of output fields:
+Each migration module must export a `public func migration` that takes a record of input fields and returns a record of output fields:
 
 ```motoko no-repl
 // migrations/20250101_000000_Init.mo
 module {
-  public func run(_ : {}) : { name : Text; balance : Nat } {
+  public func migration(_ : {}) : { name : Text; balance : Nat } {
     { name = ""; balance = 0 }
   }
 }
@@ -83,7 +83,7 @@ moc --enhanced-orthogonal-persistence \
 
 ## Input and output fields
 
-Each migration's `run` function declares which fields it reads (input) and which fields it produces (output). The relationship between input and output fields determines what happens to the state:
+Each migration's `migration` function declares which fields it reads (input) and which fields it produces (output). The relationship between input and output fields determines what happens to the state:
 
 - **Input and output** — the migration transforms this field. It reads the old value and produces a new one, potentially with a different type. The output value replaces the old one in the state.
 
@@ -97,7 +97,7 @@ For example, given the state `{a : Nat; b : Text; c : Bool}` and a migration:
 
 ```motoko no-repl
 module {
-  public func run(old : { a : Nat; b : Text }) : { a : Int; d : Float } {
+  public func migration(old : { a : Nat; b : Text }) : { a : Int; d : Float } {
     { a = old.a; d = 1.0 }
   }
 }
@@ -147,7 +147,7 @@ The first migration in every chain initializes the actor's fields. Its input is 
 ```motoko no-repl
 // migrations/20250101_000000_Init.mo
 module {
-  public func run(_ : {}) : { count : Nat; header : Text } {
+  public func migration(_ : {}) : { count : Nat; header : Text } {
     { count = 0; header = "default" }
   }
 }
@@ -160,7 +160,7 @@ To add a new field, write a migration with an empty (or minimal) input that prod
 ```motoko no-repl
 // migrations/20250201_000000_AddEmail.mo
 module {
-  public func run(_ : {}) : { email : Text } {
+  public func migration(_ : {}) : { email : Text } {
     { email = "" }
   }
 }
@@ -175,7 +175,7 @@ To change the type of a field, read it at its current type and produce it at the
 ```motoko no-repl
 // migrations/20250301_000000_CountToInt.mo
 module {
-  public func run(old : { count : Nat }) : { count : Int } {
+  public func migration(old : { count : Nat }) : { count : Int } {
     { count = old.count }
   }
 }
@@ -190,7 +190,7 @@ To rename a field, consume the old name and produce the new name:
 ```motoko no-repl
 // migrations/20250401_000000_RenameHeader.mo
 module {
-  public func run(old : { header : Text }) : { title : Text } {
+  public func migration(old : { header : Text }) : { title : Text } {
     { title = old.header }
   }
 }
@@ -205,7 +205,7 @@ To drop a field entirely, consume it in the input without producing it in the ou
 ```motoko no-repl
 // migrations/20250501_000000_DropEmail.mo
 module {
-  public func run(_ : { email : Text }) : {} {
+  public func migration(_ : { email : Text }) : {} {
     {}
   }
 }
@@ -226,7 +226,7 @@ Migrations can perform arbitrary computation. For example, splitting a full name
 import Text "mo:base/Text";
 
 module {
-  public func run(old : { name : Text }) : { firstName : Text; lastName : Text } {
+  public func migration(old : { name : Text }) : { firstName : Text; lastName : Text } {
     let parts = Text.split(old.name, #char ' ');
     let first = switch (parts.next()) { case (?f) f; case null "" };
     let last = switch (parts.next()) { case (?l) l; case null "" };
@@ -244,7 +244,7 @@ Here is how an actor's state might evolve across several deployments:
 ```motoko no-repl
 // migrations/20250101_000000_Init.mo
 module {
-  public func run(_ : {}) : { a : Nat } {
+  public func migration(_ : {}) : { a : Nat } {
     { a = 0 }
   }
 }
@@ -263,7 +263,7 @@ State: `{a : Nat}`
 ```motoko no-repl
 // migrations/20250201_000000_AddB.mo
 module {
-  public func run(_ : {}) : { b : Int } {
+  public func migration(_ : {}) : { b : Int } {
     { b = 0 }
   }
 }
@@ -283,7 +283,7 @@ State: `{a : Nat; b : Int}`
 ```motoko no-repl
 // migrations/20250301_000000_ChangeBType.mo
 module {
-  public func run(old : { b : Int }) : { b : Bool } {
+  public func migration(old : { b : Int }) : { b : Bool } {
     { b = old.b > 0 }
   }
 }
@@ -303,7 +303,7 @@ State: `{a : Nat; b : Bool}`
 ```motoko no-repl
 // migrations/20250401_000000_DropA.mo
 module {
-  public func run(_ : { a : Nat }) : {} {
+  public func migration(_ : { a : Nat }) : {} {
     {}
   }
 }
@@ -322,7 +322,7 @@ State: `{b : Bool}`
 ```motoko no-repl
 // migrations/20250501_000000_AddAText.mo
 module {
-  public func run(_ : {}) : { a : Text } {
+  public func migration(_ : {}) : { a : Text } {
     { a = "" }
   }
 }
@@ -359,7 +359,7 @@ The first migration in the chain must initialize all required fields. When a can
 
 ## Restrictions
 
-- Each migration file must be a module containing a `public func run(...)`.
+- Each migration file must be a module containing a `public func migration(...)`.
 - The `--enhanced-migration` flag cannot be combined with the inline `(with migration = ...)` syntax.
 - Enhanced multi-migration requires enhanced orthogonal persistence.
 - The state after each migration (its output merged with carried-through fields) must be compatible with the input of the next migration in the chain. The compiler rejects the program if this is not the case.

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -208,7 +208,7 @@ let error_codes : (string * string option) list =
     "M0234", None; (* Field exists but is not a function *)
     "M0238", None; (* Misplaced break or continue *)
     "M0250", None; (* Variables without initializers only allowed in actors with --enhanced-migration flag *)
-    "M0251", None; (* Enhanced migration chain validation error (bad run type, chain broken, output mismatch) *)
+    "M0251", None; (* Enhanced migration chain validation error (bad migration type, chain broken, output mismatch) *)
     "M0252", None; (* Cannot combine (with migration = ...) with --enhanced-migration *)
     "M0253", None; (* Inconsistent multi-migration signature *)
     "M0255", None; (* Upgrading enhanced migration with non-enhanced migration *)

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -767,7 +767,7 @@ and build_actor at chain ts (exp_opt : Ir.exp option) self_id es obj_typ =
           let v_dom = fresh_var "v_dom" dom_k in
           let v_rng = fresh_var "v_rng" rng_k in
           let mod_expr = varE (var (id_of_full_path file_k) mod_typ_k) in
-          let run_expr = dotE mod_expr "run" run_typ_k in
+          let run_expr = dotE mod_expr "migration" run_typ_k in
           let extract_dom =
             objectE T.Object
               (List.map (fun T.{lab=i;typ=t;_} ->

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -3918,11 +3918,11 @@ and infer_migration_chain env at =
            match Type.normalize lib_typ with
              | T.Obj(T.Module, fields, _) as mod_typ ->
                begin
-                 match Type.lookup_val_field_opt "run" fields with
-                 | Some run_typ -> (lib, mod_typ, run_typ) :: acc
-                 | None ->
-                    warn env (region_of_file lib) "M0251"
-                      "migration module does not export a `run` function, skipping";
+                match Type.lookup_val_field_opt "migration" fields with
+                | Some run_typ -> (lib, mod_typ, run_typ) :: acc
+                | None ->
+                   warn env (region_of_file lib) "M0251"
+                     "migration module does not export a `migration` function, skipping";
                     acc
                end
              | _ ->
@@ -3932,7 +3932,7 @@ and infer_migration_chain env at =
      in
      if chain = [] then
        local_error env at "M0251"
-        "--enhanced-migration: no valid migration modules found (migration modules must export a public `run` function)";
+        "--enhanced-migration: no valid migration modules found (migration modules must export a public `migration` function)";
      chain
 
 and infer_migration env obj_sort exp_opt =

--- a/test/fail/enhanced-migration/enh-mig-test1/m1.mo
+++ b/test/fail/enhanced-migration/enh-mig-test1/m1.mo
@@ -1,4 +1,4 @@
 module {
     // Introduce field a.
-    public func run(_ : {}) : { a : Text } { { a = "bla bla" } };
+    public func migration(_ : {}) : { a : Text } { { a = "bla bla" } };
 };

--- a/test/fail/enhanced-migration/enh-mig-test1/m2.mo
+++ b/test/fail/enhanced-migration/enh-mig-test1/m2.mo
@@ -1,4 +1,4 @@
 module {
     // Introduce field b;
-    public func run(_ : {}) : { b : Bool } { { b = true } };
+    public func migration(_ : {}) : { b : Bool } { { b = true } };
 };

--- a/test/fail/enhanced-migration/enh-mig-test1/m3.mo
+++ b/test/fail/enhanced-migration/enh-mig-test1/m3.mo
@@ -1,4 +1,4 @@
 module {
     // Drop a;
-    public func run(_ : { a : Text }) : {} { {} };
+    public func migration(_ : { a : Text }) : {} { {} };
 };

--- a/test/fail/enhanced-migration/enh-mig-test2/m1.mo
+++ b/test/fail/enhanced-migration/enh-mig-test2/m1.mo
@@ -1,4 +1,4 @@
 module {
     // Introduce field a.
-    public func run(_ : {}) : { a : Text } { { a = "bla bla" } };
+    public func migration(_ : {}) : { a : Text } { { a = "bla bla" } };
 };

--- a/test/fail/enhanced-migration/enh-mig-test2/m2.mo
+++ b/test/fail/enhanced-migration/enh-mig-test2/m2.mo
@@ -1,4 +1,4 @@
 module {
     // Introduce field b;
-    public func run(_ : {}) : { b : Bool } { { b = true } };
+    public func migration(_ : {}) : { b : Bool } { { b = true } };
 };

--- a/test/fail/enhanced-migration/enh-mig-test2/m3.mo
+++ b/test/fail/enhanced-migration/enh-mig-test2/m3.mo
@@ -1,4 +1,4 @@
 module {
     // Change a to float.
-    public func run(_ : { a : Text }) : { a : Float } { { a = 5.5 } };
+    public func migration(_ : { a : Text }) : { a : Float } { { a = 5.5 } };
 };

--- a/test/fail/enhanced-migration/enh-mig-test2/m4.mo
+++ b/test/fail/enhanced-migration/enh-mig-test2/m4.mo
@@ -1,4 +1,4 @@
 module {
     // Introduce a c field.
-    public func run(_ : {}) : { c : Nat } { { c = 99 } };
+    public func migration(_ : {}) : { c : Nat } { { c = 99 } };
 };

--- a/test/run-drun/enhanced-migration-fast-forward/migrations/1.mo
+++ b/test/run-drun/enhanced-migration-fast-forward/migrations/1.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { a : Nat } {
+  public func migration(_ : {}) : { a : Nat } {
     {
       a = 5;
     };

--- a/test/run-drun/enhanced-migration-fast-forward/migrations/2.mo
+++ b/test/run-drun/enhanced-migration-fast-forward/migrations/2.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { b : Int } {
+  public func migration(_ : {}) : { b : Int } {
     {
       b = -5;
     };

--- a/test/run-drun/enhanced-migration-fast-forward/migrations/3.mo
+++ b/test/run-drun/enhanced-migration-fast-forward/migrations/3.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(old : { b : Int }) : { b : Bool } {
+  public func migration(old : { b : Int }) : { b : Bool } {
     {
       b = old.b > 5;
     };

--- a/test/run-drun/enhanced-migration-fast-forward/migrations/4.mo
+++ b/test/run-drun/enhanced-migration-fast-forward/migrations/4.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_old : { a : Nat }) : {} {
+  public func migration(_old : { a : Nat }) : {} {
     {};
   }
 

--- a/test/run-drun/enhanced-migration-fast-forward/migrations/5.mo
+++ b/test/run-drun/enhanced-migration-fast-forward/migrations/5.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_old : {}) : { a : Text } {
+  public func migration(_old : {}) : { a : Text } {
     {
       a = "We got here!";
     };

--- a/test/run-drun/enhanced-migration-imported-class/migrations/version1.mo
+++ b/test/run-drun/enhanced-migration-imported-class/migrations/version1.mo
@@ -1,7 +1,7 @@
 // this migration should not be applied to any imported class, only the main prog
 module {
 
-  public func run({}) : { f : {#f} } = {
+  public func migration({}) : { f : {#f} } = {
    f = #f
   };
 

--- a/test/run-drun/enhanced-migration-incremental/migrations_1/1.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_1/1.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { a : Nat } {
+  public func migration(_ : {}) : { a : Nat } {
     {
       a = 5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_2/1.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_2/1.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { a : Nat } {
+  public func migration(_ : {}) : { a : Nat } {
     {
       a = 5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_2/2.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_2/2.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { b : Int } {
+  public func migration(_ : {}) : { b : Int } {
     {
       b = -5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_3/1.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_3/1.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { a : Nat } {
+  public func migration(_ : {}) : { a : Nat } {
     {
       a = 5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_3/2.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_3/2.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { b : Int } {
+  public func migration(_ : {}) : { b : Int } {
     {
       b = -5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_3/3.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_3/3.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(old : { b : Int }) : { b : Bool } {
+  public func migration(old : { b : Int }) : { b : Bool } {
     {
       b = old.b > 5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_4/1.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_4/1.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { a : Nat } {
+  public func migration(_ : {}) : { a : Nat } {
     {
       a = 5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_4/2.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_4/2.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { b : Int } {
+  public func migration(_ : {}) : { b : Int } {
     {
       b = -5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_4/3.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_4/3.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(old : { b : Int }) : { b : Bool } {
+  public func migration(old : { b : Int }) : { b : Bool } {
     {
       b = old.b > 5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_4/4.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_4/4.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_old : { a : Nat }) : {} {
+  public func migration(_old : { a : Nat }) : {} {
     {};
   }
 

--- a/test/run-drun/enhanced-migration-incremental/migrations_5/1.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_5/1.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { a : Nat } {
+  public func migration(_ : {}) : { a : Nat } {
     {
       a = 5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_5/2.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_5/2.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : { b : Int } {
+  public func migration(_ : {}) : { b : Int } {
     {
       b = -5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_5/3.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_5/3.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(old : { b : Int }) : { b : Bool } {
+  public func migration(old : { b : Int }) : { b : Bool } {
     {
       b = old.b > 5;
     };

--- a/test/run-drun/enhanced-migration-incremental/migrations_5/4.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_5/4.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_old : { a : Nat }) : {} {
+  public func migration(_old : { a : Nat }) : {} {
     {};
   }
 

--- a/test/run-drun/enhanced-migration-incremental/migrations_5/5.mo
+++ b/test/run-drun/enhanced-migration-incremental/migrations_5/5.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_old : {}) : { a : Text } {
+  public func migration(_old : {}) : { a : Text } {
     {
       a = "We got here!";
     };

--- a/test/run-drun/multi-migration-bad-chain/bad-chain/Init.mo
+++ b/test/run-drun/multi-migration-bad-chain/bad-chain/Init.mo
@@ -2,7 +2,7 @@ import Prim "mo:prim";
 
 module {
 
-  public func run(_ : {}) : {
+  public func migration(_ : {}) : {
     var zero : Nat;
     var one : [var Nat];
     var two : [var Text];

--- a/test/run-drun/multi-migration-bad-chain/bad-chain/Migration1.mo
+++ b/test/run-drun/multi-migration-bad-chain/bad-chain/Migration1.mo
@@ -12,7 +12,7 @@ module {
     res;
   };
 
-  public func run(
+  public func migration(
     old : {
       var zero : Nat;
       var one : [var Nat];

--- a/test/run-drun/multi-migration-bad-chain/bad-chain/Migration2.mo
+++ b/test/run-drun/multi-migration-bad-chain/bad-chain/Migration2.mo
@@ -2,7 +2,7 @@ import Prim "mo:prim";
 
 module {
 
-  public func run(old : { var zero : Nat; var three : [var (Nat, Text)] }) : {
+  public func migration(old : { var zero : Nat; var three : [var (Nat, Text)] }) : {
     var zero : Nat;
     var three : [var (Nat, Text)];
     var four : Text;

--- a/test/run-drun/multi-migration-bad-chain/bad-chain/Migration4.mo
+++ b/test/run-drun/multi-migration-bad-chain/bad-chain/Migration4.mo
@@ -2,7 +2,7 @@ import Prim "mo:prim";
 
 module {
 
-  public func run(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text }) : {
+  public func migration(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text }) : {
     var zero : Nat;
     var three : [var (Nat, Text)];
     var four : Text;

--- a/test/run-drun/multi-migration-bad-chain/bad-chain/Migration5.mo
+++ b/test/run-drun/multi-migration-bad-chain/bad-chain/Migration5.mo
@@ -2,7 +2,7 @@ import Prim "mo:prim";
 
 module {
 
-  public func run(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text; var six : Text }) : {
+  public func migration(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text; var six : Text }) : {
     zero : Nat;
     var three : [var (Nat, Text)];
     var four : Text;

--- a/test/run-drun/multi-migration/migrations/Init.mo
+++ b/test/run-drun/multi-migration/migrations/Init.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : {
+  public func migration(_ : {}) : {
     var zero : Nat;
     var one : [var Nat];
     var two : [var Text];

--- a/test/run-drun/multi-migration/migrations1/Init.mo
+++ b/test/run-drun/multi-migration/migrations1/Init.mo
@@ -1,6 +1,6 @@
 module {
 
-  public func run(_ : {}) : {
+  public func migration(_ : {}) : {
     var zero : Nat;
     var one : [var Nat];
     var two : [var Text];

--- a/test/run-drun/multi-migration/migrations1/Migration1.mo
+++ b/test/run-drun/multi-migration/migrations1/Migration1.mo
@@ -12,7 +12,7 @@ module {
     res;
   };
 
-  public func run(
+  public func migration(
     old : {
       var zero : Nat;
       var one : [var Nat];

--- a/test/run-drun/multi-migration/migrations1/Migration2.mo
+++ b/test/run-drun/multi-migration/migrations1/Migration2.mo
@@ -2,7 +2,7 @@ import Prim "mo:prim";
 
 module {
 
-  public func run(old : { var zero : Nat; var three : [var (Nat, Text)] }) : {
+  public func migration(old : { var zero : Nat; var three : [var (Nat, Text)] }) : {
     var zero : Nat;
     var three : [var (Nat, Text)];
     var four : Text;

--- a/test/run-drun/multi-migration/migrations1/Migration3.mo
+++ b/test/run-drun/multi-migration/migrations1/Migration3.mo
@@ -2,7 +2,7 @@ import Prim "mo:prim";
 
 module {
 
-  public func run(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text }) : {
+  public func migration(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text }) : {
     var zero : Nat;
     var three : [var (Nat, Text)];
     var four : Text;

--- a/test/run-drun/multi-migration/migrations1/Migration4.mo
+++ b/test/run-drun/multi-migration/migrations1/Migration4.mo
@@ -2,7 +2,7 @@ import Prim "mo:prim";
 
 module {
 
-  public func run(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text }) : {
+  public func migration(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text }) : {
     var zero : Nat;
     var three : [var (Nat, Text)];
     var four : Text;

--- a/test/run-drun/multi-migration/migrations1/Migration5.mo
+++ b/test/run-drun/multi-migration/migrations1/Migration5.mo
@@ -2,7 +2,7 @@ import Prim "mo:prim";
 
 module {
 
-  public func run(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text; var six : Text }) : {
+  public func migration(old : { var zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text; var six : Text }) : {
     zero : Nat;
     var three : [var (Nat, Text)];
     var four : Text;

--- a/test/run-drun/multi-migration/migrations1/Migration6.mo
+++ b/test/run-drun/multi-migration/migrations1/Migration6.mo
@@ -2,7 +2,7 @@ import Prim "mo:prim";
 
 module {
 
-  public func run(old : { zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text; var six : Text }) : {
+  public func migration(old : { zero : Nat; var three : [var (Nat, Text)]; var four : Text; var five : Text; var six : Text }) : {
     zero : [Nat];
     var three : [var (Nat, Text)];
     var four : Text;

--- a/test/run-drun/ok/enhanced-migration-check-no-migration.tc.ok
+++ b/test/run-drun/ok/enhanced-migration-check-no-migration.tc.ok
@@ -1,2 +1,2 @@
-multi-migration-bad-chain/bad-init/Init.mo:1.1: warning [M0251], migration module does not export a `run` function, skipping
-enhanced-migration-check-no-migration.mo:3.1-5.2: type error [M0251], --enhanced-migration: no valid migration modules found (migration modules must export a public `run` function)
+multi-migration-bad-chain/bad-init/Init.mo:1.1: warning [M0251], migration module does not export a `migration` function, skipping
+enhanced-migration-check-no-migration.mo:3.1-5.2: type error [M0251], --enhanced-migration: no valid migration modules found (migration modules must export a public `migration` function)

--- a/test/run-drun/ok/multi-migration-bad-chain.version1.drun.comp.ok
+++ b/test/run-drun/ok/multi-migration-bad-chain.version1.drun.comp.ok
@@ -1,1 +1,1 @@
-multi-migration-bad-chain/version1.mo:5.1-19.2: type error [M0251], --enhanced-migration: no valid migration modules found (migration modules must export a public `run` function)
+multi-migration-bad-chain/version1.mo:5.1-19.2: type error [M0251], --enhanced-migration: no valid migration modules found (migration modules must export a public `migration` function)


### PR DESCRIPTION
Builds on #5840 

Renames 'run' functions to 'migration' 