### PR TITLE
perf: avoid `call_indirect` for capturing closures with statically-known fi

### DIFF
--- a/.claude/plans/avoid-static-indirect-call.md
+++ b/.claude/plans/avoid-static-indirect-call.md
@@ -1,0 +1,175 @@
+# Plan: Avoid `call_indirect` for Statically-Known Functions
+
+## Problem
+
+When a top-level Motoko function (compiled as `Const.Fun`) is used as a
+first-class value and then called, the compiler may materialise it into a
+heap-allocated static closure object and then call it via `call_indirect`.
+This is pure overhead: the function index is stored into the closure only to
+be loaded back immediately.
+
+The pattern in Wasm:
+```wat
+i32.const <static_closure_ptr>   ;; materialize_const_v (Const.Fun fi)
+...
+i32.load offset=5                ;; load funptr_field back out
+call_indirect                    ;; call via table
+```
+
+Whereas it could be:
+```wat
+i32.const 0                      ;; dummy $clos
+...args...
+call $fi                         ;; direct call
+```
+
+## Key Code Locations (`compile_classical.ml`)
+
+### Call dispatch — `CallPrim` (line 11197)
+
+All Motoko function calls compile through `CallPrim _, [e1; e2]`.
+The match at line 11218 has three branches:
+
+1. **`SR.Const (_, Const.Fun (mk_fi, PrimWrapper prim))`** (line 11219):
+   Inlines the primitive directly.
+
+2. **`SR.Const (_, Const.Fun (mk_fi, _))`** (line 11238):
+   Emits `compile_unboxed_zero ^^ args ^^ Call fi` — the optimal direct call.
+   This fires when `compile_exp env ae e1` returns `SR.Const`.
+
+3. **`_, Type.Local`** (line 11247):
+   The fallthrough for runtime closures. Emits:
+   `code1 ^^ StackRep.adjust … SR.Vanilla ^^ set_clos ^^ … ^^ call_closure`
+   where `call_closure` does `load_field(funptr_field) ^^ CallIndirect`.
+
+   **Invariant**: `fun_sr` here is never `SR.Const (_, Const.Fun _)` — those
+   are caught by branch 2. However, `fun_sr` may be `SR.Vanilla` where the
+   value on the stack is a *static closure* (produced by `materialize_const_v`
+   earlier), meaning the function index was statically known at some earlier
+   point but the `SR.Const` rep was lost.
+
+### Materialisation — `materialize_const_v` (line 9251)
+
+```ocaml
+| Const.Fun (get_fi, _) -> Closure.static_closure env (get_fi ())
+```
+
+`static_closure` (line 2531) writes the function index into a shared static
+heap object:
+```ocaml
+let static_closure env fi : int32 =
+  Tagged.shared_static_obj env Tagged.Closure StaticBytes.[
+    I32 (E.add_fun_ptr env fi);
+    I32 0l
+  ]
+```
+
+`materialize_const_v` is called **only** from `materialize_const_t`, which is
+called from `StackRep.adjust` (line 9318) when converting `SR.Const → Vanilla`.
+
+### Const propagation gate — `compile_exp_with_hint` (line 12732)
+
+```ocaml
+if exp.note.Note.const
+then let (c, fill) = compile_const_exp env ae exp in fill env ae; (SR.Const c, G.nop)
+```
+
+Whether `e1` in `CallPrim` returns `SR.Const` or `SR.Vanilla` depends entirely
+on `exp.note.Note.const`. If the const annotation flows through a `let`-binding
+to the call site, branch 2 fires (direct call). If not, the value is
+materialised and branch 3 fires (indirect call).
+
+## Root Cause
+
+The missed optimisation occurs when the function index is statically known at
+the call site but the call still goes via `call_indirect`.  There are three
+distinct subcases:
+
+### Subcase 1 — `Const.Fun` materialised to static closure
+When `Note.const = true` is **not** propagated to a use site of a function
+value (e.g. a top-level function passed as argument), `StackRep.adjust
+SR.Const → Vanilla` calls `materialize_const_v (Const.Fun fi)`, which writes
+`fi` into a shared static heap object.  The callee then loads it back out via
+`call_closure` → `call_indirect`.
+
+### Subcase 2 — Capturing closure with statically-known function index
+When a function with captures is compiled (`FuncDec.lit` → `FuncDec.closure`),
+the function index `fi` is computed at line 9782 and stored into the closure's
+`funptr_field` (line 9792).  At the call site the compiler loads it back out
+and does `call_indirect`, even though `fi` was fixed at compile time.
+
+Concrete example — `bar.1` in `test/run/fmodf-forward.mo`:
+```motoko
+func bar(a : Float32, b : Float, c : Nat32) : Float {
+  func quux(a : Float32, b : Float, _ : Nat32) : Float = if (c != 0) …;
+  quux(a, b, c)   (* bar.1 allocates quux.1's closure, then call_indirect *)
+};
+```
+`quux.1` captures `c`, so `Note.const = false` and `VarE "quux"` binds as
+`VarEnv.Local (SR.Vanilla, …)`.  Yet the call could be `call $quux.1` with
+the freshly-built closure passed as `$clos`.
+
+Unlike subcase 1, a **real closure is needed** (to pass captured vars), so we
+cannot use `compile_unboxed_zero`.  The optimised emission would be:
+```wat
+get_clos              ;; closure with captured vars (as $clos argument)
+…args…
+call $quux.1          ;; direct call instead of call_indirect
+```
+
+### Subcase 3 — Function passed as argument to higher-order callee
+When a statically-known function is passed as argument to a higher-order
+function, it is materialised (subcase 1).  Inside the callee the parameter is
+`VarEnv.Local (SR.Vanilla, …)` — the static identity is permanently lost.
+Fixing this requires devirtualization / inlining and is out of scope.
+
+## Fix Directions
+
+### Option A — Preserve `Note.const` through `let`-bindings (already working)
+
+The const-analysis pass (`ir_passes/const.ml`) already propagates
+`Note.const = true` for inner functions without captures.  `FuncDec.lit`
+returns `SR.Const (_, Const.Fun _)` when `captured = []`, and the call goes
+through branch 2 (direct `Call` with `i32.const 0` dummy closure).  The
+assert in branch 3 confirms `SR.Const (_, Const.Fun _)` never reaches it.
+
+### Option B — Codegen: `SR.StaticClosure fi` (subcase 2) — **DONE (enhanced backend)**
+
+`FuncDec.closure` now returns `SR.StaticClosure fi` instead of `SR.Vanilla`.
+A special case in `compile_dec` for `LetD (VarP v, FuncE …)` non-const eagerly
+compiles the FuncE with `pre_ae`, extracts `fi` from `SR.StaticClosure fi`, and
+binds `v` as `VarEnv.Local (SR.StaticClosure fi, local_i)` so the correct SR
+reaches `CallPrim`.
+
+In `CallPrim`'s `_, Type.Local` branch, `fi_opt` is extracted:
+```ocaml
+let fi_opt = match fun_sr with SR.StaticClosure fi -> Some fi | _ -> None in
+…
+(match fi_opt with
+ | Some fi -> G.i (Call (nr fi)) ^^ FakeMultiVal.load …
+ | None    -> get_clos ^^ Closure.call_closure env n_args return_arity)
+```
+
+`StackRep.adjust (SR.StaticClosure _) SR.Vanilla` is a no-op (same i64 closure
+ptr on stack).  `SR.StaticClosure` is also wired into `to_block_type`,
+`to_var_type`, `to_string`, `drop`, `join`, and `adjust`.
+
+Verified: `test/run/fmodf-forward.mo` `$bar.1` now emits `call $quux.1` instead
+of `call_indirect`.  Classical backend (`compile_classical.ml`) not yet ported.
+
+### Option C — Linker (already done for the 0-forwarder subset)
+
+The `zero_forwarder_target` optimization in `linkModule.ml` already collapses
+call chains where a moc top-level function is a pure forwarder
+(`i32/i64.const 0; local.get 1…n-1; Call k`). This catches the cases where
+the compiler emits a 0-forwarder wrapper, but not the `static_closure +
+call_indirect` case.
+
+## Status
+
+- Branch 3 (`_, Type.Local`) assertion: **in place** — confirms the invariant
+  holds for subcase 1 (no `SR.Const (_, Const.Fun _)` leaks through).
+- Subcase 2 (capturing closure with known `fi`): **DONE** in `compile_enhanced.ml`
+  on branch `gabor/static-closure`.  Classical backend (`compile_classical.ml`)
+  not yet ported — same change applies symmetrically.
+- Subcase 3 (higher-order passing): requires devirtualization — out of scope.

--- a/.claude/plans/avoid-static-indirect-call.md
+++ b/.claude/plans/avoid-static-indirect-call.md
@@ -141,21 +141,36 @@ compiles the FuncE with `pre_ae`, extracts `fi` from `SR.StaticClosure fi`, and
 binds `v` as `VarEnv.Local (SR.StaticClosure fi, local_i)` so the correct SR
 reaches `CallPrim`.
 
-In `CallPrim`'s `_, Type.Local` branch, `fi_opt` is extracted:
+In `CallPrim`, `SR.StaticClosure fi, Type.Local` is matched at the outer level
+(before the generic `_, Type.Local` arm), emitting `Call fi` directly:
 ```ocaml
-let fi_opt = match fun_sr with SR.StaticClosure fi -> Some fi | _ -> None in
-…
-(match fi_opt with
- | Some fi -> G.i (Call (nr fi)) ^^ FakeMultiVal.load …
- | None    -> get_clos ^^ Closure.call_closure env n_args return_arity)
+| SR.StaticClosure fi, Type.Local ->
+    … code1 ^^ set_clos ^^ get_clos ^^ prepare_closure_call ^^ args ^^
+    G.i (Call (nr fi)) ^^ FakeMultiVal.load …
 ```
 
-`StackRep.adjust (SR.StaticClosure _) SR.Vanilla` is a no-op (same i64 closure
+`StackRep.adjust (SR.StaticClosure _) SR.Vanilla` is a no-op (same closure
 ptr on stack).  `SR.StaticClosure` is also wired into `to_block_type`,
 `to_var_type`, `to_string`, `drop`, `join`, and `adjust`.
 
-Verified: `test/run/fmodf-forward.mo` `$bar.1` now emits `call $quux.1` instead
-of `call_indirect`.  Classical backend (`compile_classical.ml`) not yet ported.
+#### Gotcha: mutually recursive declarations
+
+The eager `compile_exp env pre_ae e` is only safe when all free variables of
+the `FuncE` are already present in `pre_ae`.  In a mutually recursive
+declaration group, `pre_ae` grows as each `dec` is processed by `go` in
+`compile_decs_public`; a forward-referenced variable (e.g. another function
+in the same `rec` block) is not yet in `pre_ae` when the earlier `dec` is
+compiled.  Calling `compile_exp` prematurely causes `FuncDec.lit` →
+`needs_capture pre_ae var` to hit `| None -> assert false`.
+
+Fix: guard the special case with
+`VarEnv.all_in_scope pre_ae (Freevars.captured e)` — only take the eager path
+when every free variable of the `FuncE` is already bound in `pre_ae`.
+Otherwise fall through to the regular deferred `fun ae -> …` path which
+receives the fully-built `ae`.
+
+Verified: `test/run/fmodf-forward.mo` passes; `nix build .#'tests.mo-idl'`
+clean.  Both classical and enhanced backends done on branch `gabor/static-closure`.
 
 ### Option C — Linker (already done for the 0-forwarder subset)
 
@@ -169,7 +184,7 @@ call_indirect` case.
 
 - Branch 3 (`_, Type.Local`) assertion: **in place** — confirms the invariant
   holds for subcase 1 (no `SR.Const (_, Const.Fun _)` leaks through).
-- Subcase 2 (capturing closure with known `fi`): **DONE** in `compile_enhanced.ml`
-  on branch `gabor/static-closure`.  Classical backend (`compile_classical.ml`)
-  not yet ported — same change applies symmetrically.
+- Subcase 2 (capturing closure with known `fi`): **DONE** in both backends on
+  branch `gabor/static-closure`.  Mutually-recursive gotcha fixed with
+  `VarEnv.all_in_scope` guard.
 - Subcase 3 (higher-order passing): requires devirtualization — out of scope.

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -297,6 +297,9 @@ module SR = struct
     | UnboxedFloat32
     | Unreachable
     | Const of Const.t
+    (* Closure pointer on stack; function index fi is statically known.
+       Adjust to Vanilla is a no-op (same i32 on stack). *)
+    | StaticClosure of int32
 
   let unit = UnboxedTuple 0
 
@@ -323,6 +326,7 @@ module SR = struct
     | UnboxedWord32 _ -> I32Type
     | UnboxedFloat64 -> F64Type
     | UnboxedFloat32 -> F32Type
+    | StaticClosure _ -> I32Type
     | UnboxedTuple n -> fatal "to_var_type: UnboxedTuple"
     | Const _ -> fatal "to_var_type: Const"
     | Unreachable -> fatal "to_var_type: Unreachable"
@@ -9198,6 +9202,7 @@ module StackRep = struct
     | UnboxedWord32 _ -> [I32Type]
     | UnboxedFloat64 -> [F64Type]
     | UnboxedFloat32 -> [F32Type]
+    | StaticClosure _ -> [I32Type]
     | UnboxedTuple n -> Lib.List.make n I32Type
     | Const _ -> []
     | Unreachable -> []
@@ -9208,6 +9213,7 @@ module StackRep = struct
     | UnboxedWord32 pty -> prim_fun_name pty "UnboxedWord32"
     | UnboxedFloat64 -> "UnboxedFloat64"
     | UnboxedFloat32 -> "UnboxedFloat32"
+    | StaticClosure fi -> Printf.sprintf "StaticClosure %ld" fi
     | UnboxedTuple n -> Printf.sprintf "UnboxedTuple %d" n
     | Unreachable -> "Unreachable"
     | Const _ -> "Const"
@@ -9220,6 +9226,10 @@ module StackRep = struct
     | Const _, Const _ -> Vanilla
     | Const _, sr2_ -> sr2
     | sr1, Const _ -> sr1
+
+    | StaticClosure fi1, StaticClosure fi2 when fi1 = fi2 -> sr1
+    | StaticClosure _, Vanilla | Vanilla, StaticClosure _ -> Vanilla
+    | StaticClosure _, _ | _, StaticClosure _ -> Vanilla
 
     | _, Vanilla -> Vanilla
     | Vanilla, _ -> Vanilla
@@ -9234,7 +9244,7 @@ module StackRep = struct
 
   let drop env (sr_in : t) =
     match sr_in with
-    | Vanilla | UnboxedWord64 _ | UnboxedWord32 _ | UnboxedFloat64 | UnboxedFloat32 -> G.i Drop
+    | Vanilla | UnboxedWord64 _ | UnboxedWord32 _ | UnboxedFloat64 | UnboxedFloat32 | StaticClosure _ -> G.i Drop
     | UnboxedTuple n -> G.table n (fun _ -> G.i Drop)
     | Const _ | Unreachable -> G.nop
 
@@ -9322,6 +9332,8 @@ module StackRep = struct
 
     | UnboxedFloat64, UnboxedFloat32 -> G.i (Convert (Wasm.Values.F32 F32Op.DemoteF64))
     | UnboxedFloat32, UnboxedFloat64 -> G.i (Convert (Wasm.Values.F64 F64Op.PromoteF32))
+
+    | StaticClosure _, Vanilla -> G.nop (* same i32 closure ptr on stack *)
 
     | Const (_, Const.Lit (Const.Bool b)), Vanilla -> Bool.lit b
     | Const c, Vanilla -> compile_unboxed_const (materialize_const_t env c)
@@ -9814,7 +9826,7 @@ module FuncDec = struct
 
       if is_local
       then
-        SR.Vanilla,
+        SR.StaticClosure fi,
         code ^^
         get_clos
       else assert false (* no first class shared functions *)
@@ -11264,8 +11276,13 @@ and compile_prim_invocation (env : E.t) ae p es at =
          get_clos ^^
          Closure.prepare_closure_call env ^^
          compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^
-         get_clos ^^
-         Closure.call_closure env n_args return_arity
+         (match fun_sr with
+          | SR.StaticClosure fi ->
+            G.i (Call (nr fi)) ^^
+            FakeMultiVal.load env (Lib.List.make return_arity I32Type)
+          | _ ->
+            get_clos ^^
+            Closure.call_closure env n_args return_arity)
       | _, Type.Shared _ ->
          (* Non-one-shot functions have been rewritten in async.ml *)
          assert (control = Type.Returns);
@@ -13220,6 +13237,23 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
       G.(extend pre_ae, nop, (fun ae -> fill env ae; nop), unmodified)
     else (* refuted *)
       (pre_ae, G.nop, (fun _ -> PatCode.patternFailTrap env), unmodified)
+
+  (* Special case: non-const LetD binding a FuncE — may yield SR.StaticClosure fi,
+     so compile the FuncE eagerly here (with pre_ae) to extract fi before AllocHow
+     would fix the local to SR.Vanilla. *)
+  | LetD ({it = VarP v; note = typ; _}, ({it = FuncE _; _} as e)) when not e.note.Note.const ->
+    let fun_sr, fun_code = compile_exp env pre_ae e in
+    (match fun_sr with
+    | SR.StaticClosure fi ->
+      let (pre_ae1, local_i) = VarEnv.add_direct_local env pre_ae v (SR.StaticClosure fi) typ in
+      ( pre_ae1, G.nop,
+        (fun _ae -> fun_code ^^ G.i (LocalSet (nr local_i))),
+        unmodified )
+    | _ ->
+      let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how (Source.({it = VarP v; at = e.at; note = typ})) in
+      ( pre_ae1, alloc_code,
+        (fun ae -> pre_code ^^ compile_exp_as_opt env ae sr e ^^ fill_code),
+        unmodified ))
 
   | LetD (p, e) ->
     let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how p in

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -9789,7 +9789,6 @@ module FuncDec = struct
         else assert false (* no first class shared functions yet *) in
 
       let fi = E.add_fun env name f in
-
       let code =
         (* Allocate a heap object for the closure *)
         Tagged.alloc env (Int32.add (Closure.header_size env) len) Tagged.Closure ^^
@@ -9822,7 +9821,6 @@ module FuncDec = struct
 
   let lit env ae name sort control free_vars args mk_body ret_tys at =
     let captured = List.filter (VarEnv.needs_capture ae) free_vars in
-
     if ae.VarEnv.lvl = VarEnv.TopLvl then assert (captured = []);
 
     if captured = []
@@ -11254,6 +11252,10 @@ and compile_prim_invocation (env : E.t) ae p es at =
          G.i (Call (nr (mk_fi ()))) ^^
          FakeMultiVal.load env (Lib.List.make return_arity I32Type)
       | _, Type.Local ->
+         (* SR.Const (_, Const.Fun _) must have been caught above;
+            if this fires, a statically-known function escaped const-propagation
+            and will be called via call_indirect instead of a direct Call. *)
+         assert (match fun_sr with SR.Const (_, Const.Fun _) -> false | _ -> true);
          let (set_clos, get_clos) = new_local env "clos" in
 
          StackRep.of_arity return_arity,

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -13250,12 +13250,12 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
     let fun_sr, fun_code = compile_exp env pre_ae e in
     (match fun_sr with
     | SR.StaticClosure fi ->
-      let (pre_ae1, local_i) = VarEnv.add_direct_local env pre_ae v (SR.StaticClosure fi) typ in
+      let pre_ae1, local_i = VarEnv.add_direct_local env pre_ae v fun_sr typ in
       ( pre_ae1, G.nop,
         (fun _ae -> fun_code ^^ G.i (LocalSet (nr local_i))),
         unmodified )
     | _ ->
-      let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how pat in
+      let pre_ae1, alloc_code, pre_code, sr, fill_code = compile_unboxed_pat env pre_ae how pat in
       ( pre_ae1, alloc_code,
         (fun ae -> pre_code ^^ compile_exp_as_opt env ae sr e ^^ fill_code),
         unmodified ))

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -9434,6 +9434,10 @@ module VarEnv = struct
     | Some l -> not (is_non_local l)
     | None -> assert false
 
+  (* True if all names in [vars] are already bound in [ae] *)
+  let all_in_scope ae vars =
+    List.for_all (fun x -> Option.is_some (NameEnv.find_opt x ae.vars)) vars
+
   let add_local_with_heap_ind env (ae : t) name typ =
       let i = E.add_anon_local env I32Type in
       E.add_local_name env i name;
@@ -13246,7 +13250,10 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
   (* Special case: non-const LetD binding a FuncE — may yield SR.StaticClosure fi,
      so compile the FuncE eagerly here (with pre_ae) to extract fi before AllocHow
      would fix the local to SR.Vanilla. *)
-  | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e)) when not e.note.Note.const ->
+  | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e))
+    when not e.note.Note.const
+      && (match AllocHow.M.find_opt v how with Some (AllocHow.LocalImmut _) -> true | _ -> false)
+      && VarEnv.all_in_scope pre_ae (Freevars.captured e) ->
     let fun_sr, fun_code = compile_exp env pre_ae e in
     (match fun_sr with
     | SR.StaticClosure fi ->

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -11263,6 +11263,17 @@ and compile_prim_invocation (env : E.t) ae p es at =
          compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^ (* the args *)
          G.i (Call (nr (mk_fi ()))) ^^
          FakeMultiVal.load env (Lib.List.make return_arity I32Type)
+      | SR.StaticClosure fi, Type.Local ->
+         (* Capturing closure with statically-known function index: direct call *)
+         let (set_clos, get_clos) = new_local env "clos" in
+
+         StackRep.of_arity return_arity,
+         code1 ^^ set_clos ^^
+         get_clos ^^
+         Closure.prepare_closure_call env ^^
+         compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^
+         G.i (Call (nr fi)) ^^
+         FakeMultiVal.load env (Lib.List.make return_arity I32Type)
       | _, Type.Local ->
          (* SR.Const (_, Const.Fun _) must have been caught above;
             if this fires, a statically-known function escaped const-propagation
@@ -11276,13 +11287,8 @@ and compile_prim_invocation (env : E.t) ae p es at =
          get_clos ^^
          Closure.prepare_closure_call env ^^
          compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^
-         (match fun_sr with
-          | SR.StaticClosure fi ->
-            G.i (Call (nr fi)) ^^
-            FakeMultiVal.load env (Lib.List.make return_arity I32Type)
-          | _ ->
-            get_clos ^^
-            Closure.call_closure env n_args return_arity)
+         get_clos ^^
+         Closure.call_closure env n_args return_arity
       | _, Type.Shared _ ->
          (* Non-one-shot functions have been rewritten in async.ml *)
          assert (control = Type.Returns);
@@ -13241,7 +13247,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
   (* Special case: non-const LetD binding a FuncE — may yield SR.StaticClosure fi,
      so compile the FuncE eagerly here (with pre_ae) to extract fi before AllocHow
      would fix the local to SR.Vanilla. *)
-  | LetD ({it = VarP v; note = typ; _}, ({it = FuncE _; _} as e)) when not e.note.Note.const ->
+  | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e)) when not e.note.Note.const ->
     let fun_sr, fun_code = compile_exp env pre_ae e in
     (match fun_sr with
     | SR.StaticClosure fi ->
@@ -13250,7 +13256,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
         (fun _ae -> fun_code ^^ G.i (LocalSet (nr local_i))),
         unmodified )
     | _ ->
-      let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how (Source.({it = VarP v; at = e.at; note = typ})) in
+      let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how pat in
       ( pre_ae1, alloc_code,
         (fun ae -> pre_code ^^ compile_exp_as_opt env ae sr e ^^ fill_code),
         unmodified ))

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -11266,7 +11266,6 @@ and compile_prim_invocation (env : E.t) ae p es at =
       | SR.StaticClosure fi, Type.Local ->
          (* Capturing closure with statically-known function index: direct call *)
          let (set_clos, get_clos) = new_local env "clos" in
-
          StackRep.of_arity return_arity,
          code1 ^^ set_clos ^^
          get_clos ^^

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -13250,7 +13250,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
   (* Special case: non-const LetD binding a FuncE — may yield SR.StaticClosure fi,
      so compile the FuncE eagerly here (with pre_ae) to extract fi before AllocHow
      would fix the local to SR.Vanilla. *)
-  | LetD ({it = VarP v; note = typ; _} as pat, ({it = FuncE _; _} as e))
+  | LetD ({it = VarP v; note = typ; _} as p, ({it = FuncE _; _} as e))
     when not e.note.Note.const
       && AllocHow.(match M.find_opt v how with Some (LocalImmut _) -> true | _ -> false)
       && VarEnv.all_in_scope pre_ae (Freevars.captured e) ->
@@ -13262,7 +13262,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
         (fun _ae -> fun_code ^^ G.i (LocalSet (nr local_i))),
         unmodified )
     | _ ->
-      let pre_ae1, alloc_code, pre_code, sr, fill_code = compile_unboxed_pat env pre_ae how pat in
+      let pre_ae1, alloc_code, pre_code, sr, fill_code = compile_unboxed_pat env pre_ae how p in
       ( pre_ae1, alloc_code,
         (fun ae -> pre_code ^^ compile_exp_as_opt env ae sr e ^^ fill_code),
         unmodified ))

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -13250,7 +13250,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
   (* Special case: non-const LetD binding a FuncE — may yield SR.StaticClosure fi,
      so compile the FuncE eagerly here (with pre_ae) to extract fi before AllocHow
      would fix the local to SR.Vanilla. *)
-  | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e))
+  | LetD ({it = VarP v; note = typ; _} as pat, ({it = FuncE _; _} as e))
     when not e.note.Note.const
       && AllocHow.(match M.find_opt v how with Some (LocalImmut _) -> true | _ -> false)
       && VarEnv.all_in_scope pre_ae (Freevars.captured e) ->

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -13252,7 +13252,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
      would fix the local to SR.Vanilla. *)
   | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e))
     when not e.note.Note.const
-      && (match AllocHow.M.find_opt v how with Some (AllocHow.LocalImmut _) -> true | _ -> false)
+      && AllocHow.(match M.find_opt v how with Some (LocalImmut _) -> true | _ -> false)
       && VarEnv.all_in_scope pre_ae (Freevars.captured e) ->
     let fun_sr, fun_code = compile_exp env pre_ae e in
     (match fun_sr with

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -13550,7 +13550,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
      then bind the variable with that SR so CallPrim can emit a direct Call
      instead of call_indirect. Safe for non-recursive LetD since the FuncE
      does not reference v itself, and all its captures are already in pre_ae. *)
-  | LetD ({it = VarP v; note = typ; _} as pat, ({it = FuncE _; _} as e))
+  | LetD ({it = VarP v; note = typ; _} as p, ({it = FuncE _; _} as e))
     when not e.note.Note.const
       && AllocHow.(match M.find_opt v how with Some (LocalImmut _) -> true | _ -> false)
       && VarEnv.all_in_scope pre_ae (Freevars.captured e) ->
@@ -13565,7 +13565,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
       )
     | _ ->
       (* No static fi (e.g. shared sort) — generic path *)
-      let pre_ae1, alloc_code, pre_code, sr, fill_code = compile_unboxed_pat env pre_ae how pat in
+      let pre_ae1, alloc_code, pre_code, sr, fill_code = compile_unboxed_pat env pre_ae how p in
       ( pre_ae1, alloc_code,
         (fun ae -> pre_code ^^ compile_exp_as_opt env ae sr e ^^ fill_code),
         unmodified

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -361,6 +361,7 @@ module SR = struct
     | UnboxedFloat32
     | Unreachable
     | Const of Const.v
+    | StaticClosure of int32 (* closure ptr on stack, function index statically known *)
 
   let unit = UnboxedTuple 0
 
@@ -379,6 +380,7 @@ module SR = struct
     | UnboxedWord64 _ -> I64Type
     | UnboxedFloat64 -> F64Type
     | UnboxedFloat32 -> F32Type
+    | StaticClosure _ -> I64Type
     | UnboxedTuple n -> fatal "to_var_type: UnboxedTuple"
     | Const _ -> fatal "to_var_type: Const"
     | Unreachable -> fatal "to_var_type: Unreachable"
@@ -6557,6 +6559,7 @@ module StackRep = struct
     | UnboxedFloat64 -> [F64Type]
     | UnboxedFloat32 -> [F32Type]
     | UnboxedTuple n -> Lib.List.make n I64Type
+    | StaticClosure _ -> [I64Type]
     | Const _ -> []
     | Unreachable -> []
 
@@ -6568,6 +6571,7 @@ module StackRep = struct
     | UnboxedTuple n -> Printf.sprintf "UnboxedTuple %d" n
     | Unreachable -> "Unreachable"
     | Const _ -> "Const"
+    | StaticClosure fi -> Printf.sprintf "StaticClosure %ld" fi
 
   let join (sr1 : t) (sr2 : t) = match sr1, sr2 with
     | _, _ when SR.eq sr1 sr2 -> sr1
@@ -6577,6 +6581,10 @@ module StackRep = struct
     | Const _, Const _ -> Vanilla
     | Const _, sr2_ -> sr2
     | sr1, Const _ -> sr1
+
+    | StaticClosure _, Vanilla | Vanilla, StaticClosure _ -> Vanilla
+    | StaticClosure fi1, StaticClosure fi2 when fi1 = fi2 -> sr1
+    | StaticClosure _, _ | _, StaticClosure _ -> Vanilla
 
     | _, Vanilla -> Vanilla
     | Vanilla, _ -> Vanilla
@@ -6591,7 +6599,7 @@ module StackRep = struct
 
   let drop env (sr_in : t) =
     match sr_in with
-    | Vanilla | UnboxedWord64 _ | UnboxedFloat64 | UnboxedFloat32 -> G.i Drop
+    | Vanilla | UnboxedWord64 _ | UnboxedFloat64 | UnboxedFloat32 | StaticClosure _ -> G.i Drop
     | UnboxedTuple n -> G.table n (fun _ -> G.i Drop)
     | Const _ | Unreachable -> G.nop
 
@@ -6640,6 +6648,8 @@ module StackRep = struct
     else match sr_in, sr_out with
     | Unreachable, Unreachable -> G.nop
     | Unreachable, _ -> G.i Unreachable
+
+    | StaticClosure _, Vanilla -> G.nop (* same i64 closure ptr, fi info just dropped *)
 
     | UnboxedTuple n, Vanilla -> Tuple.from_stack env n
     | Vanilla, UnboxedTuple n -> Tuple.to_stack env n
@@ -9789,7 +9799,6 @@ module FuncDec = struct
         else assert false (* no first class shared functions yet *) in
 
       let fi = E.add_fun env name f in
-
       let code =
         (* Allocate a heap object for the closure *)
         Tagged.alloc env (Int64.add Closure.header_size len) Tagged.Closure ^^
@@ -9815,14 +9824,13 @@ module FuncDec = struct
 
       if is_local
       then
-        SR.Vanilla,
+        SR.StaticClosure fi,
         code ^^
         get_clos
       else assert false (* no first class shared functions *)
 
   let lit env ae name sort control free_vars args mk_body ret_tys at =
     let captured = List.filter (VarEnv.needs_capture ae) free_vars in
-
     if ae.VarEnv.lvl = VarEnv.TopLvl then assert (captured = []);
 
     if captured = []
@@ -11595,6 +11603,13 @@ and compile_prim_invocation (env : E.t) ae p es at =
          G.i (Call (nr (mk_fi()))) ^^
          FakeMultiVal.load env (Lib.List.make return_arity I64Type)
       | _, Type.Local ->
+         (* SR.Const (_, Const.Fun _) must have been caught above;
+            if this fires, a statically-known function escaped const-propagation
+            and will be called via call_indirect instead of a direct Call. *)
+         assert (match fun_sr with SR.Const (Const.Fun _) -> false | _ -> true);
+         let fi_opt = match fun_sr with
+           | SR.StaticClosure fi -> Some fi
+           | _ -> None in
          let (set_clos, get_clos) = new_local env "clos" in
 
          StackRep.of_arity return_arity,
@@ -11603,8 +11618,13 @@ and compile_prim_invocation (env : E.t) ae p es at =
          get_clos ^^
          Closure.prepare_closure_call env ^^
          compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^
-         get_clos ^^
-         Closure.call_closure env n_args return_arity
+         (match fi_opt with
+          | Some fi ->
+            G.i (Call (nr fi)) ^^
+            FakeMultiVal.load env (Lib.List.make return_arity I64Type)
+          | None ->
+            get_clos ^^
+            Closure.call_closure env n_args return_arity)
       | _, Type.Shared _ ->
          (* Non-one-shot functions have been rewritten in async.ml *)
          assert (control = Type.Returns);
@@ -13518,6 +13538,29 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
       G.(extend pre_ae, nop, (fun ae -> fill env ae; nop), unmodified)
     else (* refuted *)
       (pre_ae, G.nop, (fun _ -> PatCode.patternFailTrap env), unmodified)
+
+  (* Special case: capturing closure with statically-known function index.
+     Compile the FuncE eagerly (with pre_ae) to obtain SR.StaticClosure fi,
+     then bind the variable with that SR so CallPrim can emit a direct Call
+     instead of call_indirect. Safe for non-recursive LetD since the FuncE
+     does not reference v itself, and all its captures are already in pre_ae. *)
+  | LetD ({it = VarP v; note = typ; _}, ({it = FuncE _; _} as e)) when not e.note.Note.const ->
+    let fun_sr, fun_code = compile_exp env pre_ae e in
+    (match fun_sr with
+    | SR.StaticClosure fi ->
+      let (pre_ae1, local_i) = VarEnv.add_direct_local env pre_ae v (SR.StaticClosure fi) typ in
+      ( pre_ae1,
+        G.nop,
+        (fun _ae -> fun_code ^^ G.i (LocalSet (nr local_i))),
+        unmodified
+      )
+    | _ ->
+      (* No static fi (e.g. shared sort) — generic path *)
+      let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how (Source.({it = VarP v; at = e.at; note = typ})) in
+      ( pre_ae1, alloc_code,
+        (fun ae -> pre_code ^^ compile_exp_as_opt env ae sr e ^^ fill_code),
+        unmodified
+      ))
 
   | LetD (p, e) ->
     let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how p in

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -13550,7 +13550,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
      then bind the variable with that SR so CallPrim can emit a direct Call
      instead of call_indirect. Safe for non-recursive LetD since the FuncE
      does not reference v itself, and all its captures are already in pre_ae. *)
-  | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e))
+  | LetD ({it = VarP v; note = typ; _} as pat, ({it = FuncE _; _} as e))
     when not e.note.Note.const
       && AllocHow.(match M.find_opt v how with Some (LocalImmut _) -> true | _ -> false)
       && VarEnv.all_in_scope pre_ae (Freevars.captured e) ->

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -13550,7 +13550,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
     let fun_sr, fun_code = compile_exp env pre_ae e in
     (match fun_sr with
     | SR.StaticClosure fi ->
-      let (pre_ae1, local_i) = VarEnv.add_direct_local env pre_ae v (SR.StaticClosure fi) typ in
+      let pre_ae1, local_i = VarEnv.add_direct_local env pre_ae v fun_sr typ in
       ( pre_ae1,
         G.nop,
         (fun _ae -> fun_code ^^ G.i (LocalSet (nr local_i))),
@@ -13558,7 +13558,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
       )
     | _ ->
       (* No static fi (e.g. shared sort) — generic path *)
-      let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how pat in
+      let pre_ae1, alloc_code, pre_code, sr, fill_code = compile_unboxed_pat env pre_ae how pat in
       ( pre_ae1, alloc_code,
         (fun ae -> pre_code ^^ compile_exp_as_opt env ae sr e ^^ fill_code),
         unmodified

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -11605,7 +11605,6 @@ and compile_prim_invocation (env : E.t) ae p es at =
       | SR.StaticClosure fi, Type.Local ->
          (* Capturing closure with statically-known function index: direct call *)
          let (set_clos, get_clos) = new_local env "clos" in
-
          StackRep.of_arity return_arity,
          code1 ^^ set_clos ^^
          get_clos ^^

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -11602,8 +11602,19 @@ and compile_prim_invocation (env : E.t) ae p es at =
          compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^ (* the args *)
          G.i (Call (nr (mk_fi()))) ^^
          FakeMultiVal.load env (Lib.List.make return_arity I64Type)
+      | SR.StaticClosure fi, Type.Local ->
+         (* Capturing closure with statically-known function index: direct call *)
+         let (set_clos, get_clos) = new_local env "clos" in
+
+         StackRep.of_arity return_arity,
+         code1 ^^ set_clos ^^
+         get_clos ^^
+         Closure.prepare_closure_call env ^^
+         compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^
+         G.i (Call (nr fi)) ^^
+         FakeMultiVal.load env (Lib.List.make return_arity I64Type)
       | _, Type.Local ->
-         (* SR.Const (_, Const.Fun _) must have been caught above;
+         (* SR.Const (Const.Fun _) must have been caught above;
             if this fires, a statically-known function escaped const-propagation
             and will be called via call_indirect instead of a direct Call. *)
          assert (match fun_sr with SR.Const (Const.Fun _) -> false | _ -> true);
@@ -11615,13 +11626,8 @@ and compile_prim_invocation (env : E.t) ae p es at =
          get_clos ^^
          Closure.prepare_closure_call env ^^
          compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^
-         (match fun_sr with
-          | SR.StaticClosure fi ->
-            G.i (Call (nr fi)) ^^
-            FakeMultiVal.load env (Lib.List.make return_arity I64Type)
-          | _ ->
-            get_clos ^^
-            Closure.call_closure env n_args return_arity)
+         get_clos ^^
+         Closure.call_closure env n_args return_arity
       | _, Type.Shared _ ->
          (* Non-one-shot functions have been rewritten in async.ml *)
          assert (control = Type.Returns);
@@ -13541,7 +13547,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
      then bind the variable with that SR so CallPrim can emit a direct Call
      instead of call_indirect. Safe for non-recursive LetD since the FuncE
      does not reference v itself, and all its captures are already in pre_ae. *)
-  | LetD ({it = VarP v; note = typ; _}, ({it = FuncE _; _} as e)) when not e.note.Note.const ->
+  | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e)) when not e.note.Note.const ->
     let fun_sr, fun_code = compile_exp env pre_ae e in
     (match fun_sr with
     | SR.StaticClosure fi ->
@@ -13553,7 +13559,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
       )
     | _ ->
       (* No static fi (e.g. shared sort) — generic path *)
-      let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how (Source.({it = VarP v; at = e.at; note = typ})) in
+      let (pre_ae1, alloc_code, pre_code, sr, fill_code) = compile_unboxed_pat env pre_ae how pat in
       ( pre_ae1, alloc_code,
         (fun ae -> pre_code ^^ compile_exp_as_opt env ae sr e ^^ fill_code),
         unmodified

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -11607,9 +11607,6 @@ and compile_prim_invocation (env : E.t) ae p es at =
             if this fires, a statically-known function escaped const-propagation
             and will be called via call_indirect instead of a direct Call. *)
          assert (match fun_sr with SR.Const (Const.Fun _) -> false | _ -> true);
-         let fi_opt = match fun_sr with
-           | SR.StaticClosure fi -> Some fi
-           | _ -> None in
          let (set_clos, get_clos) = new_local env "clos" in
 
          StackRep.of_arity return_arity,
@@ -11618,11 +11615,11 @@ and compile_prim_invocation (env : E.t) ae p es at =
          get_clos ^^
          Closure.prepare_closure_call env ^^
          compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^
-         (match fi_opt with
-          | Some fi ->
+         (match fun_sr with
+          | SR.StaticClosure fi ->
             G.i (Call (nr fi)) ^^
             FakeMultiVal.load env (Lib.List.make return_arity I64Type)
-          | None ->
+          | _ ->
             get_clos ^^
             Closure.call_closure env n_args return_arity)
       | _, Type.Shared _ ->

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -6777,6 +6777,10 @@ module VarEnv = struct
     | Some l -> not (is_non_local l)
     | None -> assert false
 
+  (* True if all names in [vars] are already bound in [ae] *)
+  let all_in_scope ae vars =
+    List.for_all (fun x -> Option.is_some (NameEnv.find_opt x ae.vars)) vars
+
   let add_local_with_heap_ind env (ae : t) name typ =
       let i = E.add_anon_local env I64Type in
       E.add_local_name env i name;
@@ -13546,7 +13550,10 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
      then bind the variable with that SR so CallPrim can emit a direct Call
      instead of call_indirect. Safe for non-recursive LetD since the FuncE
      does not reference v itself, and all its captures are already in pre_ae. *)
-  | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e)) when not e.note.Note.const ->
+  | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e))
+    when not e.note.Note.const
+      && (match AllocHow.M.find_opt v how with Some (AllocHow.LocalImmut _) -> true | _ -> false)
+      && VarEnv.all_in_scope pre_ae (Freevars.captured e) ->
     let fun_sr, fun_code = compile_exp env pre_ae e in
     (match fun_sr with
     | SR.StaticClosure fi ->

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -13552,7 +13552,7 @@ and compile_dec env pre_ae how v2en dec : VarEnv.t * G.t * (VarEnv.t -> scope_wr
      does not reference v itself, and all its captures are already in pre_ae. *)
   | LetD (({it = VarP v; note = typ; _} as pat), ({it = FuncE _; _} as e))
     when not e.note.Note.const
-      && (match AllocHow.M.find_opt v how with Some (AllocHow.LocalImmut _) -> true | _ -> false)
+      && AllocHow.(match M.find_opt v how with Some (LocalImmut _) -> true | _ -> false)
       && VarEnv.all_in_scope pre_ae (Freevars.captured e) ->
     let fun_sr, fun_code = compile_exp env pre_ae e in
     (match fun_sr with

--- a/test/run/fmodf-forward.mo
+++ b/test/run/fmodf-forward.mo
@@ -64,4 +64,3 @@ let _ = baz (floatToFloat32 1.0, 2.0, 3);
 //SKIP run-ir
 //SKIP run-low
 //SKIP-SANITY-CHECKS
-//MOxC-FLAG -dl -v

--- a/test/run/fmodf-forward.mo
+++ b/test/run/fmodf-forward.mo
@@ -47,10 +47,10 @@ let _ = baz (floatToFloat32 1.0, 2.0, 3);
 //CHECK: (func $foo_clos
 //CHECK-NEXT: {{i32|i64}}.const 0
 //CHECK: call $bar.1)
-// nested bar (bar.1): builds quux.1's closure (stores captured c), dispatches via call_indirect
+// nested bar (bar.1): builds quux.1's closure (stores captured c), calls $quux.1 directly
 //CHECK: (func $bar.1
 //CHECK: .store
-//CHECK: call_indirect
+//CHECK: call $quux.1
 // quux.1 (inner quux): loads captured c from $clos — real closure, NOT a 0-forwarder
 //CHECK: (func $quux.1
 //CHECK: local.get $clos
@@ -64,3 +64,4 @@ let _ = baz (floatToFloat32 1.0, 2.0, 3);
 //SKIP run-ir
 //SKIP run-low
 //SKIP-SANITY-CHECKS
+//MOxC-FLAG -dl -v

--- a/test/run/fmodf-forward.mo
+++ b/test/run/fmodf-forward.mo
@@ -5,6 +5,16 @@ let x : Float32 = 41.99;
 let result : Float32 = x % pi32;
 debugPrint (debug_show (float32ToFloat result));
 
+// Lambda analog of foo_clos: same structure but with anonymous lambdas, direct invocation
+func foo_lam(a : Float32, b : Float, c : Nat32) : Float {
+  (func(a : Float32, b : Float, c : Nat32) : Float =
+    (func(a : Float32, b : Float, _ : Nat32) : Float = if (c != 0) (float32ToFloat a + b) else b)
+    (a, b, c))
+  (a, b, c)
+};
+
+let _ = foo_lam (floatToFloat32 1.0, 2.0, 3);
+
 // Nested closure chain: foo_clos -> bar -> quux (quux sunk into bar; bar is a forwarder)
 func foo_clos(a : Float32, b : Float, c : Nat32) : Float {
   func bar(a : Float32, b : Float, c : Nat32) : Float {
@@ -53,6 +63,17 @@ let _ = baz (floatToFloat32 1.0, 2.0, 3);
 //CHECK: call $quux.1
 // quux.1 (inner quux): loads captured c from $clos — real closure, NOT a 0-forwarder
 //CHECK: (func $quux.1
+//CHECK: local.get $clos
+// foo_lam is a 0-forwarder: calls outer anon lambda directly (no captures)
+//CHECK: (func $foo_lam
+//CHECK-NEXT: {{i32|i64}}.const 0
+//CHECK: call $@anon-func-{{[0-9.]+}})
+// outer anon lambda: builds inner anon lambda's closure (stores captured c), calls it directly
+//CHECK: (func $@anon-func-{{[0-9.]+}} (type
+//CHECK: .store
+//CHECK: call $@anon-func-{{[0-9.]+}}
+// inner anon lambda: loads captured c from $clos — real closure, NOT a 0-forwarder
+//CHECK: (func $@anon-func-{{[0-9.]+}} (type
 //CHECK: local.get $clos
 // The $fmodf wrapper is still present in the binary (unreferenced; DCE'd by wasm-opt)
 //CHECK: (func $fmodf


### PR DESCRIPTION
## Summary

- Introduces `SR.StaticClosure of int32` in both `compile_classical.ml` and `compile_enhanced.ml` to carry the statically-known Wasm function index from `FuncDec.closure` to the `CallPrim` call site
- A special case in `compile_dec` eagerly compiles `LetD (VarP v, FuncE …)` non-const expressions to extract `fi`, binding `v` as `VarEnv.Local (SR.StaticClosure fi, …)` so the call site sees the correct SR
- `CallPrim` matches `SR.StaticClosure fi, Type.Local` before the generic `_, Type.Local` arm, emitting `Call fi` directly instead of loading `funptr_field` and doing `call_indirect` — the closure is still allocated and passed as $clos
- `test/run/fmodf-forward.mo`: $bar.1 now emits `call $quux.1` instead of `call_indirect`
- Guards prevent the optimisation from firing unsafely: `AllocHow.(LocalImmut _)` (skips variables needing heap indirection for forward references) and `VarEnv.all_in_scope` (skips mutually-recursive groups where captures aren't yet in scope)

Resolves the optimization opportunity sketched in #5961.

## What is NOT done

- Subcase 3 (function passed as argument to higher-order callee) — requires devirtualization, out of scope

## Test plan

- [x] `test/run/fmodf-forward.mo` passes all phases: `[tc] [run] [comp] [valid] [FileCheck] [wasm-run]`
- [x] `tests.mo-idl` clean (mutually-recursive guard)
- [x] `tests.run-eop-release` clean including `quicksort` (AllocHow guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)