### PR TITLE
fix: report a range for illegal stable patterns

### DIFF
--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -203,7 +203,7 @@ let share_dec_field default_stab (df : dec_field) =
              | TypD _
              | MixinD _
              | ClassD _ -> None
-             | _ -> Some default_stab)
+             | _ -> Some (default_stab df.at))
           | some -> some}
     }
 
@@ -974,7 +974,7 @@ dec_nonvar :
       let_or_exp named x (func_exp x.it sp tps p t is_sugar e) (at $sloc) }
   | eo=parenthetical_opt mk_d=obj_or_class_dec  { mk_d eo }
   | MIXIN p=pat_plain dfs=obj_body {
-     let dfs = List.map (share_dec_field (Stable @@ no_region)) dfs in
+     let dfs = List.map (share_dec_field (fun at -> Stable @@ at)) dfs in
      MixinD(p, dfs) @? at $sloc
   }
   | INCLUDE x=id e=exp(ob) { IncludeD(x, e, ref None) @? at $sloc }
@@ -989,7 +989,7 @@ obj_or_class_dec :
       let named, x = xf sort $sloc in
       let e =
         if s.it = Type.Actor then
-          let default_stab = (if persistent.it then Stable else Flexible) @@ no_region in
+          let default_stab at = (if persistent.it then Stable else Flexible) @@ at in
           let id = if named then Some x else None in
           AwaitE
             (Type.AwaitFut false,
@@ -1009,7 +1009,7 @@ obj_or_class_dec :
       let x, dfs = cb in
       let dfs', tps', t' =
        if s.it = Type.Actor then
-          let default_stab = (if persistent.it then Stable else Flexible) @@ no_region in
+          let default_stab at = (if persistent.it then Stable else Flexible) @@ at in
           (List.map (share_dec_field default_stab) dfs,
            ensure_scope_bind "" tps,
            (* Not declared async: insert AsyncT but deprecate in typing *)

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -3994,7 +3994,7 @@ and check_stable_defaults env sort dec_fields =
       List.iter (fun dec_field ->
         match dec_field.it.stab, dec_field.it.dec.it with
         | Some {it = Stable; at; _}, (LetD _ | VarD _) ->
-          if at <> Source.no_region then
+          if at <> dec_field.it.dec.at then
             warn env at "M0218" "redundant `stable` keyword, this declaration is implicitly stable"
         | _ -> ())
       dec_fields
@@ -4006,7 +4006,7 @@ and check_stable_defaults env sort dec_fields =
       List.fold_left (fun acc dec_field ->
         match dec_field.it.stab, dec_field.it.dec.it with
         | Some {it = Flexible; at; _}, (LetD _ | VarD _) ->
-           if at = Source.no_region
+           if at = dec_field.it.dec.at
            then
              (local_error env dec_field.it.dec.at "M0219" "this declaration is currently implicitly transient, please declare it explicitly `transient`";
               true)

--- a/test/fail/ok/implicit-stable-pattern.tc-human.ok
+++ b/test/fail/ok/implicit-stable-pattern.tc-human.ok
@@ -1,1 +1,4 @@
-(unknown location): type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
+error[M0133]: misplaced stability modifier: allowed on var or simple let declarations only
+    ┌─ implicit-stable-pattern.mo:2:4
+  2 │     let (x,y) = (1,2) // illegal implicit stable pattern
+    │     ^^^^^^^^^^^^^^^^^ 

--- a/test/fail/ok/implicit-stable-pattern.tc.ok
+++ b/test/fail/ok/implicit-stable-pattern.tc.ok
@@ -1,1 +1,1 @@
-(unknown location): type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only
+implicit-stable-pattern.mo:2.4-2.21: type error [M0133], misplaced stability modifier: allowed on var or simple let declarations only

--- a/test/fail/ok/non-persistent.tc-human.ok
+++ b/test/fail/ok/non-persistent.tc-human.ok
@@ -7,6 +7,18 @@ error[M0219]: this declaration is currently implicitly transient, please declare
   4 │    var _y = #y; // error
     │    ^^^^^^^^^^^ 
 error[M0219]: this declaration is currently implicitly transient, please declare it explicitly `transient`
+    ┌─ non-persistent.mo:8:3
+  8 │    module _M = {};
+    │    ^^^^^^^^^^^^^^ 
+error[M0219]: this declaration is currently implicitly transient, please declare it explicitly `transient`
     ┌─ non-persistent.mo:9:3
   9 │    object _O = {}; // error
     │    ^^^^^^^^^^^^^^ 
+error[M0219]: this declaration is currently implicitly transient, please declare it explicitly `transient`
+    ┌─ non-persistent.mo:10:3
+ 10 │    func f(){};
+    │    ^^^^^^^^^^ 
+error[M0219]: this declaration is currently implicitly transient, please declare it explicitly `transient`
+    ┌─ non-persistent.mo:11:21
+ 11 │    public /*shared*/ func g() : (){};
+    │                      ^^^^^^^^^^^^^^^ 

--- a/test/fail/ok/non-persistent.tc.ok
+++ b/test/fail/ok/non-persistent.tc.ok
@@ -1,3 +1,6 @@
 non-persistent.mo:3.3-3.14: type error [M0219], this declaration is currently implicitly transient, please declare it explicitly `transient`
 non-persistent.mo:4.3-4.14: type error [M0219], this declaration is currently implicitly transient, please declare it explicitly `transient`
+non-persistent.mo:8.3-8.17: type error [M0219], this declaration is currently implicitly transient, please declare it explicitly `transient`
 non-persistent.mo:9.3-9.17: type error [M0219], this declaration is currently implicitly transient, please declare it explicitly `transient`
+non-persistent.mo:10.3-10.13: type error [M0219], this declaration is currently implicitly transient, please declare it explicitly `transient`
+non-persistent.mo:11.21-11.36: type error [M0219], this declaration is currently implicitly transient, please declare it explicitly `transient`


### PR DESCRIPTION
Does so by annotating the default stability with the range of the full declaration in the parser.
