### PR TITLE
chore: deduplicate `pos` and `region`

### DIFF
--- a/rts/motoko-rts-tests/build.rs
+++ b/rts/motoko-rts-tests/build.rs
@@ -12,11 +12,6 @@ fn main() {
             println!("cargo:rustc-link-lib=static=tommath_wasm32");
         }
 
-        "aarch64-apple-darwin" => {
-            println!("cargo:rustc-link-search=native=../_build");
-            println!("cargo:rustc-link-lib=static=tommath_aarch64");
-        }
-
         "i686-unknown-linux-gnu" => {
             println!("cargo:rustc-link-search=native=../_build");
             println!("cargo:rustc-link-lib=static=tommath_i686");

--- a/rts/motoko-rts-tests/build.rs
+++ b/rts/motoko-rts-tests/build.rs
@@ -12,6 +12,11 @@ fn main() {
             println!("cargo:rustc-link-lib=static=tommath_wasm32");
         }
 
+        "aarch64-apple-darwin" => {
+            println!("cargo:rustc-link-search=native=../_build");
+            println!("cargo:rustc-link-lib=static=tommath_aarch64");
+        }
+
         "i686-unknown-linux-gnu" => {
             println!("cargo:rustc-link-search=native=../_build");
             println!("cargo:rustc-link-lib=static=tommath_i686");

--- a/rts/motoko-rts/config.toml
+++ b/rts/motoko-rts/config.toml
@@ -2,3 +2,4 @@
 # std, and compiler_builtins and makes it easier to find symbols.
 [build]
 rustflags = ["-Crelocation-model=pic", "-Ccodegen-units=1"]
+

--- a/rts/motoko-rts/config.toml
+++ b/rts/motoko-rts/config.toml
@@ -2,4 +2,3 @@
 # std, and compiler_builtins and makes it easier to find symbols.
 [build]
 rustflags = ["-Crelocation-model=pic", "-Ccodegen-units=1"]
-

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -12040,21 +12040,21 @@ and compile_prim_invocation (env : E.t) ae p es at =
   (* Weak refs are disallowed in classical mode *)
   (* The compiler will exit with an error if it encounters a related call *)
   | OtherPrim "alloc_weak_ref", [target] ->
-    let msg = Diag.error_message Source.no_region "alloc_weak_ref" "classical"
+    let msg = Diag.error_message no_region "alloc_weak_ref" "classical"
       "Weak references are not supported in classical mode."
     in
     Diag.print_messages [msg];
     exit 0
 
   | OtherPrim "weak_get", [weak_ref] ->
-    let msg = Diag.error_message Source.no_region "weak_get" "classical"
+    let msg = Diag.error_message no_region "weak_get" "classical"
       "Weak references are not supported in classical mode."
     in
     Diag.print_messages [msg];
     exit 0
 
   | OtherPrim "weak_ref_is_live", [weak_ref] ->
-    let msg = Diag.error_message Source.no_region "weak_ref_is_live" "classical"
+    let msg = Diag.error_message no_region "weak_ref_is_live" "classical"
       "Weak references are not supported in classical mode."
     in
     Diag.print_messages [msg];

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -10213,7 +10213,6 @@ open PatCode
 
 (* All the code above is independent of the IR *)
 open Ir
-let (@@) = Stdlib.(@@) (* get the app operator back *)
 
 module AllocHow = struct
   (*

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -10213,6 +10213,7 @@ open PatCode
 
 (* All the code above is independent of the IR *)
 open Ir
+let (@@) = Stdlib.(@@) (* get the app operator back *)
 
 module AllocHow = struct
   (*

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -5643,12 +5643,11 @@ let env_var_names env =
       Arr.lit env Tagged.S [get_actor; get_func]
    )
 
-
-  let fail_assert env at =
-    let open Source in
+  let fail_assert env at' =
+    let open Wasm.Source in
     let at = {
-        left = {at.left with file = Filename.basename at.left.file};
-        right = {at.right with file = Filename.basename at.right.file}
+        left = {at'.left with file = Filename.basename at'.left.file};
+        right = {at'.right with file = Filename.basename at'.right.file}
       }
     in
     E.trap_with env (Printf.sprintf "assertion failed at %s" (string_of_region at))

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -5477,12 +5477,11 @@ module IC = struct
       Arr.lit env Tagged.S [get_actor; get_func]
    )
 
-
-  let fail_assert env at =
-    let open Source in
+  let fail_assert env at' =
+    let open Wasm.Source in
     let at = {
-        left = {at.left with file = Filename.basename at.left.file};
-        right = {at.right with file = Filename.basename at.right.file}
+        left = {at'.left with file = Filename.basename at'.left.file};
+        right = {at'.right with file = Filename.basename at'.right.file}
       }
     in
     E.trap_with env (Printf.sprintf "assertion failed at %s" (string_of_region at))

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -10623,7 +10623,6 @@ open PatCode
 
 (* All the code above is independent of the IR *)
 open Ir
-let (@@) = Stdlib.(@@) (* get the app operator back *)
 
 module AllocHow = struct
   (*

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -10623,6 +10623,7 @@ open PatCode
 
 (* All the code above is independent of the IR *)
 open Ir
+let (@@) = Stdlib.(@@) (* get the app operator back *)
 
 module AllocHow = struct
   (*

--- a/src/codegen/die.ml
+++ b/src/codegen/die.ml
@@ -1,6 +1,7 @@
 open Mo_types
 open Wasm_exts.Dwarf5
 open Meta
+open Wasm.Source
 
 (* Note [Low_pc, High_pc, Ranges are special]
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -43,10 +44,10 @@ type dw_AT = Producer of string
 
 type dw_TAG =
   | Compile_unit of string * string                            (* compilation directory, file name *)
-  | Subprogram of string * Type.typ list * Source.pos          (* name, return types, location *)
-  | LexicalBlock of Source.pos
-  | Formal_parameter of (string * Source.pos * Type.typ * int) (* name, location, type, Wasm slot *)
-  | Variable of (string * Source.pos * Type.typ * int)         (* name, location, type, Wasm slot *)
+  | Subprogram of string * Type.typ list * pos          (* name, return types, location *)
+  | LexicalBlock of pos
+  | Formal_parameter of (string * pos * Type.typ * int) (* name, location, type, Wasm slot *)
+  | Variable of (string * pos * Type.typ * int)         (* name, location, type, Wasm slot *)
   | Type of Type.typ
   | Typedef of string * Type.typ
   (*| Member*)
@@ -444,20 +445,20 @@ let tag_open : dw_TAG -> die list =
   | Subprogram (name, [retty], pos) ->
     let ds, ref_ret = type_ref retty in
     append_tag ds Wasm_exts.Abbreviation.dw_TAG_subprogram_Ret
-      (dw_attrs [Low_pc; High_pc; Name name; TypeRef ref_ret; Decl_file pos.Source.file; Decl_line pos.Source.line; Decl_column pos.Source.column; Prototyped true; External false])
+      (dw_attrs [Low_pc; High_pc; Name name; TypeRef ref_ret; Decl_file pos.file; Decl_line pos.line; Decl_column pos.column; Prototyped true; External false])
   | Subprogram (name, _, pos) ->
     [unreferencable_tag dw_TAG_subprogram
-       (dw_attrs [Low_pc; High_pc; Name name; Decl_file pos.Source.file; Decl_line pos.Source.line; Decl_column pos.Source.column; Prototyped true; External false])]
+       (dw_attrs [Low_pc; High_pc; Name name; Decl_file pos.file; Decl_line pos.line; Decl_column pos.column; Prototyped true; External false])]
   | Formal_parameter (name, pos, ty, slot) ->
     let ds, reference = type_ref ty in
     append_tag ds dw_TAG_formal_parameter
-      (dw_attrs [Name name; Decl_line pos.Source.line; Decl_column pos.Source.column; TypeRef reference; Location (loc slot ty)])
+      (dw_attrs [Name name; Decl_line pos.line; Decl_column pos.column; TypeRef reference; Location (loc slot ty)])
   | LexicalBlock pos ->
     [unreferencable_tag dw_TAG_lexical_block
-       (dw_attrs [Decl_line pos.Source.line; Decl_column pos.Source.column])]
+       (dw_attrs [Decl_line pos.line; Decl_column pos.column])]
   | Variable (name, pos, ty, slot) ->
     let ds, reference = type_ref ty in
     append_tag ds dw_TAG_variable
-      (dw_attrs [Name name; Decl_line pos.Source.line; Decl_column pos.Source.column; TypeRef reference; Location (loc slot ty)])
+      (dw_attrs [Name name; Decl_line pos.line; Decl_column pos.column; TypeRef reference; Location (loc slot ty)])
   | Type ty -> type_ ty
   | _ -> assert false

--- a/src/codegen/die.ml
+++ b/src/codegen/die.ml
@@ -1,7 +1,7 @@
 open Mo_types
 open Wasm_exts.Dwarf5
 open Meta
-open Wasm.Source
+open Source
 
 (* Note [Low_pc, High_pc, Ranges are special]
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -7,12 +7,6 @@ features are
  * Some simple peephole optimizations.
 *)
 
-(*let _cr Source.{left; right} =
-  let left, right =
-    (let Source.{ file; line; column } = left in Wasm.Source.{ file; line; column }),
-    (let Source.{ file; line; column } = right in Wasm.Source.{ file; line; column })
-  in Wasm.Source.{ left; right }*)
-
 open Wasm_exts.Ast
 open Wasm.Source
 open Wasm_exts.Values

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -11,8 +11,6 @@ open Wasm_exts.Ast
 open Wasm.Source
 open Wasm_exts.Values
 
-let cr region = region
-
 let combine_shifts const op = function
   | I32 opl, ({it = I32 l'; _} as cl), I32 opr, I32 r' when opl = opr ->
     let l, r = Int32.(to_int l', to_int r') in
@@ -194,7 +192,7 @@ let table n f = List.fold_right (^^) (Lib.List.table n f) nop
 (* Region-managing combinator *)
 
 let with_region (pos : Source.region) (body : t) : t =
-  fun d _pos rest -> body d (cr pos) rest
+  fun d _pos rest -> body d pos rest
 
 (* Depths-managing combinators *)
 

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -7,16 +7,17 @@ features are
  * Some simple peephole optimizations.
 *)
 
-open Wasm_exts.Ast
-
-let cr Source.{left; right} =
+(*let _cr Source.{left; right} =
   let left, right =
     (let Source.{ file; line; column } = left in Wasm.Source.{ file; line; column }),
     (let Source.{ file; line; column } = right in Wasm.Source.{ file; line; column })
-  in Wasm.Source.{ left; right }
+  in Wasm.Source.{ left; right }*)
 
+open Wasm_exts.Ast
 open Wasm.Source
 open Wasm_exts.Values
+
+let cr region = region
 
 let combine_shifts const op = function
   | I32 opl, ({it = I32 l'; _} as cl), I32 opr, I32 r' when opl = opr ->
@@ -331,7 +332,7 @@ let dw_tag die body =
 let dw_tag_no_children = dw_tag_open (* self-closing *)
 
 (* Marker for statement boundaries *)
-let dw_statement { Source.left; Source.right } =
+let dw_statement { left; right } =
   let open Wasm.Source in
-  let left = { file = left.Source.file; line = left.Source.line; column = left.Source.column } in
+  let left = { file = left.file; line = left.line; column = left.column } in
   i (Meta (StatementDelimiter left))

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -324,7 +324,5 @@ let dw_tag die body =
 let dw_tag_no_children = dw_tag_open (* self-closing *)
 
 (* Marker for statement boundaries *)
-let dw_statement { left; right } =
-  let open Wasm.Source in
-  let left = { file = left.file; line = left.line; column = left.column } in
+let dw_statement { left; _ } =
   i (Meta (StatementDelimiter left))

--- a/src/docs/common.ml
+++ b/src/docs/common.ml
@@ -1,4 +1,5 @@
 open Mo_def
+open Source
 
 type render_input = {
   package_opt : string option;
@@ -13,6 +14,6 @@ type render_input = {
 
 let is_scope_bind : Syntax.typ_bind -> bool =
  fun typ_bind ->
-  match typ_bind.Source.it.Syntax.sort.Source.it with
+  match typ_bind.it.Syntax.sort.it with
   | Mo_types.Type.Scope -> true
   | _ -> false

--- a/src/docs/docs.ml
+++ b/src/docs/docs.ml
@@ -1,4 +1,5 @@
 open Extract
+open Source
 
 type output_format = Plain | Adoc | Html
 
@@ -25,7 +26,7 @@ let write_file : string -> string -> unit =
 
 let extract : string -> extracted option =
  fun in_file ->
-  let parse_result = Pipeline.parse_file Source.no_region in_file in
+  let parse_result = Pipeline.parse_file no_region in_file in
   match parse_result with
   | Error err ->
       Printf.eprintf "Skipping %s:\n" in_file;

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -97,7 +97,7 @@ type extracted = {
 module MakeExtract (Env : sig
   val all_decs : Syntax.dec_field list
   val imports : (string * string) list
-  val find_trivia : Source.region -> Trivia.trivia_info
+  val find_trivia : region -> Trivia.trivia_info
 end) =
 struct
   let namespace : Namespace.t =
@@ -194,13 +194,13 @@ struct
     (tag, Trivia.doc_comment_of_trivia_info (Env.find_trivia at))
 
   let rec extract_doc mk_xref = function
-    | Source.
+    | 
         {
           it = Syntax.LetD ({ it = Syntax.VarP { it = name; _ }; _ }, rhs, _);
           _;
         } -> (
         match rhs with
-        | Source.{ it = Syntax.ObjBlockE (_, sort, _, fields); _ } ->
+        | { it = Syntax.ObjBlockE (_, sort, _, fields); _ } ->
             let mk_field_xref xref = mk_xref (Xref.XClass (name, xref)) in
             Some
               ( mk_xref (Xref.XType name),
@@ -213,9 +213,9 @@ struct
                   } )
         | _ -> Some (mk_xref (Xref.XValue name), extract_value_doc Let rhs name)
         )
-    | Source.{ it = Syntax.VarD ({ it = name; _ }, rhs); _ } -> (
+    | { it = Syntax.VarD ({ it = name; _ }, rhs); _ } -> (
         match rhs with
-        | Source.{ it = Syntax.ObjBlockE (_, sort, _, fields); _ } ->
+        | { it = Syntax.ObjBlockE (_, sort, _, fields); _ } ->
             let mk_field_xref xref = mk_xref (Xref.XClass (name, xref)) in
             Some
               ( mk_xref (Xref.XType name),
@@ -228,7 +228,7 @@ struct
                   } )
         | _ -> Some (mk_xref (Xref.XValue name), extract_value_doc Var rhs name)
         )
-    | Source.{ it = Syntax.TypD (name, ty_args, typ); _ } ->
+    | { it = Syntax.TypD (name, ty_args, typ); _ } ->
         let doc_typ =
           match typ.it with
           | Syntax.ObjT (_, fields) ->
@@ -245,7 +245,7 @@ struct
         Some
           ( mk_xref (Xref.XType name.it),
             Type { name = name.it; type_args = ty_args; typ = doc_typ } )
-    | Source.
+    | 
         {
           it =
             Syntax.ClassD
@@ -295,7 +295,7 @@ let extract_docs : Syntax.prog -> (extracted, string) result =
   let lookup_trivia (line, column) =
     PosTable.find_opt prog.note.Syntax.trivia Trivia.{ line; column }
   in
-  let find_trivia (parser_pos : Source.region) : Trivia.trivia_info =
+  let find_trivia (parser_pos : region) : Trivia.trivia_info =
     lookup_trivia (parser_pos.left.line, parser_pos.left.column) |> Option.get
   in
   let module_docs = find_trivia prog.at in

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -1,8 +1,5 @@
 open Mo_def
-open Wasm.Source
 open Source
-
-[@@@warning "-41"]
 
 type doc = {
   xref : Xref.t;

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -1,5 +1,6 @@
 open Mo_def
-open Source
+open Wasm.Source
+open Source [@@@warning "-41"]
 
 type doc = {
   xref : Xref.t;
@@ -296,7 +297,7 @@ let extract_docs : Syntax.prog -> (extracted, string) result =
     PosTable.find_opt prog.note.Syntax.trivia Trivia.{ line; column }
   in
   let find_trivia (parser_pos : Source.region) : Trivia.trivia_info =
-    lookup_trivia Source.(parser_pos.left.line, parser_pos.left.column)
+    lookup_trivia (parser_pos.left.line, parser_pos.left.column)
     |> Option.get
   in
   let module_docs = find_trivia prog.at in

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -1,6 +1,8 @@
 open Mo_def
 open Wasm.Source
-open Source [@@@warning "-41"]
+open Source
+
+[@@@warning "-41"]
 
 type doc = {
   xref : Xref.t;
@@ -297,8 +299,7 @@ let extract_docs : Syntax.prog -> (extracted, string) result =
     PosTable.find_opt prog.note.Syntax.trivia Trivia.{ line; column }
   in
   let find_trivia (parser_pos : Source.region) : Trivia.trivia_info =
-    lookup_trivia (parser_pos.left.line, parser_pos.left.column)
-    |> Option.get
+    lookup_trivia (parser_pos.left.line, parser_pos.left.column) |> Option.get
   in
   let module_docs = find_trivia prog.at in
   (* Skip the module header *)

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -194,11 +194,8 @@ struct
     (tag, Trivia.doc_comment_of_trivia_info (Env.find_trivia at))
 
   let rec extract_doc mk_xref = function
-    | 
-        {
-          it = Syntax.LetD ({ it = Syntax.VarP { it = name; _ }; _ }, rhs, _);
-          _;
-        } -> (
+    | { it = Syntax.LetD ({ it = Syntax.VarP { it = name; _ }; _ }, rhs, _); _ }
+      -> (
         match rhs with
         | { it = Syntax.ObjBlockE (_, sort, _, fields); _ } ->
             let mk_field_xref xref = mk_xref (Xref.XClass (name, xref)) in
@@ -245,21 +242,12 @@ struct
         Some
           ( mk_xref (Xref.XType name.it),
             Type { name = name.it; type_args = ty_args; typ = doc_typ } )
-    | 
-        {
-          it =
-            Syntax.ClassD
-              ( exp_opt,
-                shared_pat,
-                obj_sort,
-                name,
-                type_args,
-                ctor,
-                _,
-                _,
-                fields );
-          _;
-        } ->
+    | {
+        it =
+          Syntax.ClassD
+            (exp_opt, shared_pat, obj_sort, name, type_args, ctor, _, _, fields);
+        _;
+      } ->
         let mk_field_xref xref = mk_xref (Xref.XClass (name.it, xref)) in
         Some
           ( mk_xref (Xref.XType name.it),

--- a/src/docs/html.ml
+++ b/src/docs/html.ml
@@ -3,6 +3,7 @@ open Mo_def
 open Mo_types
 open Cow.Html
 open Common
+open Source
 
 type env = { lookup_type : Syntax.typ_path -> Xref.t option }
 
@@ -13,7 +14,7 @@ let rec join_with : t -> t list -> t =
   | x :: xs -> x ++ sep ++ join_with sep xs
 
 let space : t = string "\u{00A0}"
-let cls_span : string -> string -> t = fun cls s -> span ~cls (string s)
+let cls_span : string -> string -> t = fun cls s -> Cow.Html.span ~cls (string s)
 let fn_name : string -> t = cls_span "fnname"
 let class_name : string -> t = cls_span "classname"
 let object_name : string -> t = cls_span "objectname"
@@ -22,12 +23,12 @@ let parameter : string -> t = cls_span "parameter"
 let html_type : string -> t = cls_span "type"
 
 let rec string_of_path' : Syntax.path' -> string = function
-  | Syntax.IdH id -> id.Source.it
+  | Syntax.IdH id -> id.it
   | Syntax.DotH (path, id) ->
-      string_of_path' path.Source.it ^ "." ^ id.Source.it
+      string_of_path' path.it ^ "." ^ id.it
 
 let string_of_path : Syntax.typ_path -> string =
- fun path -> string_of_path' path.Source.it
+ fun path -> string_of_path' path.it
 
 let rec id_of_xref : Xref.t -> string = function
   | Xref.XClass (x, xref) -> Printf.sprintf "%s.%s" x (id_of_xref xref)
@@ -71,14 +72,14 @@ let html_of_comment : string -> t = function
 
 let html_of_mut : Syntax.mut -> t =
  fun mut ->
-  match mut.Source.it with
+  match mut.it with
   | Syntax.Var -> keyword "var "
   | Syntax.Const -> string ""
 
 let html_of_func_sort : Syntax.func_sort -> t =
  fun sort ->
   Mo_types.Type.(
-    match sort.Source.it with
+    match sort.it with
     | Local -> empty
     | Shared Composite -> keyword "shared composite query "
     | Shared Query -> keyword "shared query "
@@ -87,7 +88,7 @@ let html_of_func_sort : Syntax.func_sort -> t =
 let html_of_obj_sort : 'note Syntax.sort -> t =
  fun sort ->
   Mo_types.Type.(
-    match sort.Source.it with
+    match sort.it with
     | Object -> empty
     | Actor -> keyword "actor "
     | Module -> keyword "module "
@@ -96,7 +97,7 @@ let html_of_obj_sort : 'note Syntax.sort -> t =
 
 let rec html_of_type : env -> Syntax.typ -> t =
  fun env typ ->
-  match typ.Source.it with
+  match typ.it with
   | Syntax.PathT (path, typs) -> (
       html_of_path env path
       ++
@@ -146,20 +147,20 @@ let rec html_of_type : env -> Syntax.typ -> t =
 
 and html_of_typ_tag : env -> Syntax.typ_tag -> t =
  fun env typ_tag ->
-  string (Printf.sprintf "#%s" typ_tag.Source.it.Syntax.tag.Source.it)
+  string (Printf.sprintf "#%s" typ_tag.it.Syntax.tag.it)
   ++
-  match typ_tag.Source.it.Syntax.typ.Source.it with
+  match typ_tag.it.Syntax.typ.it with
   | Syntax.TupT [] -> nil
-  | _ -> string " : " ++ html_of_type env typ_tag.Source.it.Syntax.typ
+  | _ -> string " : " ++ html_of_type env typ_tag.it.Syntax.typ
 
 and html_of_typ_bind : env -> Syntax.typ_bind -> t =
  fun env typ_bind ->
-  let bound = typ_bind.Source.it.Syntax.bound in
+  let bound = typ_bind.it.Syntax.bound in
   let bound_html =
     if Syntax.is_any bound then empty
     else string " <: " ++ html_of_type env bound
   in
-  html_type typ_bind.Source.it.Syntax.var.Source.it ++ bound_html
+  html_type typ_bind.it.Syntax.var.it ++ bound_html
 
 and html_of_typ_binders : env -> Syntax.typ_bind list -> t =
  fun env typ_binders ->
@@ -173,13 +174,13 @@ and html_of_typ_binders : env -> Syntax.typ_bind list -> t =
 and html_of_typ_field : env -> Syntax.typ_field -> t =
  fun env field ->
   (* TODO mut might be wrong here *)
-  match field.Source.it with
+  match field.it with
   | Syntax.ValF (id, typ, mut) ->
-      html_of_mut mut ++ string (id.Source.it ^ " : ") ++ html_of_type env typ
+      html_of_mut mut ++ string (id.it ^ " : ") ++ html_of_type env typ
   | Syntax.TypF (id, tbs, typ) ->
       let ty_args = html_of_typ_binders env tbs in
       string "type "
-      ++ string id.Source.it
+      ++ string id.it
       ++ ty_args
       ++ string " = "
       ++ html_of_type env typ
@@ -187,7 +188,7 @@ and html_of_typ_field : env -> Syntax.typ_field -> t =
 and html_of_typ_item : env -> Syntax.typ_item -> t =
  fun env (oid, t) ->
   Option.fold ~none:empty
-    ~some:(fun id -> parameter id.Source.it ++ string " : ")
+    ~some:(fun id -> parameter id.it ++ string " : ")
     oid
   ++ html_of_type env t
 

--- a/src/docs/html.ml
+++ b/src/docs/html.ml
@@ -14,7 +14,10 @@ let rec join_with : t -> t list -> t =
   | x :: xs -> x ++ sep ++ join_with sep xs
 
 let space : t = string "\u{00A0}"
-let cls_span : string -> string -> t = fun cls s -> Cow.Html.span ~cls (string s)
+
+let cls_span : string -> string -> t =
+ fun cls s -> Cow.Html.span ~cls (string s)
+
 let fn_name : string -> t = cls_span "fnname"
 let class_name : string -> t = cls_span "classname"
 let object_name : string -> t = cls_span "objectname"
@@ -24,8 +27,7 @@ let html_type : string -> t = cls_span "type"
 
 let rec string_of_path' : Syntax.path' -> string = function
   | Syntax.IdH id -> id.it
-  | Syntax.DotH (path, id) ->
-      string_of_path' path.it ^ "." ^ id.it
+  | Syntax.DotH (path, id) -> string_of_path' path.it ^ "." ^ id.it
 
 let string_of_path : Syntax.typ_path -> string =
  fun path -> string_of_path' path.it
@@ -72,9 +74,7 @@ let html_of_comment : string -> t = function
 
 let html_of_mut : Syntax.mut -> t =
  fun mut ->
-  match mut.it with
-  | Syntax.Var -> keyword "var "
-  | Syntax.Const -> string ""
+  match mut.it with Syntax.Var -> keyword "var " | Syntax.Const -> string ""
 
 let html_of_func_sort : Syntax.func_sort -> t =
  fun sort ->
@@ -187,9 +187,7 @@ and html_of_typ_field : env -> Syntax.typ_field -> t =
 
 and html_of_typ_item : env -> Syntax.typ_item -> t =
  fun env (oid, t) ->
-  Option.fold ~none:empty
-    ~some:(fun id -> parameter id.it ++ string " : ")
-    oid
+  Option.fold ~none:empty ~some:(fun id -> parameter id.it ++ string " : ") oid
   ++ html_of_type env t
 
 let sub_declaration heading doc =

--- a/src/docs/namespace.ml
+++ b/src/docs/namespace.ml
@@ -112,14 +112,14 @@ let shadow : t -> t -> t =
   }
 
 let rec split_path : Syntax.path' -> string list * string = function
-  | Syntax.IdH id -> ([], id.Source.it)
+  | Syntax.IdH id -> ([], id.it)
   | Syntax.DotH (path, id) ->
-      let xs, x = split_path path.Source.it in
-      (List.append xs [ x ], id.Source.it)
+      let xs, x = split_path path.it in
+      (List.append xs [ x ], id.it)
 
 let lookup_type : t -> Syntax.typ_path -> Xref.t option =
  fun ns path ->
-  match split_path path.Source.it with
+  match split_path path.it with
   | [], id -> StringMap.find_opt id ns.types
   | x :: xs, id -> (
       match StringMap.find_opt x ns.values with

--- a/src/docs/plain.ml
+++ b/src/docs/plain.ml
@@ -101,7 +101,7 @@ let plain_of_obj_sort : Buffer.t -> 'note Syntax.sort -> unit =
 
 let rec plain_of_typ : Buffer.t -> render_functions -> Syntax.typ -> unit =
  fun buf rf typ ->
-  match typ.Source.it with
+  match typ.it with
   | Syntax.PathT (path, typs) ->
       bprintf buf "%s" (rf.render_path path);
       sep_by' buf "<" ", " ">" (plain_of_typ buf rf) typs
@@ -188,7 +188,7 @@ and plain_of_typ_binders :
 and plain_of_typ_field :
     Buffer.t -> render_functions -> Syntax.typ_field -> unit =
  fun buf rf field ->
-  match field.Source.it with
+  match field.it with
   | Syntax.ValF (id, typ, mut) ->
       plain_of_mut buf mut;
       bprintf buf "%s : " id.it;

--- a/src/exes/candid_tests.ml
+++ b/src/exes/candid_tests.ml
@@ -3,8 +3,7 @@
 
 *)
 open Idllib
-open Wasm.Source
-open Source [@@@warning "-41"]
+open Source
 open Syntax
 open Mo_idl
 open Printf

--- a/src/exes/candid_tests.ml
+++ b/src/exes/candid_tests.ml
@@ -3,7 +3,8 @@
 
 *)
 open Idllib
-open Source
+open Wasm.Source
+open Source [@@@warning "-41"]
 open Syntax
 open Mo_idl
 open Printf

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -1,5 +1,6 @@
 open Wasm_exts
 open Mo_config
+open Source
 
 open Printf
 
@@ -323,7 +324,7 @@ let process_files files : unit =
       let open Idllib in
       let did_file = Filename.remove_extension !out_file ^ ".did" in
       let oc = open_out did_file in
-      let module WithComments = Arrange_idl.Make(struct let trivia = Some idl_prog.Source.note.Syntax.trivia end) in
+      let module WithComments = Arrange_idl.Make(struct let trivia = Some idl_prog.note.Syntax.trivia end) in
       let idl_code = WithComments.string_of_prog idl_prog in
       output_string oc idl_code; close_out oc
     end;

--- a/src/idllib/arrange_idl.ml
+++ b/src/idllib/arrange_idl.ml
@@ -1,6 +1,7 @@
-open Source
 open Syntax
 open Wasm.Sexpr
+open Wasm.Source
+open Source [@@@warning "-41"]
 
 let string_of_prim p =
   match p with

--- a/src/idllib/arrange_idl.ml
+++ b/src/idllib/arrange_idl.ml
@@ -1,7 +1,6 @@
 open Syntax
 open Wasm.Sexpr
-open Wasm.Source
-open Source [@@@warning "-41"]
+open Source
 
 let string_of_prim p =
   match p with

--- a/src/idllib/lexer.mli
+++ b/src/idllib/lexer.mli
@@ -1,2 +1,2 @@
-val token : Lexing.lexbuf -> Parser.token  (* raise Source.ParseError *)
+val token : Lexing.lexbuf -> Parser.token  (* raise ParseError *)
 val region : Lexing.lexbuf -> Source.region

--- a/src/idllib/lexer.mll
+++ b/src/idllib/lexer.mll
@@ -1,17 +1,18 @@
 {
+open Wasm.Source
 open Parser
 module Utf8 = Lib.Utf8
 
 let convert_pos pos =
-  { Source.file = pos.Lexing.pos_fname;
-    Source.line = pos.Lexing.pos_lnum;
-    Source.column = pos.Lexing.pos_cnum - pos.Lexing.pos_bol
+  { file = pos.Lexing.pos_fname;
+    line = pos.Lexing.pos_lnum;
+    column = pos.Lexing.pos_cnum - pos.Lexing.pos_bol
   }
 
 let region lexbuf =
   let left = convert_pos (Lexing.lexeme_start_p lexbuf) in
   let right = convert_pos (Lexing.lexeme_end_p lexbuf) in
-  {Source.left = left; Source.right = right}
+  {left = left; right = right}
 
 let error lexbuf msg = raise (Source.ParseError (region lexbuf, msg))
 let error_nest start lexbuf msg =

--- a/src/idllib/lexer.mll
+++ b/src/idllib/lexer.mll
@@ -1,5 +1,5 @@
 {
-open Wasm.Source
+open Source
 open Parser
 module Utf8 = Lib.Utf8
 
@@ -14,7 +14,7 @@ let region lexbuf =
   let right = convert_pos (Lexing.lexeme_end_p lexbuf) in
   {left = left; right = right}
 
-let error lexbuf msg = raise (Source.ParseError (region lexbuf, msg))
+let error lexbuf msg = raise (ParseError (region lexbuf, msg))
 let error_nest start lexbuf msg =
   lexbuf.Lexing.lex_start_p <- start;
   error lexbuf msg

--- a/src/idllib/lexer.mll
+++ b/src/idllib/lexer.mll
@@ -4,15 +4,15 @@ open Parser
 module Utf8 = Lib.Utf8
 
 let convert_pos pos =
-  { file = pos.Lexing.pos_fname;
-    line = pos.Lexing.pos_lnum;
-    column = pos.Lexing.pos_cnum - pos.Lexing.pos_bol
+  Lexing.{ file = pos.pos_fname;
+    line = pos.pos_lnum;
+    column = pos.pos_cnum - pos.pos_bol
   }
 
 let region lexbuf =
   let left = convert_pos (Lexing.lexeme_start_p lexbuf) in
   let right = convert_pos (Lexing.lexeme_end_p lexbuf) in
-  {left = left; right = right}
+  {left; right}
 
 let error lexbuf msg = raise (ParseError (region lexbuf, msg))
 let error_nest start lexbuf msg =

--- a/src/idllib/parser.mly
+++ b/src/idllib/parser.mly
@@ -10,19 +10,19 @@ module Uint32 = Lib.Uint32
 let position_to_pos position =
   (* TBR: Remove assertion once the menhir bug is fixed. *)
   assert (Obj.is_block (Obj.repr position));
-  { file = position.Lexing.pos_fname;
+  Wasm.Source.{ file = position.Lexing.pos_fname;
     line = position.Lexing.pos_lnum;
     column = position.Lexing.pos_cnum - position.Lexing.pos_bol
   }
 
 let positions_to_region position1 position2 =
-  { left = position_to_pos position1;
+  Wasm.Source.{ left = position_to_pos position1;
     right = position_to_pos position2
   }
 
 let at (startpos, endpos) = positions_to_region startpos endpos
 
-let _anon sort at = "anon-" ^ sort ^ "-" ^ string_of_pos at.left
+let _anon sort at = "anon-" ^ sort ^ "-" ^ string_of_pos at.Wasm.Source.left
 
 let prim_typs = ["nat", Nat; "nat8", Nat8; "nat16", Nat16; "nat32", Nat32; "nat64", Nat64;
                  "int", Int; "int8", Int8; "int16", Int16; "int32", Int32; "int64", Int64;

--- a/src/idllib/parser.mly
+++ b/src/idllib/parser.mly
@@ -10,13 +10,13 @@ module Uint32 = Lib.Uint32
 let position_to_pos position =
   (* TBR: Remove assertion once the menhir bug is fixed. *)
   assert (Obj.is_block (Obj.repr position));
-  Wasm.Source.{ file = position.Lexing.pos_fname;
+  { file = position.Lexing.pos_fname;
     line = position.Lexing.pos_lnum;
     column = position.Lexing.pos_cnum - position.Lexing.pos_bol
   }
 
 let positions_to_region position1 position2 =
-  Wasm.Source.{ left = position_to_pos position1;
+  { left = position_to_pos position1;
     right = position_to_pos position2
   }
 

--- a/src/idllib/parser.mly
+++ b/src/idllib/parser.mly
@@ -22,7 +22,7 @@ let positions_to_region position1 position2 =
 
 let at (startpos, endpos) = positions_to_region startpos endpos
 
-let _anon sort at = "anon-" ^ sort ^ "-" ^ string_of_pos at.Wasm.Source.left
+let _anon sort at = "anon-" ^ sort ^ "-" ^ string_of_pos at.left
 
 let prim_typs = ["nat", Nat; "nat8", Nat8; "nat16", Nat16; "nat32", Nat32; "nat64", Nat64;
                  "int", Int; "int8", Int8; "int16", Int16; "int32", Int32; "int64", Int64;

--- a/src/idllib/pipeline.ml
+++ b/src/idllib/pipeline.ml
@@ -1,4 +1,5 @@
 open Printf
+open Source
 
 (* Diagnostics *)
 
@@ -32,7 +33,7 @@ let parse_with lexer parser name =
     let prog = parser Lexer.token lexer name in
     Ok prog
   with
-    | Source.ParseError (at, msg) ->
+    | ParseError (at, msg) ->
       error at "syntax" msg
     | Parser.Error ->
       error (Lexer.region lexer) "syntax" "unexpected token"
@@ -61,13 +62,13 @@ let parse_string s : parse_result =
 let parse_file filename : parse_result =
   try parse_file filename
   with Sys_error s ->
-    error Source.no_region "file" (sprintf "cannot open \"%s\"" filename)
+    error no_region "file" (sprintf "cannot open \"%s\"" filename)
 
 (* Type checking *)
 
 let check_prog senv prog
   : (Typing.scope * Syntax.typ option) Diag.result =
-  phase "Checking" prog.Source.note.Syntax.filename;
+  phase "Checking" prog.note.Syntax.filename;
   let r = Typing.check_prog senv prog in
   (match r with
    | Ok ((scope, _), _) ->
@@ -88,7 +89,7 @@ let merge_env imports init_env lib_env =
         if v1 = v2 then Some v1 else raise (Typing.Env.Clash k)
       ) env1 env2)
     with Typing.Env.Clash k ->
-      error Source.no_region "import" (sprintf "conflict type definition for %s" k) in
+      error no_region "import" (sprintf "conflict type definition for %s" k) in
   let env_list = List.map (fun import -> LibEnv.find import lib_env) imports in
   Diag.fold disjoint_union init_env env_list
 
@@ -98,7 +99,7 @@ let chase_imports senv imports =
   let lib_env = ref LibEnv.empty in
   let rec go file =
     if S.mem file !pending then
-      error Source.no_region "import" (sprintf "file %s must not depend on itself" file)
+      error no_region "import" (sprintf "file %s must not depend on itself" file)
     else if LibEnv.mem file !lib_env then
       Diag.return ()
     else begin
@@ -176,7 +177,7 @@ let parse_values s =
   try
     Diag.return (Parser.parse_args Lexer.token lexer)
   with
-    | Source.ParseError (at, msg) ->
+    | ParseError (at, msg) ->
       error at "syntax" msg
     | Parser.Error ->
       error (Lexer.region lexer) "syntax" "unexpected token"

--- a/src/idllib/syntax.ml
+++ b/src/idllib/syntax.ml
@@ -1,7 +1,8 @@
+open Source
 
 (* Identifiers *)
 
-type id = string Source.phrase
+type id = string phrase
 
 (* Types *)
 
@@ -24,13 +25,13 @@ type prim =
   | Reserved
   | Empty
 
-type func_mode = func_mode' Source.phrase
+type func_mode = func_mode' phrase
 and func_mode' = Oneway | Query | Composite
 
-type field_label = field_label' Source.phrase
+type field_label = field_label' phrase
 and field_label' = Id of Lib.Uint32.t | Named of string | Unnamed of Lib.Uint32.t
 
-type typ = typ' Source.phrase
+type typ = typ' phrase
 and typ' =
   | PrimT of prim                                (* primitive *)
   | VarT of id                                    (* type name *)
@@ -47,17 +48,17 @@ and typ' =
   | PrincipalT
   | PreT   (* pre-type *)
 
-and arg_typ = arg_typ' Source.phrase
+and arg_typ = arg_typ' phrase
 and arg_typ' = { name : id option; typ : typ }
-and typ_field = typ_field' Source.phrase
+and typ_field = typ_field' phrase
 and typ_field' = { label: field_label; typ : typ }
 
-and typ_meth = typ_meth' Source.phrase
+and typ_meth = typ_meth' phrase
 and typ_meth' = {var : id; meth : typ}
 
 (* Declarations *)
 
-and dec = dec' Source.phrase
+and dec = dec' phrase
 and dec' =
   | TypD of id * typ             (* type *)
   | ImportD of string * string ref  (* import *)
@@ -65,7 +66,7 @@ and dec' =
 (* Program *)
 
 type prog_note = { filename : string; trivia : Trivia.triv_table }
-type prog = (prog', prog_note) Source.annotated_phrase
+type prog = (prog', prog_note) annotated_phrase
 and prog' = { decs : dec list; actor : typ option }
 
 (* Values *)
@@ -73,7 +74,7 @@ and prog' = { decs : dec list; actor : typ option }
 (* This value AST is not to be taken serious. It is just good enough
 to translate Candid textual values into morally equivalent Motoko
 source code. See mo_idl/idl_to_mo_value.ml *)
-type value = value' Source.phrase
+type value = value' phrase
 and value' =
   | NumV of string (* Candid and Motoko syntax matches, so re-use. Includes floats. *)
   | TextV of string
@@ -87,9 +88,9 @@ and value' =
   | ServiceV of string
   | FuncV of (string * string)
   | PrincipalV of string
-and field_value = (field_label * value) Source.phrase
+and field_value = (field_label * value) phrase
 
-type args = value list Source.phrase
+type args = value list phrase
 
 (* Tests *)
 
@@ -106,7 +107,7 @@ type test' = {
   ttyp : typ list;
   desc : string option;
 }
-type test = test' Source.phrase
+type test = test' phrase
 
-type tests = (tests', string) Source.annotated_phrase
+type tests = (tests', string) annotated_phrase
 and tests' = { tdecs : dec list; tests : test list }

--- a/src/ir_def/arrange_ir.ml
+++ b/src/ir_def/arrange_ir.ml
@@ -1,6 +1,5 @@
 open Mo_types
 open Mo_values
-open Source
 open Ir
 open Wasm.Sexpr
 

--- a/src/ir_def/construct.ml
+++ b/src/ir_def/construct.ml
@@ -1,6 +1,3 @@
-
-(* WIP translation of syntaxops to use IR in place of Source *)
-open Source
 open Ir
 open Ir_effect
 open Mo_values
@@ -44,10 +41,7 @@ let fresh_vars name_base ts =
 
 (* type arguments *)
 
-let typ_arg c sort typ =
-  { it = { Ir.con = c; Ir.sort = sort; Ir.bound = typ };
-    at = no_region;
-    note = () }
+let typ_arg con sort typ = { con; sort; bound = typ } @@ no_region
 
 (* Patterns *)
 
@@ -368,16 +362,16 @@ let ifE exp1 exp2 exp3 =
 
 let falseE () = boolE false
 let trueE () = boolE true
-let notE : Ir.exp -> Ir.exp = fun e ->
+let notE : exp -> exp = fun e ->
   primE (RelPrim (T.bool, Operator.EqOp)) [e; falseE ()]
 
-let andE : Ir.exp -> Ir.exp -> Ir.exp = fun e1 e2 ->
+let andE : exp -> exp -> exp = fun e1 e2 ->
   ifE e1 e2 (falseE ())
-let orE : Ir.exp -> Ir.exp -> Ir.exp = fun e1 e2 ->
+let orE : exp -> exp -> exp = fun e1 e2 ->
   ifE e1 (trueE ()) e2
-let impliesE : Ir.exp -> Ir.exp -> Ir.exp = fun e1 e2 ->
+let impliesE : exp -> exp -> exp = fun e1 e2 ->
   orE (notE e1) e2
-let oldE : Ir.exp -> Ir.exp = fun e ->
+let oldE : exp -> exp = fun e ->
   { it = (primE (CallPrim [typ e]) [e]).it;
     at = no_region;
     note = Note.{ def with
@@ -385,7 +379,7 @@ let oldE : Ir.exp -> Ir.exp = fun e ->
     }
   }
 
-let rec conjE : Ir.exp list -> Ir.exp = function
+let rec conjE : exp list -> exp = function
   | [] -> trueE ()
   | [x] -> x
   | (x::xs) -> andE x (conjE xs)

--- a/src/ir_def/construct.ml
+++ b/src/ir_def/construct.ml
@@ -4,6 +4,8 @@ open Mo_values
 module Cons = Mo_types.Cons
 module T = Mo_types.Type
 
+let (@@) = Source.(@@)
+
 (* Field names *)
 
 let nameN s = s

--- a/src/ir_def/freevars.ml
+++ b/src/ir_def/freevars.ml
@@ -1,4 +1,3 @@
-open Source
 open Ir
 open Mo_types
 

--- a/src/ir_def/ir.ml
+++ b/src/ir_def/ir.ml
@@ -29,7 +29,7 @@ type lit =
 
 type ('a, 'b) annotated_phrase = ('a, 'b) Source.annotated_phrase = {at : region; it : 'a; mutable note: 'b}
 type 'a phrase = ('a, Note.t) annotated_phrase
-let no_region = Source.no_region
+let no_region = no_region
 
 type typ_bind' = {con : Type.con; sort : Type.bind_sort; bound : Type.typ}
 type typ_bind = typ_bind' Source.phrase

--- a/src/ir_def/ir.ml
+++ b/src/ir_def/ir.ml
@@ -1,5 +1,6 @@
 open Mo_types
 open Mo_values
+open Source
 
 type id = string
 
@@ -26,7 +27,13 @@ type lit =
 
 (* Patterns *)
 
-type 'a phrase = ('a, Note.t) Source.annotated_phrase
+type ('a, 'b) annotated_phrase = ('a, 'b) Source.annotated_phrase = {at : region; it : 'a; mutable note: 'b}
+type 'a phrase = ('a, Note.t) annotated_phrase
+let no_region = Source.no_region
+(*let annotate note it at = {it; at; note}
+  let (@@) it at = annotate Note.def it at
+ *)
+let (@@) = Source.(@@)
 
 type typ_bind' = {con : Type.con; sort : Type.bind_sort; bound : Type.typ}
 type typ_bind = typ_bind' Source.phrase
@@ -37,7 +44,7 @@ type relop = Operator.relop
 
 type mut = Const | Var
 
-type pat = (pat', Type.typ) Source.annotated_phrase
+type pat = (pat', Type.typ) annotated_phrase
 and pat' =
   | WildP                                      (* wildcard *)
   | VarP of id                                 (* variable *)
@@ -52,7 +59,7 @@ and pat_field = pat_field' Source.phrase
 and pat_field' = {name : Type.lab; pat : pat}
 
 (* Like id, but with a type attached *)
-type arg = (string, Type.typ) Source.annotated_phrase
+type arg = (string, Type.typ) annotated_phrase
 
 (* Expressions *)
 
@@ -103,13 +110,13 @@ and meta = {
     sig_ : string  (* Motoko stable signature *)
   }
 
-and field = (field', Type.typ) Source.annotated_phrase
+and field = (field', Type.typ) annotated_phrase
 and field' = {name : Type.lab; var : id} (* the var is by reference, not by value *)
 
 and case = case' Source.phrase
 and case' = {pat : pat; exp : exp}
 
-and lexp = (lexp', Type.typ) Source.annotated_phrase
+and lexp = (lexp', Type.typ) annotated_phrase
 and lexp' =
   | VarLE of id                                (* variable *)
   | IdxLE of exp * exp                         (* array indexing *)
@@ -266,13 +273,13 @@ type prog = comp_unit * flavor
 
 (* object pattern helpers *)
 
-let pats_of_obj_pat pfs = List.map (fun {Source.it={name; pat}; _} -> pat) pfs
+let pats_of_obj_pat pfs = List.map (fun {it={name; pat}; _} -> pat) pfs
 
 let map_obj_pat f pfs =
-  List.map (fun ({Source.it={name; pat}; _} as pf) -> {pf with Source.it={name; pat=f pat}}) pfs
+  List.map (fun ({it={name; pat}; _} as pf) -> {pf with it={name; pat=f pat}}) pfs
 
 let replace_obj_pat pfs pats =
-  List.map2 (fun ({Source.it={name; pat=_}; _} as pf) pat -> {pf with Source.it={name; pat}}) pfs pats
+  List.map2 (fun ({it={name; pat=_}; _} as pf) pat -> {pf with it={name; pat}}) pfs pats
 
 (* Helper for transforming prims, without missing embedded typs and ids *)
 

--- a/src/ir_def/ir.ml
+++ b/src/ir_def/ir.ml
@@ -30,10 +30,6 @@ type lit =
 type ('a, 'b) annotated_phrase = ('a, 'b) Source.annotated_phrase = {at : region; it : 'a; mutable note: 'b}
 type 'a phrase = ('a, Note.t) annotated_phrase
 let no_region = Source.no_region
-(*let annotate note it at = {it; at; note}
-  let (@@) it at = annotate Note.def it at
- *)
-let (@@) = Source.(@@)
 
 type typ_bind' = {con : Type.con; sort : Type.bind_sort; bound : Type.typ}
 type typ_bind = typ_bind' Source.phrase

--- a/src/ir_def/rename.ml
+++ b/src/ir_def/rename.ml
@@ -1,4 +1,3 @@
-open Source
 open Ir
 
 (* Identifiers and labels reside in different namespaces

--- a/src/ir_def/subst_var.ml
+++ b/src/ir_def/subst_var.ml
@@ -1,4 +1,3 @@
-open Source
 open Ir
 
 (* One traversal for each syntactic category, named by that category *)

--- a/src/ir_interpreter/interpret_ir.ml
+++ b/src/ir_interpreter/interpret_ir.ml
@@ -62,7 +62,7 @@ let context env = V.Blob env.self
 
 (* Error handling *)
 
-exception Trap of Source.region * string
+exception Trap of region * string
 
 let trap at fmt = Printf.ksprintf (fun s -> raise (Trap (at, s))) fmt
 
@@ -99,12 +99,12 @@ let string_of_arg env = function
 (* Debugging aids *)
 
 let last_env = ref (env_of_scope { trace = false; print_depth = 2} (Ir.full_flavor ()) (initial_state ()) empty_scope)
-let last_region = ref Source.no_region
+let last_region = ref no_region
 
 let print_exn flags exn =
   let trace = Printexc.get_backtrace () in
   Printf.printf "%!";
-  let at = Source.string_of_region !last_region in
+  let at = string_of_region !last_region in
   Printf.eprintf "%s: internal error, %s\n" at (Printexc.to_string exn);
   Printf.eprintf "\nLast environment:\n";
   Value.Env.iter
@@ -124,7 +124,7 @@ struct
   let yield () =
     trace_depth := 0;
     try Queue.take q () with Trap (at, msg) ->
-      Printf.eprintf "%s: execution error, %s\n" (Source.string_of_region at) msg
+      Printf.eprintf "%s: execution error, %s\n" (string_of_region at) msg
 
   let rec run () =
     if not (Queue.is_empty q) then (yield (); run ())
@@ -673,7 +673,7 @@ and match_args at args v : val_env =
   | _ ->
     let vs = V.as_tup v in
     if (List.length vs <> List.length args) then
-      failwith (Printf.sprintf "%s %s" (Source.string_of_region at) (V.string_of_val 0 T.Non v));
+      failwith (Printf.sprintf "%s %s" (string_of_region at) (V.string_of_val 0 T.Non v));
     List.fold_left V.Env.adjoin V.Env.empty (List.map2 match_arg args vs)
 
 (* Patterns *)
@@ -920,7 +920,7 @@ let interpret_prog flags (cu, flavor) =
            }
            (fun c v k ->
               async env
-                Source.no_region
+                no_region
                   (fun k' r ->
                     k' (V.Blob (V.Blob.rand32 ())))
                     k))));

--- a/src/ir_passes/async.ml
+++ b/src/ir_passes/async.ml
@@ -2,7 +2,6 @@ open Mo_types
 open Ir_def
 
 module E = Env
-open Source
 module Ir = Ir
 open Ir
 open Ir_effect

--- a/src/ir_passes/await.ml
+++ b/src/ir_passes/await.ml
@@ -1,7 +1,6 @@
 open Ir_def
 open Mo_types
 
-open Source
 open Ir
 open Ir_effect
 module R = Rename

--- a/src/ir_passes/const.ml
+++ b/src/ir_passes/const.ml
@@ -1,6 +1,5 @@
 open Mo_types
 open Ir_def
-open Source
 open Ir
 open Lbool
 

--- a/src/ir_passes/eq.ml
+++ b/src/ir_passes/eq.ml
@@ -3,7 +3,6 @@
 open Ir_def
 open Mo_types
 open Mo_values
-open Source
 open Ir
 module T = Type
 open Construct

--- a/src/ir_passes/erase_typ_field.ml
+++ b/src/ir_passes/erase_typ_field.ml
@@ -2,7 +2,6 @@ open Mo_types
 open Ir_def
 
 module E = Env
-open Source
 module Ir = Ir
 open Ir
 module T = Type

--- a/src/ir_passes/show.ml
+++ b/src/ir_passes/show.ml
@@ -2,7 +2,6 @@ open Ir_def
 open Mo_types
 open Mo_values
 (* Translates away calls to `show`. *)
-open Source
 open Ir
 module T = Type
 open Construct

--- a/src/ir_passes/tailcall.ml
+++ b/src/ir_passes/tailcall.ml
@@ -1,7 +1,6 @@
 open Ir_def
 open Mo_types
 
-open Source
 open Ir
 open Ir_effect
 open Type

--- a/src/js/astjs.ml
+++ b/src/js/astjs.ml
@@ -8,7 +8,7 @@ module Type_pretty = Mo_types.Type.MakePretty (Mo_types.Type.ElideStamps)
 
 module type Config = Mo_def.Arrange.Config
 module type TypConfig = Mo_types.Arrange_type.Config
-open  Wasm.Source
+open  Source
 
 (* AST to JSON conversion *)
 module Make (Cfg : Config) = struct
@@ -104,7 +104,7 @@ module Make (Cfg : Config) = struct
 
   let mut_js m =
     let open Syntax in
-    js_string (match m.Source.it with Const -> "Const" | Var -> "Var")
+    js_string (match m.it with Const -> "Const" | Var -> "Var")
 
   let rec typ_js =
     let open Type in
@@ -161,7 +161,7 @@ module Make (Cfg : Config) = struct
           match Field_sources.Srcs_map.find_opt track_region srcs_tbl with
           | None -> []
           | Some srcs ->
-              List.of_seq (Seq.map region_js (Source.Region_set.to_seq srcs)))
+              List.of_seq (Seq.map region_js (Region_set.to_seq srcs)))
     in
     js_string (Option.value ~default:"" depr) :: region_js r :: srcs
 
@@ -209,7 +209,7 @@ module Make (Cfg : Config) = struct
     | None -> it
 
   let id i =
-    add_source i.Source.at (to_js_object "ID" [| js_string i.Source.it |])
+    add_source i.at (to_js_object "ID" [| js_string i.it |])
 
   let rec path p =
     let open Source in
@@ -304,7 +304,7 @@ module Make (Cfg : Config) = struct
 
   let rec exp_js e =
     let open Syntax in
-    exp'_js e |> add_raw_exp e |> add_type_annotation e.Source.note.note_typ |> add_source e.Source.at
+    exp'_js e |> add_raw_exp e |> add_type_annotation e.note.note_typ |> add_source e.at
 
   and exp'_js e =
     let open Syntax in
@@ -643,10 +643,10 @@ module Make (Cfg : Config) = struct
 
   and catch_js c =
     let open Syntax in
-    to_js_object "catch" Source.[| pat_js c.it.pat; exp_js c.it.exp |]
+    to_js_object "catch" [| pat_js c.it.pat; exp_js c.it.exp |]
 
   and prog_js p =
-    to_js_object "Prog" (List.map dec_js p.Source.it |> Array.of_list)
+    to_js_object "Prog" (List.map dec_js p.it |> Array.of_list)
 end
 
 include Make (Arrange.Default)

--- a/src/js/astjs.ml
+++ b/src/js/astjs.ml
@@ -8,6 +8,7 @@ module Type_pretty = Mo_types.Type.MakePretty (Mo_types.Type.ElideStamps)
 
 module type Config = Mo_def.Arrange.Config
 module type TypConfig = Mo_types.Arrange_type.Config
+open  Wasm.Source
 
 (* AST to JSON conversion *)
 module Make (Cfg : Config) = struct
@@ -30,7 +31,6 @@ module Make (Cfg : Config) = struct
     | Without_type_rep -> None
 
   let syntax_pos_js p =
-    let open Source in
     let file =
       match Cfg.main_file with Some f when f <> p.file -> p.file | _ -> ""
     in
@@ -41,8 +41,8 @@ module Make (Cfg : Config) = struct
   let type_pos_js p =
     to_js_object "Pos"
       [|
-        js_string (string_of_int p.Source.line);
-        js_string (string_of_int p.Source.column);
+        js_string (string_of_int p.line);
+        js_string (string_of_int p.column);
       |]
 
   let prim_js p =
@@ -98,15 +98,13 @@ module Make (Cfg : Config) = struct
     |> js_string
 
   let region_js r =
-    let open Source in
     let filename = r.left.file in
     to_js_object "@@"
       [| js_string filename; type_pos_js r.left; type_pos_js r.right |]
 
   let mut_js m =
-    let open Source in
     let open Syntax in
-    js_string (match m.it with Const -> "Const" | Var -> "Var")
+    js_string (match m.Source.it with Const -> "Const" | Var -> "Var")
 
   let rec typ_js =
     let open Type in
@@ -163,7 +161,7 @@ module Make (Cfg : Config) = struct
           match Field_sources.Srcs_map.find_opt track_region srcs_tbl with
           | None -> []
           | Some srcs ->
-              List.of_seq @@ Seq.map region_js @@ Source.Region_set.to_seq srcs)
+              List.of_seq (Seq.map region_js (Source.Region_set.to_seq srcs)))
     in
     js_string (Option.value ~default:"" depr) :: region_js r :: srcs
 
@@ -181,9 +179,9 @@ module Make (Cfg : Config) = struct
             [| it; Type_pretty.string_of_typ t |> js_string; typ_js t |]
     else it
 
-  let add_source (at : Source.region) (it : Js.Unsafe.any) : Js.Unsafe.any =
+  let add_source (at : region) (it : Js.Unsafe.any) : Js.Unsafe.any =
     let open Source in
-    if Cfg.include_sources && at <> Source.no_region then
+    if Cfg.include_sources && at <> no_region then
       to_js_object "@" [| syntax_pos_js at.left; syntax_pos_js at.right; it |]
     else it
 
@@ -196,13 +194,13 @@ module Make (Cfg : Config) = struct
     ignore (Js.Unsafe.global##.Object##defineProperty it (Js.string "rawExp") descriptor);
     it
 
-  let add_trivia (at : Source.region) (it : Js.Unsafe.any) : Js.Unsafe.any =
+  let add_trivia (at : region) (it : Js.Unsafe.any) : Js.Unsafe.any =
     match Cfg.include_docs with
     | Some table -> (
         let rec lookup_trivia (line, column) =
           Trivia.PosHashtbl.find_opt table Trivia.{ line; column }
-        and find_trivia (parser_pos : Source.region) : Trivia.trivia_info =
-          lookup_trivia Source.(parser_pos.left.line, parser_pos.left.column)
+        and find_trivia (parser_pos : region) : Trivia.trivia_info =
+          lookup_trivia (parser_pos.left.line, parser_pos.left.column)
           |> Option.get
         in
         match Trivia.doc_comment_of_trivia_info (find_trivia at) with
@@ -211,8 +209,7 @@ module Make (Cfg : Config) = struct
     | None -> it
 
   let id i =
-    let open Source in
-    add_source i.at (to_js_object "ID" [| js_string i.it |])
+    add_source i.Source.at (to_js_object "ID" [| js_string i.Source.it |])
 
   let rec path p =
     let open Source in
@@ -307,8 +304,7 @@ module Make (Cfg : Config) = struct
 
   let rec exp_js e =
     let open Syntax in
-    let open Source in
-    exp'_js e |> add_raw_exp e |> add_type_annotation e.note.note_typ |> add_source e.at
+    exp'_js e |> add_raw_exp e |> add_type_annotation e.Source.note.note_typ |> add_source e.Source.at
 
   and exp'_js e =
     let open Syntax in
@@ -646,13 +642,11 @@ module Make (Cfg : Config) = struct
     |> add_source c.at
 
   and catch_js c =
-    let open Source in
     let open Syntax in
-    to_js_object "catch" [| pat_js c.it.pat; exp_js c.it.exp |]
+    to_js_object "catch" Source.[| pat_js c.it.pat; exp_js c.it.exp |]
 
   and prog_js p =
-    let open Source in
-    to_js_object "Prog" (List.map dec_js p.it |> Array.of_list)
+    to_js_object "Prog" (List.map dec_js p.Source.it |> Array.of_list)
 end
 
 include Make (Arrange.Default)

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -1,5 +1,5 @@
 open Wasm_exts
-open Wasm.Source
+open Source
 open Mo_config
 
 module Js = Js_of_ocaml.Js

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -105,7 +105,7 @@ let js_candid source =
     js_result (Pipeline.generate_idl [Js.to_string source])
       (fun prog ->
         let open Idllib in
-        let module WithComments = Arrange_idl.Make(struct let trivia = Some prog.Source.note.Syntax.trivia end) in
+        let module WithComments = Arrange_idl.Make(struct let trivia = Some prog.note.Syntax.trivia end) in
         let code = WithComments.string_of_prog prog in
         Js.some (Js.string code)))
 
@@ -156,7 +156,7 @@ let js_parse_motoko enable_recovery s =
       let include_sources = true
       let include_type_rep = Arrange.Without_type_rep
       let include_types = false
-      let include_docs = Some prog.Source.note.Syntax.trivia
+      let include_docs = Some prog.note.Syntax.trivia
       let include_parenthetical = false
       let main_file = Some main_file
     end)
@@ -183,7 +183,7 @@ let js_parse_motoko_with_deps enable_recovery path s =
       let include_sources = true
       let include_type_rep = Arrange.Without_type_rep
       let include_types = false
-      let include_docs = Some prog.Source.note.Syntax.trivia
+      let include_docs = Some prog.note.Syntax.trivia
       let include_parenthetical = false
       let main_file = Some main_file
     end) in
@@ -285,9 +285,9 @@ let js_parse_motoko_typed_with_scope_cache_impl enable_recovery paths scope_cach
           let include_sources = true
           let include_type_rep = Arrange.With_type_rep (Some sscope.Mo_frontend.Scope.fld_src_env)
           let include_types = true
-          let include_docs = Some prog.Source.note.Syntax.trivia
+          let include_docs = Some prog.note.Syntax.trivia
           let include_parenthetical = false
-          let main_file = Some prog.Source.at.left.file
+          let main_file = Some prog.at.left.file
         end)
         in
         ( Arrange.prog_js prog

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -1,5 +1,5 @@
 open Wasm_exts
-open Source
+open Wasm.Source
 open Mo_config
 
 module Js = Js_of_ocaml.Js
@@ -105,7 +105,7 @@ let js_candid source =
     js_result (Pipeline.generate_idl [Js.to_string source])
       (fun prog ->
         let open Idllib in
-        let module WithComments = Arrange_idl.Make(struct let trivia = Some prog.note.Syntax.trivia end) in
+        let module WithComments = Arrange_idl.Make(struct let trivia = Some prog.Source.note.Syntax.trivia end) in
         let code = WithComments.string_of_prog prog in
         Js.some (Js.string code)))
 
@@ -156,7 +156,7 @@ let js_parse_motoko enable_recovery s =
       let include_sources = true
       let include_type_rep = Arrange.Without_type_rep
       let include_types = false
-      let include_docs = Some prog.note.Syntax.trivia
+      let include_docs = Some prog.Source.note.Syntax.trivia
       let include_parenthetical = false
       let main_file = Some main_file
     end)
@@ -183,7 +183,7 @@ let js_parse_motoko_with_deps enable_recovery path s =
       let include_sources = true
       let include_type_rep = Arrange.Without_type_rep
       let include_types = false
-      let include_docs = Some prog.note.Syntax.trivia
+      let include_docs = Some prog.Source.note.Syntax.trivia
       let include_parenthetical = false
       let main_file = Some main_file
     end) in
@@ -285,9 +285,9 @@ let js_parse_motoko_typed_with_scope_cache_impl enable_recovery paths scope_cach
           let include_sources = true
           let include_type_rep = Arrange.With_type_rep (Some sscope.Mo_frontend.Scope.fld_src_env)
           let include_types = true
-          let include_docs = Some prog.note.Syntax.trivia
+          let include_docs = Some prog.Source.note.Syntax.trivia
           let include_parenthetical = false
-          let main_file = Some prog.at.left.file
+          let main_file = Some prog.Source.at.left.file
         end)
         in
         ( Arrange.prog_js prog
@@ -413,9 +413,11 @@ let gc_flags option =
 
 let js_contextual_dot_suggestions scope raw_exp =
   let open Mo_frontend in
+  let open Mo_def.Syntax in
+  let open Source in
   let scope = (Obj.magic scope : Scope.t) in
-  let exp = (Obj.magic raw_exp : Mo_def.Syntax.exp) in
-  let receiver_ty = exp.note.Mo_def.Syntax.note_typ in
+  let exp = (Obj.magic raw_exp : exp) in
+  let receiver_ty = exp.note.note_typ in
   let libs = scope.Scope.lib_env in
   let open Typing in
   let suggestions = contextual_dot_suggestions libs receiver_ty in

--- a/src/lang_utils/diag.ml
+++ b/src/lang_utils/diag.ml
@@ -1,7 +1,7 @@
 open Mo_config
 module G = Grace
 module GD = Grace.Diagnostic
-open Wasm.Source
+open Source
 
 type error_code = string
 type severity = Warning | Error | Info
@@ -98,7 +98,7 @@ let string_of_message msg =
     if msg.notes <> [] then
       "\n" ^ String.concat "\n" (List.map (fun note -> "note: " ^ note) msg.notes)
     else "" in
-  Printf.sprintf "%s: %s%s, %s%s%s\n" (Source.string_of_region msg.at) label code msg.text spans notes
+  Printf.sprintf "%s: %s%s, %s%s%s\n" (string_of_region msg.at) label code msg.text spans notes
 
 (** Converts a line/column based position to a byte offset.
 
@@ -119,7 +119,7 @@ let ensure_primary_span msg =
   else { prio = Primary; at_span = msg.at; label = "" } :: msg.spans
 
 let fancy_of_message (msg : message) =
-  if Source.is_no_region msg.at then string_of_message msg else
+  if is_no_region msg.at then string_of_message msg else
   let path = msg.at.left.file in
   let content = In_channel.with_open_bin path In_channel.input_all in
   let file = G.Source.{ name = Some path; content } in

--- a/src/lang_utils/diag.ml
+++ b/src/lang_utils/diag.ml
@@ -1,23 +1,24 @@
 open Mo_config
 module G = Grace
 module GD = Grace.Diagnostic
+open Wasm.Source
 
 type error_code = string
 type severity = Warning | Error | Info
 type priority = Primary | Secondary
 type span = {
   prio : priority;
-  at_span : Source.region;
+  at_span : region;
   label : string;
 }
 type edit = {
-  at_edit : Source.region;
+  at_edit : region;
   suggested_replacement : string;
 }
 type message = {
   sev : severity;
   code : error_code;
-  at : Source.region;
+  at : region;
   cat : string;
   text : string;
   spans : span list;
@@ -106,27 +107,27 @@ let string_of_message msg =
 *)
 let pos_to_byte content pos =
   let line_start = ref (-1) in
-  for _ = 1 to pos.Source.line - 1 do
+  for _ = 1 to pos.line - 1 do
     let prev = !line_start in
     line_start := String.index_from content (prev + 1) '\n';
   done;
-  !line_start + pos.Source.column + 1
+  !line_start + pos.column + 1
 
 let ensure_primary_span msg =
   if List.exists (fun span -> span.prio = Primary) msg.spans
   then msg.spans
   else { prio = Primary; at_span = msg.at; label = "" } :: msg.spans
 
-let fancy_of_message msg =
+let fancy_of_message (msg : message) =
   if Source.is_no_region msg.at then string_of_message msg else
-  let path = msg.at.Source.left.Source.file in
+  let path = msg.at.left.file in
   let content = In_channel.with_open_bin path In_channel.input_all in
   let file = G.Source.{ name = Some path; content } in
   let source : G.Source.t = `String file in
   let range r =
     G.Range.create ~source
-      (G.Byte_index.of_int (pos_to_byte content r.Source.left))
-      (G.Byte_index.of_int (pos_to_byte content r.Source.right))
+      (G.Byte_index.of_int (pos_to_byte content r.left))
+      (G.Byte_index.of_int (pos_to_byte content r.right))
   in
   let mk_span span =
     let priority = match span.prio with
@@ -135,8 +136,8 @@ let fancy_of_message msg =
     GD.Label.createf ~range:(range span.at_span) ~priority "%s" span.label in
   let labels = List.map mk_span (ensure_primary_span msg) in
   let source_text r =
-    let start = pos_to_byte content r.Source.left in
-    let stop = pos_to_byte content r.Source.right in
+    let start = pos_to_byte content r.left in
+    let stop = pos_to_byte content r.right in
     String.sub content start (stop - start)
     |> Lib.String.strip_control_chars
     |> String.trim
@@ -168,8 +169,8 @@ let string_of_severity (sev : severity) = match sev with
   | Info -> "info"
 
 let json_span ?prio ?label ?suggested_replacement r =
-  let { Source.file; line = line_start; column = column_start } = r.Source.left in
-  let { Source.line = line_end; column = column_end; _ } = r.Source.right in
+  let { file; line = line_start; column = column_start } = r.left in
+  let { line = line_end; column = column_end; _ } = r.right in
   `Assoc [
     "file", `String file;
     "line_start", `Int line_start;

--- a/src/lang_utils/diag.mli
+++ b/src/lang_utils/diag.mli
@@ -1,21 +1,23 @@
 (* A common data type for diagnostic messages *)
 
+open Source
+
 type severity
 type error_code = string
 type priority = Primary | Secondary
 type span = {
   prio : priority;
-  at_span : Source.region;
+  at_span : region;
   label : string;
 }
 type edit = {
-  at_edit : Source.region;
+  at_edit : region;
   suggested_replacement : string;
 }
 type message = {
   sev : severity;
   code : error_code;
-  at : Source.region;
+  at : region;
   cat : string;
   text : string;
   spans : span list;
@@ -25,9 +27,9 @@ type message = {
 
 type messages = message list
 
-val info_message : Source.region -> string -> ?spans:span list -> ?notes:string list -> ?edits:edit list -> string -> message
-val warning_message : Source.region -> error_code -> string -> ?spans:span list -> ?notes:string list -> ?edits:edit list -> string -> message
-val error_message : Source.region -> error_code -> string -> ?spans:span list -> ?notes:string list -> ?edits:edit list -> string -> message
+val info_message : region -> string -> ?spans:span list -> ?notes:string list -> ?edits:edit list -> string -> message
+val warning_message : region -> error_code -> string -> ?spans:span list -> ?notes:string list -> ?edits:edit list -> string -> message
+val error_message : region -> error_code -> string -> ?spans:span list -> ?notes:string list -> ?edits:edit list -> string -> message
 
 val string_of_message : message -> string
 val is_treated_as_error : message -> bool
@@ -40,9 +42,9 @@ Both success and failure can come with messages)
 
 type 'a result = ('a * messages, messages) Stdlib.result
 
-val info : Source.region -> string -> string -> unit result
-val warn : Source.region -> error_code -> string -> string -> unit result
-val error : Source.region -> error_code -> string -> string -> 'a result
+val info : region -> string -> string -> unit result
+val warn : region -> error_code -> string -> string -> unit result
+val error : region -> error_code -> string -> string -> 'a result
 
 val return : 'a -> 'a result
 val bind : 'a result -> ('a -> 'b result) -> 'b result

--- a/src/lang_utils/dune
+++ b/src/lang_utils/dune
@@ -1,7 +1,7 @@
 (library
   (name lang_utils)
 
-  (libraries lib mo_config yojson grace grace.ansi_renderer)
+  (libraries lib mo_config wasm yojson grace grace.ansi_renderer)
 
   (wrapped false)
 

--- a/src/lang_utils/source.ml
+++ b/src/lang_utils/source.ml
@@ -1,5 +1,5 @@
-type pos = Wasm.Source.pos
-type region = Wasm.Source.region
+type pos = Wasm.Source.pos = { file : string; line : int; column : int }
+type region = Wasm.Source.region = { left : pos; right : pos }
 
 open Wasm.Source
 

--- a/src/lang_utils/source.ml
+++ b/src/lang_utils/source.ml
@@ -1,5 +1,8 @@
-type pos = {file : string; line : int; column : int}
-type region = {left : pos; right : pos}
+type pos = Wasm.Source.pos
+type region = Wasm.Source.region
+
+open Wasm.Source
+
 type ('a, 'b) annotated_phrase = {at : region; it : 'a; mutable note: 'b}
 type 'a phrase = ('a, unit) annotated_phrase
 

--- a/src/lang_utils/source.mli
+++ b/src/lang_utils/source.mli
@@ -1,5 +1,5 @@
-type pos = Wasm.Source.pos
-type region = Wasm.Source.region
+type pos = Wasm.Source.pos = { file : string; line : int; column : int }
+type region = Wasm.Source.region = { left : pos; right : pos }
 type ('a, 'b) annotated_phrase = {at : region; it : 'a; mutable note: 'b}
 type 'a phrase = ('a, unit) annotated_phrase
 

--- a/src/lang_utils/source.mli
+++ b/src/lang_utils/source.mli
@@ -1,5 +1,5 @@
-type pos = {file : string; line : int; column : int}
-type region = {left : pos; right : pos}
+type pos = Wasm.Source.pos
+type region = Wasm.Source.region
 type ('a, 'b) annotated_phrase = {at : region; it : 'a; mutable note: 'b}
 type 'a phrase = ('a, unit) annotated_phrase
 

--- a/src/lang_utils/trivia.ml
+++ b/src/lang_utils/trivia.ml
@@ -59,7 +59,7 @@ type triv_table = trivia_info PosHashtbl.t
 
 let empty_triv_table = PosHashtbl.create 0
 
-let find_trivia triv_table (parser_pos : Source.region) : trivia_info =
+let find_trivia triv_table (parser_pos : region) : trivia_info =
   PosHashtbl.find triv_table
     { line = parser_pos.left.line; column = parser_pos.left.column }
 

--- a/src/lang_utils/trivia.ml
+++ b/src/lang_utils/trivia.ml
@@ -1,4 +1,4 @@
-open Source
+open Wasm.Source
 
 type line_feed = LF | CRLF
 

--- a/src/lang_utils/trivia.ml
+++ b/src/lang_utils/trivia.ml
@@ -1,4 +1,4 @@
-open Wasm.Source
+open Source
 
 type line_feed = LF | CRLF
 

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -51,7 +51,7 @@ module Make (Cfg : Config) = struct
       let rec lookup_trivia (line, column) =
         Trivia.PosHashtbl.find_opt table Trivia.{ line; column }
       and find_trivia (parser_pos : Source.region) : Trivia.trivia_info =
-        lookup_trivia Wasm.Source.(parser_pos.left.line, parser_pos.left.column) |> Option.get
+        lookup_trivia (parser_pos.left.line, parser_pos.left.column) |> Option.get
       in
       (match Trivia.doc_comment_of_trivia_info (find_trivia at) with
       | Some s -> "*" $$ [Atom s; it]

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -38,8 +38,8 @@ module Make (Cfg : Config) = struct
     | _ -> ""
     in "Pos" $$ [Atom file; Atom (string_of_int p.line); Atom (string_of_int p.column)]
 
-  let source at0 it =
-    if Cfg.include_sources && at0 <> no_region then "@" $$ [pos at0.left; pos at0.right; it] else it
+  let source at' it =
+    if Cfg.include_sources && at' <> no_region then "@" $$ [pos at'.left; pos at'.right; it] else it
 
   let typ t = Atom (Type_pretty.string_of_typ t)
 

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -39,7 +39,7 @@ module Make (Cfg : Config) = struct
     in "Pos" $$ [Atom file; Atom (string_of_int p.line); Atom (string_of_int p.column)]
 
   let source at0 it =
-    if Cfg.include_sources && at0 <> Source.no_region then "@" $$ [pos at0.left; pos at0.right; it] else it
+    if Cfg.include_sources && at0 <> no_region then "@" $$ [pos at0.left; pos at0.right; it] else it
 
   let typ t = Atom (Type_pretty.string_of_typ t)
 
@@ -48,7 +48,7 @@ module Make (Cfg : Config) = struct
     | Some table ->
       let rec lookup_trivia (line, column) =
         Trivia.PosHashtbl.find_opt table Trivia.{ line; column }
-      and find_trivia (parser_pos : Source.region) : Trivia.trivia_info =
+      and find_trivia (parser_pos : region) : Trivia.trivia_info =
         lookup_trivia (parser_pos.left.line, parser_pos.left.column) |> Option.get
       in
       (match Trivia.doc_comment_of_trivia_info (find_trivia at) with
@@ -75,7 +75,7 @@ module Make (Cfg : Config) = struct
     | Type.Module -> Atom "Module"
     | Type.Memory -> Atom "Memory"
 
-  let rec exp e = source e.Source.at (annot_typ e.note.note_typ (match e.it with
+  let rec exp e = source e.at (annot_typ e.note.note_typ (match e.it with
     | HoleE (_, e) -> "HoleE" $$ [exp !e]
     | VarE x              -> "VarE"      $$ [id x]
     | LitE l              -> "LitE"      $$ [lit !l]

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -33,14 +33,12 @@ module Make (Cfg : Config) = struct
   let ($$) head inner = Node (head, inner)
 
   let pos p =
-    let open Wasm.Source in
     let file = match Cfg.main_file with
     | Some f when f <> p.file -> p.file
     | _ -> ""
     in "Pos" $$ [Atom file; Atom (string_of_int p.line); Atom (string_of_int p.column)]
 
   let source at0 it =
-    let open Wasm.Source in
     if Cfg.include_sources && at0 <> Source.no_region then "@" $$ [pos at0.left; pos at0.right; it] else it
 
   let typ t = Atom (Type_pretty.string_of_typ t)

--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -33,11 +33,15 @@ module Make (Cfg : Config) = struct
   let ($$) head inner = Node (head, inner)
 
   let pos p =
+    let open Wasm.Source in
     let file = match Cfg.main_file with
     | Some f when f <> p.file -> p.file
     | _ -> ""
     in "Pos" $$ [Atom file; Atom (string_of_int p.line); Atom (string_of_int p.column)]
-  let source at it = if Cfg.include_sources && at <> Source.no_region then "@" $$ [pos at.left; pos at.right; it] else it
+
+  let source at0 it =
+    let open Wasm.Source in
+    if Cfg.include_sources && at0 <> Source.no_region then "@" $$ [pos at0.left; pos at0.right; it] else it
 
   let typ t = Atom (Type_pretty.string_of_typ t)
 
@@ -47,7 +51,7 @@ module Make (Cfg : Config) = struct
       let rec lookup_trivia (line, column) =
         Trivia.PosHashtbl.find_opt table Trivia.{ line; column }
       and find_trivia (parser_pos : Source.region) : Trivia.trivia_info =
-        lookup_trivia Source.(parser_pos.left.line, parser_pos.left.column) |> Option.get
+        lookup_trivia Wasm.Source.(parser_pos.left.line, parser_pos.left.column) |> Option.get
       in
       (match Trivia.doc_comment_of_trivia_info (find_trivia at) with
       | Some s -> "*" $$ [Atom s; it]
@@ -73,7 +77,7 @@ module Make (Cfg : Config) = struct
     | Type.Module -> Atom "Module"
     | Type.Memory -> Atom "Memory"
 
-  let rec exp e = source e.at (annot_typ e.note.note_typ (match e.it with
+  let rec exp e = source e.Source.at (annot_typ e.note.note_typ (match e.it with
     | HoleE (_, e) -> "HoleE" $$ [exp !e]
     | VarE x              -> "VarE"      $$ [id x]
     | LitE l              -> "LitE"      $$ [lit !l]

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -2,6 +2,7 @@ open Mo_types
 open Mo_values
 
 open Operator
+open Source
 
 
 (* Notes *)
@@ -22,27 +23,27 @@ type resolved_import =
 
 (* Identifiers *)
 
-type id = string Source.phrase
+type id = string phrase
 (* type id_ref, see below *)
-type typ_id = (string, Type.con option) Source.annotated_phrase
+type typ_id = (string, Type.con option) annotated_phrase
 
 
 (* Types *)
 
-type 'note sort = (Type.obj_sort, 'note) Source.annotated_phrase
+type 'note sort = (Type.obj_sort, 'note) annotated_phrase
 type typ_obj_sort = unit sort
 
 type migration_chain = (string * Type.typ * Type.typ) list
-type persistence = (bool, migration_chain) Source.annotated_phrase
+type persistence = (bool, migration_chain) annotated_phrase
 
 type obj_sort = persistence sort
-type func_sort = Type.func_sort Source.phrase
+type func_sort = Type.func_sort phrase
 
-type mut = mut' Source.phrase
+type mut = mut' phrase
 and mut' = Const | Var
 
-and typ_path = (path', Type.con option) Source.annotated_phrase
-and path = (path', Type.typ) Source.annotated_phrase
+and typ_path = (path', Type.con option) annotated_phrase
+and path = (path', Type.typ) annotated_phrase
 and path' =
   | IdH  of id
   | DotH of path * id
@@ -50,7 +51,7 @@ and path' =
 and async_sort = Type.async_sort
 and await_sort = Type.await_sort
 
-type typ = (typ', Type.typ) Source.annotated_phrase
+type typ = (typ', Type.typ) annotated_phrase
 and typ' =
   | PathT of typ_path * typ list                   (* type path *)
   | PrimT of string                                (* primitive *)
@@ -68,16 +69,16 @@ and typ' =
   | WeakT of typ                                   (* weak reference *)
 
 and scope = typ
-and typ_field = typ_field' Source.phrase
+and typ_field = typ_field' phrase
 and typ_field' =
   | ValF of id * typ * mut
   | TypF of typ_id * typ_bind list * typ
 
-and typ_tag = typ_tag' Source.phrase
+and typ_tag = typ_tag' phrase
 and typ_tag' = {tag : id; typ : typ}
 
-and bind_sort = Type.bind_sort Source.phrase
-and typ_bind = (typ_bind', Type.con option) Source.annotated_phrase
+and bind_sort = Type.bind_sort phrase
+and typ_bind = (typ_bind', Type.con option) annotated_phrase
 and typ_bind' = {var : id; sort : bind_sort; bound : typ;}
 
 and typ_item = id option * typ
@@ -108,7 +109,7 @@ type lit =
 
 (* Patterns *)
 
-type pat = (pat', Type.typ) Source.annotated_phrase
+type pat = (pat', Type.typ) annotated_phrase
 and pat' =
   | WildP                                      (* wildcard *)
   | VarP of id                                 (* variable *)
@@ -125,36 +126,36 @@ and pat' =
   | AsP of pat * pat                           (* conjunctive *)
 *)
 
-and pat_field = pat_field' Source.phrase
+and pat_field = pat_field' phrase
 and pat_field' =
   | ValPF of id * pat
   | TypPF of typ_id
 
-let pf_id pf = match pf.Source.it with
+let pf_id pf = match pf.it with
   | ValPF(id, _) -> id
-  | TypPF(id) -> Source.{ it = id.it; at = id.at; note = () }
+  | TypPF(id) -> { it = id.it; at = id.at; note = () }
 
-let pf_pattern pf = match pf.Source.it with
+let pf_pattern pf = match pf.it with
   | ValPF(_, pat) -> Some pat
   | TypPF(_) -> None
 
 (* Expressions *)
 
-type vis = vis' Source.phrase
+type vis = vis' phrase
 and vis' =
   | Public of string option
   | Private
   | System
 
-let is_public vis = match vis.Source.it with Public _ -> true | _ -> false
-let is_private vis = match vis.Source.it with Private -> true | _ -> false
+let is_public vis = match vis.it with Public _ -> true | _ -> false
+let is_private vis = match vis.it with Private -> true | _ -> false
 
 
 type op_typ = Type.typ ref (* For overloaded resolution; initially Type.Pre. *)
 
-type inst = ((bool * typ list) option, Type.typ list) Source.annotated_phrase (* For implicit scope instantiation *)
+type inst = ((bool * typ list) option, Type.typ list) annotated_phrase (* For implicit scope instantiation *)
 
-type sort_pat = (Type.shared_sort * pat) Type.shared Source.phrase
+type sort_pat = (Type.shared_sort * pat) Type.shared phrase
 
 type sugar = bool (* Is the source of a function body a block `<block>`,
                      subject to further desugaring during parse,
@@ -178,10 +179,10 @@ let break_label kind (id_opt : id option) =
   match kind, id_opt with
   | Break, None -> auto_s
   | Continue, None -> auto_continue_s
-  | _, Some {Source.it; _} -> it
+  | _, Some {it; _} -> it
 
 
-type id_ref = (string, mut' * exp option) Source.annotated_phrase
+type id_ref = (string, mut' * exp option) annotated_phrase
 
 and viewer_body = DotViewV of exp | DefaultV of exp
 and viewer = {
@@ -189,10 +190,10 @@ and viewer = {
     viewer_field : Type.field
   }
 
-and stab = stab' Source.phrase
+and stab = stab' phrase
 and stab' = Stable of viewer option ref | Flexible
 
-and exp = (exp', typ_note) Source.annotated_phrase
+and exp = (exp', typ_note) annotated_phrase
 and exp' =
   | HoleE of string * exp ref
   | PrimE of string                            (* primitive *)
@@ -249,13 +250,13 @@ and arg_exp = (bool * (exp ref))
 and assert_kind =
   | Runtime
 
-and dec_field = dec_field' Source.phrase
+and dec_field = dec_field' phrase
 and dec_field' = {dec : dec; vis : vis; stab: stab option}
 
-and exp_field = exp_field' Source.phrase
+and exp_field = exp_field' phrase
 and exp_field' = {mut : mut; id : id; exp : exp}
 
-and case = case' Source.phrase
+and case = case' phrase
 and case' = {pat : pat; exp : exp}
 
 (* When `Some`, this holds the expression that produces the function to apply to the receiver.
@@ -264,7 +265,7 @@ and contextual_dot_note = exp option ref
 
 (* Declarations *)
 
-and dec = (dec', typ_note) Source.annotated_phrase
+and dec = (dec', typ_note) annotated_phrase
 and dec' =
   | ExpD of exp                                (* plain unit expression *)
   | LetD of pat * exp * exp option             (* immutable, with an optional fail block *)
@@ -277,29 +278,29 @@ and dec' =
 and include_note' = { imports : import list; pat : pat; decs : dec_field list }
 and include_note = include_note' option ref
 
-and import = (import', Type.typ) Source.annotated_phrase
+and import = (import', Type.typ) annotated_phrase
 and import' = pat * string * resolved_import ref
 
 (* Program (pre unit detection) *)
 
 type prog_note = { filename : string; trivia : Trivia.triv_table }
-type prog = (prog', prog_note) Source.annotated_phrase
+type prog = (prog', prog_note) annotated_phrase
 and prog' = dec list
 
 (* Signatures (stable variables) *)
 
-type stab_sig = (stab_sig', prog_note) Source.annotated_phrase
+type stab_sig = (stab_sig', prog_note) annotated_phrase
 and stab_sig' = (dec list * stab_body)      (* type declarations & stable actor fields *)
-and stab_body = stab_body' Source.phrase    (* type declarations & stable actor fields *)
+and stab_body = stab_body' phrase    (* type declarations & stable actor fields *)
 and stab_body' =
   | Single of typ_field list
   | PrePost of (req * typ_field) list * typ_field list
   | Multi of {chain : typ_tag list; post : typ_field list}
-and req = bool Source.phrase
+and req = bool phrase
 
 (* Compilation units *)
 
-type comp_unit_body = (comp_unit_body', typ_note) Source.annotated_phrase
+type comp_unit_body = (comp_unit_body', typ_note) annotated_phrase
 and comp_unit_body' =
  | ProgU of dec list                         (* main programs *)
  | ActorU of persistence * exp option * id option * dec_field list      (* main IC actor *)
@@ -308,7 +309,7 @@ and comp_unit_body' =
      persistence * exp option * sort_pat * typ_id * typ_bind list * pat * typ option * id * dec_field list
  | MixinU of pat * dec_field list            (* Mixins *)
 
-type comp_unit = (comp_unit', prog_note) Source.annotated_phrase
+type comp_unit = (comp_unit', prog_note) annotated_phrase
 and comp_unit' = {
   imports : import list;
   body : comp_unit_body;
@@ -319,11 +320,11 @@ type lib = comp_unit
 
 (* Helpers *)
 
-let (@@) = Source.(@@)
-let (@~) it at = Source.annotate (Const, None) it at
-let (@?) it at = Source.annotate empty_typ_note it at
-let (@!) it at = Source.annotate Type.Pre it at
-let (@=) it at = Source.annotate None it at
+let (@@) = (@@)
+let (@~) it at = annotate (Const, None) it at
+let (@?) it at = annotate empty_typ_note it at
+let (@!) it at = annotate Type.Pre it at
+let (@=) it at = annotate None it at
 
 (* NB: This function is currently unused *)
 let string_of_lit = function
@@ -378,7 +379,7 @@ let is_scope name =
 (* Types & Scopes *)
 
 let arity t =
-  match t.Source.it with
+  match t.it with
   | TupT ts -> List.length ts
   | _ -> 1
 

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -363,7 +363,7 @@ open Source
 
 (* Identifiers *)
 
-let anon_id sort at = "@anon-" ^ sort ^ "-" ^ string_of_pos at.left
+let anon_id sort at = "@anon-" ^ sort ^ "-" ^ string_of_pos at.Wasm.Source.left
 let is_anon_id id = Lib.String.chop_prefix "@anon-" id.it <> None
 
 let is_privileged name =

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -363,7 +363,7 @@ open Source
 
 (* Identifiers *)
 
-let anon_id sort at = "@anon-" ^ sort ^ "-" ^ string_of_pos at.Wasm.Source.left
+let anon_id sort at = "@anon-" ^ sort ^ "-" ^ string_of_pos at.left
 let is_anon_id id = Lib.String.chop_prefix "@anon-" id.it <> None
 
 let is_privileged name =

--- a/src/mo_frontend/bi_match.mli
+++ b/src/mo_frontend/bi_match.mli
@@ -1,5 +1,6 @@
 open Mo_types
 open Type
+open Source
 
 (* `bi_match scope_opt tbs subs ret_opt` returns
    a minimal instantiation `ts` such that
@@ -45,7 +46,7 @@ open Type
 *)
 
 type reason =
-  { actual : typ; expected : typ; at : Source.region }
+  { actual : typ; expected : typ; at : region }
 
 exception Bimatch of {
   message : string;
@@ -83,7 +84,7 @@ val bi_match_subs :
   scope option ->
   bind list ->
   typ option ->
-  (typ * typ * Source.region) list ->
+  (typ * typ * region) list ->
   must_solve: typ list ->
   typ list * ctx
 
@@ -99,7 +100,7 @@ val bi_match_subs :
 val finalize :
   typ list ->
   ctx ->
-  (typ * typ * Source.region) list ->
+  (typ * typ * region) list ->
   typ list * typ ConEnv.t
 
 (** Checks that all types are closed (no unresolved type variables) *)

--- a/src/mo_frontend/coverage.ml
+++ b/src/mo_frontend/coverage.ml
@@ -11,7 +11,7 @@ module V = Value
 module ValSet = Set.Make(struct type t = V.value let compare = V.compare end)
 module TagSet = Set.Make(struct type t = string let compare = String.compare end)
 module LabMap = Map.Make(struct type t = string let compare = String.compare end)
-module AtSet = Set.Make(struct type t = Source.region let compare = compare end)
+module AtSet = Set.Make(struct type t = region let compare = compare end)
 
 type desc =
   | Any
@@ -28,9 +28,9 @@ type ctxt =
   | InTag of ctxt * string
   | InTup of ctxt * desc list * desc list * pat list * T.typ list
   | InObj of ctxt * desc LabMap.t * string * pat_field list * T.field list
-  | InAlt1 of ctxt * Source.region * pat * T.typ
-  | InAlt2 of ctxt * Source.region
-  | InCase of Source.region * case list * T.typ
+  | InAlt1 of ctxt * region * pat * T.typ
+  | InAlt2 of ctxt * region
+  | InCase of region * case list * T.typ
 
 type sets =
   { mutable cases : AtSet.t;
@@ -367,11 +367,11 @@ and fail ctxt desc sets : bool =
 
 
 type uncovered = string
-type unreached = Source.region
+type unreached = region
 
 let check_cases cases t =
   let sets = make_sets () in
-  let _exhaustive = fail (InCase (Source.no_region, cases, t)) Any sets in
+  let _exhaustive = fail (InCase (no_region, cases, t)) Any sets in
   let uncovered = List.map (string_of_desc t) (List.rev sets.missing) in
   let unreached_cases = AtSet.diff sets.cases sets.reached_cases in
   let unreached_alts = AtSet.diff sets.alts sets.reached_alts in
@@ -381,5 +381,5 @@ let (@?) it at = {it; at; note = empty_typ_note}
 
 let check_pat pat t =
   let uncovered, unreached =
-    check_cases [{pat; exp = TupE [] @? Source.no_region} @@ Source.no_region] t
+    check_cases [{pat; exp = TupE [] @? no_region} @@ no_region] t
   in uncovered, List.filter ((<>) pat.at) unreached

--- a/src/mo_frontend/definedness.ml
+++ b/src/mo_frontend/definedness.ml
@@ -34,7 +34,7 @@ let set_unions = List.fold_left S.union S.empty
 type f = usage_info M.t
 
 (* The analysis result of a recursive group, before tying the knot *)
-type group = (Source.region * S.t * S.t * S.t) list
+type group = (region * S.t * S.t * S.t) list
 
 (* Operations: Union and removal *)
 let (++) : f -> f -> f = M.union (fun _ u1 u2 -> Some (join u1 u2))

--- a/src/mo_frontend/lexer_lib.ml
+++ b/src/mo_frontend/lexer_lib.ml
@@ -4,7 +4,7 @@
   lexer.ml.
  *)
 
-open Wasm.Source
+open Source
 
 type mode = {
   privileged : bool;
@@ -23,8 +23,9 @@ let mode_verification : mode = { mode with verification = true }
 exception Error of region * string
 
 let convert_pos pos =
-  { file = pos.Lexing.pos_fname;
-    line = pos.Lexing.pos_lnum;
-    column = pos.Lexing.pos_cnum - pos.Lexing.pos_bol
+  Lexing.{
+      file = pos.pos_fname;
+      line = pos.pos_lnum;
+      column = pos.pos_cnum - pos.pos_bol
   }
 

--- a/src/mo_frontend/lexer_lib.ml
+++ b/src/mo_frontend/lexer_lib.ml
@@ -2,7 +2,10 @@
   This module exists so it can be included by lexer.ml. This way
   source_lexer.ml can use these definitions but stay internal to
   lexer.ml.
-*)
+ *)
+
+open Wasm.Source
+
 type mode = {
   privileged : bool;
   verification : bool;
@@ -17,11 +20,11 @@ let mode_priv : mode = { mode with privileged = true }
 let mode_verification : mode = { mode with verification = true }
 
 
-exception Error of Source.region * string
+exception Error of region * string
 
 let convert_pos pos =
-  { Source.file = pos.Lexing.pos_fname;
-    Source.line = pos.Lexing.pos_lnum;
-    Source.column = pos.Lexing.pos_cnum - pos.Lexing.pos_bol
+  { file = pos.Lexing.pos_fname;
+    line = pos.Lexing.pos_lnum;
+    column = pos.Lexing.pos_cnum - pos.Lexing.pos_bol
   }
 

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -286,7 +286,7 @@ and objblock eo s id ty dec_fields =
 %type<Mo_def.Syntax.typ_field> typ_field
 %type<Mo_def.Syntax.typ_bind> typ_bind
 %type<Mo_def.Syntax.typ list> typ_args
-%type<Source.region -> Mo_def.Syntax.pat> pat_opt
+%type<region -> Mo_def.Syntax.pat> pat_opt
 %type<Mo_def.Syntax.typ_tag list> seplist1(typ_tag,semicolon) seplist(typ_tag,semicolon)
 %type<Mo_def.Syntax.typ_item list> seplist(typ_item,COMMA)
 %type<Mo_def.Syntax.typ_field list> typ_obj seplist(typ_field,semicolon)

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -5,8 +5,7 @@ open Mo_types
 open Mo_values
 
 open Syntax
-open Wasm.Source
-open Source [@@@warning "-41"]
+open Source
 open Operator
 open Parser_lib
 
@@ -14,13 +13,13 @@ open Parser_lib
 (* Position handling *)
 
 let position_to_pos position =
-  Wasm.Source.{ file = position.Lexing.pos_fname;
+  { file = position.Lexing.pos_fname;
     line = position.Lexing.pos_lnum;
     column = position.Lexing.pos_cnum - position.Lexing.pos_bol
   }
 
 let positions_to_region position1 position2 =
-  Wasm.Source.{ left = position_to_pos position1;
+  { left = position_to_pos position1;
     right = position_to_pos position2
   }
 

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -671,7 +671,7 @@ exp_post(B) :
     { DotE(e, x, ref None) @? at $sloc }
   | nid = NUM_DOT_ID
     { let (num, id) = nid in
-      let Wasm.Source.{left; right} = at $sloc in
+      let {left; right} = at $sloc in
       let e =
 	LitE(ref (PreLit (num, Type.Nat))) @?
 	{ left;

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -5,7 +5,8 @@ open Mo_types
 open Mo_values
 
 open Syntax
-open Source
+open Wasm.Source
+open Source [@@@warning "-41"]
 open Operator
 open Parser_lib
 
@@ -13,13 +14,13 @@ open Parser_lib
 (* Position handling *)
 
 let position_to_pos position =
-  { file = position.Lexing.pos_fname;
+  Wasm.Source.{ file = position.Lexing.pos_fname;
     line = position.Lexing.pos_lnum;
     column = position.Lexing.pos_cnum - position.Lexing.pos_bol
   }
 
 let positions_to_region position1 position2 =
-  { left = position_to_pos position1;
+  Wasm.Source.{ left = position_to_pos position1;
     right = position_to_pos position2
   }
 
@@ -671,7 +672,7 @@ exp_post(B) :
     { DotE(e, x, ref None) @? at $sloc }
   | nid = NUM_DOT_ID
     { let (num, id) = nid in
-      let {left; right} = at $sloc in
+      let Wasm.Source.{left; right} = at $sloc in
       let e =
 	LitE(ref (PreLit (num, Type.Nat))) @?
 	{ left;

--- a/src/mo_frontend/parsing.ml
+++ b/src/mo_frontend/parsing.ml
@@ -107,7 +107,7 @@ module RecoveryConfig = struct
       let open Lexing in
       let open Source in
       let file = loc.loc_start.pos_fname in
-      let region_loc : region = {
+      let region_loc : region = Wasm.Source.{
         left  : pos = {file; line = loc.loc_start.pos_lnum; column = loc.loc_start.pos_bol};
         right : pos = {file; line = loc.loc_end.pos_lnum; column = loc.loc_end.pos_bol};
       } in
@@ -122,7 +122,7 @@ module R = MenhirRecoveryLib.Make (Parser.MenhirInterpreter) (RecoveryConfig) (R
 
 let handle_error lexbuf error_detail message_store (start, end_) explanations =
   let at =
-        Source.{left = Lexer.convert_pos start; right = Lexer.convert_pos end_}
+        Wasm.Source.{left = Lexer.convert_pos start; right = Lexer.convert_pos end_}
   in
   let lexeme = slice_lexeme lexbuf start end_ in
   let token =

--- a/src/mo_frontend/parsing.ml
+++ b/src/mo_frontend/parsing.ml
@@ -1,4 +1,5 @@
 open Mo_config
+open Source
 
 module P =
   MenhirLib.Printers.Make
@@ -31,8 +32,8 @@ let abstract_future future =
   String.concat " " ss
 
 let abstract_future_with_example future =
-  let ss      = String.concat " " @@ List.map Printers.string_of_symbol future in
-  let example = String.concat " " @@ List.map Printers.example_of_symbol future in
+  let ss      = List.map Printers.string_of_symbol future |> String.concat " " in
+  let example = List.map Printers.example_of_symbol future |> String.concat " " in
   if String.compare ss example != 0 then
     ss ^ " (e.g. '" ^ example ^ "')"
   else
@@ -107,7 +108,7 @@ module RecoveryConfig = struct
       let open Lexing in
       let open Source in
       let file = loc.loc_start.pos_fname in
-      let region_loc : region = Wasm.Source.{
+      let region_loc : region = {
         left  : pos = {file; line = loc.loc_start.pos_lnum; column = loc.loc_start.pos_bol};
         right : pos = {file; line = loc.loc_end.pos_lnum; column = loc.loc_end.pos_bol};
       } in
@@ -122,7 +123,7 @@ module R = MenhirRecoveryLib.Make (Parser.MenhirInterpreter) (RecoveryConfig) (R
 
 let handle_error lexbuf error_detail message_store (start, end_) explanations =
   let at =
-        Wasm.Source.{left = Lexer.convert_pos start; right = Lexer.convert_pos end_}
+        {left = Lexer.convert_pos start; right = Lexer.convert_pos end_}
   in
   let lexeme = slice_lexeme lexbuf start end_ in
   let token =

--- a/src/mo_frontend/scope.ml
+++ b/src/mo_frontend/scope.ml
@@ -31,12 +31,12 @@ and scope =
 and t = scope
 
 let empty : scope =
-  { val_env = T.Env.empty;
-    lib_env = T.Env.empty;
-    typ_env = T.Env.empty;
+  T.Env.{ val_env = empty;
+    lib_env = empty;
+    typ_env = empty;
     con_env = T.ConSet.empty;
-    obj_env = T.Env.empty;
-    mixin_env = T.Env.empty;
+    obj_env = empty;
+    mixin_env = empty;
     fld_src_env = Field_sources.Srcs_map.empty;
   }
 

--- a/src/mo_frontend/source_lexer.mll
+++ b/src/mo_frontend/source_lexer.mll
@@ -2,12 +2,13 @@
 open Trivia
 open Source_token
 open Lexer_lib
+open Source
 module Utf8 = Lib.Utf8
 
 let region lexbuf =
   let left = convert_pos (Lexing.lexeme_start_p lexbuf) in
   let right = convert_pos (Lexing.lexeme_end_p lexbuf) in
-  Wasm.Source.{left; right}
+  {left; right}
 
 let error lexbuf msg = raise (Error (region lexbuf, msg))
 let error_nest start lexbuf msg =

--- a/src/mo_frontend/source_lexer.mll
+++ b/src/mo_frontend/source_lexer.mll
@@ -7,7 +7,7 @@ module Utf8 = Lib.Utf8
 let region lexbuf =
   let left = convert_pos (Lexing.lexeme_start_p lexbuf) in
   let right = convert_pos (Lexing.lexeme_end_p lexbuf) in
-  {Source.left = left; Source.right = right}
+  Wasm.Source.{left; right}
 
 let error lexbuf msg = raise (Error (region lexbuf, msg))
 let error_nest start lexbuf msg =

--- a/src/mo_frontend/stability.ml
+++ b/src/mo_frontend/stability.ml
@@ -1,5 +1,5 @@
 open Mo_types
-
+open Source
 open Type
 
 module Pretty = Type.MakePretty(Type.ElideStampsAndHashes)
@@ -104,14 +104,14 @@ let match_stab_sig sig1 sig2 : unit Diag.result =
   | Multi _,  (PrePost _ |  Single _) ->
     assert (not (Type.match_stab_sig sig1 sig2));
     Diag.with_message_store (fun s ->
-      incompat_mix_migrations s Source.no_region;
+      incompat_mix_migrations s no_region;
       None)
   | _ ->
     let tfs1, mig_lab_opt = post sig1 in
     let tfs2 = pre mig_lab_opt sig2 in
     (* Assume that tfs1 and tfs2 are sorted. *)
     let res = Diag.with_message_store (fun s ->
-      Some (match_stab_fields s Source.no_region None tfs1 tfs2))
+      Some (match_stab_fields s no_region None tfs1 tfs2))
     in
     (* cross check with simpler definition *)
     match res with

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -665,12 +665,12 @@ let error_shared env t at code fmt =
     Format.kasprintf env (fun s1 -> Diag.add_msg env.msgs (type_error at code (s1^s) [] [] []); raise Recover) fmt
 
 let as_domT t =
-  match t.Source.it with
+  match t.it with
   | TupT tis -> tis
   | _ -> [(None, t)]
 
 let as_codomT sort t =
-  match sort, t.Source.it with
+  match sort, t.it with
   | T.Shared _,  AsyncT (T.Fut, _, t1) ->
     T.Promises, as_domT t1
   | _ -> T.Returns, as_domT t
@@ -4287,7 +4287,7 @@ and warn_unit_binding binder env (dec : dec) (exp : exp) =
     | `Let -> "let"
     | `Var -> "var"
   in
-  let at = Source.{dec.at with right = exp.at.left} in
+  let at = {dec.at with right = exp.at.left} in
   warn env at "M0239" "Avoid binding a unit `()` result; remove `%s` and keep the expression" binder
 
 and check_init env pat_opt exp at =

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -4,7 +4,8 @@ open Mo_values
 module Flags = Mo_config.Flags
 
 open Syntax
-open Source
+open Wasm.Source
+open Source [@@@warning "-41"]
 
 module T = Type
 module A = Effect
@@ -20,11 +21,11 @@ type usage = { assigned : bool }
 type avl = Available | Unavailable
 
 type lab_env = T.typ T.Env.t
-type val_info = T.typ * Source.region * Scope.val_kind * avl
+type val_info = T.typ * region * Scope.val_kind * avl
 type val_env  = val_info T.Env.t
 
 (* separate maps for values and types; entries only for _public_ elements *)
-type visibility_src = {depr : string option; id_region : Source.region; field_region : Source.region}
+type visibility_src = {depr : string option; id_region : region; field_region : region}
 type visibility_env = visibility_src T.Env.t * visibility_src T.Env.t
 
 let available env = T.Env.map (fun (ty, at, kind) -> (ty, at, kind, Available)) env
@@ -36,7 +37,7 @@ let initial_scope =
   }
 
 module UWSet = Set.Make(struct
-  type t = string * Source.region * Scope.val_kind
+  type t = string * region * Scope.val_kind
   let compare (_, r1, _) (_, r2, _) = Region_ord.compare r1 r2
 end)
 
@@ -60,17 +61,17 @@ type env =
     pre : bool;
     weak : bool;
     msgs : Diag.msg_store;
-    scopes : Source.region T.ConEnv.t;
+    scopes : region T.ConEnv.t;
     check_unused : bool;
     used_identifiers : usage T.Env.t ref;
     unused_warnings : UWSet.t ref;
-    shared_pat_regions : Source.region list ref;
+    shared_pat_regions : region list ref;
     reported_stable_memory : bool ref;
     errors_only : bool;
     type_recovery : bool;
     srcs : Field_sources.t;
     closest_loop : (Syntax.loop_flags * T.typ) option;
-    closest_scrutinee : (Source.region * T.typ) option;
+    closest_scrutinee : (region * T.typ) option;
     enhanced_migration : string option;
   }
 and ret_env =
@@ -367,7 +368,7 @@ let _warn_in modes env at code notes spans edits fmt =
 (* Unused identifier detection *)
 
 let emit_unused_warnings env =
-  let is_in_shared_pat pos = !(env.shared_pat_regions) |> List.exists Source.Pos_ord.(fun region ->
+  let is_in_shared_pat pos = !(env.shared_pat_regions) |> List.exists Pos_ord.(fun region ->
     compare region.left pos <= 0 && compare pos region.right <= 0)
   in
   let emit (id, region, kind) =
@@ -702,7 +703,7 @@ let string_of_region r =
   let open Source in
   let { left; right } = r in
   let basename = if left.file = "" then "" else Filename.basename left.file in
-  Source.string_of_region
+  string_of_region
     { left =  { left with file = basename };
       right = { right with file = basename } }
 
@@ -1019,7 +1020,7 @@ and check_typ_binds env typ_binds : T.con list * T.bind list * Scope.typ_env * S
   List.iter2 (fun c k ->
     match Cons.kind c with
     | T.Abs (_, T.Pre) -> T.set_kind c k
-    | k' -> assert (eq_kind env Source.no_region k k')
+    | k' -> assert (eq_kind env no_region k k')
   ) cs ks;
   let env' = add_typs env xs cs in
   let _ = List.map (fun typ_bind -> check_typ env' typ_bind.it.bound) typ_binds in
@@ -1673,7 +1674,7 @@ let check_can_dot env ctx_dot (exp : Syntax.exp) tys es at =
                 _)  when mod_id0 = mod_id1 && id0 = id1 ->
           let source =
             if e.at.left.line <> e.at.right.line then None
-            else Source.read_region e.at
+            else read_region e.at
           in
           let receiver_text, edits = match source with
             | None -> "...", []
@@ -2568,7 +2569,7 @@ and check_exp' env0 t exp : T.typ =
   (* TODO: allow shared with one scope par *)
   | FuncE (_, shared_pat,  [], pat, typ_opt, _sugar, exp), T.Func (s, c, [], ts1, ts2) ->
     let env', t2, codom = check_func_step env0.in_actor env (shared_pat, pat, typ_opt, exp) (s, c, ts1, ts2) in
-    check_sub_explained env Source.no_region t2 codom (fun explanation ->
+    check_sub_explained env no_region t2 codom (fun explanation ->
       error env exp.at "M0095"
         "function return type%a\ndoes not match expected return type%a%a"
         display_typ_expand t2
@@ -2849,7 +2850,7 @@ and infer_call env exp1 inst (parenthesized, ref_exp2) at t_expect_opt =
         "expected function type, but expression produces type%a"
         display_typ_expand t1;
       if inst.it = None then
-        info env (Source.between exp1.at exp2.at)
+        info env (between exp1.at exp2.at)
           "this looks like an unintended function call, perhaps a missing ';'?";
       T.as_func_sub T.Local n T.Non
   in
@@ -3163,11 +3164,11 @@ and is_redundant_instantiation ts env infer_instantiation =
   | Ok (b, _) -> b
 
 and debug_print_infer_defer_split exp2 t_arg t2 subs deferred =
-  print_endline (Printf.sprintf "exp2 : %s" (Source.read_region_with_markers exp2.at |> Option.value ~default:""));
+  print_endline (Printf.sprintf "exp2 : %s" (read_region_with_markers exp2.at |> Option.value ~default:""));
   print_endline (Printf.sprintf "t_arg : %s" (T.string_of_typ t_arg));
   print_endline (Printf.sprintf "t2 : %s" (T.string_of_typ t2));
   print_endline (Printf.sprintf "subs : %s" (String.concat ", " (List.map (fun (t, t', _at) -> Printf.sprintf "%s <: %s" (T.string_of_typ t) (T.string_of_typ t')) subs)));
-  print_endline (Printf.sprintf "deferred : %s" (String.concat ", " (List.map (fun (exp, t) -> Printf.sprintf "%s : %s" (Source.read_region exp.at |> Option.value ~default:"") (T.string_of_typ t)) deferred)));
+  print_endline (Printf.sprintf "deferred : %s" (String.concat ", " (List.map (fun (exp, t) -> Printf.sprintf "%s : %s" (read_region exp.at |> Option.value ~default:"") (T.string_of_typ t)) deferred)));
   print_endline ""
 
 (* Cases *)
@@ -3657,7 +3658,7 @@ and scope_of_object val_kind env fs tfs =
   let typ_env = List.fold_left (fun te tf ->
     T.Env.add tf.T.lab tf.T.typ te) T.Env.empty tfs in
   let val_env = List.fold_left (fun te f ->
-    T.Env.add f.T.lab (f.T.typ, Source.no_region, val_kind) te) T.Env.empty fs in
+    T.Env.add f.T.lab (f.T.typ, no_region, val_kind) te) T.Env.empty fs in
   Scope.{ empty with typ_env; val_env }
 
 (* TODO: remove by merging conenv and valenv or by separating typ_fields *)
@@ -3866,8 +3867,8 @@ and infer_migration_chain env at =
   | None -> []
   | Some path ->
      let region_of_file file =
-       Source.{left = {file; line = 1; column = 0 };
-               right = {file; line = 1; column = 0 } }
+       {left = {file; line = 1; column = 0 };
+        right = {file; line = 1; column = 0 } }
      in
      let norm_path = Lib.FilePath.normalise path in
      let chain =
@@ -3957,7 +3958,7 @@ and check_enhanced_migration_chain env chain stab_tfs at =
            tf.T.lab display_typ tf.T.typ)
          post
      | (file, _, typ)::mfs1 ->
-        let file_at = let file_pos = { Source.no_pos with file = file} in {left = file_pos; right=file_pos} in
+        let file_at = let file_pos = { no_pos with file = file} in {left = file_pos; right=file_pos} in
         let mf = T.{lab = T.migration_lab_of_filename file; typ; src = T.empty_src } in
         (* is this a migration function *)
         let (dom_mf, rng_mf) = check_migration_function env mf.T.typ file_at in
@@ -4108,7 +4109,7 @@ and check_stable_defaults env sort dec_fields =
       List.iter (fun dec_field ->
         match dec_field.it.stab, dec_field.it.dec.it with
         | Some {it = Stable _; at; _}, (LetD _ | VarD _) ->
-          if at <> Source.no_region then
+          if at <> no_region then
             warn env at "M0218" "redundant `stable` keyword, this declaration is implicitly stable"
         | _ -> ())
       dec_fields
@@ -4120,7 +4121,7 @@ and check_stable_defaults env sort dec_fields =
       List.fold_left (fun acc dec_field ->
         match dec_field.it.stab, dec_field.it.dec.it with
         | Some {it = Flexible; at; _}, (LetD _ | VarD _) ->
-           if at = Source.no_region
+           if at = no_region
            then
              (local_error env dec_field.it.dec.at "M0219" "this declaration is currently implicitly transient, please declare it explicitly `transient`";
               true)
@@ -4163,7 +4164,7 @@ and check_stab env sort scope dec_fields =
     | (T.Actor | T.Mixin), Some {it = Flexible; _} , (VarD _ | LetD _) -> []
     | (T.Actor | T.Mixin), Some stab, _ ->
       let at, desc =
-        if stab.at = Source.no_region
+        if stab.at = no_region
         then df.it.dec.at, "implicit "
         else stab.at, ""
       in
@@ -4388,7 +4389,7 @@ and infer_dec env dec : T.typ =
       | None, _ -> ()
       | Some { it = AsyncT (T.Fut, _, typ); at; _ }, T.Actor
       | Some ({ at; _ } as typ), T.(Module | Object) ->
-        if at = Source.no_region then
+        if at = no_region then
           warn env dec.at "M0135"
             "actor classes with non non-async return types are deprecated; please declare the return type as 'async ...'";
         let t'' = check_typ env'' typ in
@@ -4556,7 +4557,7 @@ and gather_dec env scope dec : Scope.t =
       ) scope.typ_env tfs in
       let val_env = List.fold_left (fun ve T.{ lab; typ; _ } ->
         if T.Env.mem lab ve then error_duplicate env "" { it = lab; at = i.at; note = () };
-        T.Env.add lab (typ, Source.no_region, Scope.MixinIncluded) ve
+        T.Env.add lab (typ, no_region, Scope.MixinIncluded) ve
       ) scope.val_env fs in
       { scope with typ_env; val_env }
     end
@@ -4908,7 +4909,7 @@ let check_lib scope pkg_opt lib : Scope.t Diag.result =
           let imp_scope = match cub.it with
             | ModuleU _ ->
               if cub.at = no_region then begin
-                let r = Source.{
+                let r = {
                   left = { no_pos with file = lib.note.filename };
                   right = { no_pos with file = lib.note.filename }}
                 in

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -4,8 +4,7 @@ open Mo_values
 module Flags = Mo_config.Flags
 
 open Syntax
-open Wasm.Source
-open Source [@@@warning "-41"]
+open Source
 
 module T = Type
 module A = Effect

--- a/src/mo_idl/idl_to_mo_value.ml
+++ b/src/mo_idl/idl_to_mo_value.ml
@@ -81,9 +81,9 @@ let rec value v t =
   | FuncV (s, m), _ ->
     Printf.sprintf "(actor %s : actor { %s : %s }).%s"
       (text_lit s)
-      (Idllib.Escape.escape_method Source.no_region m)
+      (Idllib.Escape.escape_method no_region m)
       (Pretty.string_of_typ t)
-      (Idllib.Escape.escape_method Source.no_region m)
+      (Idllib.Escape.escape_method no_region m)
   | PrincipalV s, _ ->
     "_Prim.principalOfActor" ^ parens ("actor " ^ text_lit s ^ " : actor {}")
   | _ -> raise (UnsupportedCandidFeature

--- a/src/mo_interpreter/interpret.ml
+++ b/src/mo_interpreter/interpret.ml
@@ -72,7 +72,7 @@ let context env = V.Blob env.self
 
 (* Error handling *)
 
-exception Trap of Source.region * string
+exception Trap of region * string
 exception Cancel of string
 
 let trap at fmt = Printf.ksprintf (fun s -> raise (Trap (at, s))) fmt
@@ -111,12 +111,12 @@ let string_of_arg env = function
 (* Debugging aids *)
 
 let last_env = ref (env_of_scope {trace = false; print_depth = 2} state empty_scope)
-let last_region = ref Source.no_region
+let last_region = ref no_region
 
 let print_exn flags exn =
   let trace = Printexc.get_backtrace () in
   Printf.printf "%!";
-  let at = Source.string_of_region !last_region in
+  let at = string_of_region !last_region in
   Printf.eprintf "%s: internal error, %s\n" at (Printexc.to_string exn);
   Printf.eprintf "\nLast environment:\n";
   Value.Env.iter (fun x d -> Printf.eprintf "%s = %s\n" x (string_of_def flags d))
@@ -138,7 +138,7 @@ struct
   let yield () =
     trace_depth := 0;
     try Queue.take q () with Trap (at, msg) ->
-      Printf.eprintf "%s: execution error, %s\n" (Source.string_of_region at) msg
+      Printf.eprintf "%s: execution error, %s\n" (string_of_region at) msg
   let rec run () =
     if not (Queue.is_empty q) then (yield (); run ())
 
@@ -1071,7 +1071,7 @@ and interpret_dec env dec (k : V.value V.cont) =
           define_id env'' id' v';
           k' v')
       else
-        async env' Source.no_region
+        async env' no_region
           (fun k'' r ->
             let env'' = adjoin_vals env' (declare_id id') in
             let env''' = { env'' with
@@ -1131,7 +1131,7 @@ let ensure_management_canister env =
               (V.async_func (T.Write) 0 1
                  (fun c v k ->
                    async env
-                     Source.no_region
+                     no_region
                      (fun k' r ->
                        k' (V.Blob (V.Blob.rand32 ())))
                      k))))

--- a/src/mo_interpreter/interpret.mli
+++ b/src/mo_interpreter/interpret.mli
@@ -1,6 +1,7 @@
 open Mo_def
 open Mo_values
 open Mo_types
+open Source
 
 module V = Value
 module T = Type
@@ -20,7 +21,7 @@ val adjoin_scope : scope -> scope -> scope
 
 val step_limit : int ref
 
-exception Trap of Source.region * string
+exception Trap of region * string
 
 val interpret_prog : flags -> scope -> Syntax.prog -> (V.value * scope) option
 val interpret_lib : flags -> scope -> Syntax.lib -> scope

--- a/src/mo_types/arrange_type.ml
+++ b/src/mo_types/arrange_type.ml
@@ -1,6 +1,6 @@
 open Type
 open Wasm.Sexpr
-open Wasm.Source
+open Source
 
 module type Config = sig
   val srcs_tbl : Field_sources.srcs_map option
@@ -72,7 +72,7 @@ module Make (Cfg : Config) = struct
         match Field_sources.Srcs_map.find_opt track_region srcs_tbl with
         | None -> []
         | Some srcs ->
-          List.of_seq (Seq.map region (Source.Region_set.to_seq srcs))
+          List.of_seq (Seq.map region (Region_set.to_seq srcs))
     in
     Atom (Option.value ~default:"" depr) :: region r :: srcs
 

--- a/src/mo_types/arrange_type.ml
+++ b/src/mo_types/arrange_type.ml
@@ -1,5 +1,6 @@
 open Type
 open Wasm.Sexpr
+open Wasm.Source
 
 module type Config = sig
   val srcs_tbl : Field_sources.srcs_map option
@@ -56,12 +57,12 @@ module Make (Cfg : Config) = struct
 
   let pos p =
     "Pos" $$
-      [ Atom (string_of_int p.Source.line)
-      ; Atom (string_of_int p.Source.column) ]
+      [ Atom (string_of_int p.line)
+      ; Atom (string_of_int p.column) ]
 
   let region at =
-    let filename = at.Source.left.Source.file in
-    "@@" $$ [Atom filename; pos at.Source.left; pos at.Source.right]
+    let filename = at.left.file in
+    "@@" $$ [Atom filename; pos at.left; pos at.right]
 
   let src {depr; track_region; region = r} =
     let srcs =
@@ -71,7 +72,7 @@ module Make (Cfg : Config) = struct
         match Field_sources.Srcs_map.find_opt track_region srcs_tbl with
         | None -> []
         | Some srcs ->
-          List.of_seq @@ Seq.map region @@ Source.Region_set.to_seq srcs
+          List.of_seq (Seq.map region (Source.Region_set.to_seq srcs))
     in
     Atom (Option.value ~default:"" depr) :: region r :: srcs
 

--- a/src/mo_types/field_sources.ml
+++ b/src/mo_types/field_sources.ml
@@ -5,16 +5,13 @@
    Note that the functionality of this module is enabled only when
    [!Mo_config.Flags.typechecker_combine_srcs = true], otherwise the functions
    will do nothing or return empty data structures. *)
-open Wasm.Source
+
+open Source
 
 module Srcs_tbl = Hashtbl.Make (struct
   type t = region
 
   let equal l r = l = r
-    (*let equal_pos l r =
-      l.line = r.line && l.column = r.column && l.file = r.file
-    in
-    equal_pos l.left r.left && equal_pos l.right r.right*)
 
   let hash s =
     let combine_int h x = (h * 65521) lxor x in

--- a/src/mo_types/field_sources.ml
+++ b/src/mo_types/field_sources.ml
@@ -5,18 +5,18 @@
    Note that the functionality of this module is enabled only when
    [!Mo_config.Flags.typechecker_combine_srcs = true], otherwise the functions
    will do nothing or return empty data structures. *)
-module Srcs_tbl = Hashtbl.Make (struct
-  type t = Source.region
+open Wasm.Source
 
-  let equal l r =
-    let open Source in
-    let equal_pos l r =
+module Srcs_tbl = Hashtbl.Make (struct
+  type t = region
+
+  let equal l r = l = r
+    (*let equal_pos l r =
       l.line = r.line && l.column = r.column && l.file = r.file
     in
-    equal_pos l.left r.left && equal_pos l.right r.right
+    equal_pos l.left r.left && equal_pos l.right r.right*)
 
   let hash s =
-    let open Source in
     let combine_int h x = (h * 65521) lxor x in
     let hash_pos {line; column; file} =
       combine_int line (combine_int column (Int32.to_int (Hash.hash file)))

--- a/src/mo_types/field_sources.ml
+++ b/src/mo_types/field_sources.ml
@@ -21,16 +21,16 @@ module Srcs_tbl = Hashtbl.Make (struct
     combine_int (hash_pos s.left) (hash_pos s.right)
 end)
 
-type srcs_tbl = Source.Region_set.t Srcs_tbl.t
+type srcs_tbl = Region_set.t Srcs_tbl.t
 type t = srcs_tbl
 
 module Srcs_map = struct
-  include Source.Region_map
+  include Region_map
 
-  let adjoin = union (fun _ rs1 rs2 -> Some (Source.Region_set.union rs1 rs2))
+  let adjoin = union (fun _ rs1 rs2 -> Some (Region_set.union rs1 rs2))
 end
 
-type srcs_map = Source.Region_set.t Srcs_map.t
+type srcs_map = Region_set.t Srcs_map.t
 
 let empty_srcs_tbl () =
   let initial_size =
@@ -41,26 +41,26 @@ let empty_srcs_tbl () =
 let get_srcs srcs_tbl r =
   if !Mo_config.Flags.typechecker_combine_srcs then
     Option.value
-      ~default:(Source.Region_set.singleton r)
+      ~default:(Region_set.singleton r)
       (Srcs_tbl.find_opt srcs_tbl r)
   else
-    Source.Region_set.empty
+    Region_set.empty
 
 let add_src srcs_tbl region =
   if !Mo_config.Flags.typechecker_combine_srcs then
     let srcs =
       match Srcs_tbl.find_opt srcs_tbl region with
-      | None -> Source.Region_set.singleton region
-      | Some srcs -> Source.Region_set.add region srcs
+      | None -> Region_set.singleton region
+      | Some srcs -> Region_set.add region srcs
     in
     Srcs_tbl.replace srcs_tbl region srcs
 
 let of_immutable_map srcs_map =
   srcs_map
-  |> Source.Region_map.to_seq
+  |> Region_map.to_seq
   |> Srcs_tbl.of_seq
 
 let of_mutable_tbl srcs_tbl =
   srcs_tbl
   |> Srcs_tbl.to_seq
-  |> Source.Region_map.of_seq
+  |> Region_map.of_seq

--- a/src/mo_types/field_sources.mli
+++ b/src/mo_types/field_sources.mli
@@ -1,16 +1,18 @@
-module Srcs_tbl : Hashtbl.S with type key = Source.region
-type srcs_tbl = Source.Region_set.t Srcs_tbl.t
+open Source
+
+module Srcs_tbl : Hashtbl.S with type key = region
+type srcs_tbl = Region_set.t Srcs_tbl.t
 type t = srcs_tbl
 
 module Srcs_map : sig
-   include module type of Source.Region_map with type key = Source.region
+   include module type of Region_map with type key = region
 
-   val adjoin : Source.Region_set.t t -> Source.Region_set.t t -> Source.Region_set.t t
+   val adjoin : Region_set.t t -> Region_set.t t -> Region_set.t t
 end
-type srcs_map = Source.Region_set.t Srcs_map.t
+type srcs_map = Region_set.t Srcs_map.t
 
 val empty_srcs_tbl : unit -> t
-val get_srcs : t -> Source.region -> Source.Region_set.t
-val add_src : t -> Source.region -> unit
+val get_srcs : t -> region -> Region_set.t
+val add_src : t -> region -> unit
 val of_immutable_map : srcs_map -> t
 val of_mutable_tbl : t -> srcs_map

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1,4 +1,5 @@
 open Field_sources
+open Source
 
 (* Representation *)
 type id = string
@@ -71,7 +72,7 @@ and scope = typ
 and bind_sort = Scope | Type
 
 and bind = {var : var; sort: bind_sort; bound : typ}
-and src = {depr : string option; track_region : Source.region; region : Source.region}
+and src = {depr : string option; track_region : region; region : region}
 and 'a gen_field = {lab : lab; typ : 'a; src : src}
 and field = typ gen_field
 and typ_field = con gen_field
@@ -81,7 +82,7 @@ and kind =
   | Def of bind list * typ
   | Abs of bind list * typ
 
-let empty_src = {depr = None; track_region = Source.no_region; region = Source.no_region}
+let empty_src = {depr = None; track_region = no_region; region = no_region}
 
 (* Stable signatures *)
 type stab_sig =
@@ -1058,7 +1059,7 @@ let add_src_field rel lubs glbs f1 f2 =
     (* Perhaps we could get away with just adding [r1] and [r2] to each other's
        tables, but we play safe here and overapproximate. *)
     let srcs =
-      Source.Region_set.(if rel == lubs then union else inter)
+      Region_set.(if rel == lubs then union else inter)
         (get_srcs src_map r1)
         (get_srcs src_map r2)
     in
@@ -1078,7 +1079,7 @@ let add_src_field_update rel eq tf1 tf2 =
       let src_map = !src_field_map in
       (* Perhaps we could get away with just adding [r1] and [r2] to each
          other's tables, but we play safe here and overapproximate. *)
-      let srcs = Source.Region_set.union (get_srcs src_map r1) (get_srcs src_map r2) in
+      let srcs = Region_set.union (get_srcs src_map r1) (get_srcs src_map r2) in
       if rel == eq then
         Srcs_tbl.replace src_map r1 srcs;
       Srcs_tbl.replace src_map r2 srcs

--- a/src/mo_types/type.mli
+++ b/src/mo_types/type.mli
@@ -1,3 +1,5 @@
+open Source
+
 (* Representation *)
 
 type id = string
@@ -62,7 +64,7 @@ and scope = typ
 and bind_sort = Scope | Type
 and bind = {var : var; sort: bind_sort; bound : typ}
 
-and src = {depr : string option; track_region : Source.region; region : Source.region}
+and src = {depr : string option; track_region : region; region : region}
 and 'a gen_field = {lab : lab; typ : 'a; src : src}
 and field = typ gen_field
 and typ_field = con gen_field

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -7,6 +7,7 @@ open Ir_def
 open Ir_interpreter
 open Ir_passes
 open Mo_config
+open Source
 
 open Printf
 
@@ -84,7 +85,7 @@ type rel_path = string
 type parse_result = (Syntax.prog * rel_path) Diag.result
 
 type no_region_parse_fn = string -> parse_result
-type parse_fn = Source.region -> no_region_parse_fn
+type parse_fn = region -> no_region_parse_fn
 
 let generic_parse_with ?(recovery=false) mode lexer parser name : _ Diag.result =
   phase "Parsing" name;
@@ -164,7 +165,7 @@ let resolve_progs =
 (* Printing dependency information *)
 
 let print_deps (file : string) : unit =
-  let (prog, _) =  Diag.run (parse_file Source.no_region file) in
+  let (prog, _) =  Diag.run (parse_file no_region file) in
   let imports = Diag.run (ResolveImport.collect_imports prog file) in
   List.iter (fun (url, path) ->
       if String.starts_with ~prefix:"blob:" url then () else
@@ -195,7 +196,7 @@ let infer_prog
     senv
     async_cap
     prog : (Type.typ * Scope.scope) Diag.result =
-  let filename = prog.Source.note.Syntax.filename in
+  let filename = prog.note.Syntax.filename in
   phase "Checking" filename;
   Cons.session ~scope:filename (fun () ->
     let r = Typing.infer_prog ~enable_type_recovery pkg_opt senv async_cap prog in
@@ -221,7 +222,7 @@ let check_progs
     | [] -> Diag.return (List.rev sscopes, senv)
     | prog::progs ->
       let open Diag.Syntax in
-      let filename = prog.Source.note.Syntax.filename in
+      let filename = prog.note.Syntax.filename in
       let async_cap = async_cap_of_prog prog in
       let* _t, sscope =
         Cons.session ~scope:filename (fun () ->
@@ -234,7 +235,7 @@ let check_progs
   go senv [] progs
 
 let check_lib senv pkg_opt lib : Scope.scope Diag.result =
-  let filename = lib.Source.note.Syntax.filename in
+  let filename = lib.note.Syntax.filename in
   Cons.session ~scope:filename (fun () ->
     phase "Checking" (Filename.basename filename);
     let open Diag.Syntax in
@@ -245,7 +246,7 @@ let check_lib senv pkg_opt lib : Scope.scope Diag.result =
 
 let lib_of_prog f prog : Syntax.lib  =
   let lib = CompUnit.comp_unit_of_prog true prog in
-  { lib with Source.note = { lib.Source.note with Syntax.filename = f } }
+  { lib with note = { lib.note with Syntax.filename = f } }
 
 (* Prelude and internals *)
 
@@ -298,11 +299,11 @@ let stable_compatible pre post : unit Diag.result =
   let* p1 = parse_stab_sig_from_file pre in
   let* p2 = parse_stab_sig_from_file post in
   let* s1 =
-    Cons.session ~scope:p1.Source.note.Syntax.filename (fun () ->
+    Cons.session ~scope:p1.note.Syntax.filename (fun () ->
       Typing.check_stab_sig initial_stat_env0 p1)
   in
   let* s2 =
-    Cons.session ~scope:p2.Source.note.Syntax.filename (fun () ->
+    Cons.session ~scope:p2.note.Syntax.filename (fun () ->
       Typing.check_stab_sig initial_stat_env0 p2)
   in
   Stability.match_stab_sig s1 s2
@@ -393,7 +394,7 @@ type load_decl_result =
   (Syntax.lib list * Syntax.prog * Scope.scope * Type.typ * Scope.scope) Diag.result
 
 let resolved_import_name ri =
-  Syntax.(match ri.Source.it with
+  Syntax.(match ri.it with
   | Unresolved -> "/* unresolved */"
   | LibPath { package = _; path }
   | IDLPath (path, _)
@@ -433,7 +434,7 @@ let chase_imports_cached parsefn senv0 imports scopes_map
       senv := Scope.adjoin !senv sscope;
       Diag.return ()
   and go pkg_opt ri =
-    let it = ri.Source.it in
+    let it = ri.it in
     let ri_name = resolved_import_name ri in
     match it with
     | Syntax.PrimPath ->
@@ -452,13 +453,13 @@ let chase_imports_cached parsefn senv0 imports scopes_map
         Diag.return ()
       else if mem it !pending then
         Diag.error
-          ri.Source.at
+          ri.at
           "M0003"
           "import"
           (Printf.sprintf "file %s must not depend on itself" f)
       else begin
         pending := add it !pending;
-        let* prog, base = parsefn ri.Source.at f in
+        let* prog, base = parsefn ri.at f in
         let* () = Static.prog prog in
         let cur_pkg_opt = if lib_pkg_opt <> None then lib_pkg_opt else pkg_opt in
         let* more_imports = ResolveImport.resolve (resolve_flags ~enhanced_migration:None cur_pkg_opt) prog base in
@@ -482,7 +483,7 @@ let chase_imports_cached parsefn senv0 imports scopes_map
       let* prog, idl_scope, actor_opt = Idllib.Pipeline.check_file f in
       if actor_opt = None then
         Diag.error
-          ri.Source.at
+          ri.at
           "M0004"
           "import"
           (Printf.sprintf "file %s does not define a service" f)
@@ -491,7 +492,7 @@ let chase_imports_cached parsefn senv0 imports scopes_map
         | exception Idllib.Exception.UnsupportedCandidFeature error_message ->
           Stdlib.Error [
             Diag.error_message
-              ri.Source.at
+              ri.at
               "M0153"
               "import"
               (Printf.sprintf "file %s uses Candid types without corresponding Motoko type" f);
@@ -519,7 +520,7 @@ let load_progs_cached
     senv
     scope_cache : load_result_cached =
   let open Diag.Syntax in
-  let* parsed = Diag.traverse (parsefn Source.no_region) files in
+  let* parsed = Diag.traverse (parsefn no_region) files in
   let* rs = resolve_progs parsed in
   let progs = List.map fst rs in
   let libs = List.concat_map snd rs in
@@ -563,7 +564,7 @@ let load_decl parse_one senv : load_decl_result =
 
 let interpret_prog denv prog : (Value.value * Interpret.scope) option =
   let open Interpret in
-  let filename = prog.Source.note.Syntax.filename in
+  let filename = prog.note.Syntax.filename in
   phase "Interpreting" filename;
   Cons.session ~scope:filename (fun () ->
     let flags = { trace = !Flags.trace; print_depth = !Flags.print_depth } in
@@ -576,7 +577,7 @@ let rec interpret_libs denv libs : Interpret.scope =
   match libs with
   | [] -> denv
   | lib::libs' ->
-    let filename = lib.Source.note.Syntax.filename in
+    let filename = lib.note.Syntax.filename in
     phase "Interpreting" (Filename.basename filename);
     let flags = { trace = !Flags.trace; print_depth = !Flags.print_depth } in
     let dscope =
@@ -607,7 +608,7 @@ let interpret_files (senv0, denv0) files : (Scope.scope * Interpret.scope) optio
 
 let run_builtin prog denv : dyn_env =
   match interpret_prog denv prog with
-  | None -> builtin_error "initializing" prog.Source.note.Syntax.filename []
+  | None -> builtin_error "initializing" prog.note.Syntax.filename []
   | Some (_v, dscope) ->
     Interpret.adjoin_scope denv dscope
 
@@ -668,7 +669,7 @@ let parse_lexer lexer : parse_result =
     Error es
   | Ok (prog, ws) -> Ok ((prog, Filename.current_dir_name), ws)
 
-let is_exp dec = match dec.Source.it with Syntax.ExpD _ -> true | _ -> false
+let is_exp dec = match dec.it with Syntax.ExpD _ -> true | _ -> false
 
 let output_scope (senv, _) t v sscope dscope =
   print_scope senv sscope dscope.Interpret.val_env;
@@ -691,7 +692,7 @@ let run_stdin lexer (senv, denv) : env option =
       let env' = (senv', denv') in
       (* TBR: hack *)
       let t', v' =
-        if Option.fold ~none:false ~some:is_exp (Lib.List.last_opt prog.Source.it)
+        if Option.fold ~none:false ~some:is_exp (Lib.List.last_opt prog.it)
         then t, v
         else Type.unit, Value.unit
       in
@@ -703,7 +704,7 @@ let run_stdin_from_file files file : Value.value option =
   let open Lib.Option.Syntax in
   let* (senv, denv) = interpret_files initial_env files in
   let* (libs, prog, senv', t, sscope) =
-    Diag.flush_messages (load_decl (parse_file Source.no_region file) senv) in
+    Diag.flush_messages (load_decl (parse_file no_region file) senv) in
   let denv' = interpret_libs denv libs in
   let* (v, dscope) = interpret_prog denv' prog in
   print_val senv t v;
@@ -721,9 +722,9 @@ let run_files_and_stdin files =
 (* Desugaring *)
 
 let desugar_unit imports u name : Ir.prog Diag.result =
-  match u.Source.it.Syntax.body.Source.it with
+  match u.it.Syntax.body.it with
   | Syntax.MixinU _ ->
-    let at = u.Source.it.Syntax.body.Source.at in
+    let at = u.it.Syntax.body.at in
     Diag.error at "M0225" "compile" "A mixin cannot be used as an entry point. It needs to be included in an actor (class)"
   | _ ->
   phase "Desugaring" name;
@@ -840,7 +841,7 @@ let rec compile_libs mode libs : Lowering.Desugar.import_declaration =
     | [] -> imports
     | l :: libs ->
       let { Syntax.body = cub; _ } = l.it in
-      let filename = l.Source.note.Syntax.filename in
+      let filename = l.note.Syntax.filename in
       let new_imports =
         Cons.session ~scope:filename (fun () ->
           match cub.it with
@@ -856,7 +857,7 @@ let rec compile_libs mode libs : Lowering.Desugar.import_declaration =
 
 and compile_unit mode (enhanced_migration:string option) do_link imports u : Wasm_exts.CustomModule.extended_module Diag.result =
   let open Diag.Syntax in
-  let name = u.Source.note.Syntax.filename in
+  let name = u.note.Syntax.filename in
   Cons.session ~scope:name (fun () ->
     let* prog_ir = desugar_unit imports u name in
     let prog_ir = ir_passes mode prog_ir name in
@@ -893,7 +894,7 @@ let compile_files mode do_link files : compile_result =
   in
   let* () =
     if Wasm_exts.CustomModule.(ext_module.wasm_features) <> []
-    then Diag.warn Source.no_region "M0191" "compile" (Printf.sprintf "code requires Wasm features %s to execute" (String.concat "," Wasm_exts.CustomModule.(ext_module.wasm_features)))
+    then Diag.warn no_region "M0191" "compile" (Printf.sprintf "code requires Wasm features %s to execute" (String.concat "," Wasm_exts.CustomModule.(ext_module.wasm_features)))
     else Diag.return ()
   in
   Diag.return (idl, ext_module)
@@ -912,7 +913,7 @@ let import_libs libs : Lowering.Desugar.import_declaration =
 let interpret_ir_progs libs progs =
   let open Diag.Syntax in
   let prog = CompUnit.combine_progs progs in
-  let name = prog.Source.note.Syntax.filename in
+  let name = prog.note.Syntax.filename in
   let imports = import_libs libs in
   let u = CompUnit.comp_unit_of_prog false prog in
   let* prog_ir = desugar_unit imports u name in

--- a/src/pipeline/resolve_import.ml
+++ b/src/pipeline/resolve_import.ml
@@ -1,5 +1,6 @@
 open Mo_def
 open Ic
+open Source
 module Traversals = Mo_frontend.Traversals
 
 (*
@@ -19,7 +20,7 @@ type url = string
 type envvar = string
 type blob = string
 
-type resolved_imports = Syntax.resolved_import Source.phrase list
+type resolved_imports = Syntax.resolved_import phrase list
 
 (* This returns a map from Syntax.resolved_import
    to the location of the first import of that library
@@ -237,7 +238,7 @@ let resolve_package_url (msgs:Diag.msg_store) (pname:string) (f:url) : filepath 
 (* Get the migration files, filter by .mo extension and sort lexicographically. *)
 let get_migration_files dir : string list Diag.result =
   if not (Sys.file_exists dir && Sys.is_directory dir) then
-    Diag.error Source.no_region "M0256" "import"
+    Diag.error no_region "M0256" "import"
       (Printf.sprintf "enhanced migration path '%s' is not a directory" dir)
   else
     Sys.readdir dir
@@ -366,14 +367,14 @@ let resolve
     let imported =
       ref (if flags.include_all_libs
            then (* outside any package, add all available package libraries *)
-             (List.fold_right (fun ri rim -> RIM.add ri Source.no_region rim)
+             (List.fold_right (fun ri rim -> RIM.add ri no_region rim)
                (package_imports base packages) RIM.empty)
            else
              (* consider only the explicitly imported package libraries *)
              RIM.empty)
     in
     (* add any implicit imports for migrations *)
-    imported := (List.fold_right (fun ri rim -> RIM.add ri Source.no_region rim)
+    imported := (List.fold_right (fun ri rim -> RIM.add ri no_region rim)
                    migration_imports !imported);
     List.iter (resolve_import_string msgs base actor_idl_path aliases packages imported)(prog_imports p);
     Some (List.map (fun (rim, at) -> rim @@ at) (RIM.bindings !imported))

--- a/src/pipeline/test_field_srcs.ml
+++ b/src/pipeline/test_field_srcs.ml
@@ -32,7 +32,7 @@ let rec remove_srcs =
   function
   | Atom _ as atom -> atom
   | Node (name, args) ->
-    Node (name, List.map remove_srcs @@ List.filter is_not_src args)
+    Node (name, List.(filter is_not_src args |> map remove_srcs))
 
 let gather_let_srcs sexpr =
   let open Wasm.Sexpr in
@@ -60,7 +60,7 @@ let gather_let_srcs sexpr =
         acc
         args
   in
-  List.of_seq @@ Sexpr_set.to_seq @@ go Sexpr_set.empty sexpr
+  Sexpr_set.(go empty sexpr |> to_seq) |> List.of_seq
 
 let arrange filename srcs_tbl : (module Mo_def.Arrange.S) =
   (module
@@ -85,7 +85,7 @@ let show (result : (Mo_def.Syntax.prog * Mo_types.Field_sources.srcs_map) Diag.r
     Format.printf "Collected sources:\n";
     List.iter
       (fun srcs -> Format.printf "%s" (Wasm.Sexpr.to_string 80 srcs))
-      (gather_let_srcs @@ Arrange.prog prog);
+      (Arrange.prog prog |> gather_let_srcs);
     Format.printf "Sources table:\n";
     Seq.iter
       (fun (define, origins) ->
@@ -184,8 +184,8 @@ let run_compare_typed_asts_test filename =
   let module Arrange_no_combine = (val arrange filename srcs_no_combine) in
   let module Arrange_combine = (val arrange filename srcs_combine) in
   (* AST should match (modulo the field sources). *)
-  let sexpr_prog_no_combine = remove_srcs @@ Arrange_no_combine.prog prog_no_combine in
-  let sexpr_prog_combine = remove_srcs @@ Arrange_combine.prog prog_combine in
+  let sexpr_prog_no_combine = Arrange_no_combine.prog prog_no_combine |> remove_srcs in
+  let sexpr_prog_combine = Arrange_combine.prog prog_combine |> remove_srcs in
   if sexpr_prog_no_combine <> sexpr_prog_combine then
     failwith
       (Format.sprintf
@@ -206,7 +206,7 @@ let get_mo_files_from_dir dir =
 
 let run_compare_typed_asts_tests_on_dir dir =
   let run_files = get_mo_files_from_dir dir in
-  List.iter (fun file -> ignore @@ run_compare_typed_asts_test file) run_files
+  List.iter (fun file -> run_compare_typed_asts_test file |> ignore) run_files
 
 let%test_unit "ASTs in test match with and without combining sources" =
   List.iter

--- a/src/pipeline/test_field_srcs.ml
+++ b/src/pipeline/test_field_srcs.ml
@@ -77,7 +77,7 @@ let show (result : (Mo_def.Syntax.prog * Mo_types.Field_sources.srcs_map) Diag.r
   match result with
   | Error msgs -> Format.printf "Diagnostics:\n%s\n" (show_msgs msgs)
   | Ok ((prog, srcs), msgs) ->
-    let filename = prog.Source.note.Mo_def.Syntax.filename in
+    let filename = prog.note.Mo_def.Syntax.filename in
     let module Arrange = (val arrange filename srcs) in
     Format.printf "Ok:\n";
     Format.printf "Collected sources:\n";
@@ -87,10 +87,10 @@ let show (result : (Mo_def.Syntax.prog * Mo_types.Field_sources.srcs_map) Diag.r
     Format.printf "Sources table:\n";
     Seq.iter
       (fun (define, origins) ->
-        Format.printf "%s:" (Source.string_of_region define);
+        Format.printf "%s:" (string_of_region define);
         Seq.iter
-          (fun origin -> Format.printf " %s" (Source.string_of_region origin))
-          (Source.Region_set.to_seq origins);
+          (fun origin -> Format.printf " %s" (string_of_region origin))
+          (Region_set.to_seq origins);
         Format.printf "\n")
       (Mo_types.Field_sources.Srcs_map.to_seq srcs);
     match msgs with
@@ -100,7 +100,7 @@ let show (result : (Mo_def.Syntax.prog * Mo_types.Field_sources.srcs_map) Diag.r
 let run_get_sources_test source =
   let open Diag.Syntax in
   let infer_prog prog senv async_cap : Mo_types.Field_sources.srcs_map Diag.result =
-    let filename = prog.Source.note.Mo_def.Syntax.filename in
+    let filename = prog.note.Mo_def.Syntax.filename in
     let* _typ, sscope =
       Mo_types.Cons.session ~scope:filename (fun () ->
         Mo_frontend.Typing.infer_prog

--- a/src/pipeline/test_field_srcs.ml
+++ b/src/pipeline/test_field_srcs.ml
@@ -2,6 +2,8 @@
     Update of the expected values could be done via [dune runtest --auto-promote].
 *)
 
+open Source
+
 module Sexpr_set = Set.Make (struct
   type t = Wasm.Sexpr.sexpr
 
@@ -86,7 +88,7 @@ let show (result : (Mo_def.Syntax.prog * Mo_types.Field_sources.srcs_map) Diag.r
       (gather_let_srcs @@ Arrange.prog prog);
     Format.printf "Sources table:\n";
     Seq.iter
-      Source.(fun (define, origins) ->
+      (fun (define, origins) ->
         Format.printf "%s:" (string_of_region define);
         Seq.iter
           (fun origin -> Format.printf " %s" (string_of_region origin))

--- a/src/pipeline/test_field_srcs.ml
+++ b/src/pipeline/test_field_srcs.ml
@@ -86,7 +86,7 @@ let show (result : (Mo_def.Syntax.prog * Mo_types.Field_sources.srcs_map) Diag.r
       (gather_let_srcs @@ Arrange.prog prog);
     Format.printf "Sources table:\n";
     Seq.iter
-      (fun (define, origins) ->
+      Source.(fun (define, origins) ->
         Format.printf "%s:" (string_of_region define);
         Seq.iter
           (fun origin -> Format.printf " %s" (string_of_region origin))
@@ -100,7 +100,7 @@ let show (result : (Mo_def.Syntax.prog * Mo_types.Field_sources.srcs_map) Diag.r
 let run_get_sources_test source =
   let open Diag.Syntax in
   let infer_prog prog senv async_cap : Mo_types.Field_sources.srcs_map Diag.result =
-    let filename = prog.note.Mo_def.Syntax.filename in
+    let filename = prog.Source.note.Mo_def.Syntax.filename in
     let* _typ, sscope =
       Mo_types.Cons.session ~scope:filename (fun () ->
         Mo_frontend.Typing.infer_prog

--- a/src/profiler/counters.ml
+++ b/src/profiler/counters.ml
@@ -8,7 +8,7 @@ such as search, sorting, etc.
 
 *)
 
-open Source
+open Wasm.Source
 module Value = Mo_values.Value
 module T = Mo_types.Type
 

--- a/src/profiler/counters.ml
+++ b/src/profiler/counters.ml
@@ -8,7 +8,7 @@ such as search, sorting, etc.
 
 *)
 
-open Wasm.Source
+open Source
 module Value = Mo_values.Value
 module T = Mo_types.Type
 

--- a/src/wasm-exts/customModuleEncode.ml
+++ b/src/wasm-exts/customModuleEncode.ml
@@ -171,7 +171,7 @@ let encode (em : extended_module) =
   let add_dwarf_string =
     add_string (function | [] -> 0 | (h, p) :: _ -> String.length h + 1 + p) dwarf_strings in
 
-  let module Instrs = Set.Make (struct type t = int * Wasm.Source.pos let compare = compare end) in
+  let module Instrs = Set.Make (struct type t = int * Source.pos let compare = compare end) in
   let statement_positions = ref Instrs.empty in
 
   let module DW_Sequence = Set.Make (struct type t = int * Instrs.t * int let compare = compare end) in
@@ -314,7 +314,7 @@ let encode (em : extended_module) =
 
     let len i =
       if Int32.to_int (Int32.of_int i) <> i then
-        Code.error Wasm.Source.no_region
+        Code.error Source.no_region
           "cannot encode length with more than 32 bit";
       vu32 (Int32.of_int i)
 
@@ -372,9 +372,9 @@ let encode (em : extended_module) =
 
     (* Expressions *)
 
-    open Wasm.Source
     open Ast
     open Values
+    open Wasm.Source
 
     let op n = u8 n
     let end_ () = op 0x0b
@@ -1202,7 +1202,7 @@ let encode (em : extended_module) =
 
             (* build the statement loc -> addr map *)
             let statement_positions = !statement_positions in
-            let module StmtsAt = Map.Make (struct type t = Wasm.Source.pos let compare = compare end) in
+            let module StmtsAt = Map.Make (struct type t = pos let compare = compare end) in
             let statements_at = StmtsAt.of_seq (Seq.map (fun (k, v) -> v, k) (Instrs.to_seq statement_positions)) in
             let is_statement_at (addr, loc) =
               match StmtsAt.find_opt loc statements_at with

--- a/src/wasm-exts/dune
+++ b/src/wasm-exts/dune
@@ -1,5 +1,5 @@
 (library
   (name wasm_exts)
-  (libraries wasm vlq yojson lib prelude mo_config)
+  (libraries wasm vlq yojson lib prelude mo_config lang_utils)
   (instrumentation (backend bisect_ppx --bisect-silent yes))
 )

--- a/src/wasm-exts/dwarf5.ml
+++ b/src/wasm-exts/dwarf5.ml
@@ -673,7 +673,7 @@ module Meta =
 struct
 
 type die
-  = StatementDelimiter of Wasm.Source.pos
+  = StatementDelimiter of Source.pos
   | Tag of int option * int * die list
   | TagClose
   | OffsetAttribute of int


### PR DESCRIPTION
This is very much a huge patch, but potentially removes a big thorn from our side. The `Wasm.Source` vs. `Lang_Utils.Source` ambiguity was nasty as hell! Everything here is completely mechanic.

We now use `pos` and `region` from `Wasm.Source` throughout, no own generative type in `Source`. They are the same type now. I most cases `open`ing `Source` is enough.

Finished the `Source.phrase` -> `Ir.phrase` transition that was done half-way. (Modulo where `note` is unit, there we reuse `Source.phrase`.)

TODO:
- [x] remove thousands of `Source.` qualifications. Not needed any more as there are no more ambiguities.
