### PR TITLE
bugfix: resolve relative flag paths in moc.js

### DIFF
--- a/.cursor/skills/build-and-test/SKILL.md
+++ b/.cursor/skills/build-and-test/SKILL.md
@@ -95,6 +95,14 @@ run only the specific tests relevant to your change:
 test-runner -baf some-test         # targeted by name pattern
 ```
 
+## JS Tests
+
+```bash
+nix build .#js.moc .#js.moc_interpreter .#js.didc -L
+```
+
+Builds JS artifacts and runs matching tests in `test/` (e.g. `test/test-moc.js`).
+
 ## Test File Conventions
 
 - `//MOC-FLAG --some-flag`: extra flags passed to `moc`

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * bugfix: Resolve relative paths in `moc.js` flags (e.g. `--enhanced-migration`, `--actor-idl`) against the source file's directory, fixing "not a directory" errors when these flags are passed with relative paths via the language server (#6002).
+
 ## 1.5.0 (2026-04-10)
 
 * motoko (`moc`)
@@ -29,8 +33,6 @@
   * bugfix: Fix type inference for `return` expressions inside unannotated lambdas passed to generic functions. Previously, the generic type parameter could resolve to `Non` instead of the actual return type, causing an IR type error (#5962).
 
   * bugfix: Fix crash when reporting errors with no source region (#5976).
-
-  * bugfix: Resolve relative paths in `moc.js` flags (e.g. `--enhanced-migration`, `--actor-idl`) against the source file's directory, fixing "not a directory" errors when these flags are passed with relative paths via the language server.
 
 * documentation (`mo-doc`)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,8 @@
 
   * bugfix: Fix crash when reporting errors with no source region (#5976).
 
+  * bugfix: Resolve relative paths in `moc.js` flags (e.g. `--enhanced-migration`, `--actor-idl`) against the source file's directory, fixing "not a directory" errors when these flags are passed with relative paths via the language server.
+
 * documentation (`mo-doc`)
 
   * feat: doc comments on individual record fields and variant tags inside a `type` declaration are now extracted and rendered (#5983).

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -173,7 +173,7 @@ let js_parse_motoko_with_deps enable_recovery path s =
     let open Diag.Syntax in
     let* prog, _ = parse_fn main_file s in
     let* deps =
-      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ~enhanced_migration:true ~base:main_file None) prog main_file
+      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ~is_main:true ~base:main_file None) prog main_file
     in
     Diag.return (prog, deps)
   in

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -173,7 +173,7 @@ let js_parse_motoko_with_deps enable_recovery path s =
     let open Diag.Syntax in
     let* prog, _ = parse_fn main_file s in
     let* deps =
-      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ~enhanced_migration:!Flags.enhanced_migration None) prog main_file
+      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ~enhanced_migration:true ~base:main_file None) prog main_file
     in
     Diag.return (prog, deps)
   in

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -141,29 +141,31 @@ let parse_verification_file = parse_file' Lexer.mode_verification
 
 type resolve_result = (Syntax.prog * ResolveImport.resolved_imports) Diag.result
 
-let resolve_flags ~enhanced_migration ~base pkg_opt =
+let resolve_flags ~is_main ~base pkg_opt =
   let base_dir = if Sys.is_directory base then base else Filename.dirname base in
-  let resolve_path p =
-    if !Flags.ocaml_js && Filename.is_relative p
-    then Filename.concat base_dir p |> Lib.FilePath.normalise
-    else p
+  let resolve_path_flag flag =
+    if not is_main then !flag else
+    Option.map (fun p ->
+      let p =
+        if !Flags.ocaml_js && Filename.is_relative p
+        then Filename.concat base_dir p |> Lib.FilePath.normalise
+        else p
+      in
+      flag := Some p; p) !flag
   in
-  let resolve_path_flag flag = Option.map (fun p -> let p = resolve_path p in flag := Some p; p) !flag in
-  let enhanced_migration = if enhanced_migration then resolve_path_flag Flags.enhanced_migration else None in
-  let actor_idl_path = resolve_path_flag Flags.actor_idl_path in
   ResolveImport.{
     package_urls = !Flags.package_urls;
     actor_aliases = !Flags.actor_aliases;
-    actor_idl_path;
+    actor_idl_path = resolve_path_flag Flags.actor_idl_path;
     include_all_libs = pkg_opt = None && Flags.(!all_libs || !ai_errors || Option.is_some !implicit_package);
-    enhanced_migration
+    enhanced_migration = if is_main then resolve_path_flag Flags.enhanced_migration else None;
   }
 
 let resolve_prog (prog, base) : resolve_result =
   Diag.map
     (fun libs -> (prog, libs))
     (ResolveImport.resolve
-       (resolve_flags ~enhanced_migration:true ~base None)
+       (resolve_flags ~is_main:true ~base None)
        prog base)
 
 let resolve_progs =
@@ -470,7 +472,7 @@ let chase_imports_cached parsefn senv0 imports scopes_map
         let* prog, base = parsefn ri.Source.at f in
         let* () = Static.prog prog in
         let cur_pkg_opt = if lib_pkg_opt <> None then lib_pkg_opt else pkg_opt in
-        let* more_imports = ResolveImport.resolve (resolve_flags ~enhanced_migration:false ~base cur_pkg_opt) prog base in
+        let* more_imports = ResolveImport.resolve (resolve_flags ~is_main:false ~base cur_pkg_opt) prog base in
         let* () = go_set cur_pkg_opt more_imports in
         let lib = lib_of_prog f prog in
         let* sscope = check_lib !senv cur_pkg_opt lib in

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -141,11 +141,20 @@ let parse_verification_file = parse_file' Lexer.mode_verification
 
 type resolve_result = (Syntax.prog * ResolveImport.resolved_imports) Diag.result
 
-let resolve_flags ~(enhanced_migration : string option) pkg_opt  =
+let resolve_flags ~enhanced_migration ~base pkg_opt =
+  let base_dir = if Sys.is_directory base then base else Filename.dirname base in
+  let resolve_path p =
+    if !Flags.ocaml_js && Filename.is_relative p
+    then Filename.concat base_dir p |> Lib.FilePath.normalise
+    else p
+  in
+  let resolve_path_flag flag = Option.map (fun p -> let p = resolve_path p in flag := Some p; p) !flag in
+  let enhanced_migration = if enhanced_migration then resolve_path_flag Flags.enhanced_migration else None in
+  let actor_idl_path = resolve_path_flag Flags.actor_idl_path in
   ResolveImport.{
     package_urls = !Flags.package_urls;
     actor_aliases = !Flags.actor_aliases;
-    actor_idl_path = !Flags.actor_idl_path;
+    actor_idl_path;
     include_all_libs = pkg_opt = None && Flags.(!all_libs || !ai_errors || Option.is_some !implicit_package);
     enhanced_migration
   }
@@ -154,7 +163,7 @@ let resolve_prog (prog, base) : resolve_result =
   Diag.map
     (fun libs -> (prog, libs))
     (ResolveImport.resolve
-       (resolve_flags ~enhanced_migration:!Flags.enhanced_migration None)
+       (resolve_flags ~enhanced_migration:true ~base None)
        prog base)
 
 let resolve_progs =
@@ -461,7 +470,7 @@ let chase_imports_cached parsefn senv0 imports scopes_map
         let* prog, base = parsefn ri.Source.at f in
         let* () = Static.prog prog in
         let cur_pkg_opt = if lib_pkg_opt <> None then lib_pkg_opt else pkg_opt in
-        let* more_imports = ResolveImport.resolve (resolve_flags ~enhanced_migration:None cur_pkg_opt) prog base in
+        let* more_imports = ResolveImport.resolve (resolve_flags ~enhanced_migration:false ~base cur_pkg_opt) prog base in
         let* () = go_set cur_pkg_opt more_imports in
         let lib = lib_of_prog f prog in
         let* sscope = check_lib !senv cur_pkg_opt lib in

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -142,16 +142,14 @@ let parse_verification_file = parse_file' Lexer.mode_verification
 type resolve_result = (Syntax.prog * ResolveImport.resolved_imports) Diag.result
 
 let resolve_flags ~is_main ~base pkg_opt =
-  let base_dir = if Sys.is_directory base then base else Filename.dirname base in
   let resolve_path_flag flag =
     if not is_main then !flag else
-    Option.map (fun p ->
-      let p =
-        if !Flags.ocaml_js && Filename.is_relative p
-        then Filename.concat base_dir p |> Lib.FilePath.normalise
-        else p
-      in
-      flag := Some p; p) !flag
+    !flag |> Option.map (fun p ->
+      if not (!Flags.ocaml_js && Filename.is_relative p) then p else
+      let base_dir = if Sys.is_directory base then base else Filename.dirname base in
+      (* moc.js has no CWD, so resolve relative flag paths against the source file's directory *)
+      let p = Filename.concat base_dir p |> Lib.FilePath.normalise in
+      flag := Some p; p)
   in
   ResolveImport.{
     package_urls = !Flags.package_urls;

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -36,7 +36,7 @@ type compile_result =
 
 val compile_files : Flags.compile_mode -> bool -> string list -> compile_result
 
-val resolve_flags : enhanced_migration:string option -> (* package_opt *) string option -> ResolveImport.flags
+val resolve_flags : enhanced_migration:bool -> base:string -> (* package_opt *) string option -> ResolveImport.flags
 val resolved_import_name : Syntax.resolved_import Source.phrase -> string
 
 (* For use in the language server *)

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -36,7 +36,7 @@ type compile_result =
 
 val compile_files : Flags.compile_mode -> bool -> string list -> compile_result
 
-val resolve_flags : enhanced_migration:bool -> base:string -> (* package_opt *) string option -> ResolveImport.flags
+val resolve_flags : is_main:bool -> base:string -> (* package_opt *) string option -> ResolveImport.flags
 val resolved_import_name : Syntax.resolved_import Source.phrase -> string
 
 (* For use in the language server *)

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -267,6 +267,17 @@ assert.deepStrictEqual(Motoko.run([], "blob.mo"), {
   result: { error: {} },
 });
 
+// Relative --enhanced-migration path resolves against the source file's directory (#6002)
+Motoko.saveFile("/project/Main.mo",
+  'persistent actor { let x : Nat; public func get() : async Nat { x } };'
+);
+Motoko.saveFile("/project/migrations/m1.mo",
+  'module { public func migration(_ : {}) : { x : Nat } { { x = 42 } }; };'
+);
+Motoko.setExtraFlags(["--enhanced-migration=migrations"]);
+const migrationResult = Motoko.check("/project/Main.mo");
+assert.deepStrictEqual(migrationResult.diagnostics, []);
+
 Motoko.setExtraFlags(["-W=M0223"]);
 assert.throws(
   () => Motoko.setExtraFlags(["--invalid-flag"]),

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -268,14 +268,14 @@ assert.deepStrictEqual(Motoko.run([], "blob.mo"), {
 });
 
 // Relative --enhanced-migration path resolves against the source file's directory (#6002)
-Motoko.saveFile("/project/Main.mo",
+Motoko.saveFile("/project/src/Main.mo",
   'persistent actor { let x : Nat; public func get() : async Nat { x } };'
 );
 Motoko.saveFile("/project/migrations/m1.mo",
   'module { public func migration(_ : {}) : { x : Nat } { { x = 42 } }; };'
 );
-Motoko.setExtraFlags(["--enhanced-migration=migrations"]);
-const migrationResult = Motoko.check("/project/Main.mo");
+Motoko.setExtraFlags(["--enhanced-migration=../migrations"]);
+const migrationResult = Motoko.check("/project/src/Main.mo");
 assert.deepStrictEqual(migrationResult.diagnostics, []);
 
 Motoko.setExtraFlags(["-W=M0223"]);


### PR DESCRIPTION
## Problem

When the language server passes flags with relative paths to `moc.js` (e.g. `--enhanced-migration=migrations` from `mops.toml`), the compiler fails with:

```
M0256: enhanced migration path 'migrations' is not a directory
```

This happens because the `moc.js` virtual filesystem stores all files with absolute paths (e.g. `/Users/.../project/migrations/Init.mo`), but `Sys.readdir("migrations")` looks for a relative path that doesn't exist in the virtual filesystem.

The native `moc` CLI is unaffected because relative paths resolve against the OS working directory.

## Root cause

`Pipeline.resolve_flags` assembled the flags record from global `Flags` values without resolving relative paths. In `moc.js` mode (`Flags.ocaml_js`), there is no meaningful CWD, so any relative path in a flag was passed through verbatim to `Sys.readdir`, `Sys.file_exists`, etc., which could not resolve it against the virtual filesystem.

## Fix

`Pipeline.resolve_flags` now takes a `~base` parameter (the source filepath) and resolves relative paths in path-bearing flags (`enhanced_migration`, `actor_idl_path`) against the source file's directory, but only when running as `moc.js`. Native `moc` is unaffected.

This is the single point where all flag values are assembled, so new path-bearing flags only need one line added to `resolve_flags` to be handled correctly.

## Test plan

Tested end-to-end via a new `enhancedMigration` test in the `vscode-motoko` extension (separate PR) that:
1. Loads a project with `[moc] args = ["--enhanced-migration=migrations"]` in `mops.toml`
2. Verifies `Main.mo` compiles without errors using migration-provided stable fields

Made with [Cursor](https://cursor.com)