### PR TITLE
experiment: incremental compilation

### DIFF
--- a/.cursor/plans/compile-mode_ir_caching_8a12d666.plan.md
+++ b/.cursor/plans/compile-mode_ir_caching_8a12d666.plan.md
@@ -1,0 +1,367 @@
+---
+name: Compile-mode IR caching
+overview: "Cache the post-IR-pass lowered IR for all dependency libraries to disk. On subsequent compiles where only the main program changes, load the cached IR and skip parsing, type-checking, lowering, and all 7 IR passes for dependencies. Expected savings: ~1,300ms out of 1,760ms (~74% faster) on Map.test.mo."
+todos:
+  - id: cli-update
+    content: Allow --moi-cache with -c mode in moc.ml (remove the --check restriction)
+    status: pending
+  - id: fresh-scoping
+    content: Add ir_scope to construct.ml fresh to namespace generated names by library context, and add bump_stamps to cons.ml for post-deserialization stamp safety
+    status: pending
+  - id: const-initial-env
+    content: Modify const.ml analyze to accept optional initial env (known_const binding names from cached lib decs)
+    status: pending
+  - id: ir-serialization
+    content: Implement IR cache serialization using Marshal with compiler version validation and Cons stamp bumping (in ir_cache.ml or extending moi_cache.ml)
+    status: pending
+  - id: pipeline-restructure
+    content: "Restructure compile_progs in pipeline.ml: split library and main IR processing, integrate IR cache load/save, handle cache-miss fallback by bypassing scope cache"
+    status: pending
+  - id: show-eq-dedup
+    content: Implement show/eq helper deduplication when linking cached lib decs with main decs (filter @show/@eq LetD duplicates)
+    status: pending
+  - id: check-ir-adjustment
+    content: Adjust Check_ir to run per-fragment only (before caching for libs, after passes for main), skip on combined IR
+    status: pending
+  - id: tests
+    content: "Add compile-mode cache tests: warm cache produces identical Wasm, cache invalidation on dep change, actor-class libs bypass cache"
+    status: pending
+isProject: false
+---
+
+# Compile-mode IR Caching
+
+## Problem
+
+When compiling with `moc -c`, **89% of the time** is spent on whole-program IR passes + codegen that walk library code unchanged between builds. Profiling `Map.test.mo` (78 deps, 15k+ lines of library code vs 1.6k main):
+
+| Phase | Time | % |
+|---|---|---|
+| Parse + check + definedness (per-lib) | 167ms | 11% |
+| Lowering (desugar) | 61ms | 4% |
+| **7 IR passes (whole-program)** | **1,076ms** | **73%** |
+| Codegen | 164ms | 11% |
+
+The current `.moi` scope cache saves ~58ms (3%) because it only helps type-checking. Libraries dominate the IR (~90% of code), so the IR passes spend ~970ms walking unchanged library code.
+
+## Architecture
+
+The key idea: **process library decs and main program decs through IR passes independently, then combine for codegen.**
+
+The main program runs through passes WITHOUT the prelude or library decs in its IR. The passes generate variable references (e.g., `@text_of_option`) by name only — resolution happens at link time in the combined IR. `const.ml` receives all cached binding names as a pre-populated initial env.
+
+```mermaid
+flowchart TD
+    subgraph cachedPath [Cached path -- skip on cache hit]
+        ParseLibs[Parse all dependency .mo files]
+        CheckLibs[Type-check all dependencies]
+        LowerLibs["compile_libs: import_unit per lib"]
+        WrapLibs["Wrap: ProgU(prelude + internals + lib_decs)"]
+        PassLibs["ir_passes on library ProgU"]
+        SerializeIR[Serialize post-pass dec list to .moic]
+    end
+
+    subgraph alwaysRun [Always runs]
+        LoadIRCache{"IR cache hit?"}
+        DeserializeIR[Load cached post-pass lib decs]
+        BumpStamps[Bump Cons.stamps past deserialized stamps]
+        ScopeCache["Load dep scopes from .moi cache"]
+        ParseMain[Parse + type-check main program]
+        LowerMain["transform_unit(main)"]
+        PassMain["ir_passes on main unit\n(const env pre-populated)"]
+        Dedup["Deduplicate @show/@eq helpers"]
+        Link["inject_decs(lib_decs, main_prog)"]
+        Codegen[Codegen to Wasm]
+    end
+
+    LoadIRCache -->|miss| ParseLibs
+    LoadIRCache -->|hit| DeserializeIR --> BumpStamps --> ScopeCache --> ParseMain
+    ParseLibs --> CheckLibs --> LowerLibs --> WrapLibs --> PassLibs --> SerializeIR --> Link
+    ParseMain --> LowerMain --> PassMain --> Dedup --> Link --> Codegen
+```
+
+### Cache interaction rules
+
+The `.moi` scope cache and `.moic` IR cache interact:
+
+- **IR cache hit**: load cached IR, use `.moi` scope cache to build `senv` for type-checking the main program. `libs` list is empty (not needed).
+- **IR cache miss**: bypass `.moi` scope cache entirely — run full type-checking to produce annotated ASTs (`libs` list), then lower + pass + cache IR. The `.moi` scope cache is NOT used because we need the typed ASTs that `check_lib` produces as a side effect.
+
+## Why it works
+
+We analyzed all 7 IR passes for compositionality:
+
+- **`erase_typ_field` / `async`**: Each uses a `con_renaming` that clones type constructors. Independent cloning produces structurally equivalent results. Codegen and `typ_hash` work structurally (not by stamp identity). The passes' own comments already anticipate fragment-wise execution ("if we run this translation on two program fragments, we would have to pass down the `con_renaming`").
+- **`show` / `eq`**: Generate helpers named `@show<typ_hash>` / `@eq<typ_hash>`. `typ_hash` normalizes through `Con` (line 136 of `typ_hash.ml`), so independent fragments produce identical helper names. Duplicates between lib and main are deduplicated at link time.
+- **`await` / `tailcall`**: Purely local per-function transformations. No cross-boundary dependencies.
+- **`const`**: Top-level functions are unconditionally `surely_true` (line 110 of `const.ml`). Library exports are all top-level module values. We pre-populate the main program's const env with ALL binding names from `passed_lib_decs` (prelude + internals + library modules).
+
+## Implementation
+
+### Step 1: CLI changes ([moc.ml](src/exes/moc.ml))
+
+Remove the restriction that `--moi-cache` requires `--check`. Allow it with `-c` as well. The same cache directory serves both:
+- `.moi` files for scope caching (speeds up `--check`)
+- `.moic` file for IR caching (speeds up `-c`)
+
+Change in [moc.ml](src/exes/moc.ml) around line 403:
+```ocaml
+(* Remove this check: *)
+(* if Option.is_some !Flags.moi_cache_dir && !mode <> Check
+   then fail "moc: --moi-cache requires --check"; *)
+```
+
+### Step 2: Fresh name scoping ([construct.ml](src/ir_def/construct.ml), [cons.ml](src/mo_types/cons.ml))
+
+**Variable names** — `Construct.fresh` generates names like `$k/0`. Cached and fresh sessions could collide. Add a library scope prefix:
+
+```ocaml
+(* construct.ml *)
+let ir_scope = ref ""
+
+let fresh name_base () : string =
+  let n = Lib.Option.get (Stamps.find_opt name_base !id_stamps) 0 in
+  id_stamps := Stamps.add name_base (n + 1) !id_stamps;
+  if !ir_scope = "" then Printf.sprintf "$%s/%i" name_base n
+  else Printf.sprintf "$%s$%s/%i" !ir_scope name_base n
+```
+
+Set `Construct.ir_scope := "libs"` before processing libraries for IR passes, reset to `""` before processing the main program.
+
+**Constructor stamps** — `Cons.clone` (used by `erase_typ_field` and `async`) calls `Cons.fresh_stamp` which uses a global counter. After `Marshal` deserialization, cached `Cons.t` objects have stamps from a previous session but the counter is NOT bumped. Add a function to bump past deserialized stamps:
+
+```ocaml
+(* cons.ml *)
+let bump_stamps_past cs =
+  List.iter (fun c ->
+    let (n, scope) = c.stamp in
+    let key = (c.name, scope) in
+    let cur = Lib.Option.get (Stamps.find_opt key !stamps.stamps) 0 in
+    if n >= cur then
+      stamps := { !stamps with stamps = Stamps.add key (n + 1) !stamps.stamps }
+  ) cs
+```
+
+Call `bump_stamps_past` after deserializing cached IR, passing all `Cons.t` found in the deserialized decs.
+
+### Step 3: Const pass modification ([const.ml](src/ir_passes/const.ml))
+
+Accept an optional initial env with pre-known constant bindings. This must include ALL binding names from `passed_lib_decs` — prelude functions (`@text_of_option`, `@new_async`, etc.), internals, library modules (`file$/path/to/Map.mo`), and any generated `@show<...>` / `@eq<...>` helpers.
+
+```ocaml
+let analyze ?(known_const = []) ((cu, _flavor) : prog) =
+  let init_env = List.fold_left (fun env name ->
+    M.add name { loc_known = true; const = surely_true } env
+  ) M.empty known_const in
+  match cu with
+  | LibU _ -> raise (Invalid_argument "cannot compile library")
+  | ProgU ds -> decs_ TopLvl init_env ds
+  | ActorU (as_opt, ds, fs, sys, typ) ->
+    let env = match as_opt with
+      | None -> init_env
+      | Some as_ -> args TopLvl init_env as_
+    in
+    let (env', _) = decs TopLvl env ds in
+    exp_ TopLvl env' sys.preupgrade;
+    exp_ TopLvl env' sys.postupgrade;
+    exp_ TopLvl env' sys.heartbeat;
+    exp_ TopLvl env' sys.timer;
+    exp_ TopLvl env' sys.inspect;
+    exp_ TopLvl env' sys.low_memory;
+    exp_ TopLvl env' sys.stable_record
+```
+
+The `pipeline.ml` call changes from `Const.analyze prog` to `Const.analyze ~known_const prog`.
+
+### Step 4: IR serialization ([ir_cache.ml](src/pipeline/ir_cache.ml) — new file)
+
+Use `Marshal` for the POC. Cache validity is ensured by compiler version hash.
+
+```ocaml
+let magic = "MOIC"
+let version = 1
+
+let write file ~compiler_hash ~dep_hash (decs : Ir.dec list) =
+  let tmp = file ^ ".tmp" in
+  let oc = open_out_bin tmp in
+  output_string oc magic;
+  output_binary_int oc version;
+  output_string oc compiler_hash;   (* Source_id.id, 40 hex chars *)
+  output_string oc dep_hash;        (* SHA-256 of all dep source hashes *)
+  Marshal.to_channel oc decs [];
+  close_out oc;
+  Sys.rename tmp file
+
+let read file ~compiler_hash ~dep_hash : Ir.dec list option =
+  try
+    let ic = open_in_bin file in
+    Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+      let magic' = really_input_string ic (String.length magic) in
+      let version' = input_binary_int ic in
+      let compiler' = really_input_string ic (String.length compiler_hash) in
+      let dep' = really_input_string ic (String.length dep_hash) in
+      if magic' <> magic || version' <> version
+         || compiler' <> compiler_hash || dep' <> dep_hash
+      then None
+      else Some (Marshal.from_channel ic : Ir.dec list))
+  with Sys_error _ | End_of_file | Failure _ -> None
+```
+
+**Cache key**: SHA-256 of the sorted `(resolved_path, MD5(source))` list for all dependencies. Cache file: `<dep_hash>.moic` in the `--moi-cache` directory.
+
+**Post-deserialization**: collect all `Cons.t` stamps from the deserialized decs and call `Cons.bump_stamps_past` to prevent collisions.
+
+### Step 5: Pipeline restructuring ([pipeline.ml](src/pipeline/pipeline.ml))
+
+Replace `compile_progs` to separate library and main processing. Key design decisions:
+
+1. **No prelude in main fragment** — the main program's IR passes run on `transform_unit(main)` alone, without prelude/internals decs. Show/eq helpers generate `VarE` references resolved at link time. `const.ml` uses the pre-populated env.
+
+2. **Cache-miss bypasses scope cache** — on IR cache miss, `chase_imports_cached` must NOT use `.moi` scope cache (we need annotated ASTs for lowering). Implement by temporarily clearing `Flags.moi_cache_dir` during `load_progs` when compiling with IR cache miss.
+
+3. **Actor class guard** — if any library has an `ActorClassU` body, skip IR caching entirely and fall through to the current full pipeline. This avoids complex interaction with `compile_unit_to_wasm`.
+
+```ocaml
+and compile_progs mode do_link libs progs =
+  match !Flags.moi_cache_dir with
+  | Some cache_dir when not (has_actor_class_libs libs) ->
+    compile_progs_cached mode do_link libs progs cache_dir
+  | _ ->
+    compile_progs_uncached mode do_link libs progs
+
+and compile_progs_uncached mode do_link libs progs =
+  (* current implementation, unchanged *)
+  let imports = compile_libs mode libs in
+  let prog = CompUnit.combine_progs progs in
+  let u = CompUnit.comp_unit_of_prog false prog in
+  compile_unit mode (!Flags.enhanced_migration) do_link imports u
+
+and compile_progs_cached mode do_link libs progs cache_dir =
+  let dep_hash = compute_dep_hash libs in
+  let moic_path = Filename.concat cache_dir (dep_hash ^ ".moic") in
+  let compiler_hash = Source_id.id in
+  (* Phase A: try loading cached library IR *)
+  let passed_lib_decs = match Ir_cache.read moic_path ~compiler_hash ~dep_hash with
+    | Some decs ->
+      (* Bump Cons stamp counter past any deserialized stamps *)
+      let cons = collect_cons_from_ir_decs decs in
+      Cons.bump_stamps_past cons;
+      decs
+    | None ->
+      (* Cache miss — must have typed ASTs. If libs is empty because
+         scope cache was used, we need to re-run load_progs without
+         scope cache. For now, libs should be populated because
+         compile_files calls load_progs before compile_progs. *)
+      let prelude_imports =
+        Lowering.Desugar.(import_prelude prelude @ import_prelude internals) in
+      let lib_imports = compile_libs mode libs in
+      let lib_prog =
+        Ir.(ProgU (prelude_imports @ lib_imports)), Ir.full_flavor () in
+      let (passed_cu, _flavor) = ir_passes mode lib_prog "libraries" in
+      let decs = match passed_cu with
+        | Ir.ProgU ds -> ds | _ -> assert false in
+      Ir_cache.write moic_path ~compiler_hash ~dep_hash decs;
+      decs
+  in
+  (* Phase B: main program IR — NO prelude, no library decs *)
+  let prog = CompUnit.combine_progs progs in
+  let u = CompUnit.comp_unit_of_prog false prog in
+  let name = u.Source.note.Syntax.filename in
+  let main_prog = Lowering.Desugar.transform_unit u in
+  (* Run IR passes with pre-populated const env *)
+  let lib_bindings = extract_binding_names passed_lib_decs in
+  let passed_main_prog = ir_passes_with_env mode main_prog name ~known_const:lib_bindings in
+  (* Phase C: combine + codegen *)
+  let combined = inject_and_dedup_lib_decs passed_lib_decs passed_main_prog in
+  compile_combined mode do_link combined name
+```
+
+**Helper functions needed:**
+
+- `has_actor_class_libs libs` — scan `libs` for any `ActorClassU` body
+- `compute_dep_hash libs` — SHA-256 of sorted `(filename, MD5(source))` pairs
+- `extract_binding_names decs` — collect all `LetD`/`VarD`/`RefD` binding names from the dec list
+- `collect_cons_from_ir_decs decs` — walk IR decs and collect all `Cons.t` objects (for stamp bumping)
+- `inject_and_dedup_lib_decs lib_decs main_prog` — prepend lib decs to main prog, filtering out any `@show<...>` / `@eq<...>` decs from main that duplicate names in lib decs
+- `ir_passes_with_env` — same as `ir_passes` but passes `~known_const` to `Const.analyze`
+- `compile_combined` — run codegen on the combined IR (equivalent to current `compile_unit` but receiving a fully-linked prog)
+
+### Step 6: Show/eq deduplication
+
+In `inject_and_dedup_lib_decs`, collect the set of binding names from `passed_lib_decs` that match `@show<...>` or `@eq<...>`. Then filter the main program's decs to remove any `LetD` whose binding name is in that set.
+
+```ocaml
+let inject_and_dedup_lib_decs lib_decs (main_cu, main_flavor) =
+  let lib_names = List.fold_left (fun s d ->
+    match d.it with
+    | Ir.LetD ({it = {Ir.var; _}; _}, _) -> StringSet.add var s
+    | _ -> s
+  ) StringSet.empty lib_decs in
+  let filter_dup d = match d.it with
+    | Ir.LetD ({it = {Ir.var; _}; _}, _)
+      when String.length var > 5
+        && (String.sub var 0 5 = "@show" || String.sub var 0 3 = "@eq<")
+        && StringSet.mem var lib_names -> false
+    | _ -> true
+  in
+  let deduped_cu = match main_cu with
+    | Ir.ProgU ds -> Ir.ProgU (lib_decs @ List.filter filter_dup ds)
+    | Ir.ActorU (a, ds, fs, sys, t) ->
+      Ir.ActorU (a, lib_decs @ List.filter filter_dup ds, fs, sys, t)
+    | Ir.LibU _ -> assert false
+  in
+  (deduped_cu, main_flavor)
+```
+
+### Step 7: Check_ir adjustment
+
+Skip `Check_ir` on the combined post-link IR. Run it per-fragment only:
+- **Library fragment**: run `Check_ir` before caching (in `compile_progs_cached`, after `ir_passes`)
+- **Main fragment**: run `Check_ir` after passes but before linking
+
+In `pipeline.ml`, `Check_ir` is called inside `desugar_unit` and each `*_translation` function via `if !Flags.check_ir then Check_ir.check_prog ...`. For the combined IR, guard the final check with a flag or simply skip it after linking.
+
+### Step 8: Tests
+
+1. **Correctness**: compile with `--moi-cache`, verify the output `.wasm` is byte-identical to compiling without cache
+2. **Cache invalidation**: change a dependency source file, verify the cache is invalidated and a fresh compile produces correct output
+3. **Actor class bypass**: test with actor class libraries, verify caching is skipped and compilation still works
+4. **Error reporting**: type errors in main program are still reported correctly with cached deps
+
+Test structure (extending existing `test/run/moi-cache/`):
+```
+//MOC-FLAG --moi-cache _out/moi-cache-dir
+//MOC-FLAG -c
+```
+
+## Risks
+
+1. **Constructor identity after independent cloning**: Codegen uses structural types for Wasm layout, so different clones of the same constructor produce identical Wasm. Verified by examining `typ_hash` (normalizes through `Con` at line 136) and codegen dispatch. Mitigated by `Cons.bump_stamps_past` to prevent stamp collisions.
+
+2. **`Marshal` stability**: `Marshal` format is OCaml-version-dependent. Since we key caches by `Source_id.id` (which changes with every compiler build), stale caches from a different OCaml version are automatically rejected.
+
+3. **Actor class libraries**: These go through `compile_unit_to_wasm` (full recursive compilation). For the POC, if ANY actor class library is present, IR caching is bypassed entirely. This is safe and simple.
+
+4. **Scope cache / IR cache ordering**: On IR cache miss, the `.moi` scope cache must NOT be used because we need annotated ASTs (produced by `check_lib`) for lowering. The `compile_files` flow ensures `load_progs` runs first — if IR caching is enabled but misses, we need `libs` populated. This is handled by checking the IR cache AFTER `load_progs` returns. If `libs` is empty (scope cache was used), we re-run `load_progs` without scope cache.
+
+5. **Main program passes without prelude decs**: The show/eq passes generate `VarE` references to prelude functions (`@text_of_option`, etc.) that don't exist in the main fragment's IR. This is safe because `VarE` is just a string reference — resolution happens in the combined IR at codegen. `const.ml` won't crash because all prelude bindings are in the pre-populated `known_const` env.
+
+## Expected impact
+
+On `Map.test.mo` with warm IR cache:
+
+| Phase | Time |
+|---|---|
+| Startup + cache deserialization | ~100ms |
+| Parse dep headers + scope cache | ~60ms |
+| Parse + check main | ~10ms |
+| Lower main | ~5ms |
+| IR passes on main (~10% of IR) | ~110ms |
+| Codegen (whole-program, not cached) | ~164ms |
+| **Total** | **~450ms** |
+
+- **Before**: 1,760ms (full compile)
+- **After**: ~450ms
+- **Savings**: ~1,310ms (74% faster)
+
+Codegen (164ms) is the floor — it always walks the full combined IR. The savings scale with the ratio of library code to main program code. For projects with large dependency trees and small main programs (the typical case), savings could reach 75-80%.

--- a/.cursor/plans/motoko_incremental_compilation_19f31db2.plan.md
+++ b/.cursor/plans/motoko_incremental_compilation_19f31db2.plan.md
@@ -1,0 +1,324 @@
+---
+name: Motoko Incremental Compilation
+overview: Design an incremental compilation mechanism for moc that allows pre-compiled dependency scopes (mo:core, packages) to be cached on disk and reused across moc invocations, integrated with mops as the primary build orchestrator.
+todos:
+  - id: scope-serializer
+    content: "Implement Scope.t / Type.t serialization: use ExpGraph-style visited-set for cyclic cons, open_binds-style create-then-fixup for deserialization. Cover all Type.t variants."
+    status: pending
+  - id: moc-cli-flags
+    content: Add --moi-cache flag to moc CLI, wire into pipeline
+    status: pending
+  - id: pipeline-moi-loading
+    content: Modify chase_imports_cached to check for .moi files before falling back to source parse + type-check
+    status: pending
+  - id: mops-integration
+    content: Add --moi-cache .mops/.moi-cache/ to mops check/build moc invocations, optionally clear cache on mops install
+    status: pending
+  - id: testing
+    content: "Verify correctness: compile with and without .moi cache, compare type errors, Wasm output, and diagnostics"
+    status: pending
+isProject: false
+---
+
+# Incremental Compilation for Motoko
+
+## Current State
+
+### How moc works today (batch compiler)
+
+Every `moc` invocation (whether `--check` or `-c`) does the **full pipeline from scratch** for the entire dependency graph:
+
+1. Parse all transitive `.mo` imports (DFS walk)
+2. Type-check every library (`check_lib`) in dependency order
+3. Accumulate `Scope.t` per library into a growing static environment
+4. Type-check entrypoint program(s) against the accumulated environment
+5. (If compiling) Desugar to IR, run IR passes, codegen to Wasm
+
+For a project using `mo:core` (42 files, ~28k lines), steps 1-3 repeat identically on every single `moc` run — even if none of the library sources changed. This is the dominant cost for `mops check` and iterative development.
+
+### The moc.js scope cache (fragile, in-memory only)
+
+The JS API (`moc.js`) exposes a `scope_cache: Scope.t Type.Env.t` — a string-keyed map from resolved import paths to their typing scopes. The vscode-motoko language server passes this map across calls to skip re-type-checking unchanged dependencies.
+
+**Why it's fragile:**
+
+- Cache keys are **file paths**, not content hashes — no automatic invalidation
+- Invalidation is entirely **client-side** (vscode-motoko manages a dependency graph and manually deletes stale entries)
+- `Scope.t` values are **opaque blobs** passed through JS via `Obj.magic` — no serialization format, no disk persistence
+- Type constructors (`Cons.t`) contain mutable `ref` cells and process-global stamps — not safely serializable with OCaml `Marshal`
+
+### How mops invokes moc
+
+`mops check` runs: `moc <file.mo> --check --package name1 path1 --package name2 path2 ...`
+
+`mops build` runs: `moc -c --idl --stable-types -o output.wasm main.mo --package name1 path1 ...`
+
+Each invocation is a fresh process. mops does **zero compilation caching** — it delegates everything to moc and expects moc to handle the full graph.
+
+---
+
+## How Other Languages Handle This
+
+### OCaml (.cmi / .cmo files) — Simplest Model
+
+Each `.ml` file compiles to:
+
+- `.cmi` (compiled module interface) — serialized type signatures
+- `.cmo` / `.cmx` (compiled object) — bytecode / native code
+
+When compiling a file that imports module `Foo`, the compiler reads `foo.cmi` instead of re-type-checking `foo.ml`. Build tools (`dune`, `ocamlfind`) handle dependency ordering and cache invalidation via file timestamps.
+
+**Key insight:** The compiler itself produces and consumes interface files. The build tool just orchestrates. Cache invalidation is trivially based on file modification time.
+
+### TypeScript (.tsbuildinfo / .d.ts)
+
+- `--incremental` saves a `.tsbuildinfo` file containing file hashes and a dependency graph
+- On rebuild, compares file hashes against saved state, skips unchanged files
+- Project references use `.d.ts` (declaration files) as compiled interfaces between sub-projects
+
+### Rust (.rmeta / query-based)
+
+- Full query-based dependency graph with content-addressed caching
+- Extremely sophisticated — overkill for Motoko's current scale
+
+### Recommendation: Follow the OCaml/TypeScript hybrid model
+
+The simplest approach that gets 80%+ of the benefit is:
+
+1. Serialize `Scope.t` to disk per library (like OCaml's `.cmi`)
+2. Use content hashing for invalidation (like TypeScript's `.tsbuildinfo`)
+3. Let mops orchestrate (like `dune` / `tsc --build`)
+
+---
+
+## Proposed Design: `.moi` Interface Cache Files
+
+### Concept
+
+Introduce a new file format `.moi` (Motoko Object Interface) that captures the type-checked `Scope.t` for a library module. When moc encounters an import, it can load the `.moi` file instead of parsing and type-checking the `.mo` source.
+
+### Architecture
+
+```mermaid
+flowchart TD
+    subgraph currentFlow [Current: Every moc Run]
+        A1[Parse mo:core 42 files] --> B1[Type-check all 42 libs]
+        B1 --> C1[Type-check user code]
+        C1 --> D1[Codegen if -c]
+    end
+
+    subgraph proposedFlow [Proposed: With .moi Cache]
+        A2["moc --moi-cache dir --check user.mo"]
+        A2 --> B2{"For each import: .moi valid?"}
+        B2 -->|"hit"| C2["Deserialize Scope.t"]
+        B2 -->|"miss"| D2["Parse + type-check from source"]
+        D2 --> E2["Write updated .moi to cache dir"]
+        C2 --> F2["Type-check only user code"]
+        E2 --> F2
+        F2 --> G2["Codegen if -c"]
+    end
+```
+
+
+
+### Phase 1: Serialization of Scope.t (moc side)
+
+The core challenge is that `Scope.t` contains `Type.t` values, which contain `Cons.t` (type constructors with mutable `ref` cells and global stamps). This makes naive `Marshal` unsafe.
+
+**Approach: Canonical serialization with stamp remapping**
+
+1. Walk the `Scope.t` and collect all referenced `con` values
+2. Assign canonical integer IDs (deterministic, based on traversal order)
+3. Serialize `Scope.t` to a binary format, replacing `con` pointers with canonical IDs and serializing their `kind` inline
+4. Include a **format version** for forward/backward compatibility
+5. Include a **Merkle fingerprint** for transitive invalidation (see below)
+
+**Merkle fingerprint for transitive invalidation:**
+
+A flat per-file content hash is insufficient. If library `A` imports `B`, and `B` changes, `A`'s cached scope is stale even though `A.mo` didn't change — because `A`'s `Scope.t` was computed against `B`'s old scope.
+
+Each `.moi` header stores:
+
+```
+format_version: u32
+source_hash: SHA-256 of this .mo file's content
+scope_fingerprint: SHA-256(source_hash || sorted(dep_name:dep_scope_fingerprint, ...))
+deps: [(dep_resolved_name, dep_scope_fingerprint), ...]
+```
+
+The `scope_fingerprint` is a Merkle hash — it changes if this file's source changes **or** if any transitive dependency's source changes (since each dep's fingerprint transitively includes its own deps).
+
+**Validation on load** (works because `chase_imports_cached` processes in dependency order — by the time we validate `A.moi`, `B` has already been loaded/validated):
+
+1. Compute `source_hash` of current `.mo` file content
+2. Compare with stored `source_hash` — if different, **cache miss** (source changed)
+3. For each `(dep_name, stored_dep_fingerprint)` in the `.moi` deps list, compare `stored_dep_fingerprint` against that dep's **current** `scope_fingerprint` (either from its freshly-validated `.moi` or from re-computation) — if any mismatch, **cache miss** (a dependency changed)
+4. All match → **cache hit**, deserialize the `Scope.t`
+
+This correctly propagates invalidation through the entire dependency chain: if a leaf library changes, every ancestor's fingerprint mismatches, triggering re-computation up the tree.
+
+**Handling cyclic type constructors in serialization:**
+
+Type constructors (`con`) can form cycles. For example, `type List = ?(Nat, List)` produces a con whose kind references itself: `Def([], Opt(Tup[Nat, Con(list_con, [])]))`. Mutually recursive types create multi-node cycles (`Tree` references `Forest`'s con; `Forest` references `Tree`'s con). A naive recursive serializer would loop forever.
+
+The codebase already solves this exact graph-cycle problem in two places we can follow:
+
+- `**ExpGraph.unfold`** ([expGraph.ml](src/lang_utils/expGraph.ml)): walks a cyclic type graph with a `seen` set, assigns integer IDs on first visit, emits back-references on revisit. Used by `typ_hash` to serialize cyclic types to canonical strings.
+- `**open_binds`** ([type.ml](src/mo_types/type.ml) line 580): creates cons with `Pre` placeholder kinds, builds kind values that reference the already-existing cons, then fills in via `set_kind`. This is the "create-then-fixup" pattern.
+
+The key insight is that by the time a `Scope.t` is returned from `check_lib`, **all cons are finalized** — no `Pre` placeholders remain. The `set_kind` guard (`Abs(_, Pre)` required) ensures write-once semantics. So the `ref` cell is effectively immutable at caching time; serialization just reads the final value.
+
+**Serialization (writing `.moi`):**
+
+1. Walk the scope, maintain a `con -> int` visited map
+2. First encounter of a con: assign canonical ID, emit its name and kind body (recurse into the kind, which may encounter other cons — assign IDs to those too)
+3. Re-encounter of a con already in the visited map: emit just the ID (back-reference, breaks the cycle)
+
+**Deserialization (reading `.moi`):**
+
+1. **First pass:** for each con definition in the file, create `Cons.fresh name (Abs([], Pre))` and register in an `int -> con` table. This mirrors how `open_binds` pre-allocates cons before their kinds are known.
+2. **Second pass:** deserialize each con's kind body, resolving con-ID references via the lookup table. Because the cons already exist, cyclic references resolve to valid pointers.
+3. `Type.set_kind` each con with its deserialized kind — the same mechanism the compiler already uses.
+4. Rebuild `Scope.t` from the deserialized cons and types.
+
+**Key files to modify:**
+
+- New module: `src/mo_types/scope_serial.ml` (or similar) — serialize/deserialize `Scope.t`
+- [pipeline.ml](src/pipeline/pipeline.ml) — add `.moi` loading path in `chase_imports_cached`
+- [moc.ml](src/exes/moc.ml) — add `--moi-cache` flag
+
+### Phase 2: moc CLI Integration
+
+Single new flag:
+
+- `--moi-cache <dir>` — use `<dir>` as a read/write cache for `.moi` files. On each import, check for a valid cached `.moi`; on cache miss, type-check from source and write the result back.
+
+This is simpler than separate read/write flags — the cache is self-populating. First run pays full cost and warms the cache; subsequent runs benefit from it. No separate "generate cache" step needed.
+
+Modified `chase_imports_cached` (note: imports are processed in dependency order, so all deps are resolved before their dependents):
+
+```
+# Maintained across the DFS traversal:
+fingerprints: Map<resolved_name, scope_fingerprint>  # populated as each lib is processed
+
+for each import (in dependency order):
+  if --moi-cache is set:
+    moi_path = <cache-dir>/<import-key>.moi
+    if moi_path exists on disk:
+      read .moi header (source_hash, scope_fingerprint, deps list)
+      own_hash = SHA-256(current .mo file on disk)
+      if own_hash != stored source_hash:
+        CACHE MISS (source changed)
+      else:
+        for each (dep_name, stored_dep_fp) in deps:
+          if fingerprints[dep_name] != stored_dep_fp:
+            CACHE MISS (a dependency changed)
+        if all deps match:
+          CACHE HIT — deserialize Scope.t, adjoin to senv
+          fingerprints[resolved_name] = stored scope_fingerprint
+          continue to next import
+
+    # Cache miss or no .moi file:
+    parse + type-check from source
+    compute scope_fingerprint
+    write .moi to moi_path  (update cache)
+    fingerprints[resolved_name] = scope_fingerprint
+  else:
+    normal parse + type-check (no caching)
+```
+
+### Phase 3: mops Integration
+
+mops simply passes `--moi-cache .mops/.moi-cache/` to every moc invocation. No separate cache generation step is needed — the cache is self-populating:
+
+1. **First `mops check` after install:** all cache misses, moc type-checks from source and populates the cache as a side effect
+2. **Subsequent `mops check` / `mops build`:** cache hits for unchanged deps, only recomputes what changed
+3. **After `mops install` (dependency update):** mops can optionally delete `.mops/.moi-cache/` for a clean slate, though Merkle fingerprints would correctly invalidate stale entries anyway
+
+Package sources are **immutable** once installed — `mo:core@0.12.0` never changes on disk — so fingerprints always match between `mops install` runs. User-authored local libraries (e.g. `--package mylib ./src/lib`) can change freely, and the Merkle invalidation handles that correctly.
+
+**Changes to mops:**
+
+- [check.ts](~/mops/cli/commands/check.ts) — add `--moi-cache .mops/.moi-cache/` to moc args
+- [build.ts](~/mops/cli/commands/build.ts) — add `--moi-cache .mops/.moi-cache/` to moc args
+- Optionally: delete `.mops/.moi-cache/` during `mops install` for a clean slate
+
+### Phase 4: vscode-motoko Integration (bonus)
+
+The same `.moi` mechanism could replace the fragile in-memory scope cache:
+
+- Language server reads `.moi` files from the mops cache directory
+- No more client-side dependency graph tracking for invalidation
+- Falls back to current behavior if no `.moi` files exist
+
+---
+
+## Key Design Decisions and Trade-offs
+
+### Why not OCaml Marshal?
+
+`Marshal.to_channel` might seem tempting, but has problems:
+
+- **Cross-scope cons identity:** `Marshal` preserves `ref` sharing *within* a single marshaled value, so a single `Marshal.to_string scope` would correctly preserve internal cycles. However, if two separately marshaled scopes reference the same logical con, they'd get different `ref` cells on deserialization, breaking identity. This matters when the entrypoint's types reference cons from its dependencies.
+- **Stamp collisions:** Deserialized stamps could collide with freshly-allocated ones in the same process. A custom deserializer can use `Cons.fresh` to get process-unique stamps.
+- **No version safety:** Any change to the OCaml type definitions silently corrupts marshaled data — segfaults at runtime.
+- **No selective invalidation:** Marshal is all-or-nothing; you can't embed Merkle fingerprints or validate individual deps.
+
+A custom serializer is more work upfront but is safer and composes properly with the invalidation design. The `ExpGraph`-style graph traversal pattern already exists in the codebase and handles cycles correctly.
+
+### Why not just speed up type-checking?
+
+Even with a perfectly fast type-checker, re-doing the same work on every invocation is wasteful. A project with 10 package dependencies could have hundreds of library files — all immutable between dependency updates.
+
+### Why Merkle fingerprints instead of flat content hashes or timestamps?
+
+- **Flat content hashes are insufficient:** If library A imports B and B changes, A's cached scope is invalid even though A's source didn't change. The Merkle fingerprint (`hash(own_source, dep_fingerprints...)`) propagates changes transitively.
+- **Timestamps are fragile:** Package files in `.mops/` can be re-installed (same content, new mtime). Content hashing is deterministic across machines (CI reproducibility).
+- **Cost is negligible:** SHA-256 of a 28k-line library is ~1ms; the fingerprint check for the entire dep tree is O(n) string comparisons where n = number of direct deps per library.
+
+### What about codegen caching?
+
+For `--check` (the hot path during development), codegen doesn't run. For `-c` (build), the libraries don't produce Wasm individually (only the entrypoint does) — so scope caching covers the dominant cost. Actor class imports are an exception (each produces Wasm), but those are rare.
+
+---
+
+## Complexity Estimate
+
+
+| Component            | Effort | Risk                                                                                                                                                                                                                              |
+| -------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Scope.t serializer   | Medium | Cyclic cons are handled by the `ExpGraph`-style visited-set + `open_binds`-style create-then-fixup pattern. Main work is covering all `Type.t` variants. The `ref` cells are effectively immutable at cache time — not a blocker. |
+| moc CLI flags        | Low    | Straightforward flag plumbing                                                                                                                                                                                                     |
+| Pipeline integration | Medium | Merkle fingerprint validation in `chase_imports_cached`, fingerprint map threading                                                                                                                                                |
+| mops integration     | Low    | Adding flags to existing moc invocations + post-install hook                                                                                                                                                                      |
+| vscode-motoko        | Low    | Optional, can use .moi files as drop-in replacement for scope cache                                                                                                                                                               |
+
+
+---
+
+## Simplest Viable Starting Point
+
+If the full serialization story is too much, a **simpler first step** exists:
+
+**Persistent moc daemon / long-running process**
+
+Instead of serializing `Scope.t` to disk, keep a `moc` process alive between invocations:
+
+- `moc --server` listens on a Unix socket or stdin/stdout
+- mops sends check/compile requests
+- The moc process maintains `scope_cache` in memory across requests
+- Invalidation: mops tells moc which files changed (or moc watches with inotify)
+
+This avoids the serialization problem entirely but requires a process management story in mops. It's conceptually similar to what TypeScript's `tsc --watch` and `tsserver` do.
+
+**Trade-off:** Simpler implementation, but doesn't survive process restarts and adds operational complexity (daemon lifecycle, error recovery). The `.moi` approach is more robust long-term.
+
+---
+
+## Recommended Path
+
+1. **Start with `.moi` for `--check` only** — this is the hot path during development
+2. **Target `mo:core` and mops packages first** — immutable sources, simple invalidation
+3. **Integrate with mops** — add `--moi-dir` passthrough, generate cache on `mops install`
+4. **Later:** extend to full compilation, actor class caching, and language server integration
+

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -402,8 +402,8 @@ let () =
     eprintf "moc: --enhanced-migration flag requires --enhanced-orthogonal-persistence flag\n"; exit 1
   end;
 
-  if Option.is_some !Flags.moi_cache_dir && !mode <> Check
-  then fail "moc: --moi-cache requires --check";
+  if Option.is_some !Flags.moi_cache_dir && !mode <> Check && !mode <> Compile
+  then fail "moc: --moi-cache requires --check or -c";
   
   if not !Flags.skip_gc_deprecation_warning 
   then begin

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -257,7 +257,11 @@ let argspec =
 
   "--skip-gc-deprecation-warning",
   Arg.Unit (fun () -> Flags.skip_gc_deprecation_warning := true),
-  " skip the deprecation warning for the GC strategy flags"
+  " skip the deprecation warning for the GC strategy flags";
+
+  "--moi-cache",
+  Arg.String (fun dir -> Flags.moi_cache_dir := Some dir),
+  "<dir>  use <dir> as read/write cache for .moi interface files (incremental compilation)"
 
   ]
 
@@ -397,6 +401,9 @@ let () =
   then begin
     eprintf "moc: --enhanced-migration flag requires --enhanced-orthogonal-persistence flag\n"; exit 1
   end;
+
+  if Option.is_some !Flags.moi_cache_dir && !mode <> Check
+  then fail "moc: --moi-cache requires --check";
   
   if not !Flags.skip_gc_deprecation_warning 
   then begin

--- a/src/ir_def/construct.ml
+++ b/src/ir_def/construct.ml
@@ -32,6 +32,13 @@ let fresh name_base () : string =
   id_stamps := Stamps.add name_base (n + 1) !id_stamps;
   Printf.sprintf "$%s/%i" name_base n
 
+let get_id_stamps () = Stamps.bindings !id_stamps
+let set_id_stamps entries =
+  id_stamps := List.fold_left (fun m (k, v) ->
+    let cur = Lib.Option.get (Stamps.find_opt k m) 0 in
+    if v > cur then Stamps.add k v m else m
+  ) !id_stamps entries
+
 let fresh_id name_base () : id =
   fresh name_base ()
 

--- a/src/ir_def/construct.mli
+++ b/src/ir_def/construct.mli
@@ -27,6 +27,8 @@ val typ_of_var : var -> typ
 val arg_of_var : var -> arg
 val var_of_arg : arg -> var
 
+val get_id_stamps : unit -> (string * int) list
+val set_id_stamps : (string * int) list -> unit
 val fresh_id : string -> unit -> id
 val fresh_var : string -> typ -> var
 val fresh_vars : string -> typ list -> var list

--- a/src/ir_passes/const.ml
+++ b/src/ir_passes/const.ml
@@ -226,13 +226,13 @@ and block lvl env (ds, body) =
   let exp_const = exp lvl env' body in
   all [decs_const; exp_const]
 
-and comp_unit = function
+and comp_unit init_env = function
   | LibU _ -> raise (Invalid_argument "cannot compile library")
-  | ProgU ds -> decs_ TopLvl M.empty ds
+  | ProgU ds -> decs_ TopLvl init_env ds
   | ActorU (as_opt, ds, fs, {meta; preupgrade; postupgrade; heartbeat; timer; inspect; low_memory; stable_record; stable_type}, typ) ->
     let env = match as_opt with
-      | None -> M.empty
-      | Some as_ -> args TopLvl M.empty as_
+      | None -> init_env
+      | Some as_ -> args TopLvl init_env as_
     in
     let (env', _) = decs TopLvl env ds in
     exp_ TopLvl env' preupgrade;
@@ -243,5 +243,8 @@ and comp_unit = function
     exp_ TopLvl env' low_memory;
     exp_ TopLvl env' stable_record
 
-let analyze ((cu, _flavor) : prog) =
-  ignore (comp_unit cu)
+let analyze ?(known_const = []) ((cu, _flavor) : prog) =
+  let init_env = List.fold_left (fun env name ->
+    M.add name { loc_known = true; const = surely_true } env
+  ) M.empty known_const in
+  ignore (comp_unit init_env cu)

--- a/src/ir_passes/const.mli
+++ b/src/ir_passes/const.mli
@@ -1,2 +1,2 @@
 open Ir_def
-val analyze : Ir.prog -> unit
+val analyze : ?known_const:string list -> Ir.prog -> unit

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -89,6 +89,8 @@ let typechecker_combine_srcs = ref false (* useful for the language server *)
 let blob_import_placeholders = ref false (* when enabled, blob:file imports resolve as empty blobs *)
 let generate_view_queries = ref false
 
+let moi_cache_dir : string option ref = ref None
+
 let default_warning_levels = M.empty
   |> M.add "M0223" Allow (* don't report redundant instantions *)
   |> M.add "M0235" Allow (* don't deprecate for non-caffeine *)

--- a/src/mo_types/cons.ml
+++ b/src/mo_types/cons.ml
@@ -55,6 +55,15 @@ let clone c k =
    hash = hash name stamp;
    kind = ref k}
 
+let bump_stamps_past cs =
+  List.iter (fun c ->
+    let (n, scope) = c.stamp in
+    let key = (c.name, scope) in
+    let cur = Lib.Option.get (Stamps.find_opt key !stamps.stamps) 0 in
+    if n >= cur then
+      stamps := { !stamps with stamps = Stamps.add key (n + 1) !stamps.stamps }
+  ) cs
+
 let kind c = !(c.kind)
 let unsafe_set_kind c k = c.kind := k
 

--- a/src/mo_types/cons.mli
+++ b/src/mo_types/cons.mli
@@ -15,6 +15,8 @@ val name : 'a t -> string
 
 val to_string : bool -> string -> 'a t -> string
 
+val bump_stamps_past : 'a t list -> unit
+
 val kind : 'a t -> 'a
 val unsafe_set_kind : 'a t -> 'a -> unit (* cf. Type.set_kind *)
 

--- a/src/pipeline/dune
+++ b/src/pipeline/dune
@@ -18,6 +18,7 @@
     ir_passes
     codegen
     rts
+    source_id
   )
   (modules (:standard \ test_field_srcs))
   (inline_tests)

--- a/src/pipeline/ir_cache.ml
+++ b/src/pipeline/ir_cache.ml
@@ -1,0 +1,56 @@
+let magic = "MOIC"
+let version = 1
+
+let binary_hash =
+  try Digest.to_hex (Digest.file Sys.executable_name)
+  with Sys_error _ -> Digest.to_hex (Digest.string Source_id.id)
+
+let binary_hash_len = String.length binary_hash
+
+type cache_data = {
+  decs : Ir_def.Ir.dec list;
+  id_stamps : (string * int) list;
+}
+
+let mkdir_p dir =
+  let rec go d =
+    if Sys.file_exists d then ()
+    else begin go (Filename.dirname d);
+      (try Sys.mkdir d 0o755 with Sys_error _ -> ()) end
+  in go dir
+
+let write file ~dep_hash (data : cache_data) =
+  mkdir_p (Filename.dirname file);
+  let tmp = file ^ ".tmp" in
+  let oc = open_out_bin tmp in
+  (try
+    Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+      output_string oc magic;
+      output_binary_int oc version;
+      output_string oc binary_hash;
+      output_string oc dep_hash;
+      Marshal.to_channel oc data [Marshal.Closures]
+    );
+    Sys.rename tmp file
+  with exn ->
+    (try Sys.remove tmp with Sys_error _ -> ());
+    raise exn)
+
+let read file ~dep_hash : cache_data option =
+  if not (Sys.file_exists file) then None
+  else
+    try
+      let ic = open_in_bin file in
+      Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+        let magic' = really_input_string ic (String.length magic) in
+        let version' = input_binary_int ic in
+        let compiler' = really_input_string ic binary_hash_len in
+        let dep' = really_input_string ic (String.length dep_hash) in
+        if magic' <> magic || version' <> version
+           || compiler' <> binary_hash || dep' <> dep_hash
+        then None
+        else Some (Marshal.from_channel ic : cache_data))
+    with Sys_error _ | End_of_file | Failure _ -> None
+
+let moic_path ~cache_dir ~dep_hash =
+  Filename.concat cache_dir (dep_hash ^ ".moic")

--- a/src/pipeline/ir_cache.mli
+++ b/src/pipeline/ir_cache.mli
@@ -1,0 +1,8 @@
+type cache_data = {
+  decs : Ir_def.Ir.dec list;
+  id_stamps : (string * int) list;
+}
+
+val write : string -> dep_hash:string -> cache_data -> unit
+val read : string -> dep_hash:string -> cache_data option
+val moic_path : cache_dir:string -> dep_hash:string -> string

--- a/src/pipeline/moi_cache.ml
+++ b/src/pipeline/moi_cache.ml
@@ -1,0 +1,483 @@
+module T = Mo_types.Type
+module Cons = Mo_types.Cons
+module Scope = Mo_frontend.Scope
+
+let magic = "MOI\x01"
+let format_version = 1
+let compiler_hash = Digest.string Source_id.id
+
+type fingerprint = string
+
+type header = {
+  source_hash : fingerprint;
+  scope_fingerprint : fingerprint;
+  deps : (string * fingerprint) list;
+}
+
+(* ---- Binary writer ---- *)
+
+module W = struct
+  let create () = Buffer.create 4096
+  let contents = Buffer.contents
+
+  let byte buf b = Buffer.add_char buf (Char.chr (b land 0xFF))
+
+  let u32 buf n =
+    byte buf n;
+    byte buf (n lsr 8);
+    byte buf (n lsr 16);
+    byte buf (n lsr 24)
+
+  let raw buf s = Buffer.add_string buf s
+
+  let str buf s =
+    u32 buf (String.length s);
+    raw buf s
+
+  let option buf f = function
+    | None -> byte buf 0
+    | Some x -> byte buf 1; f buf x
+
+  let list buf f xs =
+    u32 buf (List.length xs);
+    List.iter (f buf) xs
+end
+
+(* ---- Binary reader ---- *)
+
+module R = struct
+  type t = { data : string; mutable pos : int }
+  let create s = { data = s; pos = 0 }
+
+  let byte r =
+    if r.pos >= String.length r.data then
+      failwith "moi: unexpected end of data";
+    let b = Char.code (String.unsafe_get r.data r.pos) in
+    r.pos <- r.pos + 1; b
+
+  let u32 r =
+    let b0 = byte r in
+    let b1 = byte r in
+    let b2 = byte r in
+    let b3 = byte r in
+    b0 lor (b1 lsl 8) lor (b2 lsl 16) lor (b3 lsl 24)
+
+  let raw r n =
+    if r.pos + n > String.length r.data then
+      failwith "moi: unexpected end of data";
+    let s = String.sub r.data r.pos n in
+    r.pos <- r.pos + n; s
+
+  let str r = let n = u32 r in raw r n
+
+  let option r f =
+    if byte r = 0 then None else Some (f r)
+
+  let list r f =
+    let n = u32 r in
+    List.init n (fun _ -> f r)
+end
+
+(* ---- Prim / enum tags ---- *)
+
+let prim_tag = function
+  | T.Null -> 0  | T.Bool -> 1  | T.Nat -> 2   | T.Nat8 -> 3
+  | T.Nat16 -> 4 | T.Nat32 -> 5 | T.Nat64 -> 6 | T.Int -> 7
+  | T.Int8 -> 8  | T.Int16 -> 9 | T.Int32 -> 10 | T.Int64 -> 11
+  | T.Float -> 12 | T.Float32 -> 13 | T.Char -> 14 | T.Text -> 15
+  | T.Blob -> 16 | T.Error -> 17 | T.Principal -> 18 | T.Region -> 19
+
+let tag_prim = function
+  | 0 -> T.Null  | 1 -> T.Bool  | 2 -> T.Nat   | 3 -> T.Nat8
+  | 4 -> T.Nat16 | 5 -> T.Nat32 | 6 -> T.Nat64 | 7 -> T.Int
+  | 8 -> T.Int8  | 9 -> T.Int16 | 10 -> T.Int32 | 11 -> T.Int64
+  | 12 -> T.Float | 13 -> T.Float32 | 14 -> T.Char | 15 -> T.Text
+  | 16 -> T.Blob | 17 -> T.Error | 18 -> T.Principal | 19 -> T.Region
+  | n -> failwith (Printf.sprintf "moi: bad prim tag %d" n)
+
+let obj_sort_tag = function
+  | T.Object -> 0 | T.Actor -> 1 | T.Mixin -> 2
+  | T.Module -> 3 | T.Memory -> 4
+
+let tag_obj_sort = function
+  | 0 -> T.Object | 1 -> T.Actor | 2 -> T.Mixin
+  | 3 -> T.Module | 4 -> T.Memory
+  | n -> failwith (Printf.sprintf "moi: bad obj_sort tag %d" n)
+
+let func_sort_tag = function
+  | T.Local -> 0
+  | T.Shared T.Query -> 1
+  | T.Shared T.Write -> 2
+  | T.Shared T.Composite -> 3
+
+let tag_func_sort = function
+  | 0 -> T.Local
+  | 1 -> T.Shared T.Query
+  | 2 -> T.Shared T.Write
+  | 3 -> T.Shared T.Composite
+  | n -> failwith (Printf.sprintf "moi: bad func_sort tag %d" n)
+
+let control_tag = function
+  | T.Returns -> 0 | T.Promises -> 1 | T.Replies -> 2
+
+let tag_control = function
+  | 0 -> T.Returns | 1 -> T.Promises | 2 -> T.Replies
+  | n -> failwith (Printf.sprintf "moi: bad control tag %d" n)
+
+let async_sort_tag = function
+  | T.Fut -> 0 | T.Cmp -> 1
+
+let tag_async_sort = function
+  | 0 -> T.Fut | 1 -> T.Cmp
+  | n -> failwith (Printf.sprintf "moi: bad async_sort tag %d" n)
+
+let bind_sort_tag = function
+  | T.Scope -> 0 | T.Type -> 1
+
+let tag_bind_sort = function
+  | 0 -> T.Scope | 1 -> T.Type
+  | n -> failwith (Printf.sprintf "moi: bad bind_sort tag %d" n)
+
+(* ---- Con collection ---- *)
+
+(* Collect all unique cons reachable from a type, in DFS first-encounter order *)
+let collect_cons_from_typs typs =
+  let seen = ref T.ConSet.empty in
+  let acc = ref [] in
+  let add_con c =
+    if T.ConSet.mem c !seen then false
+    else begin seen := T.ConSet.add c !seen; acc := c :: !acc; true end
+  in
+  let rec walk_typ = function
+    | T.Var _ | T.Prim _ | T.Any | T.Non | T.Pre -> ()
+    | T.Con (c, ts) ->
+      if add_con c then walk_kind (Cons.kind c);
+      List.iter walk_typ ts
+    | T.Obj (_, fs, tfs) ->
+      List.iter walk_field fs;
+      List.iter walk_typ_field tfs
+    | T.Variant fs -> List.iter walk_field fs
+    | T.Array t | T.Opt t | T.Mut t | T.Named (_, t) | T.Weak t ->
+      walk_typ t
+    | T.Tup ts -> List.iter walk_typ ts
+    | T.Func (_, _, bs, ts1, ts2) ->
+      List.iter walk_bind bs;
+      List.iter walk_typ ts1;
+      List.iter walk_typ ts2
+    | T.Async (_, s, t) -> walk_typ s; walk_typ t
+  and walk_field f = walk_typ f.T.typ
+  and walk_typ_field (tf : T.typ_field) =
+    if add_con tf.T.typ then walk_kind (Cons.kind tf.T.typ)
+  and walk_bind b = walk_typ b.T.bound
+  and walk_kind = function
+    | T.Def (bs, t) | T.Abs (bs, t) ->
+      List.iter walk_bind bs; walk_typ t
+  in
+  List.iter walk_typ typs;
+  List.rev !acc
+
+let collect_cons_from_scope (scope : Scope.t) =
+  let typs = T.Env.fold (fun _ t acc -> t :: acc) scope.Scope.lib_env [] in
+  collect_cons_from_typs typs
+
+(* ---- Serialize types ---- *)
+
+let write_scope buf (scope : Scope.t) =
+  let cons = collect_cons_from_scope scope in
+  let con_map =
+    List.fold_left (fun (m, i) c -> T.ConEnv.add c i m, i + 1)
+      (T.ConEnv.empty, 0) cons |> fst
+  in
+  let con_index c =
+    match T.ConEnv.find_opt c con_map with
+    | Some i -> i
+    | None -> failwith ("moi: con not in table: " ^ Cons.name c)
+  in
+
+  (* write con declarations (names) *)
+  W.u32 buf (List.length cons);
+  List.iter (fun c -> W.str buf (Cons.name c)) cons;
+
+  (* write con kind bodies *)
+  let rec write_typ t =
+    match t with
+    | T.Var (v, i) -> W.byte buf 0; W.str buf v; W.u32 buf i
+    | T.Con (c, ts) ->
+      W.byte buf 1; W.u32 buf (con_index c);
+      W.u32 buf (List.length ts); List.iter write_typ ts
+    | T.Prim p -> W.byte buf 2; W.byte buf (prim_tag p)
+    | T.Obj (s, fs, tfs) ->
+      W.byte buf 3; W.byte buf (obj_sort_tag s);
+      W.list buf write_field fs;
+      W.list buf write_typ_field tfs
+    | T.Variant fs -> W.byte buf 4; W.list buf write_field fs
+    | T.Array t -> W.byte buf 5; write_typ t
+    | T.Opt t -> W.byte buf 6; write_typ t
+    | T.Tup ts ->
+      W.byte buf 7; W.u32 buf (List.length ts); List.iter write_typ ts
+    | T.Func (s, c, bs, ts1, ts2) ->
+      W.byte buf 8;
+      W.byte buf (func_sort_tag s);
+      W.byte buf (control_tag c);
+      W.list buf write_bind bs;
+      W.u32 buf (List.length ts1); List.iter write_typ ts1;
+      W.u32 buf (List.length ts2); List.iter write_typ ts2
+    | T.Async (s, sc, t) ->
+      W.byte buf 9; W.byte buf (async_sort_tag s);
+      write_typ sc; write_typ t
+    | T.Mut t -> W.byte buf 10; write_typ t
+    | T.Any -> W.byte buf 11
+    | T.Non -> W.byte buf 12
+    | T.Named (n, t) -> W.byte buf 13; W.str buf n; write_typ t
+    | T.Weak t -> W.byte buf 14; write_typ t
+    | T.Pre -> failwith "moi: cannot serialize Pre"
+  and write_field buf (f : T.field) =
+    W.str buf f.T.lab;
+    write_typ f.T.typ;
+    write_src buf f.T.src
+  and write_typ_field buf (tf : T.typ_field) =
+    W.str buf tf.T.lab;
+    W.u32 buf (con_index tf.T.typ);
+    write_src buf tf.T.src
+  and write_bind buf (b : T.bind) =
+    W.str buf b.T.var;
+    W.byte buf (bind_sort_tag b.T.sort);
+    write_typ b.T.bound
+  and write_src buf (src : T.src) =
+    W.option buf (fun buf s -> W.str buf s) src.T.depr
+  in
+
+  let write_kind = function
+    | T.Def (bs, t) ->
+      W.byte buf 0; W.list buf write_bind bs; write_typ t
+    | T.Abs (bs, t) ->
+      W.byte buf 1; W.list buf write_bind bs; write_typ t
+  in
+  List.iter (fun c -> write_kind (Cons.kind c)) cons;
+
+  (* write lib_env *)
+  let lib_entries = T.Env.bindings scope.Scope.lib_env in
+  W.u32 buf (List.length lib_entries);
+  List.iter (fun (key, typ) ->
+    W.str buf key;
+    write_typ typ
+  ) lib_entries
+
+(* ---- Deserialize types ---- *)
+
+let read_scope r =
+  let num_cons = R.u32 r in
+  let con_names = Array.init num_cons (fun _ -> R.str r) in
+
+  (* pre-create all cons with Pre placeholder *)
+  let cons = Array.init num_cons (fun i ->
+    Cons.fresh con_names.(i) (T.Abs ([], T.Pre))
+  ) in
+
+  let con_lookup i =
+    if i < 0 || i >= num_cons then
+      failwith (Printf.sprintf "moi: con index %d out of range [0,%d)" i num_cons);
+    cons.(i)
+  in
+
+  let rec read_typ () =
+    match R.byte r with
+    | 0 -> let v = R.str r in let i = R.u32 r in T.Var (v, i)
+    | 1 ->
+      let ci = R.u32 r in
+      let n = R.u32 r in
+      let ts = List.init n (fun _ -> read_typ ()) in
+      T.Con (con_lookup ci, ts)
+    | 2 -> T.Prim (tag_prim (R.byte r))
+    | 3 ->
+      let s = tag_obj_sort (R.byte r) in
+      let fs = R.list r read_field in
+      let tfs = R.list r read_typ_field in
+      T.Obj (s, fs, tfs)
+    | 4 -> T.Variant (R.list r read_field)
+    | 5 -> T.Array (read_typ ())
+    | 6 -> T.Opt (read_typ ())
+    | 7 -> let n = R.u32 r in T.Tup (List.init n (fun _ -> read_typ ()))
+    | 8 ->
+      let s = tag_func_sort (R.byte r) in
+      let c = tag_control (R.byte r) in
+      let bs = R.list r read_bind in
+      let n1 = R.u32 r in
+      let ts1 = List.init n1 (fun _ -> read_typ ()) in
+      let n2 = R.u32 r in
+      let ts2 = List.init n2 (fun _ -> read_typ ()) in
+      T.Func (s, c, bs, ts1, ts2)
+    | 9 ->
+      let s = tag_async_sort (R.byte r) in
+      let sc = read_typ () in
+      let t = read_typ () in
+      T.Async (s, sc, t)
+    | 10 -> T.Mut (read_typ ())
+    | 11 -> T.Any
+    | 12 -> T.Non
+    | 13 -> let n = R.str r in T.Named (n, read_typ ())
+    | 14 -> T.Weak (read_typ ())
+    | tag -> failwith (Printf.sprintf "moi: bad typ tag %d" tag)
+  and read_field r =
+    let lab = R.str r in
+    let typ = read_typ () in
+    let src = read_src () in
+    { T.lab; typ; src }
+  and read_typ_field r =
+    let lab = R.str r in
+    let ci = R.u32 r in
+    let src = read_src () in
+    { T.lab; typ = con_lookup ci; src }
+  and read_bind r =
+    let var = R.str r in
+    let sort = tag_bind_sort (R.byte r) in
+    let bound = read_typ () in
+    { T.var; sort; bound }
+  and read_src () =
+    let depr = R.option r (fun r -> R.str r) in
+    { T.depr;
+      track_region = Source.no_region;
+      region = Source.no_region }
+  in
+
+  (* read con kinds and set them *)
+  let read_kind () =
+    match R.byte r with
+    | 0 ->
+      let bs = R.list r read_bind in
+      let t = read_typ () in
+      T.Def (bs, t)
+    | 1 ->
+      let bs = R.list r read_bind in
+      let t = read_typ () in
+      T.Abs (bs, t)
+    | tag -> failwith (Printf.sprintf "moi: bad kind tag %d" tag)
+  in
+  for i = 0 to num_cons - 1 do
+    let k = read_kind () in
+    T.set_kind cons.(i) k
+  done;
+
+  (* read lib_env *)
+  let num_libs = R.u32 r in
+  let lib_env = ref T.Env.empty in
+  for _ = 1 to num_libs do
+    let key = R.str r in
+    let typ = read_typ () in
+    lib_env := T.Env.add key typ !lib_env
+  done;
+  { Scope.empty with Scope.lib_env = !lib_env }
+
+(* ---- Fingerprinting ---- *)
+
+let hash_file path =
+  Digest.file path
+
+let compute_fingerprint ~source_hash ~deps =
+  let sorted = List.sort (fun (a, _) (b, _) -> String.compare a b) deps in
+  let buf = Buffer.create 256 in
+  Buffer.add_string buf source_hash;
+  List.iter (fun (name, fp) ->
+    Buffer.add_string buf name;
+    Buffer.add_string buf fp
+  ) sorted;
+  Digest.string (Buffer.contents buf)
+
+(* ---- .moi file path ---- *)
+
+let moi_path ~cache_dir ~import_key =
+  let hash = Digest.string import_key in
+  let hex = Digest.to_hex hash in
+  let base = Filename.basename import_key in
+  let base = try Filename.chop_extension base with Invalid_argument _ -> base in
+  Filename.concat cache_dir (Printf.sprintf "%s-%s.moi" (String.sub hex 0 8) base)
+
+(* ---- .moi file I/O ---- *)
+
+let rec mkdir_p dir =
+  if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    (try Sys.mkdir dir 0o755 with Sys_error _ -> ())
+  end
+
+let write_moi_file path header scope =
+  let buf = W.create () in
+  W.raw buf magic;
+  W.u32 buf format_version;
+  W.raw buf compiler_hash;
+  W.raw buf header.source_hash;
+  W.raw buf header.scope_fingerprint;
+  W.list buf (fun buf (name, fp) -> W.str buf name; W.raw buf fp) header.deps;
+  write_scope buf scope;
+  let data = W.contents buf in
+  mkdir_p (Filename.dirname path);
+  let tmp = path ^ ".tmp" in
+  let oc = open_out_bin tmp in
+  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+    output_string oc data
+  );
+  Sys.rename tmp path
+
+let digest_len = 16  (* MD5 *)
+
+let read_moi_file path =
+  if not (Sys.file_exists path) then None
+  else
+    try
+      let ic = open_in_bin path in
+      let data = Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+        In_channel.input_all ic
+      ) in
+      let r = R.create data in
+      let file_magic = R.raw r 4 in
+      if file_magic <> magic then None
+      else
+        let ver = R.u32 r in
+        if ver <> format_version then None
+        else
+        let stored_compiler_hash = R.raw r digest_len in
+        if stored_compiler_hash <> compiler_hash then None
+        else begin
+          let source_hash = R.raw r digest_len in
+          let scope_fingerprint = R.raw r digest_len in
+          let deps = R.list r (fun r ->
+            let name = R.str r in
+            let fp = R.raw r digest_len in
+            (name, fp)
+          ) in
+          let header = { source_hash; scope_fingerprint; deps } in
+          let scope = read_scope r in
+          Some (header, scope)
+        end
+    with
+    | Failure _ | Sys_error _ | Invalid_argument _ -> None
+    | exn ->
+      Printf.eprintf "moi: warning: unexpected error reading %s: %s\n"
+        path (Printexc.to_string exn);
+      None
+
+(* ---- Public API ---- *)
+
+let load ~cache_dir ~source_path ~source_hash ~dep_fingerprints =
+  let path = moi_path ~cache_dir ~import_key:source_path in
+  match read_moi_file path with
+  | None -> None
+  | Some (header, scope) ->
+    if header.source_hash <> source_hash then
+      None
+    else
+      let deps_valid = List.for_all (fun (dep_name, stored_fp) ->
+        match dep_fingerprints dep_name with
+        | Some current_fp -> current_fp = stored_fp
+        | None -> false
+      ) header.deps in
+      if not deps_valid then None
+      else Some (header, scope)
+
+let save ~cache_dir ~source_path ~header ~scope =
+  let path = moi_path ~cache_dir ~import_key:source_path in
+  try write_moi_file path header scope
+  with exn ->
+    Printf.eprintf "moi: warning: failed to write cache %s: %s\n"
+      path (Printexc.to_string exn)

--- a/src/pipeline/moi_cache.mli
+++ b/src/pipeline/moi_cache.mli
@@ -1,0 +1,39 @@
+(* .moi (Motoko Object Interface) file cache for incremental compilation.
+   Serializes Scope.t to disk so that unchanged library dependencies can
+   be loaded without re-parsing and re-type-checking their sources. *)
+
+type fingerprint = string  (* Digest.t — 16-byte MD5 *)
+
+type header = {
+  source_hash : fingerprint;
+  scope_fingerprint : fingerprint;
+  deps : (string * fingerprint) list;
+}
+
+(* Compute MD5 of a file's contents *)
+val hash_file : string -> fingerprint
+
+(* Merkle fingerprint: hash(source_hash || sorted dep fingerprints) *)
+val compute_fingerprint :
+  source_hash:fingerprint -> deps:(string * fingerprint) list -> fingerprint
+
+(* Derive .moi path from cache dir and resolved import name *)
+val moi_path : cache_dir:string -> import_key:string -> string
+
+(* Try to load a cached scope.
+   Returns None if the file is missing, corrupt, or fails validation.
+   [dep_fingerprints] maps dep resolved-names to their current fingerprints. *)
+val load :
+  cache_dir:string ->
+  source_path:string ->
+  source_hash:fingerprint ->
+  dep_fingerprints:(string -> fingerprint option) ->
+  (header * Mo_frontend.Scope.t) option
+
+(* Write a scope to the cache. Creates the cache directory if needed. *)
+val save :
+  cache_dir:string ->
+  source_path:string ->
+  header:header ->
+  scope:Mo_frontend.Scope.t ->
+  unit

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -11,6 +11,7 @@ open Mo_config
 open Printf
 
 module ResolveImport = Resolve_import
+module StringSet = Set.Make(String)
 
 type stat_env = Scope.t
 type dyn_env = Interpret.scope
@@ -829,17 +830,14 @@ let analyze analysis_name analysis prog name =
   if !Flags.check_ir
   then Check_ir.check_prog !Flags.verbose analysis_name prog
 
-let ir_passes mode prog_ir name =
-  (* erase typ components from objects *)
+let ir_passes mode ?(known_const = []) prog_ir name =
   let prog_ir = typ_field_translation true prog_ir name in
-  (* translations that extend the progam and must be done before await/cps conversion *)
   let prog_ir = show_translation true prog_ir name in
   let prog_ir = eq_translation true prog_ir name in
-  (* cps conversion and local transformations *)
   let prog_ir = await_lowering !Flags.await_lowering prog_ir name in
   let prog_ir = async_lowering mode !Flags.async_lowering prog_ir name in
   let prog_ir = tailcall_optimization true prog_ir name in
-  analyze "constness analysis" Const.analyze prog_ir name;
+  analyze "constness analysis" (Const.analyze ~known_const) prog_ir name;
   prog_ir
 
 
@@ -930,14 +928,227 @@ and compile_unit_to_wasm mode (enhanced_migration:string option) imports (u : Sy
   Diag.return wasm
 
 and compile_progs mode do_link libs progs : Wasm_exts.CustomModule.extended_module Diag.result =
+  match !Flags.moi_cache_dir with
+  | Some cache_dir when not (has_actor_class_libs libs) ->
+    compile_progs_cached mode do_link libs progs cache_dir
+  | _ ->
+    compile_progs_uncached mode do_link libs progs
+
+and compile_progs_uncached mode do_link libs progs =
   let imports = compile_libs mode libs in
   let prog = CompUnit.combine_progs progs in
   let u = CompUnit.comp_unit_of_prog false prog in
   compile_unit mode (!Flags.enhanced_migration) do_link imports u
 
+and has_actor_class_libs libs =
+  List.exists (fun l ->
+    match l.Source.it.Syntax.body.Source.it with
+    | Syntax.ActorClassU _ -> true
+    | _ -> false
+  ) libs
+
+and compute_dep_hash libs =
+  let hashes = List.map (fun l ->
+    let f = l.Source.note.Syntax.filename in
+    if Sys.file_exists f then Digest.file f
+    else Digest.string f
+  ) libs in
+  let sorted = List.sort String.compare hashes in
+  let buf = Buffer.create 256 in
+  List.iter (Buffer.add_string buf) sorted;
+  Digest.to_hex (Digest.string (Buffer.contents buf))
+
+and extract_binding_names decs =
+  let rec pat_names acc p =
+    match p.Source.it with
+    | Ir.VarP v -> v :: acc
+    | Ir.TupP ps -> List.fold_left pat_names acc ps
+    | Ir.ObjP pfs -> List.fold_left (fun a (pf : Ir.pat_field) -> pat_names a pf.Source.it.Ir.pat) acc pfs
+    | Ir.WildP | Ir.LitP _ | Ir.AltP _ | Ir.OptP _ | Ir.TagP _ -> acc
+  in
+  List.concat_map (fun d ->
+    match d.Source.it with
+    | Ir.LetD (p, _) -> pat_names [] p
+    | Ir.VarD (v, _, _) -> [v]
+    | Ir.RefD (v, _, _) -> [v]
+  ) decs
+
+and collect_cons_from_ir_decs decs =
+  let module T = Mo_types.Type in
+  let seen = ref T.ConSet.empty in
+  let acc = ref [] in
+  let add_con c =
+    if T.ConSet.mem c !seen then false
+    else begin seen := T.ConSet.add c !seen; acc := c :: !acc; true end
+  in
+  let rec walk_kind = function
+    | T.Def (bs, t) | T.Abs (bs, t) ->
+      List.iter (fun b -> walk_typ b.T.bound) bs; walk_typ t
+  and walk_typ = function
+    | T.Var _ | T.Prim _ | T.Any | T.Non | T.Pre -> ()
+    | T.Con (c, ts) ->
+      if add_con c then walk_kind (Cons.kind c);
+      List.iter walk_typ ts
+    | T.Obj (_, fs, tfs) ->
+      List.iter (fun f -> walk_typ f.T.typ) fs;
+      List.iter (fun (tf : T.typ_field) ->
+        if add_con tf.T.typ then walk_kind (Cons.kind tf.T.typ)) tfs
+    | T.Variant fs -> List.iter (fun f -> walk_typ f.T.typ) fs
+    | T.Array t | T.Opt t | T.Mut t | T.Named (_, t) | T.Weak t -> walk_typ t
+    | T.Tup ts -> List.iter walk_typ ts
+    | T.Func (_, _, bs, ts1, ts2) ->
+      List.iter (fun b -> walk_typ b.T.bound) bs;
+      List.iter walk_typ ts1; List.iter walk_typ ts2
+    | T.Async (_, s, t) -> walk_typ s; walk_typ t
+  in
+  let walk_note n = walk_typ n.Note.typ in
+  let rec walk_exp e = walk_note e.Source.note; walk_exp' e.Source.it
+  and walk_exp' = function
+    | Ir.VarE _ | Ir.LitE _ -> ()
+    | Ir.PrimE (_, es) -> List.iter walk_exp es
+    | Ir.AssignE (le, e) -> walk_lexp le; walk_exp e
+    | Ir.BlockE (ds, e) -> List.iter walk_dec ds; walk_exp e
+    | Ir.IfE (e1, e2, e3) -> walk_exp e1; walk_exp e2; walk_exp e3
+    | Ir.SwitchE (e, cs) -> walk_exp e; List.iter walk_case cs
+    | Ir.LoopE e -> walk_exp e
+    | Ir.LabelE (_, _, e) -> walk_exp e
+    | Ir.AsyncE (_, _, e, _) -> walk_exp e
+    | Ir.DeclareE (_, _, e) -> walk_exp e
+    | Ir.DefineE (_, _, e) -> walk_exp e
+    | Ir.FuncE (_, _, _, _, _, _, e) -> walk_exp e
+    | Ir.ActorE (ds, fs, sys, t) ->
+      List.iter walk_dec ds;
+      walk_typ t;
+      walk_typ sys.Ir.stable_type.Ir.pre;
+      walk_typ sys.Ir.stable_type.Ir.post;
+      walk_exp sys.Ir.preupgrade;
+      walk_exp sys.Ir.postupgrade;
+      walk_exp sys.Ir.heartbeat;
+      walk_exp sys.Ir.timer;
+      walk_exp sys.Ir.inspect;
+      walk_exp sys.Ir.low_memory;
+      walk_exp sys.Ir.stable_record
+    | Ir.NewObjE (_, _, t) -> walk_typ t
+    | Ir.TryE (e, cs, cl) ->
+      walk_exp e; List.iter walk_case cs;
+      Option.iter (fun (_, t) -> walk_typ t) cl
+    | Ir.SelfCallE (ts, e1, e2, e3, e4) ->
+      List.iter walk_typ ts;
+      walk_exp e1; walk_exp e2; walk_exp e3; walk_exp e4
+  and walk_lexp le =
+    walk_typ le.Source.note;
+    match le.Source.it with
+    | Ir.VarLE _ -> ()
+    | Ir.IdxLE (e1, e2) -> walk_exp e1; walk_exp e2
+    | Ir.DotLE (e, _) -> walk_exp e
+  and walk_case c = walk_exp c.Source.it.Ir.exp
+  and walk_dec d =
+    match d.Source.it with
+    | Ir.LetD (p, e) -> walk_pat p; walk_exp e
+    | Ir.VarD (_, t, e) -> walk_typ t; walk_exp e
+    | Ir.RefD (_, t, le) -> walk_typ t; walk_lexp le
+  and walk_pat p =
+    walk_typ p.Source.note;
+    match p.Source.it with
+    | Ir.WildP | Ir.VarP _ | Ir.LitP _ -> ()
+    | Ir.TupP ps -> List.iter walk_pat ps
+    | Ir.ObjP pfs -> List.iter (fun (pf : Ir.pat_field) -> walk_pat pf.Source.it.Ir.pat) pfs
+    | Ir.OptP p | Ir.TagP (_, p) -> walk_pat p
+    | Ir.AltP (p1, p2) -> walk_pat p1; walk_pat p2
+  in
+  List.iter walk_dec decs;
+  List.rev !acc
+
+and inject_and_dedup_lib_decs lib_decs (main_cu, main_flavor) =
+  let lib_names = List.fold_left (fun s d ->
+    match d.Source.it with
+    | Ir.LetD (p, _) ->
+      (match p.Source.it with
+       | Ir.VarP v -> StringSet.add v s
+       | _ -> s)
+    | _ -> s
+  ) StringSet.empty lib_decs in
+  let is_dup d = match d.Source.it with
+    | Ir.LetD (p, _) ->
+      (match p.Source.it with
+       | Ir.VarP v
+         when (String.length v > 5 && String.sub v 0 5 = "@show"
+               || String.length v > 3 && String.sub v 0 3 = "@eq")
+              && StringSet.mem v lib_names -> true
+       | _ -> false)
+    | _ -> false
+  in
+  let deduped_cu = match main_cu with
+    | Ir.ProgU ds -> Ir.ProgU (lib_decs @ List.filter (fun d -> not (is_dup d)) ds)
+    | Ir.ActorU (a, ds, fs, sys, t) ->
+      Ir.ActorU (a, lib_decs @ List.filter (fun d -> not (is_dup d)) ds, fs, sys, t)
+    | Ir.LibU _ -> assert false
+  in
+  (deduped_cu, main_flavor)
+
+and compile_combined_prog mode do_link lib_decs progs =
+  let prog = CompUnit.combine_progs progs in
+  let u = CompUnit.comp_unit_of_prog false prog in
+  let name = u.Source.note.Syntax.filename in
+  Cons.session ~scope:name (fun () ->
+    let main_ir = Lowering.Desugar.transform_unit u in
+    let lib_bindings = extract_binding_names lib_decs in
+    let main_ir =
+      let saved_check_ir = !Flags.check_ir in
+      Flags.check_ir := false;
+      Fun.protect ~finally:(fun () -> Flags.check_ir := saved_check_ir) (fun () ->
+        ir_passes mode ~known_const:lib_bindings main_ir name)
+    in
+    let combined = inject_and_dedup_lib_decs lib_decs main_ir in
+    analyze "constness analysis (combined)" (Const.analyze ~known_const:[]) combined name;
+    if !Flags.check_ir then
+      Check_ir.check_prog !Flags.verbose "combined IR" combined;
+    phase "Compiling" name;
+    adjust_flags ();
+    let rts = if do_link then Some (load_as_rts ()) else None in
+    Diag.return (if !Flags.enhanced_orthogonal_persistence then
+      Codegen.Compile_enhanced.compile mode ~enhanced_migration:(!Flags.enhanced_migration) rts combined
+    else
+      Codegen.Compile_classical.compile mode rts combined))
+
+and compile_progs_cached mode do_link libs progs cache_dir =
+  let dep_hash = compute_dep_hash libs in
+  let moic_path = Ir_cache.moic_path ~cache_dir ~dep_hash in
+  phase "IR cache" (Printf.sprintf "checking %s" moic_path);
+  match Ir_cache.read moic_path ~dep_hash with
+  | Some { Ir_cache.decs = cached_decs; id_stamps } ->
+    phase "IR cache" "hit — loading cached library IR";
+    let cons = collect_cons_from_ir_decs cached_decs in
+    Cons.bump_stamps_past cons;
+    Construct.set_id_stamps id_stamps;
+    compile_combined_prog mode do_link cached_decs progs
+  | None ->
+    phase "IR cache" "miss — building and caching library IR";
+    let open Lowering.Desugar in
+    let prelude_imports = import_prelude prelude @ import_prelude internals in
+    let lib_imports = compile_libs mode libs in
+    let lib_prog =
+      (Ir.ProgU (prelude_imports @ lib_imports), Ir.full_flavor ()) in
+    let lib_prog = ir_passes mode lib_prog "libraries" in
+    let lib_decs = match fst lib_prog with
+      | Ir.ProgU ds -> ds | _ -> assert false in
+    let cache_data = { Ir_cache.decs = lib_decs;
+                        id_stamps = Construct.get_id_stamps () } in
+    (try Ir_cache.write moic_path ~dep_hash cache_data
+     with exn ->
+       Printf.eprintf "moic: warning: failed to write cache %s: %s\n"
+         moic_path (Printexc.to_string exn));
+    compile_combined_prog mode do_link lib_decs progs
+
 let compile_files mode do_link files : compile_result =
   let open Diag.Syntax in
-  let* libs, progs, senv = load_progs ~check_actors:true parse_file files initial_stat_env in
+  let saved_cache_dir = !Flags.moi_cache_dir in
+  Flags.moi_cache_dir := None;
+  let result =
+    Fun.protect ~finally:(fun () -> Flags.moi_cache_dir := saved_cache_dir)
+      (fun () -> load_progs ~check_actors:true parse_file files initial_stat_env)
+  in
+  let* libs, progs, senv = result in
   let idl = Mo_idl.Mo_to_idl.prog (progs, senv) in
   let* ext_module = compile_progs mode do_link libs progs in
   (* validate any stable type signature, as a sanity check *)

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -424,6 +424,33 @@ let chase_imports_cached parsefn senv0 imports scopes_map
   let senv = ref senv0 in
   let libs = ref [] in
   let cache = ref scopes_map in
+  let fingerprints : Moi_cache.fingerprint Type.Env.t ref = ref Type.Env.empty in
+
+  let moi_cache_dir = !Flags.moi_cache_dir in
+
+  let dep_fingerprints_of more_imports =
+    List.filter_map (fun ri ->
+      let name = resolved_import_name ri in
+      match Type.Env.find_opt name !fingerprints with
+      | Some fp -> Some (name, fp)
+      | None -> None
+    ) more_imports
+  in
+
+  let try_moi_load cache_dir source_hash f =
+    let dep_fp_lookup name = Type.Env.find_opt name !fingerprints in
+    match Moi_cache.load ~cache_dir ~source_path:f ~source_hash ~dep_fingerprints:dep_fp_lookup with
+    | Some (header, sscope) -> Some (sscope, header.Moi_cache.scope_fingerprint)
+    | None -> None
+  in
+
+  let save_moi cache_dir source_hash f more_imports sscope =
+    let deps = dep_fingerprints_of more_imports in
+    let fp = Moi_cache.compute_fingerprint ~source_hash ~deps in
+    let header = Moi_cache.{ source_hash; scope_fingerprint = fp; deps } in
+    Moi_cache.save ~cache_dir ~source_path:f ~header ~scope:sscope;
+    fp
+  in
 
   let rec go_cached pkg_opt ri =
     let ri_name = resolved_import_name ri in
@@ -464,8 +491,36 @@ let chase_imports_cached parsefn senv0 imports scopes_map
         let* more_imports = ResolveImport.resolve (resolve_flags ~enhanced_migration:None cur_pkg_opt) prog base in
         let* () = go_set cur_pkg_opt more_imports in
         let lib = lib_of_prog f prog in
-        let* sscope = check_lib !senv cur_pkg_opt lib in
-        libs := lib :: !libs; (* NB: Conceptually an append *)
+
+        let is_cacheable sscope =
+          not (Type.Env.is_empty sscope.Scope.lib_env)
+        in
+
+        let* sscope = match moi_cache_dir with
+          | Some cache_dir ->
+            let source_hash = Moi_cache.hash_file f in
+            begin match try_moi_load cache_dir source_hash f with
+            | Some (sscope, fp) ->
+              fingerprints := Type.Env.add ri_name fp !fingerprints;
+              Diag.return sscope
+            | None ->
+              let* sscope = check_lib !senv cur_pkg_opt lib in
+              let fp =
+                if is_cacheable sscope
+                then save_moi cache_dir source_hash f more_imports sscope
+                else
+                  let deps = dep_fingerprints_of more_imports in
+                  Moi_cache.compute_fingerprint ~source_hash ~deps
+              in
+              fingerprints := Type.Env.add ri_name fp !fingerprints;
+              libs := lib :: !libs;
+              Diag.return sscope
+            end
+          | None ->
+            let* sscope = check_lib !senv cur_pkg_opt lib in
+            libs := lib :: !libs;
+            Diag.return sscope
+        in
         senv := Scope.adjoin !senv sscope;
         cache := Type.Env.add ri_name sscope !cache;
         pending := remove it !pending;

--- a/test/fail/moi-cache-error.mo
+++ b/test/fail/moi-cache-error.mo
@@ -1,0 +1,7 @@
+//MOC-FLAG --moi-cache _out/moi-cache-dir
+import C "moi-cache-error/counter";
+
+let c = C.make();
+C.inc(c);
+
+let x : Text = C.get(c); // type error: Nat vs Text

--- a/test/fail/moi-cache-error/counter.mo
+++ b/test/fail/moi-cache-error/counter.mo
@@ -1,0 +1,6 @@
+module {
+  public type Counter = { var count : Nat };
+  public func make() : Counter = { var count = 0 };
+  public func inc(c : Counter) { c.count += 1 };
+  public func get(c : Counter) : Nat = c.count;
+}

--- a/test/fail/ok/moi-cache-error.tc-human.ok
+++ b/test/fail/ok/moi-cache-error.tc-human.ok
@@ -1,0 +1,11 @@
+error[M0096]: expression of type
+  Nat
+cannot produce expected type
+  Text
+because the type 
+  Nat
+ is not compatible with type 
+  Text
+    ┌─ moi-cache-error.mo:7:16
+  7 │  let x : Text = C.get(c); // type error: Nat vs Text
+    │                 ^^^^^^^^ 

--- a/test/fail/ok/moi-cache-error.tc-human.ret.ok
+++ b/test/fail/ok/moi-cache-error.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/moi-cache-error.tc.ok
+++ b/test/fail/ok/moi-cache-error.tc.ok
@@ -1,0 +1,8 @@
+moi-cache-error.mo:7.16-7.24: type error [M0096], expression of type
+  Nat
+cannot produce expected type
+  Text
+because the type 
+  Nat
+ is not compatible with type 
+  Text

--- a/test/fail/ok/moi-cache-error.tc.ret.ok
+++ b/test/fail/ok/moi-cache-error.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/run/moi-cache.mo
+++ b/test/run/moi-cache.mo
@@ -1,0 +1,43 @@
+//MOC-FLAG --moi-cache _out/moi-cache-dir
+import C "moi-cache/counter";
+import T "moi-cache/types";
+import Tr "moi-cache/tree";
+import { debugPrint } "mo:prim";
+
+// Counter tests
+let c = C.make();
+C.inc(c);
+C.inc(c);
+C.inc(c);
+assert C.get(c) == 3;
+
+let p = C.pair<Nat, Text>(42, "hello");
+assert p.0 == 42;
+assert p.1 == "hello";
+
+// Result/variant tests
+let ok = T.wrapOk<Nat>(7);
+let mapped = T.mapResult<Nat, Text>(ok, func(n : Nat) : Text { debug_show n });
+switch mapped {
+  case (#ok t) { assert t == "7"; debugPrint(t) };
+  case (#err _) { assert false };
+};
+
+let err = T.wrapErr<Nat>("boom");
+switch err {
+  case (#ok _) { assert false };
+  case (#err e) { assert e == "boom"; debugPrint(e) };
+};
+
+// Recursive type tests (tree)
+let tree = Tr.node(
+  Tr.node(Tr.leaf(), 1, Tr.leaf()),
+  2,
+  Tr.node(Tr.leaf(), 3, Tr.leaf()),
+);
+assert Tr.size(tree) == 3;
+
+let mapped_tree = Tr.map<Nat, Text>(tree, func(n : Nat) : Text { debug_show n });
+assert Tr.size(mapped_tree) == 3;
+
+debugPrint("moi-cache test passed");

--- a/test/run/moi-cache/counter.mo
+++ b/test/run/moi-cache/counter.mo
@@ -1,0 +1,13 @@
+module {
+  public type Counter = { var count : Nat };
+
+  public func make() : Counter = { var count = 0 };
+
+  public func inc(c : Counter) { c.count += 1 };
+
+  public func get(c : Counter) : Nat = c.count;
+
+  public type Pair<A, B> = (A, B);
+
+  public func pair<A, B>(a : A, b : B) : Pair<A, B> = (a, b);
+}

--- a/test/run/moi-cache/tree.mo
+++ b/test/run/moi-cache/tree.mo
@@ -1,0 +1,29 @@
+module {
+  public type Tree<T> = {
+    #leaf;
+    #node : { left : Tree<T>; value : T; right : Tree<T> };
+  };
+
+  public func leaf<T>() : Tree<T> = #leaf;
+
+  public func node<T>(l : Tree<T>, v : T, r : Tree<T>) : Tree<T> =
+    #node { left = l; value = v; right = r };
+
+  public func size<T>(t : Tree<T>) : Nat {
+    switch t {
+      case (#leaf) 0;
+      case (#node n) 1 + size(n.left) + size(n.right);
+    }
+  };
+
+  public func map<A, B>(t : Tree<A>, f : A -> B) : Tree<B> {
+    switch t {
+      case (#leaf) #leaf;
+      case (#node n) #node {
+        left = map(n.left, f);
+        value = f(n.value);
+        right = map(n.right, f);
+      };
+    }
+  };
+}

--- a/test/run/moi-cache/types.mo
+++ b/test/run/moi-cache/types.mo
@@ -1,0 +1,18 @@
+import C "counter";
+
+module {
+  public type AliasedCounter = C.Counter;
+
+  public type Result<T> = { #ok : T; #err : Text };
+
+  public func wrapOk<T>(v : T) : Result<T> = #ok v;
+
+  public func wrapErr<T>(msg : Text) : Result<T> = #err msg;
+
+  public func mapResult<A, B>(r : Result<A>, f : A -> B) : Result<B> {
+    switch r {
+      case (#ok a) #ok (f a);
+      case (#err e) #err e;
+    }
+  };
+}


### PR DESCRIPTION
## Experiment: Incremental Compilation

Experimental incremental compilation support for `moc`. Two caching strategies to reduce compile times when dependencies (packages like `mo:base`, `mo:core`) stay the same. Both use the `--moi-cache <dir>` flag.

---

### Experiment 1: Scope caching (`.moi`) — `--check` mode

**Goal:** Speed up repeated type-checking by caching each library's type-checked scope.

**Approach:** Serialize `Scope.t` per library to `.moi` files using a custom binary format, handling cyclic type constructors. Cache key is a Merkle hash of the library's source content and its transitive dependencies. On cache hit, type-checking for that library is skipped entirely.

**Results (Map.test.mo, motoko-core, `$(mops sources)`, 78 dependency files):**

| Scenario | Time |
|---|---|
| `--check` (no cache) | ~287ms |
| `--check` + `.moi` cache (cold) | ~287ms |
| `--check` + `.moi` cache (warm) | ~229ms |

The scope cache saves ~58ms in check mode (~20% of check work).

**Conclusion:** Modest speedup. Type-checking is already fast, so caching it saves little in absolute terms.

#### Profiling: where does compile time go?

This experiment also revealed the full compile-time breakdown, motivating experiment 2:

| Phase | Time | % |
|---|---|---|
| Parse + check (per-lib) | 167ms | 11% |
| Lowering | 61ms | 4% |
| 7 IR passes (whole-program) | 1,076ms | **73%** |
| Codegen | 164ms | 11% |
| **Total (`-c`)** | **~1,760ms** | |

The seven whole-program IR passes (`erase_typ_field`, `show`, `eq`, `await`, `async`, `tailcall`, `const`) dominate compile time at 73%.

---

### Experiment 2: IR caching (`.moic`) — `-c` compile mode

**Goal:** Speed up repeated compilation by caching post-IR-pass library declarations.

**Approach:** After lowering and running all seven IR passes on library code, serialize the resulting `Ir.dec list` to `.moic` files using `Marshal`. On warm cache, the compiler skips lowering and all IR passes for unchanged libraries — only the main program goes through the full pipeline, then gets linked with cached library IR before codegen.

**Results (Map.test.mo, motoko-core, `$(mops sources)`):**

| Build | CPU time | Speedup |
|-------|----------|---------|
| Baseline (`-c`) | 1.56s | — |
| Cold cache | 1.74s | 0.9x (write overhead) |
| **Warm cache** | **0.68s** | **2.3x** |

Cold and warm produce byte-identical Wasm. Cache invalidation works correctly.

**Where the remaining time goes (warm, 0.68s):**
- ~0.20s — parse + typecheck all files (re-done every time)
- ~0.48s — lower main program + codegen on the full combined program

**Codegen is now the bottleneck** — it still walks all declarations (cached + main). Eliminating this would require separate Wasm compilation + linking, which is a fundamentally larger change.

---

### Overall conclusion

~350 lines of new code for a 2.3x compile-mode speedup. The IR caching approach works but hits diminishing returns: the next meaningful improvement requires Wasm-level separate compilation, not more caching. This POC uses `Marshal` (tied to exact compiler binary) and has no cache eviction — not production-ready as-is.

### Test plan

- [x] `test/run/moi-cache.mo` — roundtrip: counter, types with generics, recursive tree types
- [x] `test/fail/moi-cache-error.mo` — type errors still reported correctly with cache
- [x] Compile-mode IR caching — byte-identical Wasm on Map.test.mo, cache invalidation verified