### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
         os: [ ubuntu-latest, macos-15-intel, ubuntu-24.04-arm, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: cachix/install-nix-action@v31
-    - uses: cachix/cachix-action@v17
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
+    - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
       with:
         name: ic-hs-test
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/comment-artifact-link.yml
+++ b/.github/workflows/comment-artifact-link.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml

--- a/.github/workflows/nightly-macos-test.yml
+++ b/.github/workflows/nightly-macos-test.yml
@@ -8,7 +8,7 @@ jobs:
   common-tests:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Common Tests
         uses: ./.github/actions/test-blueprint
@@ -21,7 +21,7 @@ jobs:
   gc-tests:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run GC Tests
         uses: ./.github/actions/test-blueprint
@@ -37,7 +37,7 @@ jobs:
         build_type: [release, debug]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Tests
         uses: ./.github/actions/test-blueprint
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get `motoko` Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Populate `moc`
         uses: ./.github/actions/test-blueprint
         with:
@@ -69,14 +69,14 @@ jobs:
         # we have to keep it elsewhere and restore later.
         run: cp -r ./.github/actions/test-blueprint ..
       - name: Get `motoko-core` Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: dfinity/motoko-core
           fetch-depth: "0"
       - name: Restore the `test-blueprint` action
         run:  mv ../test-blueprint ./.github/actions
       - name: Set up `mops`
-        uses: dfinity/motoko-core/.github/actions/setup@main
+        uses: dfinity/motoko-core/.github/actions/setup@cd37dbfb6ae63552b1151324cf7e3ae461278b4c # main
       - name: Set up `mops` cache
         run: |
           npx ic-mops --version
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest # No need to run on macOS, the ubuntu runner should be cheaper to run.
     steps:
       - name: Create Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const date = new Date().toISOString().split('T')[0];

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Get the version from the PR title
       id: get_version
@@ -52,12 +52,12 @@ jobs:
     if: github.event.pull_request.merged
     steps:
     - name: Create GitHub App Token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
       id: app-token
       with:
         app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
         private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Checkout the merge commit so we can tag it
         ref: ${{ github.event.pull_request.merge_commit_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Checkout (for tag->master validation)
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Extract changelog
         # Skip this step for draft releases. Leave the release body empty.
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -88,9 +88,9 @@ jobs:
       cancel-in-progress: true
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v17
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
           name: ic-hs-test
           # NB: No auth token, we don't expect to push new stuff here
@@ -99,7 +99,7 @@ jobs:
         run: nix build --max-jobs 1 '.#"release-files-${{ matrix.os }}"'
 
       - name: Upload Release Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: release-files-${{ matrix.os }}
           path: result/*
@@ -117,7 +117,7 @@ jobs:
     needs: [prepare, changelog, build]
     steps:
       - name: Download all release artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: release-assets
           pattern: release-files-*
@@ -160,7 +160,7 @@ jobs:
           find release-assets -type f -ls || true
 
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token
         with:
           app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
@@ -168,7 +168,7 @@ jobs:
           repositories: motoko,node-motoko
 
       - name: Upload Release Assets
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
           repo_token: ${{ steps.app-token.outputs.token }}
           tag: ${{ github.event_name == 'workflow_dispatch' && steps.rewrite_draft_assets.outputs.tag || github.ref_name }}
@@ -180,7 +180,7 @@ jobs:
 
       - name: Notify node-motoko of new release
         if: ${{ github.event_name == 'push' }}
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: caffeinelabs/node-motoko

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Common Tests
         uses: ./.github/actions/test-blueprint
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run GC Tests
         uses: ./.github/actions/test-blueprint
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # fetch full history so that git merge-base works
           fetch-depth: 0
@@ -69,7 +69,7 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token
         with:
           app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
@@ -92,9 +92,9 @@ jobs:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v17
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
           name: ic-hs-test
       - name: Fetch report
@@ -102,7 +102,7 @@ jobs:
       - name: Resolve symlinks
         run: cp -rL report-site report-site-copy
       - name: Push report to GitHub pages
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: report-site-copy
@@ -115,9 +115,9 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v17
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
           name: ic-hs-test
       - name: nix-build
@@ -127,7 +127,7 @@ jobs:
       # https://github.com/actions/upload-artifact/issues/92
       - run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: moc-${{ matrix.os }}
           path: ${{ env.UPLOAD_PATH }}
@@ -175,7 +175,7 @@ jobs:
     needs: [verify-common-gc, verify-main-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "master"
       - name: Automatically closing successful trials
@@ -189,11 +189,11 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref == 'master' && github.event.pull_request.changed_files == 1
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "master"
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token-for-approvals
         with:
           app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}

--- a/.github/workflows/update-flake-lock-trial.yml
+++ b/.github/workflows/update-flake-lock-trial.yml
@@ -25,17 +25,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Determinate Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@b66b36319cc6fde4ea85edd583b088c65d6b8710 # main
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token
         with:
           app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@main
+        uses: DeterminateSystems/update-flake-lock@ff43f160ef7014ae1a1fd85699fb6a44f436135b # main
         with:
           branch: "update_flake_lock_action_trial"
           inputs: |

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -21,17 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Determinate Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@b66b36319cc6fde4ea85edd583b088c65d6b8710 # main
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token
         with:
           app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@main
+        uses: DeterminateSystems/update-flake-lock@ff43f160ef7014ae1a1fd85699fb6a44f436135b # main
         with:
           branch: "update_flake_lock_action_daily"
           inputs: |


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v6` -> `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
  - Version: v6.0.2 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd

- `cachix/install-nix-action@v31` -> `cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4`
  - Version: v31.10.4 | Latest: v31.10.4 | Release age: 396d
  - Commit: https://github.com/cachix/install-nix-action/commit/616559265b40713947b9c190a8ff4b507b5df49b
  - Warnings: Latest release v31.10.4 is only 1 day(s) old (< 7 days). Using previous safe release.

- `cachix/cachix-action@v17` -> `cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17`
  - Version: v17 | Latest: v17 | Release age: 22d
  - Commit: https://github.com/cachix/cachix-action/commit/1eb2ef646ac0255473d23a5907ad7b04ce94065c

- `actions/github-script@v7` -> `actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0`
  - Version: v7.1.0 | Latest: v9.0.0 | Release age: 217d
  - Commit: https://github.com/actions/github-script/commit/f28e40c7f34bde8b3046d885e986cb6290c5673b
  - Warnings: Latest release v9.0.0 is only 0 day(s) old (< 7 days). Using previous safe release.

- `dfinity/motoko-core/.github/actions/setup@main` -> `dfinity/motoko-core/.github/actions/setup@cd37dbfb6ae63552b1151324cf7e3ae461278b4c # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/motoko-core/commit/cd37dbfb6ae63552b1151324cf7e3ae461278b4c

- `actions/create-github-app-token@v3` -> `actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3`
  - Version: v3 | Latest: v3.0.0 | Release age: 27d
  - Commit: https://github.com/actions/create-github-app-token/commit/f8d387b68d61c58ab83c6c016672934102569859

- `actions/upload-artifact@v7` -> `actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7`
  - Version: v7 | Latest: v3.2.2 | Release age: 24d
  - Commit: https://github.com/actions/upload-artifact/commit/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

- `actions/download-artifact@v8` -> `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1`
  - Version: v8.0.1 | Latest: v3.1.0-node20 | Release age: 24d
  - Commit: https://github.com/actions/download-artifact/commit/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `svenstaro/upload-release-action@v2` -> `svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5`
  - Version: 2.11.5 | Latest: 2.11.5 | Release age: 24d
  - Commit: https://github.com/svenstaro/upload-release-action/commit/29e53e917877a24fad85510ded594ab3c9ca12de

- `peter-evans/repository-dispatch@v4` -> `peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1`
  - Version: v4.0.1 | Latest: v4.0.1 | Release age: 146d
  - Commit: https://github.com/peter-evans/repository-dispatch/commit/28959ce8df70de7be546dd1250a005dd32156697

- `JamesIves/github-pages-deploy-action@v4` -> `JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0`
  - Version: v4.8.0 | Latest: v4.8.0 | Release age: 90d
  - Commit: https://github.com/JamesIves/github-pages-deploy-action/commit/d92aa235d04922e8f08b40ce78cc5442fcfbfa2f

- `DeterminateSystems/nix-installer-action@main` -> `DeterminateSystems/nix-installer-action@b66b36319cc6fde4ea85edd583b088c65d6b8710 # main`
  - Version: main | Latest: v22 | Release age: 11d
  - Commit: https://github.com/DeterminateSystems/nix-installer-action/commit/b66b36319cc6fde4ea85edd583b088c65d6b8710

- `DeterminateSystems/update-flake-lock@main` -> `DeterminateSystems/update-flake-lock@ff43f160ef7014ae1a1fd85699fb6a44f436135b # main`
  - Version: main | Latest: v28 | Release age: 134d
  - Commit: https://github.com/DeterminateSystems/update-flake-lock/commit/ff43f160ef7014ae1a1fd85699fb6a44f436135b


### Files modified

- `.github/workflows/build.yml`
- `.github/workflows/comment-artifact-link.yml`
- `.github/workflows/nightly-macos-test.yml`
- `.github/workflows/release-pr.yml`
- `.github/workflows/release.yml`
- `.github/workflows/test.yml`
- `.github/workflows/update-flake-lock-trial.yml`
- `.github/workflows/update-flake-lock.yml`

### Security warnings

- Latest release v31.10.4 is only 1 day(s) old (< 7 days). Using previous safe release.
- Latest release v9.0.0 is only 0 day(s) old (< 7 days). Using previous safe release.
- 1 security advisory(ies) found
- Action has 1 known advisory(ies)