### PR TITLE
fix: resolve moc.js relative flag paths against project root, not source file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Motoko compiler changelog
 
+## Unreleased
+
+* motoko (`moc`)
+
+  * bugfix: Fix `moc.js` resolution of relative flag paths (e.g. `--enhanced-migration`, `--actor-idl`): resolve against the project root (via new `setProjectRoot` API) instead of the source file's directory, matching native `moc` behavior. The language server should call `setProjectRoot(path)` before processing files.
+
 ## 1.5.1 (2026-04-13)
 
 * motoko (`moc`)

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -15,6 +15,7 @@ let () =
   Js.export "Motoko"
     (object%js
       val version = js_version
+      method setProjectRoot path = Flags.js_project_root := Some (Js.to_string path)
       method setExtraFlags argv = js_set_extra_flags argv
       method saveFile name content = js_save_file name content
       method removeFile name = js_remove_file name

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -63,6 +63,7 @@ let force_gc = ref false
 let global_timer = ref true
 let experimental_field_aliasing = ref false
 let ocaml_js = ref false
+let js_project_root : string option ref = ref None
 let rts_stack_pages_default = 32 (* 2MB *)
 let rts_stack_pages : int option ref = ref None
 let rtti = ref false

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -145,11 +145,12 @@ let resolve_flags ~is_main ~base pkg_opt =
   let resolve_path_flag flag =
     if not is_main then !flag else
     !flag |> Option.map (fun p ->
-      if not (!Flags.ocaml_js && Filename.is_relative p) then p else
-      let base_dir = if Sys.is_directory base then base else Filename.dirname base in
-      (* moc.js has no CWD, so resolve relative flag paths against the source file's directory *)
-      let p = Filename.concat base_dir p |> Lib.FilePath.normalise in
-      flag := Some p; p)
+      (* moc.js has no real CWD; resolve relative flag paths against the project root set via setProjectRoot *)
+      match !Flags.js_project_root with
+      | Some root when Filename.is_relative p ->
+        let p = Filename.concat root p |> Lib.FilePath.normalise in
+        flag := Some p; p
+      | _ -> p)
   in
   ResolveImport.{
     package_urls = !Flags.package_urls;

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -267,14 +267,15 @@ assert.deepStrictEqual(Motoko.run([], "blob.mo"), {
   result: { error: {} },
 });
 
-// Relative --enhanced-migration path resolves against the source file's directory (#6002)
+// Relative --enhanced-migration path resolves against setProjectRoot (#6002)
 Motoko.saveFile("/project/src/Main.mo",
   'persistent actor { let x : Nat; public func get() : async Nat { x } };'
 );
 Motoko.saveFile("/project/migrations/m1.mo",
   'module { public func migration(_ : {}) : { x : Nat } { { x = 42 } }; };'
 );
-Motoko.setExtraFlags(["--enhanced-migration=../migrations"]);
+Motoko.setExtraFlags(["--enhanced-migration=migrations"]);
+Motoko.setProjectRoot("/project");
 const migrationResult = Motoko.check("/project/src/Main.mo");
 assert.deepStrictEqual(migrationResult.diagnostics, []);
 


### PR DESCRIPTION
## Problem

PR #6002 fixed relative flag paths in `moc.js` (e.g. `--enhanced-migration`, `--actor-idl`) by resolving them against the **source file's directory**. This is incorrect when the source file is in a subdirectory — e.g. with `src/Main.mo`, a flag `--enhanced-migration=migrations` resolves to `src/migrations` instead of the project-root-level `migrations/`.

### Root cause

js_of_ocaml's virtual filesystem is a flat key-value store with literal string matching — there is no CWD-based path resolution like a real OS provides. The VS Code extension saves files at absolute paths (e.g. `/Users/.../project/migrations/m1.mo`) but `mops.toml` flags use relative paths (`migrations`). These strings never match without explicit resolution.

### Fix

Replace the source-file-relative resolution with a `setProjectRoot(path)` API. The language server calls `setProjectRoot(projectRoot)` once, and `resolve_path_flag` expands relative flag paths against that root — making them match the absolute paths used by `saveFile`.

Native `moc` is unaffected (it relies on OS CWD, and the old `ocaml_js` gate was always false for it).

## Test plan

- [x] `dune build --root src` passes
- [x] `nix build .#js.moc -L` passes (includes `test/test-moc.js`)
- [x] JS test covers `setProjectRoot` + absolute file paths + relative flag path scenario
- [ ] Companion change needed in `vscode-motoko` to call `Motoko.setProjectRoot(projectRoot)`

Made with [Cursor](https://cursor.com)