### PR TITLE
Add AI coding skills for Motoko

### DIFF
--- a/.agents/skills/migrating-motoko-enhanced/SKILL.md
+++ b/.agents/skills/migrating-motoko-enhanced/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: migrating-motoko-enhanced
+description: >-
+  Enhanced multi-migration for Motoko actors. Use when writing migration files,
+  upgrading canister state, changing actor field types, or working with the
+  migrations/ directory and --enhanced-migration flag.
+---
+
+# Enhanced Multi-Migration
+
+Manage canister state evolution through a chain of migration modules. Each migration captures one logical change (add, rename, drop, transform a field) and the compiler verifies the entire chain is consistent.
+
+## When to Use
+
+- Adding, removing, or renaming persistent actor fields
+- Changing a field's type
+- Restructuring state across canister upgrades
+- Project has `--enhanced-migration=migrations` in canister args in `mops.toml`
+
+## Critical Rules
+
+- **Never use** `stable` keyword, `preupgrade`/`postupgrade`, or inline `(with migration = ...)`
+- Actor variables are declared **without initializers** — values come from the migration chain
+- The actor body must be **static** (no top-level side effects except `<system>` calls like timers)
+- Each migration file exports `public func migration({...}) : {...}`
+- Files are applied in **lexicographic order** — use timestamp prefixes
+
+## Directory Layout
+
+```text
+backend/
+├── main.mo
+├── types.mo
+├── lib/
+├── mixins/
+└── migrations/
+    ├── 20250101_000000_Init.mo
+    ├── 20250315_120000_AddProfile.mo
+    └── 20250601_090000_RenameField.mo
+```
+
+## Actor Syntax
+
+With enhanced migration, actor variables have no initializer:
+
+```motoko
+actor {
+  var name : Text;       // value comes from migration chain
+  var balance : Nat;     // likewise
+  let frozen : Bool;     // let bindings can also be uninitialized
+
+  public func greet() : async Text {
+    "Hello, " # name # "! Balance: " # debug_show balance;
+  };
+};
+```
+
+## Migration Module Structure
+
+Each migration module takes a record of input fields and returns a record of output fields:
+
+```motoko
+// migrations/20250101_000000_Init.mo
+module {
+  public func migration(_ : {}) : { name : Text; balance : Nat } {
+    { name = ""; balance = 0 }
+  }
+}
+```
+
+## Input / Output Field Semantics
+
+| Field appears in | Effect |
+| ---------------- | ------ |
+| Input and output | Field is transformed (old value read, new value produced) |
+| Output only      | New field added to state |
+| Input only       | Field consumed and removed from state |
+| Neither          | Field carried through unchanged |
+
+Given state `{a : Nat; b : Text; c : Bool}` and migration:
+
+```motoko
+module {
+  public func migration(old : { a : Nat; b : Text }) : { a : Int; d : Float } {
+    { a = old.a; d = 1.0 }
+  }
+}
+```
+
+- `a`: transformed `Nat → Int`
+- `b`: consumed (removed)
+- `c`: carried through unchanged
+- `d`: newly introduced
+- Result: `{a : Int; c : Bool; d : Float}`
+
+## Common Patterns
+
+### Initialize state (first migration, always required)
+
+```motoko
+// migrations/20250101_000000_Init.mo
+module {
+  public func migration(_ : {}) : { count : Nat; header : Text } {
+    { count = 0; header = "default" }
+  }
+}
+```
+
+### Add a field
+
+```motoko
+// migrations/20250201_000000_AddEmail.mo
+module {
+  public func migration(_ : {}) : { email : Text } {
+    { email = "" }
+  }
+}
+```
+
+### Add an optional field
+
+```motoko
+module {
+  public func migration(_ : {}) : { assignee : ?Principal } {
+    { assignee = null }
+  }
+}
+```
+
+### Change a field's type
+
+```motoko
+// migrations/20250301_000000_CountToInt.mo
+module {
+  public func migration(old : { count : Nat }) : { count : Int } {
+    { count = old.count }
+  }
+}
+```
+
+### Rename a field
+
+```motoko
+// migrations/20250401_000000_RenameHeader.mo
+module {
+  public func migration(old : { header : Text }) : { title : Text } {
+    { title = old.header }
+  }
+}
+```
+
+### Remove a field
+
+```motoko
+// migrations/20250501_000000_DropEmail.mo
+module {
+  public func migration(_ : { email : Text }) : {} {
+    {}
+  }
+}
+```
+
+### Transform data (split a field)
+
+```motoko
+// migrations/20250601_000000_SplitName.mo
+import Text "mo:core/Text";
+
+module {
+  public func migration(old : { name : Text }) : { firstName : Text; lastName : Text } {
+    let parts = Text.split(old.name, #char ' ');
+    let first = switch (parts.next()) { case (?f) f; case (null) "" };
+    let last = switch (parts.next()) { case (?l) l; case (null) "" };
+    { firstName = first; lastName = last }
+  }
+}
+```
+
+### Bool to variant
+
+```motoko
+module {
+  public func migration(old : { var completed : Bool }) : { var status : { #pending; #completed } } {
+    { var status = if (old.completed) { #completed } else { #pending } }
+  }
+}
+```
+
+### Map over a collection
+
+```motoko
+import Map "mo:core/Map";
+
+module {
+  type OldTask = { id : Nat; title : Text; var completed : Bool };
+  type NewTask = { id : Nat; title : Text; var status : { #pending; #completed } };
+
+  public func migration(old : { var tasks : Map.Map<Nat, OldTask> })
+    : { var tasks : Map.Map<Nat, NewTask> } {
+    let tasks = old.tasks.map<Nat, OldTask, NewTask>(
+      func(_, task) {
+        {
+          id = task.id;
+          title = task.title;
+          var status = if (task.completed) { #completed } else { #pending };
+        }
+      }
+    );
+    { var tasks }
+  }
+}
+```
+
+### Add field to each record in a Map
+
+```motoko
+import Map "mo:core/Map";
+
+module {
+  type OldUser = { name : Text; email : Text };
+  type NewUser = { name : Text; email : Text; bio : Text };
+
+  public func migration(old : { users : Map.Map<Nat, OldUser> })
+    : { users : Map.Map<Nat, NewUser> } {
+    let users = old.users.map<Nat, OldUser, NewUser>(
+      func(_, u) { { u with bio = "" } }
+    );
+    { users }
+  }
+}
+```
+
+## How Migrations Compose
+
+Migrations form a chain. The compiler verifies each migration's input is compatible with the state produced by all preceding migrations.
+
+| Migration     | Input            | Output                           | Effect                    |
+| ------------- | ---------------- | -------------------------------- | ------------------------- |
+| `Init`        | `{}`             | `{name : Text; balance : Nat}`  | Initializes both fields   |
+| `AddProfile`  | `{}`             | `{profile : Text}`              | Adds a new field          |
+| `RenameField` | `{name : Text}`  | `{displayName : Text}`          | Renames name → displayName|
+
+After the full chain: `{displayName : Text; balance : Nat; profile : Text}`. The actor must declare fields compatible with this final state.
+
+## Lifecycle Example: Todo App
+
+Shows how patterns combine across four deployments.
+
+```motoko
+// migrations/20250101_000000_Init.mo
+module {
+  public func migration(_ : {}) : { var nextId : Nat } {
+    { var nextId = 0 }
+  }
+}
+```
+
+```motoko
+// migrations/20250201_000000_AddTasks.mo
+import Map "mo:core/Map";
+module {
+  type Task = { id : Nat; text : Text; completed : Bool };
+  public func migration(_ : {}) : { tasks : Map.Map<Nat, Task> } {
+    { tasks = Map.empty<Nat, Task>() }
+  }
+}
+```
+
+```motoko
+// migrations/20250301_000000_TaskStatus.mo — transform Bool → variant
+import Map "mo:core/Map";
+module {
+  type OldTask = { id : Nat; text : Text; completed : Bool };
+  type NewTask = { id : Nat; text : Text; status : { #pending; #inProgress; #completed } };
+  public func migration(old : { tasks : Map.Map<Nat, OldTask> })
+    : { tasks : Map.Map<Nat, NewTask> } {
+    let tasks = old.tasks.map<Nat, OldTask, NewTask>(
+      func(_, task) {
+        { id = task.id; text = task.text;
+          status = if (task.completed) #completed else #pending }
+      }
+    );
+    { tasks }
+  }
+}
+```
+
+```motoko
+// migrations/20250401_000000_AddDueDate.mo — add field to each record
+import Map "mo:core/Map";
+module {
+  type Status = { #pending; #inProgress; #completed };
+  type OldTask = { id : Nat; text : Text; status : Status };
+  type NewTask = { id : Nat; text : Text; status : Status; due : Int };
+  public func migration(old : { tasks : Map.Map<Nat, OldTask> })
+    : { tasks : Map.Map<Nat, NewTask> } {
+    let tasks = old.tasks.map<Nat, OldTask, NewTask>(
+      func(_, task) { { task with due = 0 } }
+    );
+    { tasks }
+  }
+}
+```
+
+Final state: `{ var nextId : Nat; tasks : Map.Map<Nat, { id : Nat; text : Text; status : { #pending; #inProgress; #completed }; due : Int }> }`
+
+## Runtime Behavior
+
+- On **fresh deploy**: all migrations run in order
+- On **upgrade**: only not-yet-applied migrations run (already-applied are skipped)
+- **Fast-forward**: safe to skip intermediate deployments — all unapplied migrations run sequentially
+- If a migration traps, the upgrade is aborted and the canister stays on the old version
+
+## Compiling
+
+```bash
+moc --enhanced-orthogonal-persistence \
+    --default-persistent-actors \
+    --enhanced-migration=migrations \
+    src/main.mo -o main.wasm
+```
+
+With mops, split args between global `[moc]` and per-canister `[canisters.backend]`. The migration flag is per-canister because different canisters may use different migration directories:
+
+```toml
+[moc]
+args = ["--enhanced-orthogonal-persistence", "--default-persistent-actors"]
+
+[canisters.backend]
+args = ["--enhanced-migration=migrations"]
+```
+
+Then `mops check --fix` and `mops build` work as usual.
+
+## Restrictions
+
+- Cannot combine `--enhanced-migration` with inline `(with migration = ...)`
+- Requires enhanced orthogonal persistence
+- Actor variables must not have initializers
+- Actor body must be static (no top-level side effects except `<system>` calls)
+- State after each migration must be compatible with the next migration's input
+- Final state must match the actor's declared fields
+- Fields in last migration's output not declared in the actor are rejected
+
+## Checklist
+
+- [ ] `migrations/` directory exists next to actor source
+- [ ] First migration initializes all fields (`Init.mo` with empty input)
+- [ ] Files named with timestamp prefixes for correct ordering
+- [ ] Each file exports `public func migration({...}) : {...}`
+- [ ] Actor variables declared without initializers
+- [ ] `--enhanced-migration=migrations` in `[canisters.backend] args` in `mops.toml`
+- [ ] Run `mops check --fix` to verify chain consistency
+- [ ] Run `mops build` to compile
+
+## Additional Resources
+
+- Load `writing-motoko` for general Motoko language reference and mo:core APIs

--- a/.agents/skills/migrating-motoko-enhanced/SKILL.md
+++ b/.agents/skills/migrating-motoko-enhanced/SKILL.md
@@ -164,11 +164,9 @@ module {
 
 ```motoko
 // migrations/20250601_000000_SplitName.mo
-import Text "mo:core/Text";
-
 module {
   public func migration(old : { name : Text }) : { firstName : Text; lastName : Text } {
-    let parts = Text.split(old.name, #char ' ');
+    let parts = old.name.split(#char ' ');
     let first = switch (parts.next()) { case (?f) f; case (null) "" };
     let last = switch (parts.next()) { case (?l) l; case (null) "" };
     { firstName = first; lastName = last }

--- a/.agents/skills/migrating-motoko-enhanced/SKILL.md
+++ b/.agents/skills/migrating-motoko-enhanced/SKILL.md
@@ -356,3 +356,4 @@ Then `mops check --fix` and `mops build` work as usual.
 ## Additional Resources
 
 - Load `writing-motoko` for general Motoko language reference and mo:core APIs
+- Load `migrating-motoko` for inline migration without `--enhanced-migration`

--- a/.agents/skills/migrating-motoko-enhanced/SKILL.md
+++ b/.agents/skills/migrating-motoko-enhanced/SKILL.md
@@ -164,6 +164,8 @@ module {
 
 ```motoko
 // migrations/20250601_000000_SplitName.mo
+import Text "mo:core/Text";
+
 module {
   public func migration(old : { name : Text }) : { firstName : Text; lastName : Text } {
     let parts = old.name.split(#char ' ');

--- a/.agents/skills/migrating-motoko/SKILL.md
+++ b/.agents/skills/migrating-motoko/SKILL.md
@@ -66,9 +66,9 @@ actor { ... };
 
 ## Migration Function Rules
 
-- Type: `func (old : { ... }) : { ... }` — local, non-generic, both records must have stable field types
-- **Domain**: old stable fields (names and types from the previous version)
-- **Codomain**: new stable fields (must exist in the new actor with compatible types)
+- Type: `func (old : { ... }) : { ... }` — local, non-generic, both records must use persistable types (no functions or mutable arrays)
+- **Domain**: old actor fields (names and types from the previous version)
+- **Codomain**: new actor fields (must exist in the new actor with compatible types)
 - Runs **only on upgrade** — on fresh install, initializers run normally
 - If the migration traps, the upgrade is aborted and the canister stays on the old version
 
@@ -166,21 +166,11 @@ func(old : { var state : Int }) : { var value : Int } {
 
 Consume it in the input, omit from output. Compiler warns — ensure the loss is intentional.
 
-## Differences from Enhanced Migration
-
-| | Inline `(with migration = ...)` | Enhanced `--enhanced-migration` |
-|-|---|----|
-| Migration count | One per upgrade | Chain of modules in a directory |
-| Actor fields | Can have initializers | Must not have initializers |
-| Actor body | No static restriction | Must be static |
-| Flag needed | None | `--enhanced-migration=migrations` |
-| Combination | Cannot use both | Cannot use both |
-
 ## Checklist
 
 - [ ] Decide: implicit (compatible change) or explicit (migration function)
 - [ ] If explicit: define old types inline in `migration.mo`
-- [ ] Migration type: `func (old : RecordIn) : RecordOut` with stable fields
+- [ ] Migration type: `func (old : RecordIn) : RecordOut` with persistable types
 - [ ] Attach with `(with migration = Migration.run)` before the actor
 - [ ] Do not use `preupgrade`/`postupgrade` for data migration
 - [ ] Verify with `mops check --fix` and `mops build`

--- a/.agents/skills/migrating-motoko/SKILL.md
+++ b/.agents/skills/migrating-motoko/SKILL.md
@@ -47,6 +47,8 @@ actor {
 Or inline:
 
 ```motoko
+import Int "mo:core/Int";
+
 (with migration = func(old : { var state : Int }) : { var newState : Float } {
   { var newState = old.state.toFloat() }
 })

--- a/.agents/skills/migrating-motoko/SKILL.md
+++ b/.agents/skills/migrating-motoko/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: migrating-motoko
+description: >-
+  Inline actor migration with (with migration = ...). Use when upgrading
+  canister state, changing field types, or writing migration functions
+  without the --enhanced-migration flag.
+---
+
+# Inline Actor Migration
+
+Migrate actor state across canister upgrades using a migration expression attached to the actor. Each upgrade has at most one migration function.
+
+**For multi-migration with a `migrations/` directory**, load `migrating-motoko-enhanced` instead.
+
+## When to Use
+
+### Implicit migration (no code needed)
+
+The runtime allows the upgrade if the new program is compatible with the old:
+
+- Adding actor fields
+- Removing actor fields
+- Changing mutability (`var` ↔ `let`)
+- Adding variant constructors
+- Widening types (`Nat` → `Int`)
+
+### Explicit migration required
+
+- Renaming fields
+- Changing a field's type (e.g. `Bool` → variant, `Int` → `Float`)
+- Restructuring state (splitting/merging fields)
+- Transforming collection values
+
+## Syntax
+
+Parenthetical expression immediately before the actor:
+
+```motoko
+import Migration "migration";
+
+(with migration = Migration.run)
+actor {
+  var newState : Float = 0.0;
+};
+```
+
+Or inline:
+
+```motoko
+(with migration = func(old : { var state : Int }) : { var newState : Float } {
+  { var newState = old.state.toFloat() }
+})
+actor {
+  var newState : Float = 0.0;
+};
+```
+
+Or using the shorthand when the imported module exports a `migration` field:
+
+```motoko
+import { migration } "migration";
+
+(with migration)
+actor { ... };
+```
+
+## Migration Function Rules
+
+- Type: `func (old : { ... }) : { ... }` — local, non-generic, both records must have stable field types
+- **Domain**: old stable fields (names and types from the previous version)
+- **Codomain**: new stable fields (must exist in the new actor with compatible types)
+- Runs **only on upgrade** — on fresh install, initializers run normally
+- If the migration traps, the upgrade is aborted and the canister stays on the old version
+
+### Field semantics
+
+| Field appears in | Effect |
+| ---------------- | ------ |
+| Input and output | Field is transformed |
+| Output only      | New field produced by migration |
+| Input only       | Field consumed (compiler warns about possible data loss) |
+| Neither          | Carried through or initialized by declaration |
+
+## Migration Module Pattern
+
+Keep migrations in a separate module. Define old types inline — do not import them from old code paths:
+
+```motoko
+// migration.mo
+import Types "types";
+import Map "mo:core/Map";
+
+module {
+  type OldTask = { id : Nat; title : Text; completed : Bool };
+
+  type OldActor = {
+    var tasks : Map.Map<Nat, OldTask>;
+    var nextId : Nat;
+  };
+
+  type NewActor = {
+    var tasks : Map.Map<Nat, Types.Task>;
+    var nextId : Nat;
+  };
+
+  public func run(old : OldActor) : NewActor {
+    let tasks = old.tasks.map<Nat, OldTask, Types.Task>(
+      func(_, task) {
+        {
+          id = task.id;
+          title = task.title;
+          due = 0;
+          var status = if (task.completed) #completed else #pending;
+        }
+      }
+    );
+    { var tasks; var nextId = old.nextId };
+  };
+};
+```
+
+```motoko
+// main.mo
+import Migration "migration";
+
+(with migration = Migration.run)
+actor {
+  var tasks : Map.Map<Nat, Types.Task>;
+  var nextId : Nat = 0;
+};
+```
+
+## Common Patterns
+
+### Add field with default
+
+```motoko
+old.users.map<Nat, OldUser, NewUser>(
+  func(_, u) { { u with zipCode = "" } }
+)
+```
+
+### Add optional field
+
+```motoko
+{ task with var assignee = null : ?Principal }
+```
+
+### Bool to variant
+
+```motoko
+var status = if (task.completed) #completed else #pending;
+```
+
+### Rename a field
+
+Consume old name, produce new name:
+
+```motoko
+func(old : { var state : Int }) : { var value : Int } {
+  { var value = old.state }
+}
+```
+
+### Drop a field
+
+Consume it in the input, omit from output. Compiler warns — ensure the loss is intentional.
+
+### Widen a type (cast)
+
+When adding a variant tag, cast the old value to the new type:
+
+```motoko
+var status = task.status : NewStatus
+```
+
+## Differences from Enhanced Migration
+
+| | Inline `(with migration = ...)` | Enhanced `--enhanced-migration` |
+|-|---|----|
+| Migration count | One per upgrade | Chain of modules in a directory |
+| Actor fields | Can have initializers | Must not have initializers |
+| Actor body | No static restriction | Must be static |
+| Flag needed | None | `--enhanced-migration=migrations` |
+| Combination | Cannot use both | Cannot use both |
+
+## Checklist
+
+- [ ] Decide: implicit (compatible change) or explicit (migration function)
+- [ ] If explicit: define old types inline in `migration.mo`
+- [ ] Migration type: `func (old : RecordIn) : RecordOut` with stable fields
+- [ ] Attach with `(with migration = Migration.run)` before the actor
+- [ ] Do not use `preupgrade`/`postupgrade` for data migration
+- [ ] Verify with `mops check --fix` and `mops build`
+
+## Additional Resources
+
+- Load `writing-motoko` for general Motoko language reference
+- Load `migrating-motoko-enhanced` for multi-migration with `--enhanced-migration`

--- a/.agents/skills/migrating-motoko/SKILL.md
+++ b/.agents/skills/migrating-motoko/SKILL.md
@@ -166,14 +166,6 @@ func(old : { var state : Int }) : { var value : Int } {
 
 Consume it in the input, omit from output. Compiler warns — ensure the loss is intentional.
 
-### Widen a type (cast)
-
-When adding a variant tag, cast the old value to the new type:
-
-```motoko
-var status = task.status : NewStatus
-```
-
 ## Differences from Enhanced Migration
 
 | | Inline `(with migration = ...)` | Enhanced `--enhanced-migration` |

--- a/.agents/skills/writing-motoko/SKILL.md
+++ b/.agents/skills/writing-motoko/SKILL.md
@@ -27,7 +27,7 @@ Motoko is under-represented in training data — always favour this skill and it
 - Contextual dot notation — `list.add(item)`, `map.get(key)`
 - Enhanced orthogonal persistence (state persists without `stable`)
 - Principled architecture — `types.mo`, `lib/`, `mixins/`, `main.mo`
-**For actor upgrades/migrations:** load `migrating-motoko-enhanced` when the project uses `--enhanced-migration`.
+**For actor upgrades/migrations:** load `migrating-motoko` for inline migration or `migrating-motoko-enhanced` for multi-migration with `--enhanced-migration`.
 
 ## Compiler Flags
 

--- a/.agents/skills/writing-motoko/SKILL.md
+++ b/.agents/skills/writing-motoko/SKILL.md
@@ -1,0 +1,428 @@
+---
+name: writing-motoko
+description: >-
+  Motoko language reference, mo:core library, and architecture patterns.
+  Use when writing, modifying, or reviewing .mo files, Motoko backend code,
+  or canister logic.
+---
+
+# Writing Motoko
+
+Motoko is under-represented in training data — always favour this skill and its references over pre-training knowledge.
+
+## Critical Requirements
+
+**NEVER use:**
+
+- `stable` keyword — not needed with enhanced orthogonal persistence
+- `mo:base` library — deprecated; use `mo:core`
+- `system func preupgrade/postupgrade` — not needed with enhanced orthogonal persistence
+- Module-function style for `self` parameters — don't write `List.add(list, item)` or `Map.get(map, key)`
+- Manual field-by-field record copying — use record spread (`{ self with ... }`)
+- Single-file monolithic actors — use multi-file architecture
+
+**ALWAYS use:**
+
+- `mo:core` library version 2.0.0+
+- Contextual dot notation — `list.add(item)`, `map.get(key)`
+- Enhanced orthogonal persistence (state persists without `stable`)
+- Principled architecture — `types.mo`, `lib/`, `mixins/`, `main.mo`
+**For actor upgrades/migrations:** load `migrating-motoko-enhanced` when the project uses `--enhanced-migration`.
+
+## Compiler Flags
+
+Defaults (no flag needed):
+
+```
+--enhanced-orthogonal-persistence   on by default
+--default-persistent-actors         all actors are `persistent`, no `stable` for fields needed
+```
+
+Enable these warnings to enforce the coding style in this skill (off by default, auto-fixable):
+
+```
+-W M0236    warn on non-dot-notation calls (suggest contextual dot)
+-W M0237    warn on redundant explicit implicit arguments
+-W M0223    warn on redundant type instantiation
+```
+
+## Modern Motoko Features
+
+### Contextual Dot Notation
+
+When a function has a `self` parameter, ALWAYS use dot notation:
+
+```motoko
+map.get(key);
+list.add(item);
+array.filter(func x = x > 0);
+caller.toText();
+myNat.toText();
+"hello".concat(" world");
+
+let doubled = numbers.map(func x = x * 2).filter(func x = x > 10);
+```
+
+### Lambda Argument Types
+
+Never annotate lambda argument types — the compiler infers them:
+
+```motoko
+pairs.map(func(k, v) { k # ": " # v });         // ✓
+pairs.map(func((k, v) : (Text, Text)) : Text {   // ✗ redundant
+  k # ": " # v
+});
+```
+
+### Implicit Parameters
+
+The compiler infers comparison functions automatically:
+
+```motoko
+let map = Map.empty<Nat, Text>();
+map.add(5, "hello");                      // Nat.compare inferred
+
+let ages = Map.empty<Text, Nat>();
+ages.add("Alice", 30);                    // Text.compare auto-derived
+
+// Custom types — define compare in a same-named module → auto-inferred
+module Point {
+  public func compare(a : Point, b : Point) : Order.Order { ... };
+};
+let points = Map.empty<Point, Text>();
+points.add({ x = 1; y = 2 }, "A");       // Point.compare inferred
+```
+
+Never pass implicit arguments explicitly when the compiler derives them:
+
+```motoko
+m.add(1, "hello");                        // ✓
+Map.add(m, Nat.compare, 1, "hello");      // ✗
+```
+
+### Equality and Comparison
+
+`==` uses compiler-generated structural equality — fine for primitives but prefer `mo:core` functions for explicit semantics:
+
+```motoko
+Principal.equal(a, b)                     // ✓ mo:core, explicit
+a == b                                    // structural, OK for primitives
+
+Nat.compare(x, y)                        // ✓ returns Order
+Text.equal(s1, s2)                       // ✓ mo:core
+```
+
+Functions like `equal` and `compare` don't have a `self` parameter, so they are NOT called with dot notation.
+
+### Mixins
+
+Composable actor services with granular state injection. Mixin parameters are immutable bindings — `var` is NOT valid in parameter syntax:
+
+```motoko
+mixin (users : List.List<User>) {
+  public shared ({ caller }) func register(username : Text) : async Bool {
+    users.add(UserLib.new(caller, username));
+    true;
+  };
+};
+
+actor {
+  let users = List.empty<User>();
+  include AuthMixin(users);
+};
+```
+
+To share mutable state, pass a mutable container (`List`, `Map`, etc.) — its contents are mutable even through an immutable binding. For scalar state (e.g. a counter), the mixin can create a local `var` from an initial value, but that `var` is mixin-local and not visible to the actor.
+
+For structured mutable state, pass a record with `var` fields. A module can define both its state type and its mixin:
+
+```motoko
+// lib/Counter.mo
+module {
+  public type State = { var count : Nat; var name : Text };
+  public func initState() : State { { var count = 0; var name = "" } };
+};
+
+// mixins/Counter.mo
+mixin (state : CounterLib.State) {
+  public func increment() : async Nat { state.count += 1; state.count };
+};
+
+// main.mo
+let counterState = CounterLib.initState();
+include CounterMixin(counterState);
+```
+
+### Record Spread
+
+Use record spread to avoid copying fields one by one:
+
+```motoko
+{ self with newField = "" };                                           // ✓
+{ id = self.id; text = self.text; completed = self.completed; newField = "" }; // ✗
+```
+
+**Caveat**: record spread cannot leave `var` fields un-overridden (M0179). When converting to a different type (e.g. internal → public), you must copy fields explicitly if the source has `var` fields that the target doesn't.
+
+## Architecture Pattern
+
+```text
+backend/
+├── types.mo         # Central schema, state definitions
+├── lib/             # Domain logic (stateless modules with self pattern)
+├── mixins/          # Service layer (state injected via mixin parameters)
+├── migrations/      # Enhanced migration files (--enhanced-migration projects)
+│   └── <timestamp>_<Name>.mo
+└── main.mo          # Composition root (state owner, NO public methods)
+```
+
+Entity types go in `types.mo`. State fields are direct actor bindings — no wrapper:
+
+```motoko
+// types.mo
+module {
+  public type User = { id : Principal; var username : Text; var isActive : Bool };
+};
+
+// main.mo
+actor {
+  let users = List.empty<Types.User>();
+  var nextPostId : Nat = 0;
+  include AuthMixin(users);
+};
+```
+
+## Import Path Conventions
+
+Paths are **relative to the importing file**. No `.mo` extension, no `/lib.mo` suffix.
+
+```motoko
+// From main.mo
+import Types "types";
+import AuthMixin "mixins/Auth";
+import UserLib "lib/User";
+// From lib/*.mo or mixins/*.mo
+import Types "../types";
+// Core library — always absolute
+import Map "mo:core/Map";
+
+// WRONG — these all cause M0009
+import Types "types.mo";
+import Types "types/lib.mo";
+import Types "backend/types";
+```
+
+## Shared Types
+
+Public functions accept/return only **shared types** (serializable):
+
+- Shared: `Nat`, `Int`, `Text`, `Bool`, `Principal`, `Blob`, `Float`, `[T]`, `?T`, records, variants
+- **Not shared**: functions, `var` fields, objects, `Map`, `Set`, `List`, `Queue`, `Stack`
+
+Convert internal mutable containers to shared types at the API boundary:
+
+```motoko
+public type PostInternal = { id : Nat; likedBy : Set.Set<Principal> };
+public type Post = { id : Nat; likedBy : [Principal] };
+
+public func toPublic(self : Types.PostInternal) : Types.Post {
+  { self with likedBy = Set.toArray(self.likedBy) };
+};
+```
+
+## Collections
+
+| Structure | Use Case        | Key Operations     | Complexity  |
+| --------- | --------------- | ------------------ | ----------- |
+| Map       | Key-value pairs | get, add, remove   | O(log n)    |
+| List      | Growable array  | add, get, at       | O(1) access |
+| Queue     | FIFO processing | pushBack, popFront | O(1)        |
+| Stack     | LIFO processing | push, pop          | O(1)        |
+| Array     | Fixed collection| index, map, filter | O(1) access |
+| Set       | Unique values   | contains, add      | O(log n)    |
+
+```motoko
+import Map "mo:core/Map";
+import List "mo:core/List";
+import Set "mo:core/Set";
+```
+
+**Import requirement**: Extension methods (dot notation) on a type only work when the corresponding `mo:core` module is imported. For example, `myArray.find(...)` requires `import Array "mo:core/Array"`; iterator chaining requires `import Iter "mo:core/Iter"`; `myBool.toText()` requires `import Bool "mo:core/Bool"`. The compiler hints at the missing import in the error message.
+
+**Warning**: Never call `list.add()` inside a `retain` callback. Use `mapInPlace` instead.
+
+Always use opaque type aliases (`List.List<T>`, `Map.Map<K, V>`, `Set.Set<T>`) in type declarations.
+
+### Iteration
+
+Build pipelines with `Iter` and materialize only at the end. Never create intermediate arrays:
+
+```motoko
+self.values().map(toJson).toArray()                // ✓ single allocation
+Array.map(List.toArray(self), toJson)              // ✗ two allocations
+
+let doubled = numbers.map(func x = x * 2).filter(func x = x > 10);
+let sum = scores.filter(func s = s > 15).foldLeft(0, func(acc, s) = acc + s);
+```
+
+### `contains` vs `find`
+
+- **`contains(element)`** — equality check. Does NOT take a predicate.
+- **`find(predicate)`** — predicate search. Returns `?T`.
+
+```motoko
+numbers.contains(3);                          // implicit Nat.equal
+friends.contains(Principal.equal, p);          // explicit equality
+numbers.find(func(n) { n > 3 });              // returns ?Nat
+```
+
+### Explicit Type Instantiation
+
+When `.map()` transforms to a **different** type, provide type parameters (M0098 without):
+
+```motoko
+let photos = internalPhotos.map<PhotoInternal, Photo>(
+  func(p) { { id = p.id; url = p.url; uploadedBy = p.uploadedBy.toText() } }
+);
+```
+
+Omit type parameters when they can be inferred — don't add them redundantly.
+
+## Option Handling
+
+```motoko
+// Trap on unexpected null
+let user = switch (users.find(func(u) { u.id == caller })) {
+  case (?u) { u };
+  case (null) { Runtime.trap("User not found") };
+};
+
+// Return ?T when absence is normal
+public query func findUserByName(name : Text) : async ?User {
+  users.find(func(u) { u.name == name });
+};
+```
+
+## Module with Self Pattern
+
+```motoko
+// lib/User.mo
+module {
+  public type User = Types.User;
+  public func new(id : Principal, name : Text) : User {
+    { id; var name; var isActive = true };
+  };
+  public func ban(self : User) { self.isActive := false };
+};
+// Usage: user.ban();
+```
+
+## Security
+
+Every public update function MUST verify the caller via `{caller}` destructuring. Enforce authorization on the backend.
+
+## Function Literals as Arguments
+
+Do NOT put a semicolon after a function body passed as an argument:
+
+```motoko
+list.filter(func(item) { item.id != targetId })   // ✓
+list.filter(func(item) { item.id != targetId };)   // ✗ unexpected token ';'
+```
+
+## Common Compile Error Patterns
+
+| Error pattern                                          | Fix                                         |
+| ------------------------------------------------------ | ------------------------------------------- |
+| `field append does not exist`                          | `.concat()`                                 |
+| `field put does not exist` (Map)                       | `.add()`                                    |
+| `field delete is deprecated` (Map)                     | `.remove()`                                 |
+| `Int cannot produce expected type Nat`                 | `Int.abs(intValue)`                         |
+| `syntax error, unexpected token '.'`                   | `#text (searchTerm.toLower())`              |
+| `syntax error, unexpected token ','`                   | `for ((key, value) in map.entries())`       |
+| `Compatibility error [M0170]`                          | Load `migrating-motoko-enhanced`            |
+| `shared function has non-shared parameter/return type` | Return `[T]` not `List<T>`, no `var` fields |
+| `send capability required`                             | Add `<system>` capability                   |
+| `field compare does not exist` on Time                 | Use `Int.compare`                           |
+| `unexpected token ';'` in function call                | Remove `;` before `)`                       |
+| `unbound variable X`                                   | `import X "mo:core/X"`                      |
+| `M0098` no best choice for type param                  | `list.map<In, Out>(...)`                    |
+| `M0096` on `contains` callback                         | `find(pred) != null`                        |
+| `M0009` import file does not exist                     | Relative path, no `.mo` extension           |
+| `M0072` field X does not exist                         | Import the `mo:core` module for that type   |
+| `unexpected token 'label'` in parameter                | `label` is a keyword; rename the parameter  |
+
+## Control Flow
+
+```motoko
+// Switch — option unwrapping
+let value = switch (map.get(key)) {
+  case (?v) { v };
+  case (null) { Runtime.trap("Key not found") };
+};
+
+// Switch — variant matching
+type Status = { #active; #inactive; #pending : Text };
+switch (status) {
+  case (#active) { "User is active" };
+  case (#inactive) { "User is inactive" };
+  case (#pending(reason)) { "Pending: " # reason };
+};
+
+// Switch — value matching
+switch (statusCode) {
+  case (200) { "OK" };
+  case (404) { "Not Found" };
+  case _ { "Unknown" };
+};
+
+// For loops
+for ((key, value) in map.entries()) {
+  Debug.print(key.toText() # ": " # value);
+};
+for (item in list.values()) {
+  total += item.score;
+};
+```
+
+Prefer `.foldLeft()` or `.map()` over imperative loops when possible.
+
+Use `break` and `continue` in loops:
+
+```motoko
+for (item in iter) {
+  if (item.id == targetId) {
+    result := ?item;
+    break;
+  };
+};
+
+for (item in list.values()) {
+  if (not item.isActive) continue;
+  process(item);
+};
+```
+
+## Quick Reference
+
+**Basic Types:** `Nat` `Int` `Text` `Bool` `Principal` `?T` `[T]` `[var T]` `Blob` `Float` — `Time.now()` returns `Int` (nanoseconds)
+
+**Common Operations:** `debug_show(value)` → Text | `assert condition` | `# "text"` concatenation | `break` / `continue` in loops
+
+## Best Practices
+
+1. Always `mo:core`, never `mo:base`
+2. No `stable` keyword — enhanced orthogonal persistence handles state
+3. Dot notation for all `self`-parameter functions
+4. Never annotate lambda argument types — let the compiler infer
+5. Never pass implicit arguments explicitly
+6. Unwrap with `switch` + `Runtime.trap()` on null; `?T` only when absence is expected
+7. types.mo / lib/ / mixins/ / main.mo structure
+8. Mixins receive only needed state slices
+9. Queries for read-only, updates for state changes
+10. Iterator chaining to avoid intermediate collections
+11. Record spread `{ self with ... }` instead of copying fields
+
+## Additional Resources
+
+- **Complete examples**: [examples.md](examples.md) — full working code samples, type conversions

--- a/.agents/skills/writing-motoko/SKILL.md
+++ b/.agents/skills/writing-motoko/SKILL.md
@@ -31,12 +31,13 @@ Motoko is under-represented in training data — always favour this skill and it
 
 ## Compiler Flags
 
-Defaults (no flag needed):
+Required for this skill's conventions:
 
 ```
---enhanced-orthogonal-persistence   on by default
---default-persistent-actors         all actors are `persistent`, no `stable` for fields needed
+--default-persistent-actors         all actors are `persistent`, no `stable` keyword needed
 ```
+
+`--enhanced-orthogonal-persistence` is on by default.
 
 Enable these warnings to enforce the coding style in this skill (off by default, auto-fixable):
 
@@ -102,17 +103,14 @@ Map.add(m, Nat.compare, 1, "hello");      // ✗
 
 ### Equality and Comparison
 
-`==` uses compiler-generated structural equality — fine for primitives but prefer `mo:core` functions for explicit semantics:
+`==` uses compiler-generated structural equality. `equal`/`compare` from `mo:core` are primarily used as implicit arguments for `Map`, `Set`, `contains`, etc.
+
+Some modules use `self` (dot-callable): `Text`, `Principal`, `Bool`, `Char`, `Blob`. Others use `x, y` (not dot-callable): `Nat`, `Int`, `Float`, sized integers.
 
 ```motoko
-Principal.equal(a, b)                     // ✓ mo:core, explicit
-a == b                                    // structural, OK for primitives
-
-Nat.compare(x, y)                        // ✓ returns Order
-Text.equal(s1, s2)                       // ✓ mo:core
+s1.equal(s2)                             // Text.equal has self
+Nat.compare(x, y)                        // Nat.compare does not
 ```
-
-Functions like `equal` and `compare` don't have a `self` parameter, so they are NOT called with dot notation.
 
 ### Mixins
 
@@ -271,8 +269,8 @@ let sum = scores.filter(func s = s > 15).foldLeft(0, func(acc, s) = acc + s);
 - **`find(predicate)`** — predicate search. Returns `?T`.
 
 ```motoko
-numbers.contains(3);                          // implicit Nat.equal
-friends.contains(Principal.equal, p);          // explicit equality
+numbers.contains(3);                          // Nat.equal auto-derived
+friends.contains(p);                          // Principal.equal auto-derived
 numbers.find(func(n) { n > 3 });              // returns ?Nat
 ```
 

--- a/.agents/skills/writing-motoko/examples.md
+++ b/.agents/skills/writing-motoko/examples.md
@@ -1,0 +1,409 @@
+# Motoko Examples
+
+Complete working examples demonstrating modern Motoko patterns. All examples verified with moc 1.5.0.
+
+## Principled Architecture
+
+### types.mo
+
+```motoko
+module {
+  public type UserId = Principal;
+
+  public type User = {
+    id : UserId;
+    var username : Text;
+    var bio : Text;
+    var isActive : Bool;
+  };
+
+  public type UserPublic = {
+    id : UserId;
+    username : Text;
+    bio : Text;
+    isActive : Bool;
+  };
+
+  public type Post = {
+    id : Nat;
+    author : User;
+    var title : Text;
+    var content : Text;
+    var published : Bool;
+  };
+
+  public type PostPublic = {
+    id : Nat;
+    authorId : Principal;
+    title : Text;
+    content : Text;
+    published : Bool;
+  };
+};
+```
+
+### lib/User.mo
+
+```motoko
+import Types "../types";
+
+module {
+  public type User = Types.User;
+
+  public func new(id : Types.UserId, username : Text) : User {
+    { id; var username; var bio = ""; var isActive = true };
+  };
+
+  public func updateBio(self : User, newBio : Text) {
+    if (newBio.size() > 280) return;
+    self.bio := newBio;
+  };
+
+  public func ban(self : User) { self.isActive := false };
+
+  public func isValid(self : User) : Bool {
+    self.username.size() > 0 and self.isActive;
+  };
+
+  public func toPublic(self : User) : Types.UserPublic {
+    { id = self.id; username = self.username; bio = self.bio; isActive = self.isActive };
+  };
+};
+```
+
+### lib/Post.mo
+
+```motoko
+import Types "../types";
+
+module {
+  public type Post = Types.Post;
+
+  public func new(id : Nat, author : Types.User, title : Text) : Post {
+    { id; author; var title; var content = ""; var published = false };
+  };
+
+  public func publish(self : Post) {
+    if (self.content.size() > 0) { self.published := true };
+  };
+
+  public func setContent(self : Post, content : Text) {
+    self.content := content;
+  };
+};
+```
+
+### mixins/Auth.mo
+
+```motoko
+import Types "../types";
+import UserLib "../lib/User";
+import List "mo:core/List";
+
+mixin (users : List.List<Types.User>) {
+
+  func findUser(p : Principal) : ?Types.User {
+    users.find(func(u) { u.id == p });
+  };
+
+  public shared ({ caller }) func register(username : Text) : async Bool {
+    switch (findUser(caller)) {
+      case (?_) return false;
+      case (null) {
+        users.add(UserLib.new(caller, username));
+        return true;
+      };
+    };
+  };
+
+  public shared query ({ caller }) func getProfile() : async ?Types.UserPublic {
+    switch (findUser(caller)) {
+      case (?user) { ?user.toPublic() };
+      case (null) { null };
+    };
+  };
+
+  public shared ({ caller }) func updateBio(newBio : Text) : async Bool {
+    switch (findUser(caller)) {
+      case (null) false;
+      case (?user) { user.updateBio(newBio); true };
+    };
+  };
+};
+```
+
+### mixins/Blog.mo
+
+```motoko
+import Types "../types";
+import PostLib "../lib/Post";
+import List "mo:core/List";
+import Runtime "mo:core/Runtime";
+
+mixin (
+  users : List.List<Types.User>,
+  posts : List.List<Types.Post>,
+) {
+
+  public shared ({ caller }) func createPost(title : Text) : async Nat {
+    let author = switch (users.find(func(u) { u.id == caller })) {
+      case (?u) u;
+      case (null) { Runtime.trap("User not registered") };
+    };
+    let pid = posts.size();
+    posts.add(PostLib.new(pid, author, title));
+    pid;
+  };
+
+  public shared ({ caller }) func publishPost(postId : Nat) : async Bool {
+    switch (posts.find(func(p) { p.id == postId })) {
+      case (null) false;
+      case (?post) {
+        if (post.author.id != caller) { return false };
+        post.publish();
+        true;
+      };
+    };
+  };
+
+  public query func getAllPosts() : async [Types.PostPublic] {
+    posts.map<Types.Post, Types.PostPublic>(
+      func(p) { { id = p.id; authorId = p.author.id; title = p.title; content = p.content; published = p.published } }
+    ).toArray();
+  };
+};
+```
+
+### main.mo
+
+```motoko
+import List "mo:core/List";
+import Types "types";
+import AuthMixin "mixins/Auth";
+import BlogMixin "mixins/Blog";
+
+actor Main {
+  let users = List.empty<Types.User>();
+  let posts = List.empty<Types.Post>();
+
+  include AuthMixin(users);
+  include BlogMixin(users, posts);
+};
+```
+
+## Iterator Chaining
+
+Note: `import Array` enables `.find()`, `.any()`, `.all()` on arrays; `import Iter` enables `.map()`, `.filter()` on iterators; `import Bool` enables `.toText()` on booleans.
+
+```motoko
+import Array "mo:core/Array";
+import Bool "mo:core/Bool";
+import Iter "mo:core/Iter";
+
+actor {
+  let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  public query func demonstrateIterators() : async Text {
+    var output = "";
+
+    let doubled = numbers.values().map(func x = x * 2).filter(func x = x > 10).toArray();
+    output := output # "Doubled > 10: " # doubled.toText() # "\n";
+
+    let sum = numbers.values().foldLeft(0, func(acc, x) = acc + x);
+    output := output # "Sum: " # sum.toText() # "\n";
+
+    switch (numbers.find(func x = x > 5)) {
+      case (?found) { output := output # "Found: " # found.toText() # "\n" };
+      case (null) {};
+    };
+
+    let hasLarge = numbers.any(func x = x > 8);
+    let allPositive = numbers.all(func x = x > 0);
+    output := output # "Has large: " # hasLarge.toText() # "\n";
+    output := output # "All positive: " # allPositive.toText() # "\n";
+
+    output;
+  };
+};
+```
+
+## Map with Custom Key Types
+
+```motoko
+import Map "mo:core/Map";
+import Order "mo:core/Order";
+import Int "mo:core/Int";
+
+actor {
+  type Point = { x : Int; y : Int };
+
+  module Point {
+    public func compare(a : Point, b : Point) : Order.Order {
+      switch (Int.compare(a.x, b.x)) {
+        case (#equal) { Int.compare(a.y, b.y) };
+        case (other) { other };
+      };
+    };
+  };
+
+  let pointMap = Map.empty<Point, Text>();
+
+  public func addPoint(x : Int, y : Int, pointLabel : Text) : async () {
+    pointMap.add({ x; y }, pointLabel);
+  };
+
+  public query func getPoint(x : Int, y : Int) : async ?Text {
+    pointMap.get({ x; y });
+  };
+};
+```
+
+## Timer with Periodic Cleanup
+
+```motoko
+import Timer "mo:core/Timer";
+import Time "mo:core/Time";
+import List "mo:core/List";
+
+actor {
+  let logs = List.empty<(Int, Text)>();
+  var timerId : Nat = 0;
+
+  public func startCleanup() : async () {
+    timerId := Timer.recurringTimer<system>(
+      #seconds(3600),
+      func() : async () {
+        let oneHourAgo = Time.now() - 3_600_000_000_000;
+        let recent = logs.filter(func(timestamp, _) { timestamp > oneHourAgo });
+        logs.clear();
+        logs.addAll(recent.values());
+      },
+    );
+  };
+
+  public func stopCleanup() : async () {
+    Timer.cancelTimer(timerId);
+  };
+};
+```
+
+## Shared Type Boundary
+
+```motoko
+import List "mo:core/List";
+import Principal "mo:core/Principal";
+import Set "mo:core/Set";
+import Time "mo:core/Time";
+
+actor {
+  type PhotoInternal = {
+    id : Nat;
+    url : Text;
+    uploadedBy : Principal;
+    likedBy : Set.Set<Principal>;
+    createdAt : Int;
+  };
+
+  type Photo = {
+    id : Nat;
+    url : Text;
+    uploadedBy : Text;
+    likedBy : [Principal];
+    createdAt : Int;
+  };
+
+  let photos = List.empty<PhotoInternal>();
+
+  func toPublic(self : PhotoInternal) : Photo {
+    {
+      self with
+      uploadedBy = self.uploadedBy.toText();
+      likedBy = Set.toArray(self.likedBy);
+    };
+  };
+
+  public shared ({ caller }) func upload(url : Text) : async Nat {
+    let id = photos.size();
+    photos.add({
+      id;
+      url;
+      uploadedBy = caller;
+      likedBy = Set.empty<Principal>();
+      createdAt = Time.now();
+    });
+    id;
+  };
+
+  public query func getPhotos() : async [Photo] {
+    photos.map<PhotoInternal, Photo>(func(p) { toPublic(p) }).toArray();
+  };
+};
+```
+
+## In-Place Mutation Patterns
+
+Use `find` + direct field mutation for updating a single item. Use `mapInPlace` when transforming all items:
+
+```motoko
+import List "mo:core/List";
+
+actor {
+  type Todo = { id : Nat; text : Text; var completed : Bool };
+
+  let todos = List.empty<Todo>();
+  var nextId : Nat = 0;
+
+  public func addTodo(text : Text) : async Nat {
+    let id = nextId;
+    nextId += 1;
+    todos.add({ id; text; var completed = false });
+    id;
+  };
+
+  public func toggleTodo(targetId : Nat) : async Bool {
+    switch (todos.find(func(t) { t.id == targetId })) {
+      case (?todo) { todo.completed := not todo.completed; true };
+      case (null) false;
+    };
+  };
+
+  public func completeAll() : async () {
+    todos.mapInPlace(func(todo) { { todo with var completed = true } });
+  };
+};
+```
+
+## Type Conversions
+
+```motoko
+// Nat ↔ Int
+let n : Nat = 42;
+let i : Int = n.toInt();
+let backToNat = Int.abs(i);
+
+// Nat size widening: Nat8 → Nat16 → Nat32 → Nat64
+let nat8 : Nat8 = 255;
+let nat16 = nat8.toNat16();
+let nat32 = nat16.toNat32();
+let nat64 = nat32.toNat64();
+let backToNat8 = Nat8.fromNat64(nat64);
+
+// Int size widening: Int8 → Int16 → Int32 → Int64
+let int8 : Int8 = -128;
+let int16 = int8.toInt16();
+let int32 = int16.toInt32();
+let int64 = int32.toInt64();
+let backToInt8 = Int8.fromInt64(int64);
+
+// To/from Text
+let text = n.toText();               // "42"
+let maybeNat = Nat.fromText("42");   // : ?Nat
+let maybeInt = Int.fromText("-5");   // : ?Int
+
+// To Float
+let f = n.toFloat();
+
+// Time is Int (nanoseconds)
+let timestamp = Time.now();          // requires import Time "mo:core/Time"
+let milliseconds = timestamp / 1_000_000;
+```

--- a/.agents/skills/writing-motoko/examples.md
+++ b/.agents/skills/writing-motoko/examples.md
@@ -193,12 +193,13 @@ actor Main {
 
 ## Iterator Chaining
 
-Note: `import Array` enables `.find()`, `.any()`, `.all()` on arrays; `import Iter` enables `.map()`, `.filter()` on iterators; `import Bool` enables `.toText()` on booleans.
+Note: `import Array` enables `.find()`, `.any()`, `.all()` on arrays; `import Iter` enables `.map()`, `.filter()` on iterators; `import Bool` enables `.toText()` on booleans; `import Nat` enables `.toText()` on natural numbers.
 
 ```motoko
 import Array "mo:core/Array";
 import Bool "mo:core/Bool";
 import Iter "mo:core/Iter";
+import Nat "mo:core/Nat";
 
 actor {
   let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -374,6 +375,8 @@ actor {
 ```
 
 ## Type Conversions
+
+Requires `import Nat "mo:core/Nat"`, `import Int "mo:core/Int"`, etc. for dot-notation methods.
 
 ```motoko
 // Nat ↔ Int


### PR DESCRIPTION
## Summary

- Adds two AI assistant skills in `.agents/` so that any AI tool (Cursor, Claude Code, etc.) working in this repo has accurate, up-to-date Motoko guidance instead of relying on stale training data.
- **writing-motoko**: mo:core library, contextual dot notation, implicit parameters, equality vs `==`, mixins (including state record pattern), principled architecture, shared types, collections, iterator pipelines, control flow, recommended compiler flags (`-W M0236,M0237,M0223`), and common compile error patterns.
- **migrating-motoko-enhanced**: enhanced multi-migration system — migration module structure, input/output field semantics, common patterns (init, add, rename, remove, transform, collection mapping), a full Todo app lifecycle example, mops config (`[moc]` global + `[canisters.backend]` per-canister), and a pre-flight checklist.

## Notes

- All code examples verified against moc 1.5.0 with mo:core 2.0.0.
- Skills are intentionally opinionated: no `stable`, no `mo:base`, no `preupgrade`/`postupgrade`, dot notation everywhere.

## Test plan

- [ ] Verify skills render correctly in GitHub
- [ ] Smoke-test with an AI assistant on a Motoko task in this repo


Made with [Cursor](https://cursor.com)