### PR TITLE
chore: bump `OCaml` 4.14 → 5.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775525138,
-        "narHash": "sha256-BQb70+B378ECLO8iQT3P/b1hCC5/CJVHZdeulY8futc=",
+        "lastModified": 1776221942,
+        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d96b37bbeb9840f1c0ebfe90585ef5067b69bbb3",
+        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
         "type": "github"
       },
       "original": {
@@ -223,22 +223,6 @@
         "type": "github"
       }
     },
-    "ocaml-vlq-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1629909858,
-        "narHash": "sha256-et4gfL9IVNkmTLp/S03eAQuRifsuxexvABdC3G7t1MU=",
-        "owner": "flowtype",
-        "repo": "ocaml-vlq",
-        "rev": "66238f9539292b5e0cf73cb8d80dbd3f41732c27",
-        "type": "github"
-      },
-      "original": {
-        "owner": "flowtype",
-        "repo": "ocaml-vlq",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "candid-src": "candid-src",
@@ -253,7 +237,6 @@
         "nix-update-flake": "nix-update-flake",
         "nixpkgs": "nixpkgs",
         "ocaml-recovery-parser-src": "ocaml-recovery-parser-src",
-        "ocaml-vlq-src": "ocaml-vlq-src",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,10 +41,6 @@
       url = "github:kritzcreek/motoko-matchers/5ba5f52bd9a5649dedf5e2a1ccd55d98ed7ff982";
       flake = false;
     };
-    ocaml-vlq-src = {
-      url = "github:flowtype/ocaml-vlq";
-      flake = false;
-    };
     grace-src = {
       url = "github:johnyob/grace/15251666a11a780dfd09f23e1b0c1e6b0e366dcf";
       flake = false;
@@ -68,7 +64,6 @@
     , motoko-base-src
     , motoko-core-src
     , motoko-matchers-src
-    , ocaml-vlq-src
     , grace-src
     , ocaml-recovery-parser-src
     }: flake-utils.lib.eachDefaultSystem (system:
@@ -83,7 +78,6 @@
             motoko-base-src
             motoko-core-src
             motoko-matchers-src
-            ocaml-vlq-src
             ocaml-recovery-parser-src
             grace-src;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -117,7 +117,6 @@
         num
         stdint
         wasm
-        vlq
         zarith
         yojson
         ppxlib

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -5,7 +5,7 @@
 
     # Selecting the ocaml version
     # Also update ocaml-version in src/*/.ocamlformat!
-    (self: super: { ocamlPackages = self.ocaml-ng.ocamlPackages_4_14; })
+    (self: super: { ocamlPackages = self.ocaml-ng.ocamlPackages_5_3; })
 
     (self: super: rec {
       # Additional ocaml packages

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -427,18 +427,18 @@ let contextual_dot_args e1 e2 dot_note =
   let arity = match dot_note.note.note_typ with
     | T.Func(_, _, _, args, _) -> List.length args
     | _ -> raise (Invalid_argument "non-function type in contextual dot note") in
-  let effect eff =
+  let effec eff =
     match (e1.note.note_eff, eff) with
     | T.Triv, T.Triv -> T.Triv
     | _, _ -> T.Await
   in
   let args = match e2 with
     | { it = TupE []; at; note = { note_eff;_ } } ->
-       { it = e1.it; at; note = { note_eff = effect note_eff; note_typ = e1.note.note_typ } }
+       { it = e1.it; at; note = { note_eff = effec note_eff; note_typ = e1.note.note_typ } }
     | { it = TupE exps; at; note = { note_eff; note_typ = T.Tup ts } } when arity <> 2 ->
-       { it = TupE (e1::exps); at; note = { note_eff = effect note_eff; note_typ = T.Tup (e1.note.note_typ::ts) } }
+       { it = TupE (e1::exps); at; note = { note_eff = effec note_eff; note_typ = T.Tup (e1.note.note_typ::ts) } }
     | { at; note = { note_eff; _ }; _ } ->
-       { it = TupE ([e1; e2]); at; note = { note_eff = effect note_eff; note_typ = T.Tup ([e1.note.note_typ; e2.note.note_typ]) } }
+       { it = TupE ([e1; e2]); at; note = { note_eff = effec note_eff; note_typ = T.Tup ([e1.note.note_typ; e2.note.note_typ]) } }
   in args
 
 let is_import d =

--- a/src/wasm-exts/customModuleEncode.ml
+++ b/src/wasm-exts/customModuleEncode.ml
@@ -74,6 +74,35 @@ open Dwarf5.Meta
 
 open CustomModule
 
+(* VLQ Base64 encoder for source maps.
+   Derived from https://github.com/flowtype/ocaml-vlq (MIT license).
+   Copyright (c) 2018-present, Facebook, Inc.
+   Only the encode path is included; decode (which depends on the
+   removed-in-OCaml-5 Stream module) is not needed by moc. *)
+module Vlq_base64 : sig
+  val encode : Buffer.t -> int -> unit
+end = struct
+  let shift = 5
+  let vlq_base = 1 lsl shift
+  let vlq_base_mask = vlq_base - 1
+  let vlq_continuation_bit = vlq_base
+  let base64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+  let char_of_digit d = base64.[d]
+
+  let rec encode_vlq buf vlq =
+    let digit = vlq land vlq_base_mask in
+    let vlq = vlq lsr shift in
+    if vlq = 0 then Buffer.add_char buf (char_of_digit digit)
+    else begin
+      Buffer.add_char buf (char_of_digit (digit lor vlq_continuation_bit));
+      encode_vlq buf vlq
+    end
+
+  let encode buf value =
+    let vlq = if value < 0 then ((-value) lsl 1) + 1 else value lsl 1 in
+    encode_vlq buf vlq
+end
+
 (* Version *)
 
 let version = 1l
@@ -272,10 +301,10 @@ let encode (em : extended_module) =
     let il = il - 1 in
     let if_ = add_source file !sources in
     if ol <> !prev_ol then Buffer.add_char map ';';
-    Vlq.Base64.encode map (oc - !prev_oc);             (* output column *)
-    Vlq.Base64.encode map (if_ - !prev_if);            (* sources index *)
-    Vlq.Base64.encode map (il - !prev_il);             (* input row *)
-    Vlq.Base64.encode map (ic - !prev_ic);             (* input column *)
+    Vlq_base64.encode map (oc - !prev_oc);             (* output column *)
+    Vlq_base64.encode map (if_ - !prev_if);            (* sources index *)
+    Vlq_base64.encode map (il - !prev_il);             (* input row *)
+    Vlq_base64.encode map (ic - !prev_ic);             (* input column *)
     Buffer.add_char map ',';
 
     prev_if := if_; prev_ol := ol; prev_oc := oc; prev_il := il; prev_ic := ic; incr segs

--- a/src/wasm-exts/dune
+++ b/src/wasm-exts/dune
@@ -1,5 +1,5 @@
 (library
   (name wasm_exts)
-  (libraries wasm vlq yojson lib prelude mo_config lang_utils)
+  (libraries wasm yojson lib prelude mo_config lang_utils)
   (instrumentation (backend bisect_ppx --bisect-silent yes))
 )


### PR DESCRIPTION
## Summary

Upgrade the OCaml compiler from 4.14 to 5.3.

### Changes

- **`nix/pkgs.nix`**: `ocamlPackages_4_14` → `ocamlPackages_5_3`
- **`src/wasm-exts/customModuleEncode.ml`**: Inline the VLQ Base64 encoder (from `ocaml-vlq`, MIT license). The external `vlq` package depends on `Stream` which was removed in OCaml 5.x. Only the encode path is needed by `moc` (for source maps); decode is not used.
- **`src/wasm-exts/dune`**: Drop `vlq` library dependency
- **`flake.nix`**: Remove `vlq` from build inputs

### Status

- [x] `nix build .#moc` — passes
- [x] `nix build .#js.moc` — passes
- [x] Full CI test suite — passes

### Notes

The `ocaml-vlq` package is marked as broken for OCaml 5.x in nixpkgs due to its use of `Stream.t` (removed in OCaml 5.0). Since `moc` only uses `Vlq.Base64.encode` (4 call sites for source map generation), inlining the ~20 lines of encode logic is simpler than maintaining a compatibility shim.

The `ocaml-vlq-src` flake input has been dropped (separate PR #6027) as it was already unused — the package came from nixpkgs directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)