### PR TITLE
chore: drop `Lib.List.take/drop` — now in OCaml 5.3 `stdlib`

### DIFF
--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -443,13 +443,6 @@ struct
        | [] -> false
        | hd' :: tl' -> equal hd hd' && is_prefix equal tl tl')
 
-  (* tail-recursive map *)
-  let[@tail_mod_cons] rec safe_map f l = match l with
-    | [] -> []
-    | x :: xs ->
-      f x :: (safe_map[@tailcall]) f xs
-    [@@coverage off]
-
   let align cmp xs ys =
     let next (xs, ys) = match xs, ys with
       | [], [] -> None

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -415,16 +415,6 @@ struct
 
   let index_of x = index_where ((=) x)
 
-  let rec compare f xs ys =
-    match xs, ys with
-    | [], [] -> 0
-    | [], _ -> -1
-    | _, [] -> +1
-    | x::xs', y::ys' ->
-      match f x y with
-      | 0 -> compare f xs' ys'
-      | n -> n
-
   let rec is_ordered f xs =
     match xs with
     | [] | [_] -> true

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -481,18 +481,6 @@ struct
     | 0l, x::_ -> x
     | n, _::xs' when n > 0l -> nth xs' (Int32.sub n 1l)
     | _ -> failwith "nth"
-
-  let rec take n xs =
-    match n, xs with
-    | 0l, _ -> []
-    | n, x::xs' when n > 0l -> x :: take (Int32.sub n 1l) xs'
-    | _ -> failwith "take"
-
-  let rec drop n xs =
-    match n, xs with
-    | 0l, _ -> xs
-    | n, _::xs' when n > 0l -> drop (Int32.sub n 1l) xs'
-    | _ -> failwith "drop"
 end
 
 module Array =

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -353,9 +353,6 @@ type ('a, 'b) these =
 
 module List =
 struct
-  let equal p xs ys =
-    try List.for_all2 p xs ys with _ -> false
-
   let rec make n x = make' n x []
   and make' n x xs =
     if n = 0 then xs else make' (n - 1) x (x::xs)

--- a/src/lib/lib.ml
+++ b/src/lib/lib.ml
@@ -372,25 +372,13 @@ struct
          grouping ((hd::l1)::acc) l2
     in grouping [] l
 
-  let rec take n xs = (* present in OCaml 5.3 *)
-    match n, xs with
-    | _ when n <= 0 -> []
-    | n, x::xs' when n > 0 -> x :: take (n - 1) xs'
-    | _ -> failwith "take"
-
-  let rec drop n xs = (* present in OCaml 5.3 *)
-    match n, xs with
-    | 0, _ -> xs
-    | n, _::xs' when n > 0 -> drop (n - 1) xs'
-    | _ -> failwith "drop"
-
   let rec replicate e = function
     | 0 -> []
     | n -> e :: replicate e (n - 1)
 
   let split_at n xs =
     if n <= List.length xs
-    then (take n xs, drop n xs)
+    then (List.take n xs, List.drop n xs)
     else (xs, [])
 
   let split3 l =

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -60,8 +60,6 @@ sig
   val make : int32 -> 'a -> 'a list
   val length : 'a list -> int32
   val nth : 'a list -> int32 -> 'a (* raises Failure *)
-  val take : int32 -> 'a list -> 'a list (* raises Failure *)
-  val drop : int32 -> 'a list -> 'a list (* raises Failure *)
 end
 
 module Array :

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -31,8 +31,6 @@ sig
   val make : int -> 'a -> 'a list
   val table : int -> (int -> 'a) -> 'a list
   val group : ('a -> 'a -> bool) -> 'a list -> 'a list list
-  val take : int -> 'a list -> 'a list (* raises Failure *)
-  val drop : int -> 'a list -> 'a list (* raises Failure *)
   val replicate : 'a -> int -> 'a list
   val split_at : int -> 'a list -> ('a list * 'a list)
   val split3 : ('a * 'b * 'c) list -> ('a list * 'b list * 'c list)

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -27,7 +27,6 @@ type ('a, 'b) these =
 
 module List :
 sig
-  val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
   val make : int -> 'a -> 'a list
   val table : int -> (int -> 'a) -> 'a list
   val group : ('a -> 'a -> bool) -> 'a list -> 'a list list

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -43,7 +43,6 @@ sig
   val index_of : 'a -> 'a list -> int option
   val index_where : ('a -> bool) -> 'a list -> int option
 
-  val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
   val is_ordered : ('a -> 'a -> int) -> 'a list -> bool
   val is_strictly_ordered : ('a -> 'a -> int) -> 'a list -> bool
   val is_prefix : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool

--- a/src/lib/lib.mli
+++ b/src/lib/lib.mli
@@ -49,8 +49,6 @@ sig
 
   val iter_pairs : ('a -> 'a -> unit) -> 'a list -> unit
 
-  val safe_map : ('a -> 'b) -> 'a list -> 'b list
-
   (** Assumes the two lists have been sorted with respect to the comparison function *)
   val align : ('a -> 'b -> int) -> 'a list -> 'b list -> ('a, 'b) these Seq.t
 end

--- a/src/linking/linkModule.ml
+++ b/src/linking/linkModule.ml
@@ -112,8 +112,6 @@ exception LinkError of string
 exception TooLargeDataSegments of string
 
 
-let safe_map = Lib.List.safe_map
-
 type imports = (int32 * name) list
 
 let map_module f (em : extended_module) = { em with module_ = f em.module_ }
@@ -308,7 +306,7 @@ let remove_non_ic_exports (em : extended_module) : extended_module =
 type renumbering = int32 -> int32
 
 let resolve imports exports : (int32 * int32) list =
-  List.flatten (safe_map (fun (fi, name) ->
+  List.flatten (List.map (fun (fi, name) ->
     match NameMap.find_opt name exports with
     | Some fi' -> [ (fi, fi') ]
     | None -> []
@@ -360,21 +358,21 @@ let rename_globals rn : module_' -> module_' = fun m ->
     | GlobalSet v -> GlobalSet (var v)
     | i -> i
   and instr i = phrase instr' i
-  and instrs is = safe_map instr is in
+  and instrs is = List.map instr is in
 
   let func' f = { f with body = instrs f.body } in
   let func = phrase func' in
-  let funcs = safe_map func in
+  let funcs = List.map func in
 
   let const = phrase instrs in
 
   let global' g = { g with value = const g.value } in
   let global = phrase global' in
-  let globals = safe_map global in
+  let globals = List.map global in
 
   let table_segment' (s : var list segment') = { s with offset = const s.offset; } in
   let table_segment = phrase (table_segment') in
-  let table_segments = safe_map table_segment in
+  let table_segments = List.map table_segment in
 
   let segment_mode' (dmode : segment_mode') = 
     match dmode with 
@@ -385,7 +383,7 @@ let rename_globals rn : module_' -> module_' = fun m ->
   let segment_mode = phrase (segment_mode') in
   let data_segment' (s : data_segment') = { s with dmode = segment_mode s.dmode; } in
   let data_segment = phrase (data_segment') in
-  let data_segments = safe_map data_segment in
+  let data_segments = List.map data_segment in
 
   (* The exports are used to resolve `GOT.mem`. 
      Therefore, also update the exported global indices. *)
@@ -396,7 +394,7 @@ let rename_globals rn : module_' -> module_' = fun m ->
   let export_desc = phrase (export_desc') in
   let export' (e: export') = { e with edesc = export_desc e.edesc } in
   let export = phrase export' in
-  let exports = safe_map export in
+  let exports = List.map export in
 
   { m with
     funcs = funcs m.funcs;
@@ -435,21 +433,21 @@ let fill_global (global : int32) (value : Wasm_exts.Values.value) (uses_memory64
     | GlobalSet v when v.it = global -> assert false
     | i -> i
   and instr i = phrase instr' i
-  and instrs is = safe_map instr is in
+  and instrs is = List.map instr is in
 
   let func' f = { f with body = instrs f.body } in
   let func = phrase func' in
-  let funcs = safe_map func in
+  let funcs = List.map func in
 
   let const = phrase instrs in
 
   let global' g = { g with value = const g.value } in
   let global = phrase global' in
-  let globals = safe_map global in
+  let globals = List.map global in
 
   let table_segment' (s : var list segment') = { s with offset = const s.offset; } in
   let table_segment = phrase (table_segment') in
-  let table_segments = safe_map table_segment in
+  let table_segments = List.map table_segment in
 
   let segment_mode' (dmode : segment_mode') = 
     match dmode with 
@@ -460,7 +458,7 @@ let fill_global (global : int32) (value : Wasm_exts.Values.value) (uses_memory64
   let segment_mode = phrase (segment_mode') in
   let data_segment' (s : data_segment') = { s with dmode = segment_mode s.dmode; } in
   let data_segment = phrase (data_segment') in
-  let data_segments = safe_map data_segment in
+  let data_segments = List.map data_segment in
 
 
   { m with
@@ -472,8 +470,8 @@ let fill_global (global : int32) (value : Wasm_exts.Values.value) (uses_memory64
 
 let rename_funcs_name_section rn (ns : name_section) =
   { ns with
-    function_names = safe_map (fun (fi, name) -> (rn fi, name)) ns.function_names;
-    locals_names = safe_map (fun (fi, locals) -> (rn fi, locals)) ns.locals_names;
+    function_names = List.map (fun (fi, name) -> (rn fi, name)) ns.function_names;
+    locals_names = List.map (fun (fi, locals) -> (rn fi, locals)) ns.locals_names;
   }
 
 let rename_funcs_extended rn (em : extended_module) =
@@ -501,11 +499,11 @@ let rename_types rn m =
     | If (bty, is1, is2) -> If (block_type bty, instrs is1, instrs is2)
     | i -> i
   and instr i = phrase instr' i
-  and instrs is = safe_map instr is in
+  and instrs is = List.map instr is in
 
   let func' f = { f with ftype = ty_var f.ftype; body = instrs f.body } in
   let func = phrase func' in
-  let funcs = safe_map func in
+  let funcs = List.map func in
 
   let idesc' = function
     | FuncImport tv -> FuncImport (ty_var tv)
@@ -513,7 +511,7 @@ let rename_types rn m =
   let idesc = phrase idesc' in
   let import' i = { i with idesc = idesc i.idesc } in
   let import = phrase import' in
-  let imports = safe_map import in
+  let imports = List.map import in
 
   { m with
     funcs = funcs m.funcs;
@@ -830,7 +828,7 @@ let collect_got_imports (m : module_') : got_import list =
    This is done by adding the library memory base (`lib_heap_start`) to the offset
    that is stored in the exported global that corresponds to the GOT.mem import. *)
 let patch_got_mem_accesses got_mem_imports memory_base = fun m ->
-  let phrase_one_to_many f x = safe_map (fun y -> { x with it = y }) (f x.it) in
+  let phrase_one_to_many f x = List.map (fun y -> { x with it = y }) (f x.it) in
 
   let find_got_mem global_index =
     List.find_opt (fun (index, _, _) -> index = global_index) got_mem_imports
@@ -860,11 +858,11 @@ let patch_got_mem_accesses got_mem_imports memory_base = fun m ->
     | If (ty, is1, is2) -> [If (ty, instrs is1, instrs is2)]
     | i -> [i]
   and instr (i: instr) : instr list = phrase_one_to_many instr' i
-  and instrs (is : instr list) : instr list = List.flatten (safe_map instr is) in
+  and instrs (is : instr list) : instr list = List.flatten (List.map instr is) in
 
   let func' f = { f with body = instrs f.body } in
   let func = phrase func' in
-  let funcs = safe_map func in
+  let funcs = List.map func in
 
   { m with
     funcs = funcs m.funcs;
@@ -881,7 +879,7 @@ let replace_got_imports (lib_memory_base : int32) (table_size : int32) (imports:
       | _ -> None
     ) imports
   in
-  let elements = safe_map
+  let elements = List.map
     (fun (_, _, function_index) -> function_index @@ no_region)
     got_func_imports
   in
@@ -918,7 +916,7 @@ let replace_got_imports (lib_memory_base : int32) (table_size : int32) (imports:
     | GlobalType (I64Type, _) -> mk_i64_global 0L
     | _ -> raise (LinkError "GOT.mem global type is not supported"))
   in
-  let dummy_globals = safe_map
+  let dummy_globals = List.map
     (fun (global_index, global_type, _) -> (global_index, dummy_global global_type))
     memory_imports
   in
@@ -929,7 +927,7 @@ let replace_got_imports (lib_memory_base : int32) (table_size : int32) (imports:
   in
   let new_globals = function_globals @ dummy_globals
     |> List.sort (fun (left, _) (right, _) -> compare left right)
-    |> safe_map (fun (_, global) -> global @@ no_region)
+    |> List.map (fun (_, global) -> global @@ no_region)
   in
   (* Move GOT globals from import section to the beginning of module's global section.
      The movement is based on the following assumption that is checked in `collect_got_imports`:
@@ -1089,7 +1087,7 @@ let link (em1 : extended_module) libname (em2 : extended_module) =
     Hashtbl.to_seq type_indices |>
     List.of_seq |>
     List.sort (fun (_, idx1) (_, idx2) -> compare idx1 idx2) |>
-    safe_map (fun (ty, _) -> ty @@ no_region)
+    List.map (fun (ty, _) -> ty @@ no_region)
   in
 
   let add_initial_call function_name =
@@ -1118,7 +1116,7 @@ let link (em1 : extended_module) libname (em2 : extended_module) =
     let segment_mode = phrase (segment_mode') in
     let data_segment' (s : data_segment') = { s with dmode = segment_mode s.dmode; } in
     let data_segment = phrase (data_segment') in
-    let data_segments = safe_map data_segment in
+    let data_segments = List.map data_segment in
     { m with datas = data_segments m.datas; }
   in
 
@@ -1199,7 +1197,7 @@ let link (em1 : extended_module) libname (em2 : extended_module) =
 
   (* Rename global and function indices in GOT stuff *)
   let got_imports =
-    safe_map (function
+    List.map (function
       | { global_index; global_type; kind = GotFunc { function_index }} ->
         { global_index = globals2 global_index;
           global_type;

--- a/src/mo_idl/idl_to_mo_value.ml
+++ b/src/mo_idl/idl_to_mo_value.ml
@@ -90,7 +90,7 @@ let rec value v t =
     (Diag.error_message v.at "M0165" "import" "odd expected type"))
 
 let rec args vs = function
-  | ts when List.(compare_lengths vs.it ts < 0 && for_all is_defaultable (Lib.List.drop (length vs.it) ts)) ->
+  | ts when List.(compare_lengths vs.it ts < 0 && for_all is_defaultable (drop (length vs.it) ts)) ->
     let vs' = vs.it @ Lib.List.replicate { vs with it = NullV } List.(length ts - length vs.it) in
     args {vs with it = vs'} ts
   | ts -> parens_comma (List.map2 value (List.map2 enrich ts vs.it) ts)

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -2015,8 +2015,8 @@ let pp_print_list ?(pp_sep = pp_print_cut) pp_v ppf v =
      if len < max then
        pp_print_list ~pp_sep pp_v ppf v
      else
-       let pre_vs = Lib.List.take (max / 2) v in
-       let post_vs = Lib.List.drop (len - (max / 2)) v in
+       let pre_vs = List.take (max / 2) v in
+       let post_vs = List.drop (len - (max / 2)) v in
        pp_print_list ~pp_sep pp_v ppf pre_vs;
        pp_sep ppf ();
        fprintf ppf "...@ ";

--- a/src/mo_values/value.ml
+++ b/src/mo_values/value.ml
@@ -134,7 +134,7 @@ let rec compare x1 x2 =
   | Nat32 n1, Nat32 n2 -> Nat32.compare n1 n2
   | Nat64 n1, Nat64 n2 -> Nat64.compare n1 n2
   | Opt v1, Opt v2 -> compare v1 v2
-  | Tup vs1, Tup vs2 -> Lib.List.compare compare vs1 vs2
+  | Tup vs1, Tup vs2 -> List.compare compare vs1 vs2
   | Array a1, Array a2 -> Lib.Array.compare compare a1 a2
   | Obj fs1, Obj fs2 -> Env.compare compare fs1 fs2
   | Variant (l1, v1), Variant (l2, v2) ->

--- a/src/wasm-exts/ast.ml
+++ b/src/wasm-exts/ast.ml
@@ -340,11 +340,11 @@ let rename_funcs rn : module_' -> module_' = fun m ->
     | If (ty, is1, is2) -> If (ty, instrs is1, instrs is2)
     | i -> i
   and instr i = phrase instr' i
-  and instrs is = Lib.List.safe_map instr is in
+  and instrs is = List.map instr is in
 
   let func' f = { f with body = instrs f.body } in
   let func = phrase func' in
-  let funcs = Lib.List.safe_map func in
+  let funcs = List.map func in
 
   let edesc' = function
     | FuncExport v -> FuncExport (var v)
@@ -352,7 +352,7 @@ let rename_funcs rn : module_' -> module_' = fun m ->
   let edesc = phrase edesc' in
   let export' e = { e with edesc = edesc e.edesc } in
   let export = phrase export' in
-  let exports = Lib.List.safe_map export in
+  let exports = List.map export in
 
   let segment' f s = { s with init  = f s.init } in
   let segment f = phrase (segment' f) in
@@ -361,5 +361,5 @@ let rename_funcs rn : module_' -> module_' = fun m ->
     funcs = funcs m.funcs;
     exports = exports m.exports;
     start = Option.map var m.start;
-    elems = Lib.List.safe_map (segment (Lib.List.safe_map var)) m.elems;
+    elems = List.map (segment (List.map var)) m.elems;
   }


### PR DESCRIPTION
## Summary

Follow-up to #6028 (OCaml 4.14 → 5.3 bump). Five isolated commits, each removing a `Lib.List*` function that is now redundant with the stdlib (or dead code). Easy to review one-by-one.

## Commits

### 1. `drop Lib.List.take/drop` — now in OCaml 5.3 stdlib

OCaml 5.3 adds `List.take` / `List.drop` to the stdlib. Three call sites in the tree retargeted; `Lib.List.split_at` now delegates to the stdlib versions.

**Semantics note.** The custom versions raised `Failure` on short list; stdlib returns the short result. All three call sites guard `n ∈ [0, length xs]`, so the difference is not observable:

- `src/mo_idl/idl_to_mo_value.ml:93` — `drop (length vs.it) ts` guarded by `compare_lengths vs.it ts < 0`.
- `src/mo_types/type.ml:2018-2019` — `take (max/2)` / `drop (len − max/2)` guarded by `len >= max`.

### 2. `drop Lib.List.equal` — in stdlib since 4.12

No callers in tree. Stdlib's `List.equal eq l1 l2` returns `false` on length mismatch, matching the custom `try List.for_all2 … with _ -> false`.

### 3. `drop Lib.List.compare` — in stdlib since 4.12

Stdlib's `List.compare` has identical lexicographic semantics (shorter list < longer). One caller in `src/mo_values/value.ml` updated.

### 4. `drop dead Lib.List32.take / Lib.List32.drop`

No callers anywhere in the source tree. The `int32`-indexed variants are not provided by stdlib (so this isn't a stdlib-alignment change like its int-variant siblings), just dead-code cleanup while the surrounding module is being touched.

### 5. `drop Lib.List.safe_map` — stdlib `List.map` is TMC-tail-recursive since OCaml 5.1

Our `safe_map` was a hand-rolled `[@tail_mod_cons]` variant of `List.map` to avoid stack overflow on long lists. OCaml 5.1 reimplemented `Stdlib.List.map` using the same attribute, so the wrapper is now dead weight. All ~30 call sites (most of them in `src/linking/linkModule.ml`, a few in `src/wasm-exts/ast.ml`) replaced with `List.map`. Per @crusso's review.

## Test plan

- [x] `nix develop -c make -C src moc` — builds clean after each commit.
- [x] Broader test execution deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)