### PR TITLE
test-runner: auto-detect persistence mode per test

### DIFF
--- a/.agents/skills/build-and-test/SKILL.md
+++ b/.agents/skills/build-and-test/SKILL.md
@@ -103,13 +103,24 @@ relevant to your change:
 test-runner -baf some-test         # targeted by name pattern
 ```
 
-**EOP (Enhanced Orthogonal Persistence) tests**: By default, `run-drun/` tests
-run in non-EOP mode. To run the EOP variant, prefix the command with
-`EXTRA_MOC_ARGS="--enhanced-orthogonal-persistence"`:
+**EOP (Enhanced Orthogonal Persistence) tests**: `test-runner` detects the
+persistence mode automatically from markers in the test file — you don't
+need to set any environment variable. The rules (mirrored from `test/run.sh`):
 
-```bash
-EXTRA_MOC_ARGS="--enhanced-orthogonal-persistence" test-runner -baf run-drun/some-test
-```
+- `//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY` (or `# ...` in `.drun`),
+  `//MOC-FLAG --enhanced-orthogonal-persistence`, or
+  `//MOC-FLAG --enhanced-migration...` → run in EOP mode only.
+- `//CLASSICAL-PERSISTENCE-ONLY`, `//INCREMENTAL-GC-ONLY`,
+  `//GENERATIONAL-GC-ONLY`, `//MOC-FLAG --legacy-persistence`, or
+  `//MOC-FLAG --{incremental,generational,compacting,copying}-gc` → run in
+  classical mode only.
+- No persistence-relevant marker → run in **both** modes; both must pass
+  against the same `ok/*.ok` golden.
+
+For backwards compatibility, if `EXTRA_MOC_ARGS` is set and already contains
+`--enhanced-orthogonal-persistence` (e.g. legacy nix-driven workflows),
+inference is skipped and `test-runner` runs once with the inherited
+environment.
 
 ## JS Tests
 

--- a/.agents/skills/build-and-test/SKILL.md
+++ b/.agents/skills/build-and-test/SKILL.md
@@ -103,25 +103,6 @@ relevant to your change:
 test-runner -baf some-test         # targeted by name pattern
 ```
 
-**EOP (Enhanced Orthogonal Persistence) tests**: `test-runner` detects the
-persistence mode automatically from markers in the test file — you don't
-need to set any environment variable. The rules (mirrored from `test/run.sh`):
-
-- `//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY` (or `# ...` in `.drun`),
-  `//MOC-FLAG --enhanced-orthogonal-persistence`, or
-  `//MOC-FLAG --enhanced-migration...` → run in EOP mode only.
-- `//CLASSICAL-PERSISTENCE-ONLY`, `//INCREMENTAL-GC-ONLY`,
-  `//GENERATIONAL-GC-ONLY`, `//MOC-FLAG --legacy-persistence`, or
-  `//MOC-FLAG --{incremental,generational,compacting,copying}-gc` → run in
-  classical mode only.
-- No persistence-relevant marker → run in **both** modes; both must pass
-  against the same `ok/*.ok` golden.
-
-For backwards compatibility, if `EXTRA_MOC_ARGS` is set and already contains
-`--enhanced-orthogonal-persistence` (e.g. legacy nix-driven workflows),
-inference is skipped and `test-runner` runs once with the inherited
-environment.
-
 ## JS Tests
 
 ```bash

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -1,5 +1,7 @@
+mod mode;
 mod review;
 mod test_runner;
+use crate::mode::Mode;
 use crate::test_runner::SubnetType;
 use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -10,6 +12,7 @@ use regex::Regex;
 use std::cell::RefCell;
 use std::env;
 use std::io::Read;
+use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -260,30 +263,72 @@ fn run_single_test(test_name: String, args: &TestRunnerArgs) -> SingleTestResult
         None
     };
 
-    let flags: Option<String> = match (args.accept, mode_flag) {
-        (true, Some(m)) => Some(format!("-a{m}")),
-        (true, None) => Some("-a".to_string()),
-        (false, Some(m)) => Some(format!("-{m}")),
-        (false, None) => None,
+    // Legacy: if EXTRA_MOC_ARGS already forces EOP, run once inheriting env;
+    // otherwise infer mode(s) from in-test markers.
+    let inherited_eop = env::var("EXTRA_MOC_ARGS")
+        .unwrap_or_default()
+        .contains("--enhanced-orthogonal-persistence");
+    let modes = if inherited_eop {
+        vec![Mode::Eop]
+    } else {
+        mode::infer_modes(Path::new(&test_name))
     };
+    let multi_mode = modes.len() > 1;
 
-    let mut cmd = Command::new("test/run.sh");
-    if let Some(f) = &flags {
-        cmd.arg(f);
+    let mut combined_stdout = String::new();
+    let mut combined_stderr = String::new();
+    let mut success = true;
+
+    for (i, mode) in modes.iter().copied().enumerate() {
+        // Multi-mode accept: accept on i==0; later modes diff against the
+        // fresh golden, catching cross-mode divergence.
+        let mut flags = String::new();
+        if args.accept && i == 0 {
+            flags.push('a');
+        }
+        if let Some(m) = mode_flag {
+            flags.push(m);
+        }
+
+        let mut cmd = Command::new("test/run.sh");
+        if !flags.is_empty() {
+            cmd.arg(format!("-{flags}"));
+        }
+        cmd.arg(&test_name);
+
+        let extra = mode.extra_moc_args();
+        if !inherited_eop && !extra.is_empty() {
+            let existing = env::var("EXTRA_MOC_ARGS").unwrap_or_default();
+            cmd.env(
+                "EXTRA_MOC_ARGS",
+                if existing.is_empty() {
+                    extra.to_string()
+                } else {
+                    format!("{existing} {extra}")
+                },
+            );
+        }
+
+        let out = cmd.output().unwrap_or_else(|_| {
+            panic!("Failed to run test: {:?}.", test_name.as_str())
+        });
+        if !out.status.success() {
+            success = false;
+        }
+
+        if multi_mode {
+            let header = format!("=== mode: {} ===\n", mode.label());
+            combined_stdout.push_str(&header);
+            combined_stderr.push_str(&header);
+        }
+        combined_stdout.push_str(&String::from_utf8_lossy(&out.stdout));
+        combined_stderr.push_str(&String::from_utf8_lossy(&out.stderr));
     }
-    cmd.arg(&test_name);
-
-    let running_test = cmd.output().unwrap_or_else(|_| {
-        panic!(
-            "OS-related error. Failed to run test: {:?}.",
-            test_name.as_str()
-        )
-    });
 
     SingleTestResult {
-        success: running_test.status.success(),
-        stdout: String::from_utf8_lossy(&running_test.stdout).to_string(),
-        stderr: String::from_utf8_lossy(&running_test.stderr).to_string(),
+        success,
+        stdout: combined_stdout,
+        stderr: combined_stderr,
         test_name,
     }
 }

--- a/test-runner/src/mode.rs
+++ b/test-runner/src/mode.rs
@@ -1,0 +1,221 @@
+//! Per-test persistence mode inference for test-runner.
+//!
+//! Motoko tests self-declare their applicable persistence mode(s) via markers.
+//! Unmarked tests are run in both classical and EOP (both must agree on the
+//! same `ok/*.ok`). See `scan_force_eop`/`scan_force_classical` for markers.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Mode {
+    Classical,
+    Eop,
+}
+
+impl Mode {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Mode::Classical => "classical",
+            Mode::Eop => "eop",
+        }
+    }
+
+    /// Flags appended to `EXTRA_MOC_ARGS` for this mode (empty = leave env untouched).
+    pub fn extra_moc_args(&self) -> &'static str {
+        match self {
+            Mode::Classical => "",
+            Mode::Eop => "--enhanced-orthogonal-persistence",
+        }
+    }
+}
+
+/// Infer applicable modes. For `.drun`, a marker on the `.drun` itself wins
+/// over any marker in referenced `.mo` files (e.g. classical→EOP upgrade
+/// scenarios). Conflicts are warned and fall back to both modes.
+pub fn infer_modes(path: &Path) -> Vec<Mode> {
+    let Ok(content) = fs::read_to_string(path) else {
+        return vec![Mode::Classical, Mode::Eop];
+    };
+
+    let (mut eop, mut classical) = scan_markers(&content);
+    let is_drun = path.extension().and_then(|e| e.to_str()) == Some("drun");
+    if is_drun && !eop && !classical {
+        for mo in referenced_mo_files(path, &content) {
+            if let Ok(c) = fs::read_to_string(&mo) {
+                let (e, cl) = scan_markers(&c);
+                eop |= e;
+                classical |= cl;
+            }
+        }
+    }
+
+    match (eop, classical) {
+        (true, false) => vec![Mode::Eop],
+        (false, true) => vec![Mode::Classical],
+        (e, _) => {
+            if e {
+                eprintln!(
+                    "test-runner: {} has conflicting persistence-mode markers; running in both modes",
+                    path.display()
+                );
+            }
+            vec![Mode::Classical, Mode::Eop]
+        }
+    }
+}
+
+/// `.mo` tokens referenced from a `.drun`, resolved relative to its dir.
+fn referenced_mo_files(drun_path: &Path, content: &str) -> Vec<PathBuf> {
+    let parent = drun_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut seen = HashSet::new();
+    content
+        .split_whitespace()
+        .filter(|t| t.ends_with(".mo") && seen.insert(t.to_string()))
+        .map(|t| parent.join(t))
+        .collect()
+}
+
+/// Single-pass scan returning (force_eop, force_classical).
+fn scan_markers(content: &str) -> (bool, bool) {
+    let (mut eop, mut classical) = (false, false);
+    for line in content.lines() {
+        eop |= line.contains("ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY");
+        classical |= line.contains("CLASSICAL-PERSISTENCE-ONLY")
+            || line.contains("INCREMENTAL-GC-ONLY")
+            || line.contains("GENERATIONAL-GC-ONLY");
+        let Some(rest) = line.trim_start().strip_prefix("//MOC-FLAG") else {
+            continue;
+        };
+        for f in rest.split_whitespace() {
+            eop |= f == "--enhanced-orthogonal-persistence" || f.starts_with("--enhanced-migration");
+            classical |= matches!(
+                f,
+                "--legacy-persistence"
+                    | "--incremental-gc"
+                    | "--generational-gc"
+                    | "--compacting-gc"
+                    | "--copying-gc"
+            );
+        }
+    }
+    (eop, classical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(name: &str, contents: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("motoko-mode-test-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join(name);
+        fs::File::create(&path).unwrap().write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    fn modes_of(name: &str, contents: &str) -> Vec<Mode> {
+        infer_modes(&write_tmp(name, contents))
+    }
+
+    const C: Mode = Mode::Classical;
+    const E: Mode = Mode::Eop;
+
+    #[test]
+    fn unmarked_mo_runs_both() {
+        assert_eq!(modes_of("plain.mo", "actor {}\n"), vec![C, E]);
+    }
+
+    #[test]
+    fn eop_only_marker_mo() {
+        assert_eq!(modes_of("eop.mo", "//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY\n"), vec![E]);
+    }
+
+    #[test]
+    fn classical_only_marker_mo() {
+        assert_eq!(modes_of("classic.mo", "//CLASSICAL-PERSISTENCE-ONLY\n"), vec![C]);
+    }
+
+    #[test]
+    fn moc_flag_enhanced_op_implies_eop() {
+        assert_eq!(modes_of("f1.mo", "//MOC-FLAG --enhanced-orthogonal-persistence\n"), vec![E]);
+    }
+
+    #[test]
+    fn moc_flag_enhanced_migration_implies_eop() {
+        assert_eq!(modes_of("f2.mo", "//MOC-FLAG --enhanced-migration migrations/\n"), vec![E]);
+    }
+
+    #[test]
+    fn moc_flag_legacy_implies_classical() {
+        assert_eq!(modes_of("f3.mo", "//MOC-FLAG --legacy-persistence\n"), vec![C]);
+    }
+
+    #[test]
+    fn moc_flag_incremental_gc_implies_classical() {
+        assert_eq!(modes_of("f4.mo", "//MOC-FLAG --incremental-gc\n"), vec![C]);
+    }
+
+    #[test]
+    fn incremental_gc_only_marker_implies_classical() {
+        assert_eq!(modes_of("f5.mo", "//INCREMENTAL-GC-ONLY\n"), vec![C]);
+    }
+
+    #[test]
+    fn conflicting_markers_fall_back_to_both() {
+        assert_eq!(
+            modes_of(
+                "conflict.mo",
+                "//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY\n//MOC-FLAG --legacy-persistence\n"
+            ),
+            vec![C, E]
+        );
+    }
+
+    fn drun_project(name: &str, drun: &str, mos: &[(&str, &str)]) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("motoko-mode-{}-{}", name, std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{name}.drun"));
+        fs::write(&path, drun).unwrap();
+        for (rel, body) in mos {
+            let p = dir.join(rel);
+            fs::create_dir_all(p.parent().unwrap()).unwrap();
+            fs::write(p, body).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn drun_classical_marker() {
+        let p = drun_project("d1", "# CLASSICAL-PERSISTENCE-ONLY\n", &[]);
+        assert_eq!(infer_modes(&p), vec![C]);
+    }
+
+    #[test]
+    fn drun_classical_marker_wins_over_referenced_mo_eop_flag() {
+        // Mirrors migration-paths.drun: .drun-level marker wins over per-.mo flags.
+        let p = drun_project(
+            "d2",
+            "# CLASSICAL-PERSISTENCE-ONLY\ninstall $ID proj/a.mo \"\"\nupgrade $ID proj/b.mo \"\"\n",
+            &[("proj/a.mo", "actor {}\n"), ("proj/b.mo", "//MOC-FLAG --enhanced-orthogonal-persistence\n")],
+        );
+        assert_eq!(infer_modes(&p), vec![C]);
+    }
+
+    #[test]
+    fn drun_picks_up_referenced_mo_marker() {
+        let p = drun_project(
+            "d3",
+            "install $ID proj/a.mo \"\"\n",
+            &[("proj/a.mo", "//MOC-FLAG --enhanced-orthogonal-persistence\n")],
+        );
+        assert_eq!(infer_modes(&p), vec![E]);
+    }
+
+    #[test]
+    fn nonexistent_file_defaults_to_both() {
+        assert_eq!(infer_modes(&PathBuf::from("/nonexistent.mo")), vec![C, E]);
+    }
+}


### PR DESCRIPTION
## Summary
- `test-runner` now infers applicable persistence mode(s) from markers in each test file; no more manual `EXTRA_MOC_ARGS=--enhanced-orthogonal-persistence`.
- Unmarked tests run in both classical and EOP against the shared `ok/*.ok`. Marker/flag conventions match those already honored by `test/run.sh`.
- In multi-mode `-a` accept, only the first mode accepts; later modes diff against the fresh golden to catch cross-mode divergence.
- Legacy `EXTRA_MOC_ARGS` env path preserved for CI/Nix (inference skipped, single inherited invocation).
- Zero changes to `test/run.sh`.

## Test plan
- [x] `cargo test --bin test-runner mode::` (13 tests)
- [x] Smoke: `test-runner -bf bad-field-dec` inside nix, runs both modes, passes
- [x] Smoke: `test-runner -baf bad-field-dec` inside nix, accept-then-verify, passes

closes LANG-1273

Made with [Cursor](https://cursor.com)