### PR TITLE
docs(skill): clarify field initializers in migrating-motoko skill

### DIFF
--- a/.agents/skills/migrating-motoko/SKILL.md
+++ b/.agents/skills/migrating-motoko/SKILL.md
@@ -123,14 +123,18 @@ module {
 
 ```motoko
 // main.mo
+import Map "mo:core/Map";
+import Types "types";
 import Migration "migration";
 
 (with migration = Migration.run)
 actor {
-  var tasks : Map.Map<Nat, Types.Task>;
+  var tasks = Map.empty<Nat, Types.Task>();
   var nextId : Nat = 0;
 };
 ```
+
+Fields must have initializers — the migration function runs only on **upgrade**. On fresh install the initializers are used.
 
 ## Common Patterns
 


### PR DESCRIPTION
The example actor in the `migrating-motoko` skill showed a field without an initializer, which would fail to compile on fresh install. Migrations only run on upgrade, so fields still need initializers.

Updated the example to use `Map.empty<...>()` and added the missing `Map`/`Types` imports, plus a one-line note explaining the constraint.

Made with [Cursor](https://cursor.com)