### PR TITLE
ci: bump `cachix-action` v16 -> v17 in `test-blueprint`

### DIFF
--- a/.github/actions/test-blueprint/action.yml
+++ b/.github/actions/test-blueprint/action.yml
@@ -44,9 +44,9 @@ runs:
       with:
         swap-storage: false
 
-    - uses: cachix/install-nix-action@v31
+    - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
 
-    - uses: cachix/cachix-action@v16
+    - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
       with:
         name: ic-hs-test
         authToken: ${{ inputs.cachix-auth-token }}


### PR DESCRIPTION
## Summary

Every `build` workflow run on master currently emits a deprecation annotation:

> **Node.js 20 actions are deprecated.** The following actions are running on Node.js 20 and may not work as expected: `cachix/cachix-action@v16`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

Source: `.github/actions/test-blueprint/action.yml` was missed when the rest of the repo bumped `cachix/cachix-action` v16 → v17. The other workflows (`build.yml`, `release.yml`, `test.yml`) already use the v17 SHA `1eb2ef6…`.

This PR brings the composite action in line:

| action | before | after |
|--|--|--|
| `cachix/cachix-action` | `@v16` | `@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17` |
| `cachix/install-nix-action` | `@v31` | `@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5` |

(Both SHAs match the pins already in use elsewhere in the repo. `install-nix-action` isn't deprecated — included for style consistency.)

## Test plan

- [ ] CI passes (build / test / common-tests / gc-tests on all matrix legs)
- [x] Deprecation annotation about `cachix/cachix-action@v16` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)