### PR TITLE
chore: switch GitHub App auth from `app-id` to `client-id`

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
       id: app-token
       with:
-        app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
+        client-id: ${{ vars.GENERIC_CI_RW_APP_CLIENT_ID }}
         private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
+          client-id: ${{ vars.GENERIC_CI_RW_APP_CLIENT_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
           repositories: motoko,node-motoko
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
+          client-id: ${{ vars.GENERIC_CI_RW_APP_CLIENT_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
 
       - name: Run Performance Tests
@@ -196,7 +196,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token-for-approvals
         with:
-          app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
+          client-id: ${{ vars.GENERIC_CI_RW_APP_CLIENT_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
       - name: Hand out single-file review approvals
         env:

--- a/.github/workflows/update-flake-lock-trial.yml
+++ b/.github/workflows/update-flake-lock-trial.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
+          client-id: ${{ vars.GENERIC_CI_RW_APP_CLIENT_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@3d82c7e1a46ddcc239881a2ac62b0d9d970dc96b # main

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
+          client-id: ${{ vars.GENERIC_CI_RW_APP_CLIENT_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@3d82c7e1a46ddcc239881a2ac62b0d9d970dc96b # main

--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776221942,
-        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
+        "lastModified": 1777077449,
+        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
+        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
         "type": "github"
       },
       "original": {
@@ -247,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775704356,
-        "narHash": "sha256-A9JX65WofIF8OKrkMsjznSYNj/A4hfJfEGonsEQ9kxA=",
+        "lastModified": 1777259803,
+        "narHash": "sha256-fIb/EoVu/1U0qVrE6qZCJ2WCfprRpywNIAVzKEACIQc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "55660228072f38c64c4d2fd227944334dc3f4326",
+        "rev": "a6cb2224d975e16b5e67de688c6ad306f7203425",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

`actions/create-github-app-token` deprecated the `app-id` input in favour of `client-id` — the canonical GitHub App identifier. Every job that creates an installation token currently logs a warning:

> Input `app-id` has been deprecated with message: Use 'client-id' instead.

Org admin has provisioned `vars.GENERIC_CI_RW_APP_CLIENT_ID`. This PR migrates all six call sites:

- `.github/workflows/release-pr.yml`
- `.github/workflows/release.yml`
- `.github/workflows/test.yml` (×2)
- `.github/workflows/update-flake-lock.yml`
- `.github/workflows/update-flake-lock-trial.yml`

Each site flips
```
app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
```
to
```
client-id: ${{ vars.GENERIC_CI_RW_APP_CLIENT_ID }}
```

## Why no SHA bump

The existing pin (`1b10c78c…`) already resolves to v3.1.1 of `actions/create-github-app-token`, which supports both inputs. Only the input field name needs to change.

## Test plan

- [x] Test workflow passes on the PR
- [x] No `app-id deprecated` warning in any annotated run
- [x] `update-flake-lock-trial` cron runs cleanly (it's the simplest end-to-end exercise of the App token path) — See #6061

🤖 Generated with [Claude Code](https://claude.com/claude-code)