### PR TITLE
fix: enhanced migration functions instead of inlined code

### DIFF
--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -824,11 +824,11 @@ and build_actor at chain ts (exp_opt : Ir.exp option) self_id es obj_typ0 =
          produce type_k.
          Base case (k=0): ICStableRead(type_0) loads the pre-migration actor
          or returns defaults on fresh install. *)
-      let step_decls = ref [] in
+      let step_decls = Dynarray.create () in
       let emit_step k body =
         let step_typ = T.Func (T.Local, T.Returns, [], [], [mem_typ_at k]) in
         let step = fresh_var (Printf.sprintf "migrate_step_%d" k) step_typ in
-        step_decls := nary_funcD step [] body :: !step_decls;
+        Dynarray.add_last step_decls (nary_funcD step [] body);
         callE (varE step) [] (unitE ())
       in
       let rec build_nested k =
@@ -895,7 +895,7 @@ and build_actor at chain ts (exp_opt : Ir.exp option) self_id es obj_typ0 =
       T.Multi {chain = chain_fields; post = stab_fields},
       I.{pre = mem_typ_at 0; post = mem_ty},
       blockE (
-        List.rev !step_decls @ [
+        Dynarray.to_list step_decls @ [
           letD final_state init_call;
           expD (primE (I.ICStableStore mem_ty) []);
         ]) (varE final_state)

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -814,15 +814,26 @@ and build_actor at chain ts (exp_opt : Ir.exp option) self_id es obj_typ0 =
       assert (n <> 0);
       let mem_typ_at idx = List.nth mem_typs idx
       in
-      (* Nested if-expression: each level k produces state_k : type_k.
+      (* Each level k is emitted as its own local function migrate_step_k,
+         so per-step IC complexity stays independent of N (lifts the
+         IC0505 wasm-function-complexity cap on chain length). Body of
+         migrate_step_k:
          If m_k was already performed, ICStableRead(type_k) loads the state.
-         Otherwise, recursively build state_{k-1}, run m_k, and merge output
-         with carried fields from state_{k-1} to produce type_k.
+         Otherwise, recursively build state_{k-1} via migrate_step_{k-1}(),
+         run m_k, and merge output with carried fields from state_{k-1} to
+         produce type_k.
          Base case (k=0): ICStableRead(type_0) loads the pre-migration actor
          or returns defaults on fresh install. *)
+      let step_decls = ref [] in
+      let emit_step k body =
+        let step_typ = T.Func (T.Local, T.Returns, [], [], [mem_typ_at k]) in
+        let step = fresh_var (Printf.sprintf "migrate_step_%d" k) step_typ in
+        step_decls := nary_funcD step [] body :: !step_decls;
+        callE (varE step) [] (unitE ())
+      in
       let rec build_nested k =
         if k = 0 then
-          primE (I.ICStableRead (mem_typ_at 0)) []
+          emit_step k (primE (I.ICStableRead (mem_typ_at 0)) [])
         else
           let mem_typ_k = mem_typ_at k in
           let (_, mem_typ_k_fields) = T.as_obj mem_typ_k in
@@ -874,17 +885,20 @@ and build_actor at chain ts (exp_opt : Ir.exp option) self_id es obj_typ0 =
               expD (rts_register_migration mig_lab_k)]
             merge_result
           in
-          ifE (rts_was_migration_performed mig_lab_k)
-            (primE (I.ICStableRead mem_typ_k) [])
-            else_branch
+          emit_step k
+            (ifE (rts_was_migration_performed mig_lab_k)
+              (primE (I.ICStableRead mem_typ_k) [])
+              else_branch)
       in
       let final_state = fresh_var "final_state" mem_ty in
+      let init_call = build_nested n in
       T.Multi {chain = chain_fields; post = stab_fields},
       I.{pre = mem_typ_at 0; post = mem_ty},
-      blockE [
-        letD final_state (build_nested n);
-        expD (primE (I.ICStableStore mem_ty) []);
-      ] (varE final_state)
+      blockE (
+        List.rev !step_decls @ [
+          letD final_state init_call;
+          expD (primE (I.ICStableStore mem_ty) []);
+        ]) (varE final_state)
     end
     else match exp_opt with
     | None ->

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -892,13 +892,11 @@ and build_actor at chain ts (exp_opt : Ir.exp option) self_id es obj_typ0 =
       in
       let final_state = fresh_var "final_state" mem_ty in
       let init_call = build_nested n in
+      Dynarray.add_last step_decls (letD final_state init_call);
+      Dynarray.add_last step_decls (expD (primE (I.ICStableStore mem_ty) []));
       T.Multi {chain = chain_fields; post = stab_fields},
       I.{pre = mem_typ_at 0; post = mem_ty},
-      blockE (
-        Dynarray.to_list step_decls @ [
-          letD final_state init_call;
-          expD (primE (I.ICStableStore mem_ty) []);
-        ]) (varE final_state)
+      blockE (Dynarray.to_list step_decls) (varE final_state)
     end
     else match exp_opt with
     | None ->


### PR DESCRIPTION
`build_nested` previously emitted the entire enhanced-migration chain as a single deeply-nested if-expression inside the actor's init body. Each level inlined `ICStableRead(mem_typ_k)`, per-field dom-extract / range-merge, and the recursive sub-expression, so the whole chain compiled into one Wasm function whose IC complexity grew linearly with N.

Each chain level k is now wrapped in its own local function `migrate_step_k : () -> mem_typ_k`. Level k either ICStableReads its own type (if the migration was already performed) or calls `migrate_step_{k-1}`, runs `m_k`, and merges the result. The actor init body just calls `migrate_step_n`.

**Main concern**: stack grows linearly with the number of migrations now. We can take the risk for now to unblock and then we can fix this with a follow-up fix.

## Measurements

Same experiment as [motoko-enhanced-migration-experiments/RESULTS.md](https://github.com/caffeinelabs/motoko-enhanced-migration-experiments/blob/main/RESULTS.md). Measured as `mops build backend` wall-time, median of 5 runs:

| N    | master moc                       | current change                  |
|-----:|----------------------------------|----------------------------------|
|   86 | 3.3s &nbsp;&nbsp; 851 KB &nbsp;&nbsp; 1,032,211 | 3.2s &nbsp;&nbsp; 825 KB &nbsp;&nbsp; 55,952 |
|   87 | 3.5s &nbsp;&nbsp; 858 KB &nbsp;&nbsp; 1,044,147 | 3.0s &nbsp;&nbsp; 832 KB &nbsp;&nbsp; 56,502 |
|   90 | 3.4s &nbsp;&nbsp; 879 KB &nbsp;&nbsp; 1,079,955 | 3.6s &nbsp;&nbsp; 852 KB &nbsp;&nbsp; 58,152 |
|  100 | 3.8s &nbsp;&nbsp; 949 KB &nbsp;&nbsp; 1,199,315 | 3.5s &nbsp;&nbsp; 919 KB &nbsp;&nbsp; 63,552 |
|  200 | 5.5s &nbsp;&nbsp; 1.62 MB &nbsp;&nbsp; 2,392,915 | 4.9s &nbsp;&nbsp; 1.55 MB &nbsp;&nbsp; 118,152 |
|  300 | 9.8s &nbsp;&nbsp; 2.33 MB &nbsp;&nbsp; 3,586,515 | 6.3s &nbsp;&nbsp; 2.21 MB &nbsp;&nbsp; 172,752 |
|  400 | 15.9s &nbsp;&nbsp; 3.04 MB &nbsp;&nbsp; 4,780,115 | 8.0s &nbsp;&nbsp; 2.86 MB &nbsp;&nbsp; 227,302 |
|  500 | 23.8s &nbsp;&nbsp; 4.94 MB &nbsp;&nbsp; 5,976,219 | 9.5s &nbsp;&nbsp; 3.51 MB &nbsp;&nbsp; 281,902 |
| 1000 | 108s &nbsp;&nbsp; 9.86 MB &nbsp;&nbsp; 11,946,719 | 21.7s &nbsp;&nbsp; 6.79 MB &nbsp;&nbsp; 554,802 |

(Columns: build time, wasm size, max wasm-function complexity.)

**NB**: wasms compress nicely with gzip to under 1MB, so size should not be a big concern for now.

Master moc fails with wasm-function-complexity limit (1M) at N=86.

Fixes LANG-1281
