### PR TITLE
docs: replace dfx references with icp-cli

### DIFF
--- a/doc/md/12-base-core-migration.md
+++ b/doc/md/12-base-core-migration.md
@@ -29,7 +29,12 @@ If you are migrating an existing project, you can keep the `base` import and gra
 ### Important considerations
 
 :::warning Version requirements
-The `core` package depends on new language features, so make sure to update to the latest dfx (0.28+) or Motoko compiler (0.15+) before migrating.
+The `core` package depends on new language features, so make sure to update to the latest Motoko compiler (0.15+) before migrating. You can pin the compiler version in your `mops.toml`:
+
+```toml
+[toolchain]
+moc = "0.15.1"
+```
 :::
 
 When updating to the `core` package:
@@ -958,7 +963,7 @@ If you encounter errors like `field Array_tabulateVar does not exist in module`,
 **Solution:**
 2. Ensure you're using the latest Motoko compiler version
 3. Update the `core` package to the latest version in your `mops.toml`
-4. Clean and rebuild your project: `dfx stop && dfx start --clean`
+4. Reinstall the canister to deploy the updated Wasm with a clean state: `icp deploy <canister_name> --mode reinstall`
 
 ### Migration issues
 

--- a/doc/md/2-install.mdx
+++ b/doc/md/2-install.mdx
@@ -10,9 +10,9 @@ import { OsType, useOs } from "/src/hooks/useOs";
 
 Follow these steps to set up your local Motoko development environment.
 
-### 1. Install the IC SDK
+### 1. Install icp-cli and Mops
 
-To develop Motoko projects, you need the [Motoko compiler (`moc`)](https://github.com/dfinity/motoko/releases). The Internet Computer Software Development Kit (IC SDK) includes the latest version of `moc` along with utilities for creating, deploying, and managing applications.
+To develop Motoko projects, you need [icp-cli](https://github.com/dfinity/icp-cli) for deploying and managing canisters, and [Mops](https://mops.one/) as the Motoko package manager. Mops also manages the Motoko compiler (`moc`) via its toolchain — icp-cli's Motoko recipe invokes `moc` through `mops toolchain bin moc`.
 
 <AdornedTabs defaultValue={useOs().current}>
 <TabItem value={OsType.Linux} label="Linux">
@@ -22,20 +22,19 @@ To develop Motoko projects, you need the [Motoko compiler (`moc`)](https://githu
 <input type="checkbox"/> Open a terminal window.
 <div>
 </div>
-<input type="checkbox"/> Download and <a href="https://nodejs.org/en/download/package-manager">install Node.js</a>.
+<input type="checkbox"/> Download and <a href="https://nodejs.org/en/download/package-manager">install Node.js</a> (version 22 or later).
 
 ---------
 
 ```bash
-sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm ic-mops
 ```
 
-To customize your IC SDK installation, you can use the interactive installation prompt or set [environment variables](/building-apps/developer-tools/dfx/dfx-envars) for a terminal session.
-
-Confirm the IC SDK has been installed (you may need to open a new terminal window):
+Confirm the tools have been installed:
 
 ```bash
-dfx --version
+icp --version
+mops --version
 ```
 
 </TabItem>
@@ -46,7 +45,7 @@ dfx --version
 <input type="checkbox"/> Open a terminal window.
 <div>
 </div>
-<input type="checkbox"/> Download and <a href="https://nodejs.org/en/download/package-manager">install Node.js</a>. Using <a href="https://brew.sh/"> HomeBrew </a> is recommended.
+<input type="checkbox"/> Download and <a href="https://nodejs.org/en/download/package-manager">install Node.js</a> (version 22 or later). Using <a href="https://brew.sh/"> HomeBrew </a> is recommended.
 <div>
 </div>
 <input type="checkbox"/> Apple silicon machines: Download and install Rosetta: <code>softwareupdate --install-rosetta</code>
@@ -54,15 +53,14 @@ dfx --version
 ---------
 
 ```bash
-sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm ic-mops
 ```
 
-To customize your IC SDK installation, you can use the interactive installation prompt or set [environment variables](/building-apps/developer-tools/dfx/dfx-envars) for a terminal session.
-
-Confirm the IC SDK has been installed (you may need to open a new terminal window):
+Confirm the tools have been installed:
 
 ```bash
-dfx --version
+icp --version
+mops --version
 ```
 
 </TabItem>
@@ -71,7 +69,7 @@ dfx --version
 
 #### Prerequisites
 
-`dfx` is not natively supported on Windows. You will need to install a Linux instance via Windows Subsystem for Linux and run all commands within that Linux instance.
+`icp` requires WSL for local development on Windows. You will need to install a Linux instance via Windows Subsystem for Linux and run all commands within that Linux instance.
 
 <input type="checkbox"/> Download and install <a href="https://docs.microsoft.com/en-us/windows/wsl/install"> Windows Subsystem for Linux</a>.
 <div>
@@ -85,20 +83,19 @@ dfx --version
 <input type="checkbox"/> Open the WSL Linux environment. Run all following commands within this environment.
 <div>
 </div>
-<input type="checkbox"/> Download and <a href="https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl">install Node.js</a> within your WSL Linux environment.
+<input type="checkbox"/> Download and <a href="https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl">install Node.js</a> (version 22 or later) within your WSL Linux environment.
 
 ---------
 
 ```bash
-sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm ic-mops
 ```
 
-To customize your IC SDK installation, you can use the interactive installation prompt or set [environment variables](/building-apps/developer-tools/dfx/dfx-envars) for a terminal session.
-
-Confirm the IC SDK has been installed (you may need to open a new terminal window):
+Confirm the tools have been installed:
 
 ```bash
-dfx --version
+icp --version
+mops --version
 ```
 
 </TabItem>
@@ -156,4 +153,3 @@ Develop cross-chain applications and integrate directly with other blockchains.
 - **[Motoko core package](./core/index.md)**
 
 - **[Motoko example projects](https://github.com/dfinity/examples/tree/master/motoko)**
-

--- a/doc/md/fundamentals/2-actors/3-data-persistence.md
+++ b/doc/md/fundamentals/2-actors/3-data-persistence.md
@@ -121,7 +121,7 @@ When upgrading a canister, it is important to verify that the upgrade can procee
 -   Breaking clients due to a Candid interface change.
 
 With [enhanced orthogonal persistence](./6-orthogonal-persistence/enhanced.md), Motoko rejects incompatible changes of stable declarations during an upgrade attempt.
-Moreover, `dfx` checks the two conditions before attempting the upgrade and warns users as necessary.
+Moreover, `icp` checks the two conditions before attempting the upgrade and warns users as necessary.
 
 A Motoko canister upgrade is safe provided:
 
@@ -135,13 +135,13 @@ With [classical orthogonal persistence](./6-orthogonal-persistence/classical.md)
 
 ## Upgrading a canister
 
-If you have a Motoko canister that has already been deployed, then you make changes to that canister's code and want to upgrade it, the command `dfx deploy` will check that the interface is compatible, and if not, displays a warning:
+If you have a Motoko canister that has already been deployed, then you make changes to that canister's code and want to upgrade it, the command `icp deploy` will check that the interface is compatible, and if not, displays a warning:
 
 ```
 You are making a BREAKING change. Other canisters or frontend clients relying on your canister may stop working.
 ```
 
-Motoko canisters using enhanced orthogonal persistence implement an extra safeguard in the runtime system to ensure that the stable data is compatible to exclude any data corruption or misinterpretation. Moreover, `dfx` also warns about incompatibility and dropping stable variables.
+Motoko canisters using enhanced orthogonal persistence implement an extra safeguard in the runtime system to ensure that the stable data is compatible to exclude any data corruption or misinterpretation. Moreover, `icp` also warns about incompatibility and dropping stable variables.
 
 ## Data migration
 

--- a/doc/md/fundamentals/2-actors/4-compatibility.md
+++ b/doc/md/fundamentals/2-actors/4-compatibility.md
@@ -11,7 +11,7 @@ When upgrading a canister, it is important to verify that the upgrade can procee
 -   Introducing an incompatible change in stable declarations.
 -   Breaking clients due to a Candid interface change.
 
-`dfx` checks these properties statically before attempting the upgrade.
+`icp` checks these properties statically before attempting the upgrade.
 Moreover, with [enhanced orthogonal persistence](./6-orthogonal-persistence/enhanced.md), Motoko rejects incompatible changes of stable declarations.
 
 ## Upgrade example
@@ -129,14 +129,14 @@ This is to guarantee that the stable state is always kept safe.
 Error from Canister ...: Canister called `ic0.trap` with message: RTS error: Memory-incompatible program upgrade.
 ```
 
-In addition to Motoko's runtime check, `dfx` raises a warning message for these incompatible changes, including the breaking Candid change.
+In addition to Motoko's runtime check, `icp` raises a warning message for these incompatible changes, including the breaking Candid change.
 
 Motoko tolerates Candid interface changes, since these are more likely to be intentional, breaking changes.
 
 :::danger
-Versions of Motoko using [classical orthogonal persistence](./6-orthogonal-persistence/classical.md) will drop the state and reinitialize the counter with `0.0`, if the `dfx` warning is ignored.
+Versions of Motoko using [classical orthogonal persistence](./6-orthogonal-persistence/classical.md) will drop the state and reinitialize the counter with `0.0`, if the `icp` warning is ignored.
 
-For this reason, users should always heed any compatibility warnings issued by `dfx`.
+For this reason, users should always heed any compatibility warnings issued by `icp`.
 :::
 
 
@@ -284,7 +284,7 @@ The `actor` section after the chain lists the final stable fields, just like a V
 
 ### How compatibility is checked
 
-When upgrading from one version to another, `dfx` and `moc --stable-compatible` compare the old and new stable signatures:
+When upgrading from one version to another, `icp` and `moc --stable-compatible` compare the old and new stable signatures:
 
 - **Old Version 4.0.0 to new Version 4.0.0:** The post-signature (final `actor` fields) of the old code must be compatible with the pre-signature of the new code. The pre-signature of the new code is derived by walking backward through its migration chain: the last unapplied migration determines which fields must be present. Migrations that were already applied (present in the old signature's chain) are skipped automatically.
 
@@ -343,15 +343,15 @@ The upgrade from the second to the third signature is valid: migration `02_Chang
 
 ## Upgrade tooling
 
-`dfx` incorporates an upgrade check. For this purpose, it uses the Motoko compiler (`moc`) that supports:
+`icp` incorporates an upgrade check. For this purpose, it uses the Motoko compiler (`moc`) that supports:
 
 -   `moc --stable-types …​`: Emits stable types to a `.most` file.
 
 -   `moc --stable-compatible <pre> <post>`: Checks two `.most` files for upgrade compatibility.
 
-Motoko embeds `.did` and `.most` files as Wasm custom sections for use by `dfx` or other tools. The `--stable-compatible` check works across all [stable signature versions](#stable-signature-versions) (1.0.0, 3.0.0, and 4.0.0), so `dfx` can verify compatibility regardless of the migration style used by either version.
+Motoko embeds `.did` and `.most` files as Wasm custom sections for use by `icp` or other tools. The `--stable-compatible` check works across all [stable signature versions](#stable-signature-versions) (1.0.0, 3.0.0, and 4.0.0), so `icp` can verify compatibility regardless of the migration style used by either version.
 
-To upgrade e.g. from `cur.wasm` to `nxt.wasm`, `dfx` checks that both the Candid interface and stable variables are compatible:
+To upgrade e.g. from `cur.wasm` to `nxt.wasm`, `icp` checks that both the Candid interface and stable variables are compatible:
 
 ```
 didc check nxt.did cur.did  // nxt <: cur
@@ -371,7 +371,7 @@ cannot be consumed at new type
 With [enhanced orthogonal persistence](./6-orthogonal-persistence/enhanced.md), compatibility errors of stable variables are always detected in the runtime system and if failing, the upgrade is safely rolled back.
 
 :::danger
-With [classical orthogonal persistence](./6-orthogonal-persistence/classical.md), however, an upgrade attempt from `v2.wasm` to `v3.wasm` is unpredictable and may lead to partial or complete data loss if the `dfx` warning is ignored.
+With [classical orthogonal persistence](./6-orthogonal-persistence/classical.md), however, an upgrade attempt from `v2.wasm` to `v3.wasm` is unpredictable and may lead to partial or complete data loss if the `icp` warning is ignored.
 :::
 
 ## Adding record fields
@@ -390,7 +390,7 @@ to *incompatible* stable type interface:
 
 ### Problem
 
-When trying this upgrade, `dfx` issues the following warning:
+When trying this upgrade, `icp` issues the following warning:
 
 ```
 Stable interface compatibility check issued an ERROR for canister ...
@@ -428,7 +428,7 @@ There are two solutions: using a sequence of simple upgrades, or the second, rec
 ``` motoko no-repl file=../../examples/Card-v1b.mo
 ```
 
-`dfx` will issue a warning that `map` will be dropped.
+`icp` will issue a warning that `map` will be dropped.
 
 Make sure you have previously migrated the old state to `newMap` before applying this final reduced version.
 

--- a/doc/md/fundamentals/2-actors/6-orthogonal-persistence/classical.md
+++ b/doc/md/fundamentals/2-actors/6-orthogonal-persistence/classical.md
@@ -12,7 +12,7 @@ Upon upgrade, the classical orthogonal persistence mechanism serializes all stab
 * Shared immutable heap objects can duplicated, leading to potential state explosion on upgrades.
 * Deeply nested structures can lead to a call stack overflow.
 * The serialization and deserialization is expensive and can hit ICP's instruction limits.
-* There is no built-in stable compatibility check in the runtime system. If users ignore the `dfx` upgrade warning, data may be lost or an upgrade fails.
+* There is no built-in stable compatibility check in the runtime system. If users ignore the `icp` upgrade warning, data may be lost or an upgrade fails.
 
 :::danger
 The above-mentioned issues can lead to a stuck canister that can no longer be upgraded.
@@ -29,14 +29,16 @@ previously available only with `moc` compiler flag `--enhanced-orthogonal-persis
 
 Users unwilling or unable to migrate their code can re-enable support for classical orthogonal persistence using the new compiler flag `--legacy-persistence`.
 
-To re-activate classical orthogonal persistence under `dfx`, the following command-line argument needs to be specified in `dfx.json`:
+To re-activate classical orthogonal persistence under `icp`, the following command-line argument needs to be specified in `icp.yaml`:
 
-```
-...
-    "type" : "motoko"
-    ...
-    "args" : "--legacy-persistence"
-...
+```yaml
+canisters:
+  - name: my_canister
+    recipe:
+      type: "@dfinity/motoko@v4.1.0"
+      configuration:
+        main: src/my_canister/main.mo
+        args: "--legacy-persistence"
 ```
 :::
 

--- a/doc/md/fundamentals/2-actors/6-orthogonal-persistence/enhanced.md
+++ b/doc/md/fundamentals/2-actors/6-orthogonal-persistence/enhanced.md
@@ -51,7 +51,7 @@ Compatible changes for immutable types are largely analogous to the allowed Moto
 * Supporting shared function parameter contravariance and return type covariance.
 * Any other change according to Motoko's subtyping rule.
 
-The runtime system checks migration compatibility on upgrade, and if not fulfilled, rolls back the upgrade. This compatibility check serves as an additional safety measure on top of the `dfx` warning that can be bypassed by users.
+The runtime system checks migration compatibility on upgrade, and if not fulfilled, rolls back the upgrade. This compatibility check serves as an additional safety measure on top of the `icp` warning that can be bypassed by users.
 
 Any more complex change can be performed with programmatic instruction, see [explicit migration](../../2-actors/3-data-persistence.md#explicit-migration).
 
@@ -69,23 +69,23 @@ Graph-copy-based stabilization can be performed in three steps:
 1. Initiate the explicit stabilization before the upgrade:
 
 ```
-dfx canister call CANISTER_ID __motoko_stabilize_before_upgrade "()"
+icp canister call CANISTER_ID __motoko_stabilize_before_upgrade "()"
 ```
 
 2. Run the upgrade:
 
 ```
-dfx deploy CANISTER_ID
+icp deploy CANISTER_ID
 ```
 
 3. Complete the explicit destabilization after the upgrade:
 
 ```
-dfx canister call CANISTER_ID __motoko_destabilize_after_upgrade "()"
+icp canister call CANISTER_ID __motoko_destabilize_after_upgrade "()"
 ```
 
 Remarks:
-* When receiving the `dfx` error "The request timed out." during explicit stabilization, upgrade, or destabilization, one can simply repeat the call until it completes.
+* When receiving the `icp` error "The request timed out." during explicit stabilization, upgrade, or destabilization, one can simply repeat the call until it completes.
 * Step 3 (explicit destabilization) may not be needed if the corresponding operation fits into the upgrade message.
 
 ### Old stable memory

--- a/doc/md/fundamentals/7-modules-imports.md
+++ b/doc/md/fundamentals/7-modules-imports.md
@@ -66,7 +66,7 @@ import Render "mo:redraw/Render";
 import Mono5x5 "mo:redraw/glyph/Mono5x5";
 ```
 
-You can define dependencies for a project using a package manager or in the project `dfx.json` configuration file.
+You can define dependencies for a project using a package manager or in the project `icp.yaml` configuration file.
 
 In this example, the `Render` module is in the default location for source code in the `redraw` package and the `Mono5x5` module is in a `redraw` package subdirectory called `glyph`.
 
@@ -74,19 +74,7 @@ In this example, the `Render` module is in the default location for source code 
 
 Modules can also be imported from other packages, such as those imported from a package manager.
 
-Dependencies are managed using a package manager or defined in the project's `dfx.json` file. Motoko supports package managers like [Mops](https://mops.one/) to install third-party libraries.
-
-### Configuring the package manager in `dfx.json`
-
-```json
-{
-  "defaults": {
-    "build": {
-      "packtool": "mops sources"
-    }
-  }
-}
-```
+Dependencies are managed using a package manager or defined in the project's `icp.yaml` file. Motoko supports package managers like [Mops](https://mops.one/) to install third-party libraries.
 
 ### Installing a package with a package manager
 
@@ -97,6 +85,16 @@ Then import the package into your Motoko code:
 ```motoko no-repl
 import Vec "mo:vector";
 ```
+
+:::tip Pinning the Motoko compiler version
+Mops manages the `moc` compiler used to build your project. You can pin a specific version by adding a `[toolchain]` section to your `mops.toml`:
+
+```toml
+[toolchain]
+moc = "0.15.1"
+```
+:::
+
 
 ## Naming imported modules
 
@@ -117,7 +115,7 @@ import BigMap "canister:BigMap";
 import Connectd "canister:Connectd";
 ```
 
-`BigMap` and `Connectd` are separate canisters defined in `dfx.json`. Canister functions are shared and may require `await` to call them.
+`BigMap` and `Connectd` are separate canisters defined in `icp.yaml`. Canister functions are shared and may require `await` to call them.
 
 Unlike a Motoko module, an imported canister:
 
@@ -125,21 +123,21 @@ Unlike a Motoko module, an imported canister:
 - Has its type derived from a `.did` file, not from Motoko itself.
 
 :::danger
-When importing from another canister, the canister must be listed as a dependency in the importing canister's `dfx.json`. These must both:
+When importing from another canister, both canisters must be defined in the same `icp.yaml` project file.
 
-1. Be listed in the `dependencies` array of `my_canister`.
-2. Have their own canister definitions specified elsewhere in the same file.
-
-```json
-{
-  "canisters": {
-    "my_canister": {
-      "main": "src/my_canister/main.mo",
-      "type": "motoko",
-      "dependencies": ["BigMap", "Connectd"]
-    }
-  }
-}
+```yaml
+canisters:
+  - name: my_canister
+    recipe:
+      type: "@dfinity/motoko@v4.1.0"
+      configuration:
+        main: src/my_canister/main.mo
+  - name: BigMap
+    recipe:
+      # BigMap canister definition
+  - name: Connectd
+    recipe:
+      # Connectd canister definition
 ```
 
 :::

--- a/doc/md/motoko-tooling/1-canpack.mdx
+++ b/doc/md/motoko-tooling/1-canpack.mdx
@@ -39,7 +39,7 @@ npm install -g canpack
 
 ## Using Canpack
 
-In a project directory that contains a `dfx.json` and `mops.toml` file, you can use Canpack by first creating a new file called `canpack.json` with the following content:
+In a project directory that contains an `icp.yaml` and `mops.toml` file, you can use Canpack by first creating a new file called `canpack.json` with the following content:
 
 ```json
 {
@@ -61,18 +61,15 @@ Then, generate the required files using the command:
 canpack
 ```
 
-In the project's `dfx.json` file, configure the `"dependencies"` for your project's Motoko canister:
+In the project's `icp.yaml` file, configure your project's Motoko canister:
 
-```json
-{
-    "canisters": {
-        "my_project_backend": {
-            "dependencies": ["motoko_rust"],
-            "main": "src/my_project_backend/main.mo",
-            "type": "motoko"
-        }
-    },
-}
+```yaml
+canisters:
+  - name: my_project_backend
+    recipe:
+      type: "@dfinity/motoko@v4.1.0"
+      configuration:
+        main: src/my_project_backend/main.mo
 ```
 
 Then, to write a Motoko canister that imports Rust crates, import `Rust` from the `motoko_rust` canister:

--- a/doc/md/motoko-tooling/2-dev-containers.md
+++ b/doc/md/motoko-tooling/2-dev-containers.md
@@ -5,7 +5,7 @@ hide_table_of_contents: true
 
 # Developer containers
 
-Developer containers are a local development option that uses [Docker](https://www.docker.com/get-started/) and [VS Code](https://code.visualstudio.com/) to run local containerized environments. Containers are isolated from the rest of your local environment, and files within a container cannot be used by applications outside of the container unless explicitly mounted and given access. Developer containers are a good option for developers on Windows systems, since `dfx` is not natively supported for local development on Windows.
+Developer containers are a local development option that uses [Docker](https://www.docker.com/get-started/) and [VS Code](https://code.visualstudio.com/) to run local containerized environments. Containers are isolated from the rest of your local environment, and files within a container cannot be used by applications outside of the container unless explicitly mounted and given access. Developer containers are a good option for developers on Windows systems, since `icp` requires WSL for local development on Windows.
 
 Dev containers have additional benefits, including:
 
@@ -29,10 +29,10 @@ Make sure Docker is running, then navigate into your project's directory. Create
 {
   "name": "ICP Dev Environment",
   "image": "ghcr.io/dfinity/icp-dev-env-slim:latest",
-  "forwardPorts": [4943, 5173],
+  "forwardPorts": [8000, 5173],
   "portsAttributes": {
-    "4943": {
-      "label": "dfx",
+    "8000": {
+      "label": "icp",
       "onAutoForward": "ignore"
     },
     "5173": {

--- a/doc/md/motoko-tooling/3-mo-doc.md
+++ b/doc/md/motoko-tooling/3-mo-doc.md
@@ -6,40 +6,36 @@ sidebar_position: 3
 
 `mo-doc` is a command-line tool for generating documentation for Motoko source code. It processes source files and generates documentation in various formats.
 
-Download `mo-doc` from Motoko's [GitHub releases page](https://github.com/dfinity/motoko/releases) or simply use the binary included in your [dfx](https://github.com/dfinity/sdk) installation:
-
-``` bash
-$(dfx cache show)/mo-doc [options]
-```
+Download `mo-doc` from Motoko's [GitHub releases page](https://github.com/dfinity/motoko/releases).
 
 ### Generate in HTML format (default)
 
 ```bash
-$(dfx cache show)/mo-doc
+mo-doc
 ```
 
 ### Generate in Markdown format
 
-```
-$(dfx cache show)/mo-doc --format plain
+```bash
+mo-doc --format plain
 ```
 
 ### Generate in AsciiDoc format
 
-```
-$(dfx cache show)/mo-doc --format adoc
+```bash
+mo-doc --format adoc
 ```
 
 ### Use a custom source code directory (defaults to `src`)
 
-```
-$(dfx cache show)/mo-doc --src path/to/motoko/files
+```bash
+mo-doc --src path/to/motoko/files
 ```
 
 ### Use a custom output directory (defaults to `docs`)
 
-```
-$(dfx cache show)/mo-doc --output path/to/custom/output
+```bash
+mo-doc --output path/to/custom/output
 ```
 
 ## Options

--- a/doc/md/motoko-tooling/4-motoko-vs-code.md
+++ b/doc/md/motoko-tooling/4-motoko-vs-code.md
@@ -34,8 +34,8 @@ Below are the default key bindings for commonly used features supported in the e
 
 - The [Mops](https://mops.one/) and [Vessel](https://github.com/dfinity/vessel) Motoko package managers are supported out-of-the-box in this extension.
 - Quickly convert between Motoko types using code snippets such as `array-2-buffer` or `principal-2-text`.
-- In case you're hoping to learn Motoko without installing `dfx`, the Motoko VS Code extension works standalone on all major operating systems (including Windows).
-- This extension also provides schema validation and autocompletion for `dfx.json` configuration files.
+- In case you're hoping to learn Motoko without installing `icp`, the Motoko VS Code extension works standalone on all major operating systems (including Windows).
+- This extension also provides schema validation and autocompletion for `icp.yaml` configuration files.
 - View type information and documentation by hovering over function names, imports, and other expressions.
 - Deploy temporary canisters to the ICP mainnet directly from the editor.
 

--- a/doc/md/reference/3-changelog.mdx
+++ b/doc/md/reference/3-changelog.mdx
@@ -13,11 +13,6 @@ You can determine the version of your `moc` installation using
 ```bash
 moc --version
 ```
-
-If using `moc` via `dfx`, you can determine the version of moc bundled with `dfx` using:
-```bash
-$(dfx cache show)/moc --version
-```
 :::
 
 ```md reference


### PR DESCRIPTION
## Summary

Replaces all `dfx` references in the active (`doc/md/`, excluding `old/`) documentation with their `icp-cli` equivalents, following the deprecation of `dfx`.

- **Install page**: rewritten around `npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm ic-mops`; clarifies that `moc` is managed via `mops toolchain`, not bundled with icp-cli
- **Config files**: `dfx.json` → `icp.yaml` throughout; JSON snippets converted to YAML
- **Commands**: `dfx deploy` → `icp deploy`, `dfx canister call` → `icp canister call`, network commands updated
- **Compiler version pinning**: added `mops.toml` `[toolchain]` tip in modules/imports and core migration docs
- **core migration troubleshooting**: replaced network restart with `icp deploy --mode reinstall`
- **mo-doc**: removed `$(dfx cache show)/mo-doc` alternative; examples now use the binary directly
- **Changelog**: removed `$(dfx cache show)/moc --version` snippet
- **Dev containers**: port `4943` → `8000`, label `dfx` → `icp`

## Open questions / items to revisit before merging

- [ ] **Canpack** ([`1-canpack.mdx`](doc/md/motoko-tooling/1-canpack.mdx)): updated `dfx.json` references to `icp.yaml` and converted the canister config snippet to YAML — but it's unclear whether Canpack has been updated to support `icp.yaml` yet. May need to revert or add a compatibility note until Canpack officially supports icp-cli.
- [ ] **Dev containers** ([`2-dev-containers.md`](doc/md/motoko-tooling/2-dev-containers.md)): updated port and label, but the dev container image (`ghcr.io/dfinity/icp-dev-env-slim:latest`) may not yet include `icp-cli`. This page may need to be reverted or marked as work-in-progress until the image is updated.
- [ ] **Install page use cases** ([`2-install.mdx`](doc/md/2-install.mdx)): the "Explore Motoko use cases" section at the bottom links to example projects — worth checking whether these examples still use `dfx`/`dfx.json` and whether they should be dropped or replaced.

## Test plan

- [ ] Verify `icp` command mappings against the [icp-cli dfx migration guide](https://skills.internetcomputer.org/.well-known/skills/icp-cli/references/dfx-migration.md)
- [ ] Confirm Canpack compatibility with `icp.yaml` before merging canpack changes
- [ ] Confirm dev container image ships `icp-cli` before merging dev container changes
- [ ] Review example project links in install page

🤖 Generated with [Claude Code](https://claude.com/claude-code)