### PR TITLE
doc: fix off-by-one in `9-error-handling.md` file-embeds

### DIFF
--- a/doc/md/fundamentals/9-error-handling.md
+++ b/doc/md/fundamentals/9-error-handling.md
@@ -39,7 +39,7 @@ type Result<Ok, Err> = { #ok : Ok; #err : Err }
 
 Unlike option types, the Result type includes a second type parameter `Err` which allows you to specify exactly what kind of error occurred. This makes error handling more informative and flexible.
 
-``` motoko no-repl file=../examples/todo-error.mo#L60-L60
+``` motoko no-repl file=../examples/todo-error.mo#L59-L59
 ```
 
 The previous example can be revised to use `Result` types:

--- a/doc/md/old/writing-motoko/errors.md
+++ b/doc/md/old/writing-motoko/errors.md
@@ -70,7 +70,7 @@ type Result<Ok, Err> = { #ok : Ok; #err : Err }
 
 Because of the second type parameter, `Err`, the `Result` type lets you select the type used to describe errors. Define a `TodoError` type that the `markDone` function will use to signal errors:
 
-``` motoko no-repl file=../../examples/todo-error.mo#L60-L60
+``` motoko no-repl file=../../examples/todo-error.mo#L59-L59
 ```
 
 The original example is now revised as:


### PR DESCRIPTION
## Summary

- Fix off-by-one line reference in two `error-handling` docs that embed an empty line instead of the `TodoError` type definition.
- `doc/md/examples/todo-error.mo` line 60 is blank; line 59 holds the `public type TodoError = …` line. Embeds now point at L59.
- Same fix applied to the legacy `doc/md/old/writing-motoko/errors.md` so historical doc-site renders also display the type.

Fixes #6077.

## Test plan

- [ ] Render `doc/md/fundamentals/9-error-handling.md` (or the corresponding section of the dfinity/developer-docs sync) and confirm the `Result`-introduction code block now shows `public type TodoError = { #notFound; #alreadyDone : Time };`.
- [ ] Same check for `doc/md/old/writing-motoko/errors.md` (legacy path).
- [ ] No CI tests cover docusaurus file-embed expansion, so verification is visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)