### PR TITLE
chore: bump `rustc-nightly` to 2026-05-04 (May the fourth)

### DIFF
--- a/.agents/skills/bump-rust-nightly/SKILL.md
+++ b/.agents/skills/bump-rust-nightly/SKILL.md
@@ -75,9 +75,6 @@ Use `NIGHTLY_RELEASE_CARGO_OPTIONS` in `rts/Makefile`.
 #### `failed to select version for rustc-literal-escaper = "^0.0.7"`
 The vendored std deps are stale — re-run the `rustStdDepsHash` probe (step 4).
 
-#### Lifetime warning `mismatched_lifetime_syntaxes`
-Add explicit `'_` to `Ref<Box<[u8]>>` → `Ref<'_, Box<[u8]>>` return types.
-
 ### 7. macOS test slowness
 The wasm64 debug test suite runs under `wasmtime` in the nix sandbox. On
 macOS/arm64 it can be **~10x slower** than Linux, sometimes appearing to hang.

--- a/.agents/skills/bump-rust-nightly/SKILL.md
+++ b/.agents/skills/bump-rust-nightly/SKILL.md
@@ -1,0 +1,147 @@
+# Bumping the Rust Nightly Toolchain
+
+This skill guides you through bumping the `rustc-nightly` version used to build
+the Motoko RTS. Branch: `gabor/bump-nightly-rustc`, PR: caffeinelabs/motoko#5743.
+
+## Files to Change
+
+| File | What to update |
+|------|----------------|
+| `nix/pkgs.nix` | Nightly date string in `rust-bin.nightly."YYYY-MM-DD"` |
+| `nix/rts.nix` | `rustStdDepsHash` (fixed-output derivation hash) |
+| `flake.lock` | Run `nix flake update rust-overlay` to get latest overlay |
+| `rts/motoko-rts/Cargo.toml` | Bump any exact-pinned crate versions if vendoring fails |
+| `rts/motoko-rts/Cargo.lock` | Run `cargo update` in `rts/motoko-rts/` |
+| `rts/motoko-rts-tests/Cargo.lock` | Run `cargo update` in `rts/motoko-rts-tests/` |
+
+## Step-by-Step
+
+### 1. Switch branch and rebase
+```sh
+git checkout gabor/bump-nightly-rustc
+git rebase origin/master
+```
+
+### 2. Update rust-overlay
+```sh
+cd ~/motoko && nix flake update rust-overlay
+```
+
+### 3. Set nightly date in `nix/pkgs.nix`
+```nix
+rust-nightly = self.rust-bin.nightly."YYYY-MM-DD".default.override {
+```
+Start with a recent date (e.g. a few weeks before today). If tests hang or
+fail, bisect backwards by 2-4 weeks at a time.
+
+### 4. Get new `rustStdDepsHash`
+Set it to a dummy value first:
+```nix
+rustStdDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+```
+Then run:
+```sh
+nix build .#rts 2>&1 | grep "got:"
+```
+Paste the `got:` hash back into `nix/rts.nix`. Note: this hash is often
+**identical across several months** of nightly dates.
+
+### 5. Update Cargo lockfiles
+```sh
+cd rts/motoko-rts       && cargo update
+cd rts/motoko-rts-tests && cargo update
+```
+If `nix build .#rts` fails with "failed to select version for `foo = =X.Y.Z`",
+bump that exact pin in `rts/motoko-rts/Cargo.toml` and re-run `cargo update foo`.
+
+### 6. Build and test
+```sh
+nix build .#rts
+```
+Watch for compiler errors — common ones encountered and their fixes:
+
+#### `.json target specs require -Zjson-target-spec`
+Add `-Zjson-target-spec` to `NIGHTLY_CARGO_OPTIONS` in `rts/Makefile`.
+
+#### `target-pointer-width: invalid type: string "32", expected u16`
+Change `"target-pointer-width": "32"` → `"target-pointer-width": 32` (integer)
+in `rts/motoko-rts/wasm32-none-shared.json` and `wasm64-none-shared.json`.
+
+#### `panic_immediate_abort is now a real panic strategy`
+Remove `panic_immediate_abort` from `-Zbuild-std-features` and add
+`-Zunstable-options -Cpanic=immediate-abort` to `RTS_RELEASE_COMPILE_FLAGS`.
+Use `NIGHTLY_RELEASE_CARGO_OPTIONS` in `rts/Makefile`.
+
+#### `failed to select version for rustc-literal-escaper = "^0.0.7"`
+The vendored std deps are stale — re-run the `rustStdDepsHash` probe (step 4).
+
+#### Lifetime warning `mismatched_lifetime_syntaxes`
+Add explicit `'_` to `Ref<Box<[u8]>>` → `Ref<'_, Box<[u8]>>` return types.
+
+### 7. macOS test slowness
+The wasm64 debug test suite runs under `wasmtime` in the nix sandbox. On
+macOS/arm64 it can be **~10x slower** than Linux, sometimes appearing to hang.
+This is likely due to the system virus scanner (XProtect/MRT) intercepting
+wasm memory operations, not a code regression.
+
+**Do not reduce the test object counts** — instead push to CI and let Linux
+confirm correctness. Then trigger the `nightly-macos-test` GitHub Actions
+workflow on the branch to populate cachix with macOS binaries:
+```sh
+gh workflow run nightly-macos-test --repo caffeinelabs/motoko --ref <branch>
+```
+Once cachix is populated, local `nix build` downloads pre-built artifacts
+instead of running the slow tests.
+
+**`nightly-macos-test` has two distinct macOS failure modes:**
+
+1. **OOM on `systems-go-tests`** — fails in ~4 min with `patch: **** out of memory`
+   while building `ocaml4.14.2-merlin-*` from scratch (before any tests run).
+   Runner memory pressure, not a code issue. Re-trigger the workflow; each run
+   pushes more artifacts to cachix, and eventually merlin gets cached too.
+
+2. **Slow `gc-tests` / `common-tests`** — same XProtect/wasm64 malaise as local:
+   these jobs run but take 10× longer than Linux. They will eventually finish and
+   push their artifacts to cachix. Be patient — do not cancel them.
+
+**Re-trigger pattern:** keep re-triggering until all jobs pass; each run makes
+progress by caching more derivations:
+```sh
+gh workflow run nightly-macos-test --repo caffeinelabs/motoko --ref <branch>
+```
+
+### 8. Commit
+```
+chore: bump rustc-nightly to YYYY-MM-DD
+
+- nightly date: old → new
+- rust-overlay: updated to YYYY-MM-DD
+- rustStdDepsHash: updated for new nightly
+- rts/Makefile: <list any Makefile fixes>
+- wasm{32,64}-none-shared.json: <if changed>
+- motoko-rts: bump foo =X.Y.Z → =X.Y+1.Z
+- cargo update: motoko-rts, motoko-rts-tests
+```
+
+### 9. Push and watch CI
+```sh
+git push --force-with-lease origin gabor/bump-nightly-rustc
+gh run watch <run-id> --repo caffeinelabs/motoko
+```
+
+## Makefile Structure (as of 2026-04-01)
+
+```makefile
+RTS_COMPILE_FLAGS=-C target-feature=+bulk-memory
+RTS_RELEASE_COMPILE_FLAGS=$(RTS_COMPILE_FLAGS) -Zunstable-options -Cpanic=immediate-abort
+NIGHTLY_CARGO_OPTIONS=-Zjson-target-spec -Zbuild-std=core,alloc
+NIGHTLY_RELEASE_CARGO_OPTIONS=$(NIGHTLY_CARGO_OPTIONS) --release -Zbuild-std-features="optimize_for_size"
+```
+
+## Notes
+- `rustStdDepsHash` has been stable (`sha256-ZMCepUZNyqXZcR3EduSV38zFbI89WneU1iTXj3L38RA=`)
+  from at least 2026-02-15 through 2026-03-31.
+- `libm` is exact-pinned (`=0.2.x`) in `motoko-rts/Cargo.toml` — bump it if
+  `cargo update` in `motoko-rts-tests` moves it and the vendor fails.
+- The nix sandbox uses `pkgs.wasmtime` from the pinned nixpkgs rev — check
+  `wasmtime` version doesn't regress performance between nixpkgs bumps.

--- a/.agents/skills/bump-rust-nightly/SKILL.md
+++ b/.agents/skills/bump-rust-nightly/SKILL.md
@@ -75,37 +75,33 @@ Use `NIGHTLY_RELEASE_CARGO_OPTIONS` in `rts/Makefile`.
 #### `failed to select version for rustc-literal-escaper = "^0.0.7"`
 The vendored std deps are stale — re-run the `rustStdDepsHash` probe (step 4).
 
-### 7. macOS test slowness
-The wasm64 debug test suite runs under `wasmtime` in the nix sandbox. On
-macOS/arm64 it can be **~10x slower** than Linux, sometimes appearing to hang.
-This is likely due to the system virus scanner (XProtect/MRT) intercepting
-wasm memory operations, not a code regression.
+### 7. `.#rts` vs `.#rts-checked` on macOS
 
-**Do not reduce the test object counts** — instead push to CI and let Linux
-confirm correctness. Then trigger the `nightly-macos-test` GitHub Actions
-workflow on the branch to populate cachix with macOS binaries:
+`flake.nix` distinguishes two derivations:
+
+- **`.#rts`** — the build alone. On darwin this skips the host-side `cargo
+  test` suite, so `nix build .#rts` is fast and is what you iterate on locally.
+- **`.#rts-checked`** — always runs the `cargo test` suite. On darwin this
+  exercises the wasm64 debug tests under `wasmtime` in the nix sandbox, which
+  can be **~10× slower** than Linux (likely due to XProtect/MRT intercepting
+  wasm memory ops). Triggered in CI by the `nightly-macos-test` workflow's
+  `rts-checked` job; not normally needed locally.
+
+**Local bump loop:** `nix build .#rts` until green. Push and let CI's
+`rts-checked` exercise the slow path on macOS.
+
+**If `nightly-macos-test` jobs fail or time out**, re-trigger — each run
+caches more derivations, so subsequent runs make progress:
 ```sh
 gh workflow run nightly-macos-test --repo caffeinelabs/motoko --ref <branch>
 ```
-Once cachix is populated, local `nix build` downloads pre-built artifacts
-instead of running the slow tests.
+Two known failure modes that are *not* code regressions:
 
-**`nightly-macos-test` has two distinct macOS failure modes:**
-
-1. **OOM on `systems-go-tests`** — fails in ~4 min with `patch: **** out of memory`
-   while building `ocaml4.14.2-merlin-*` from scratch (before any tests run).
-   Runner memory pressure, not a code issue. Re-trigger the workflow; each run
-   pushes more artifacts to cachix, and eventually merlin gets cached too.
-
-2. **Slow `gc-tests` / `common-tests`** — same XProtect/wasm64 malaise as local:
-   these jobs run but take 10× longer than Linux. They will eventually finish and
-   push their artifacts to cachix. Be patient — do not cancel them.
-
-**Re-trigger pattern:** keep re-triggering until all jobs pass; each run makes
-progress by caching more derivations:
-```sh
-gh workflow run nightly-macos-test --repo caffeinelabs/motoko --ref <branch>
-```
+1. **OOM on `systems-go-tests`** — fails in ~4 min with `patch: **** out of
+   memory` while building `ocaml4.14.2-merlin-*` from scratch (before any
+   tests run). Runner memory pressure. Re-trigger.
+2. **Slow `gc-tests` / `common-tests`** — same XProtect/wasm64 malaise; they
+   eventually finish. Be patient, don't cancel.
 
 ### 8. Commit
 ```

--- a/.agents/skills/bump-rust-nightly/SKILL.md
+++ b/.agents/skills/bump-rust-nightly/SKILL.md
@@ -1,7 +1,7 @@
 # Bumping the Rust Nightly Toolchain
 
 This skill guides you through bumping the `rustc-nightly` version used to build
-the Motoko RTS. Branch: `gabor/bump-nightly-rustc`, PR: caffeinelabs/motoko#5743.
+the Motoko RTS.
 
 ## Files to Change
 

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -45,7 +45,7 @@
     (self: super: {
       # When you change the rust-nightly version,
       # make sure to change the rustStdDepsHash in ./rts.nix accordingly.
-      rust-nightly = self.rust-bin.nightly."2026-04-22".default.override {
+      rust-nightly = self.rust-bin.nightly."2026-05-04".default.override {
         extensions = [ "rust-src" ];
         targets = [ "wasm32-wasip1" ];
       };

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -45,7 +45,7 @@
     (self: super: {
       # When you change the rust-nightly version,
       # make sure to change the rustStdDepsHash in ./rts.nix accordingly.
-      rust-nightly = self.rust-bin.nightly."2026-04-08".default.override {
+      rust-nightly = self.rust-bin.nightly."2026-04-22".default.override {
         extensions = [ "rust-src" ];
         targets = [ "wasm32-wasip1" ];
       };

--- a/nix/rts.nix
+++ b/nix/rts.nix
@@ -13,7 +13,7 @@ let
   vendorRustStdDeps = "${cargoVendorTools}/bin/vendor-rust-std-deps";
 
   # SHA256 of Rust std deps
-  rustStdDepsHash = "sha256-DMMk4gsb1g5/AP/nZgVHWksjTrV87CQTZnep+LImgF4=";
+  rustStdDepsHash = "sha256-Xl15nU07T1ipdQQ6V9nxh7iBRgeLyf2/317N+MrFzBs=";
 
   # Vendor directory for Rust std deps
   rustStdDeps = pkgs.stdenvNoCC.mkDerivation {

--- a/nix/rts.nix
+++ b/nix/rts.nix
@@ -13,7 +13,7 @@ let
   vendorRustStdDeps = "${cargoVendorTools}/bin/vendor-rust-std-deps";
 
   # SHA256 of Rust std deps
-  rustStdDepsHash = "sha256-Xl15nU07T1ipdQQ6V9nxh7iBRgeLyf2/317N+MrFzBs=";
+  rustStdDepsHash = "sha256-92QH5QOdms57sl2sDMJxx/yS1T90mZp5L9N0nTxckn0=";
 
   # Vendor directory for Rust std deps
   rustStdDeps = pkgs.stdenvNoCC.mkDerivation {

--- a/rts/README.md
+++ b/rts/README.md
@@ -70,7 +70,7 @@ If you change dependencies (e.g. bump versions, add more crates), Make sure that
 `motoko-rts-tests/Cargo.lock` is up to date. This can be done by running
 `cargo build --target=wasm32-wasip1` in `motoko-rts-tests/` directory.
 
-**Updating rustc**: see [`.agents/skills/bump-rust-nightly/SKILL.md`](../.agents/skills/bump-rust-nightly/SKILL.md) for the full recipe — nightly date, `rustStdDepsHash` probe, Cargo lockfile updates, common compiler-error fixes, macOS test slowness, and CI-trigger pattern.
+**Updating rustc**: see [`.agents/skills/bump-rust-nightly/SKILL.md`](../.agents/skills/bump-rust-nightly/SKILL.md) for the full recipe — nightly date, `rustStdDepsHash` probe, Cargo lockfile updates, common compiler-error fixes, and CI-trigger pattern.
 
 Running RTS tests
 -----------------

--- a/rts/README.md
+++ b/rts/README.md
@@ -70,27 +70,7 @@ If you change dependencies (e.g. bump versions, add more crates), Make sure that
 `motoko-rts-tests/Cargo.lock` is up to date. This can be done by running
 `cargo build --target=wasm32-wasip1` in `motoko-rts-tests/` directory.
 
-**Updating rustc**:
-
-1. Update the Rust version of `rust-nightly` in `nix/pkgs.nix`
-   CAVEAT: there is a second `rust-stable` for the stable `rustc` too.
-2. Invalidate `rustStdDepsHash` in `nix/rts.nix`.
-3. Run `nix build .#rts`. You should get an error message about the expected
-   value of `rustStdDepsHash`.
-4. Update `rustStdDepsHash` with the expected value in the error message.
-
-(Can this be automated?)
-
---------
-**The above doesn't always work**
-
-Sometimes you want to also bump the  `.toml` dependencies...
-
-E.g. when you get `perhaps a crate was updated and forgotten to be
-re-vendored?`, proceed as follows:
-[Invalid recipe deleted. Try `cargo update in `rts/motoko-rts*`,
- invalidate hashes: {`cargoVendorTools.cargoSha256`, `rustStdDepsHash`, `rtsDeps.sha256`}
- all at the same time and then `nix build .#rts -K` to examine the build products.]
+**Updating rustc**: see [`.agents/skills/bump-rust-nightly/SKILL.md`](../.agents/skills/bump-rust-nightly/SKILL.md) for the full recipe — nightly date, `rustStdDepsHash` probe, Cargo lockfile updates, common compiler-error fixes, macOS test slowness, and CI-trigger pattern.
 
 Running RTS tests
 -----------------

--- a/rts/motoko-rts-tests/Cargo.lock
+++ b/rts/motoko-rts-tests/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "byteorder"
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"

--- a/rts/motoko-rts/Cargo.lock
+++ b/rts/motoko-rts/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"


### PR DESCRIPTION
## Summary

- Bumps the Motoko RTS Rust toolchain from `nightly-2026-04-08` to today's nightly, **`nightly-2026-05-04`** (May the fourth — bleeding edge, embraced for the joke value).
- Refreshes `rustStdDepsHash` in `nix/rts.nix` for the new nightly: `sha256-DMMk4gsb1g5/AP/nZgVHWksjTrV87CQTZnep+LImgF4=` → `sha256-92QH5QOdms57sl2sDMJxx/yS1T90mZp5L9N0nTxckn0=`.
- `cargo update` from the original April-22 attempt picked up minor bumps (`libc` 0.2.184 → 0.2.186, `bitflags` 2.11.0 → 2.11.1); no further moves between 04-22 and 05-04.
- `flake.lock` rust-overlay was already at the latest revision; no change.

## Skill housekeeping

- Promotes the `bump-rust-nightly` skill from the user-local `.claude/skills/` to the repo-shared `.agents/skills/bump-rust-nightly/SKILL.md` (matching the convention used by `build-and-test`, `migrating-motoko`, etc.) and renames `skill.md` → `SKILL.md`.
- Replaces the 21-line "Updating rustc" recipe in `rts/README.md` (steps 1–4 plus the "doesn't always work" appendix) with a one-line pointer to the skill. The skill carries the canonical version — including the cases the appendix flagged as unreliable — so the README no longer duplicates (and risks contradicting) it.
- Drops the stale `Branch: gabor/bump-nightly-rustc, PR: caffeinelabs/motoko#5743` reference from the skill preamble — that was the first-ever bump-nightly PR; every subsequent bump (including this one) uses a different branch, so anchoring the skill to a specific historical PR is misleading.

## Test plan

- [x] `nix build .#rts` succeeds locally on aarch64-darwin with the May-4 nightly.
- [x] CI green on Linux (the macOS slowness caveat documented in the skill applies — patience may be required for the wasm64 debug suite).
- [ ] If macOS jobs OOM or time out, follow the re-trigger pattern in the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)