### PR TITLE
experiment: compress stable type signatures (dedup + intersection mining)

### DIFF
--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -989,7 +989,7 @@ and build_actor at chain ts (exp_opt : Ir.exp option) self_id es obj_typ0 =
     | None -> ds in
   let meta =
     I.{ candid = candid;
-        sig_ = T.string_of_stab_sig sig_} in
+        sig_ = Stab_sig_compress.string_of sig_} in
   let with_stable_vars wrap =
     let vs = fresh_vars "v" (List.map (fun f -> f.T.typ) mem_fields) in
     blockE

--- a/src/mo_types/stab_sig_compress.ml
+++ b/src/mo_types/stab_sig_compress.ml
@@ -1,0 +1,286 @@
+open Type
+
+module HashMap = Map.Make (String)
+
+(* === Generic stab_sig field traversals ====================================== *)
+
+let map_fields f = function
+  | Single fs -> Single (List.map f fs)
+  | PrePost (pre, post) ->
+    PrePost (List.map (fun (req, fld) -> (req, f fld)) pre,
+             List.map f post)
+  | Multi { chain; post } ->
+    Multi { chain = List.map f chain; post = List.map f post }
+
+let fold_fields f init = function
+  | Single fs -> List.fold_left f init fs
+  | PrePost (pre, post) ->
+    let acc = List.fold_left (fun acc (_, fld) -> f acc fld) init pre in
+    List.fold_left f acc post
+  | Multi { chain; post } ->
+    let acc = List.fold_left f init chain in
+    List.fold_left f acc post
+
+let collect_field cs f = ConSet.union cs (cons f.typ)
+
+(* === Substitution ========================================================== *)
+
+(* Like [Type.subst] but additionally rewrites cons stored in [Obj]'s
+   type-component list ([tfs]); safe here because every value in [cmap]
+   is a closed cons reference. *)
+let rec rewrite cmap t =
+  match t with
+  | Var _ | Prim _ | Any | Non | Pre -> t
+  | Con (c, ts) ->
+    let c' = try ConEnv.find c cmap with Not_found -> c in
+    Con (c', List.map (rewrite cmap) ts)
+  | Opt t -> Opt (rewrite cmap t)
+  | Mut t -> Mut (rewrite cmap t)
+  | Array t -> Array (rewrite cmap t)
+  | Weak t -> Weak (rewrite cmap t)
+  | Tup ts -> Tup (List.map (rewrite cmap) ts)
+  | Async (s, t1, t2) -> Async (s, rewrite cmap t1, rewrite cmap t2)
+  | Func (s, c, tbs, ts1, ts2) ->
+    Func (s, c,
+          List.map (fun b -> { b with bound = rewrite cmap b.bound }) tbs,
+          List.map (rewrite cmap) ts1,
+          List.map (rewrite cmap) ts2)
+  | Obj (s, fs, tfs) ->
+    Obj (s,
+         List.map (fun f -> { f with typ = rewrite cmap f.typ }) fs,
+         List.map (fun f ->
+           let c' = try ConEnv.find f.typ cmap with Not_found -> f.typ in
+           { f with typ = c' }) tfs)
+  | Variant fs ->
+    Variant (List.map (fun f -> { f with typ = rewrite cmap f.typ }) fs)
+  | Named (n, t) -> Named (n, rewrite cmap t)
+
+let rewrite_field cmap f = { f with typ = rewrite cmap f.typ }
+
+(* === Pass 1: structural dedup ============================================== *)
+
+let rec is_bare_alias = function
+  | Con _ -> true
+  | Mut t -> is_bare_alias t
+  | _ -> false
+
+let pick_rep = function
+  | [] -> assert false
+  | first :: rest ->
+    List.fold_left
+      (fun best c -> if Cons.compare c best < 0 then c else best)
+      first rest
+
+let dedup sig_ =
+  let all_cons = fold_fields collect_field ConSet.empty sig_ in
+  let groups =
+    ConSet.fold (fun c acc ->
+      match Cons.kind c with
+      | Def ([], body) when not (is_bare_alias body) ->
+        (try
+           let h = Typ_hash.typ_hash body in
+           let lst = try HashMap.find h acc with Not_found -> [] in
+           HashMap.add h (c :: lst) acc
+         with _ -> acc)
+      | _ -> acc) all_cons HashMap.empty
+  in
+  let cmap =
+    HashMap.fold (fun _ members acc ->
+      match members with
+      | [] | [_] -> acc
+      | _ ->
+        let rep = pick_rep members in
+        List.fold_left (fun acc c ->
+          if Cons.eq c rep then acc
+          else ConEnv.add c rep acc) acc members) groups ConEnv.empty
+  in
+  if ConEnv.is_empty cmap then sig_
+  else begin
+    ConSet.iter (fun c ->
+      if not (ConEnv.mem c cmap) then
+        match Cons.kind c with
+        | Def (tbs, body) ->
+          Cons.unsafe_set_kind c (Def (tbs, rewrite cmap body))
+        | Abs _ -> ()) all_cons;
+    map_fields (rewrite_field cmap) sig_
+  end
+
+(* === Pass 2: anchored-intersection mining ================================== *)
+
+(* Field dictionary: assign a stable int id per (label, mutability,
+   structural type) triple. *)
+
+let field_key f =
+  let mut, t = match f.typ with Mut t -> "v", t | t -> "i", t in
+  Printf.sprintf "%s|%s|%s" f.lab mut (Typ_hash.typ_hash t)
+
+type dict = {
+  mutable next_id : int;
+  ids : (string, int) Hashtbl.t;
+  by_id : (int, field) Hashtbl.t;
+}
+
+let make_dict () =
+  { next_id = 0;
+    ids = Hashtbl.create 256;
+    by_id = Hashtbl.create 256 }
+
+let intern d f =
+  let k = field_key f in
+  match Hashtbl.find_opt d.ids k with
+  | Some id -> id
+  | None ->
+    let id = d.next_id in
+    Hashtbl.add d.ids k id;
+    Hashtbl.add d.by_id id f;
+    d.next_id <- id + 1;
+    id
+
+let field_of_id d id = Hashtbl.find d.by_id id
+
+(* Sorted int array set ops *)
+
+let arr_inter a b =
+  let na = Array.length a and nb = Array.length b in
+  let buf = Array.make (min na nb) 0 in
+  let k = ref 0 and i = ref 0 and j = ref 0 in
+  while !i < na && !j < nb do
+    if a.(!i) = b.(!j) then (buf.(!k) <- a.(!i); incr k; incr i; incr j)
+    else if a.(!i) < b.(!j) then incr i
+    else incr j
+  done;
+  Array.sub buf 0 !k
+
+let arr_diff a b =
+  let na = Array.length a and nb = Array.length b in
+  let buf = Array.make na 0 in
+  let k = ref 0 and i = ref 0 and j = ref 0 in
+  while !i < na do
+    if !j >= nb || a.(!i) < b.(!j) then (buf.(!k) <- a.(!i); incr k; incr i)
+    else if a.(!i) = b.(!j) then (incr i; incr j)
+    else incr j
+  done;
+  Array.sub buf 0 !k
+
+let arr_key a =
+  let buf = Buffer.create (Array.length a * 6) in
+  Array.iter (fun x ->
+    Buffer.add_string buf (string_of_int x);
+    Buffer.add_char buf ',') a;
+  Buffer.contents buf
+
+(* A cons is factorable if its kind is [Def([], Obj(Object, fs, []))] —
+   a plain object record with no type-component fields — and it is not
+   structurally self-recursive (recursive types cannot be intersected
+   with [and] because [Type.glb] rejects forward/recursive references). *)
+
+let factorable c =
+  match Cons.kind c with
+  | Def ([], (Obj (Object, fs, []) as body)) ->
+    if ConSet.mem c (cons body) then None
+    else
+      (try
+        let _ = Typ_hash.typ_hash body in
+        Some fs
+      with _ -> None)
+  | _ -> None
+
+type record = {
+  cons : con;
+  mutable parents : con list;
+  mutable delta : int array;
+}
+
+(* Cost model: declaring a base of [s] fields used by [r] records saves
+   ~ (r-1) * (s-1) - 1 field-equivalents.  Threshold: positive savings. *)
+let score size users = (users - 1) * (size - 1) - 1
+
+let mine sig_ =
+  let all_cons = fold_fields collect_field ConSet.empty sig_ in
+  let dict = make_dict () in
+  let records = ConSet.fold (fun c acc ->
+    match factorable c with
+    | None -> acc
+    | Some fs ->
+      let ids = Array.of_list (List.map (intern dict) fs) in
+      Array.sort compare ids;
+      { cons = c; parents = []; delta = ids } :: acc
+  ) all_cons [] in
+
+  let bases : con list ref = ref [] in
+  let base_idx = ref 0 in
+
+  let mine_step () =
+    (* Inverted index over current deltas *)
+    let inv : (int, record list) Hashtbl.t = Hashtbl.create 256 in
+    List.iter (fun r ->
+      Array.iter (fun id ->
+        let lst = try Hashtbl.find inv id with Not_found -> [] in
+        Hashtbl.replace inv id (r :: lst)
+      ) r.delta
+    ) records;
+    (* Anchored intersections, deduplicated by canonical bitmap *)
+    let candidates : (string, int array * record list) Hashtbl.t =
+      Hashtbl.create 64 in
+    Hashtbl.iter (fun _id users ->
+      if List.length users >= 2 then begin
+        let inter = match users with
+          | r :: rs ->
+            List.fold_left (fun acc r -> arr_inter acc r.delta) r.delta rs
+          | [] -> assert false
+        in
+        if Array.length inter >= 2 then
+          Hashtbl.replace candidates (arr_key inter) (inter, users)
+      end
+    ) inv;
+    Hashtbl.fold (fun _ (inter, users) acc ->
+      let s = score (Array.length inter) (List.length users) in
+      if s <= 0 then acc
+      else match acc with
+        | None -> Some (s, inter, users)
+        | Some (s', _, _) when s > s' -> Some (s, inter, users)
+        | _ -> acc
+    ) candidates None
+  in
+
+  let rec loop () =
+    match mine_step () with
+    | None -> ()
+    | Some (_, inter, users) ->
+      let fs = Array.to_list inter
+        |> List.map (field_of_id dict)
+        |> List.sort compare_field in
+      let body = Obj (Object, fs, []) in
+      let base =
+        Cons.fresh (Printf.sprintf "Base__%d" !base_idx) (Def ([], body)) in
+      incr base_idx;
+      bases := base :: !bases;
+      List.iter (fun u ->
+        u.parents <- base :: u.parents;
+        u.delta <- arr_diff u.delta inter
+      ) users;
+      loop ()
+  in
+  loop ();
+
+  let factor : (con, con list * field list) Hashtbl.t = Hashtbl.create 64 in
+  List.iter (fun r ->
+    if r.parents <> [] then begin
+      let delta_fs = Array.to_list r.delta
+        |> List.map (field_of_id dict)
+        |> List.sort compare_field in
+      Hashtbl.add factor r.cons (List.rev r.parents, delta_fs)
+    end
+  ) records;
+  let extras =
+    List.fold_left (fun s c -> ConSet.add c s) ConSet.empty !bases in
+  (extras, factor)
+
+(* === Top-level ============================================================= *)
+
+let string_of sig_ =
+  Cons.session ~scope:"stab_sig_compress" (fun () ->
+    let sig_ = dedup sig_ in
+    let extras, factor = mine sig_ in
+    let lookup c = Hashtbl.find_opt factor c in
+    string_of_stab_sig_factored ~extras ~factor:lookup sig_)

--- a/src/mo_types/stab_sig_compress.mli
+++ b/src/mo_types/stab_sig_compress.mli
@@ -1,0 +1,16 @@
+(* Compress a stable signature for printing.
+
+   Two passes are applied before serialisation:
+   1. Structural deduplication of zero-arity, parameter-less [Def] cons
+      whose bodies hash equal under [Typ_hash.typ_hash].
+   2. Anchored-intersection mining over plain [Object] records: for each
+      reachable field, the largest itemset shared by all records
+      containing it is a candidate base. Bases that pay off (per a
+      simple cost model) are minted as fresh synthetic [Cons.t]s and
+      every covered record is rewritten as
+      [Base__N and Base__M and { delta }].
+
+   Stability checks compare types structurally, so the rewrite is
+   observable only as a smaller [.most] file. *)
+
+val string_of : Type.stab_sig -> string

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -2238,6 +2238,22 @@ and pp_typ_field vs ppf {lab; typ = c; src} =
   let op, sbs, st = pps_of_kind' vs (Cons.kind c) in
   fprintf ppf "@[<2>type %s%a %s@ %a@]" lab sbs () op st ()
 
+and pp_typ_field_factored factor vs ppf ({lab; typ = c; src} as tf) =
+  match factor c with
+  | None ->
+    pp_typ_field vs ppf tf
+  | Some (parents, delta_fs) ->
+    let pp_parent ppf p = pr ppf (string_of_con p) in
+    let pp_and ppf () = fprintf ppf "@ and " in
+    if delta_fs = [] then
+      fprintf ppf "@[<2>type %s =@ %a@]" lab
+        (pp_print_list ~pp_sep:pp_and pp_parent) parents
+    else
+      fprintf ppf "@[<2>type %s =@ %a%a%a@]" lab
+        (pp_print_list ~pp_sep:pp_and pp_parent) parents
+        pp_and ()
+        (pp_typ' vs) (Obj (Object, delta_fs, []))
+
 and pp_stab_field vs ppf {lab; typ; src} =
   match typ with
   | Mut t' ->
@@ -2361,6 +2377,86 @@ and pp_stab_sig ppf sig_ =
   in
   fprintf ppf "@[<v 0>%a%a%a;@]"
     (pp_print_list ~pp_sep:semi (pp_typ_field vs)) tfs
+    (if tfs = [] then fun ppf () -> () else semi) ()
+    pp_stab_actor sig_
+
+(* Like [pp_stab_sig] but accepts additional [extras] cons (synthetic bases)
+   to print as type-decls, and a [factor] callback that, if it returns
+   [Some (parents, delta_fs)] for a cons, renders that cons's body as
+   [parents and ... and { delta_fs }]. Cons whose factor returns [None] are
+   rendered the standard way (using [Cons.kind c]).
+
+   Type-decls are emitted in stable topological order: a cons whose factor
+   names parents is emitted only after all those parents have been emitted. *)
+and pp_stab_sig_factored extras factor ppf sig_ =
+  let all_fields = match sig_ with
+    | Single tfs -> tfs
+    | PrePost (pre, post) -> List.map snd pre @ post
+    | Multi {chain; post} -> chain @ post
+  in
+  let cs = List.fold_right (cons_field false) all_fields ConSet.empty in
+  let cs = ConSet.union cs extras in
+  let vs = vs_of_cs cs in
+  let ds =
+    let cs' = ConSet.filter (fun c ->
+      match Cons.kind c with
+      | Def ([], Prim p) when string_of_con c = string_of_prim p -> false
+      | Def ([], Any) when string_of_con c = "Any" -> false
+      | Def ([], Non) when string_of_con c = "None" -> false
+      | Def _ -> true
+      | Abs _ -> false) cs in
+    ConSet.elements cs' in
+  let tfs0 =
+    List.sort compare_field
+      (List.map (fun c ->
+        { lab = string_of_con c;
+          typ = c;
+          src = empty_src }) ds)
+  in
+  let tfs =
+    let emitted = ref ConSet.empty in
+    let result = ref [] in
+    let pending = ref tfs0 in
+    let progress = ref true in
+    while !pending <> [] && !progress do
+      progress := false;
+      let next = ref [] in
+      List.iter (fun tf ->
+        let ready = match factor tf.typ with
+          | None -> true
+          | Some (parents, _) ->
+            List.for_all (fun p -> ConSet.mem p !emitted) parents
+        in
+        if ready then begin
+          result := tf :: !result;
+          emitted := ConSet.add tf.typ !emitted;
+          progress := true
+        end else
+          next := tf :: !next
+      ) !pending;
+      pending := List.rev !next
+    done;
+    List.rev !result @ !pending
+  in
+  let pp_stab_actor ppf sig_ =
+    match sig_ with
+    | Single tfs ->
+      fprintf ppf "@[<v 2>%s{@;<0 0>%a@;<0 -2>}@]"
+        (string_of_obj_sort Actor)
+        (pp_print_list ~pp_sep:semi (pp_stab_field vs)) tfs
+    | PrePost (pre, post) ->
+      fprintf ppf "@[<v 2>%s({@;<0 0>%a@;<0 -2>}, {@;<0 0>%a@;<0 -2>})@]"
+        (string_of_obj_sort Actor)
+        (pp_print_list ~pp_sep:semi (pp_pre_stab_field vs)) pre
+        (pp_print_list ~pp_sep:semi (pp_stab_field vs)) post
+    | Multi {chain; post} ->
+       fprintf ppf "@[<v 2>{@;<0 0>%a@;<0 -2>}@;<0-2>%s {@;<0 0>%a@;<0 -2>}@]"
+        (pp_print_list ~pp_sep:semi (pp_mig_field vs)) chain
+        (string_of_obj_sort Actor)
+        (pp_print_list ~pp_sep:semi (pp_stab_field vs)) post
+  in
+  fprintf ppf "@[<v 0>%a%a%a;@]"
+    (pp_print_list ~pp_sep:semi (pp_typ_field_factored factor vs)) tfs
     (if tfs = [] then fun ppf () -> () else semi) ()
     pp_stab_actor sig_
 
@@ -2671,4 +2767,13 @@ let string_of_stab_sig stab_sig : string =
   | PrePost _ -> "// Version: 3.0.0\n"
   | Multi _ -> "// Version: 4.0.0\n") ^
   Format.asprintf "@[<v 0>%a@]@\n" (fun ppf -> Pretty.pp_stab_sig ppf) stab_sig
+
+let string_of_stab_sig_factored ~extras ~factor stab_sig : string =
+  let module Pretty = MakePretty(ParseableStamps) in
+  (match stab_sig with
+  | Single _ -> "// Version: 1.0.0\n"
+  | PrePost _ -> "// Version: 3.0.0\n"
+  | Multi _ -> "// Version: 4.0.0\n") ^
+  Format.asprintf "@[<v 0>%a@]@\n"
+    (fun ppf -> Pretty.pp_stab_sig_factored extras factor ppf) stab_sig
 

--- a/src/mo_types/type.mli
+++ b/src/mo_types/type.mli
@@ -351,6 +351,11 @@ val match_stab_fields : field list -> (bool * field) list -> bool
 
 val string_of_stab_sig : stab_sig -> string
 
+val string_of_stab_sig_factored :
+  extras:ConSet.t ->
+  factor:(con -> (con list * field list) option) ->
+  stab_sig -> string
+
 val motoko_runtime_information_type : typ
 
 (* Well-known labels *)


### PR DESCRIPTION
## Why

Long enhanced-migration chains explode the `motoko:stable-types` WASM custom section past the IC's 1 MiB ceiling. The printer redeclares the same shape under a fresh nominal name at every step, and each migration step grows the record with a few extra fields. Two patterns dominate the noise:

1. **Verbatim repetition** — the same variant `{#added : Nat; #removed : Nat}` reappears under hundreds of distinct `Event__N` aliases.
2. **Field-set drift** — successive migrations of `Item`/`Order`/`User` keep most fields and add a few; printed in full each time.

PR #6074 attacked (1) only. This PR attacks both.

## Approach

Two passes layered into a new module `Stab_sig_compress` (see `src/mo_types/stab_sig_compress.ml`), invoked once before serialization:

### Stage 1 — structural deduplication (same as #6074)

Group every reachable, parameter-less, non-recursive `Def` constructor by `Typ_hash.typ_hash` of its body. Pick one canonical rep per group. Rewrite every reference to point at the rep. Bare aliases (`type X = Y`) are skipped to avoid degenerating into `type X = X`.

### Stage 2 — anchored intersection mining

The remaining noise is in **records that share most fields**. Naive pairwise mining is `O(N²)` over migrations and would dominate compile time, so we use a closed-frequent-itemset-style pass:

1. **Intern fields**: each `(label, mut, structural-type-hash)` triple becomes an integer ID. Each record becomes a sorted `int array` (its field-bag). The full input is `O(N · k_avg)`.
2. **Inverted index**: `field_id → records-containing-it`. Built once per round.
3. **Anchored intersection**: for each field `f` with ≥ 2 users, intersect those users' field-bags. The result is the maximal field set co-occurring with `f` in at least those records. This gives candidate **bases**.
4. **Score & pick**: `saved = (size − 1) × (users − 1) − overhead`. Pick the best, mint a synthetic `Base__N` constructor, register it in the factor table, remove its fields from each covered record's "delta", and add it to that record's parent list. Repeat until no candidate has positive score.
5. **Print**: the modified printer (`pp_stab_sig_factored` in `type.ml`) walks records in topological order over the parent DAG and emits `T = Parent₁ and Parent₂ … and { delta }` using Motoko's existing intersection-type syntax. SCC-detected cycles fall back to the un-factored form.

Total work per round is `Σ_f |inv[f]| · k_avg ≈ N · k_avg²`; rounds are bounded by total fields, but in practice the first few rounds cover most records. Decoding is unchanged — `dfx`/`mops` parse the same `.most` grammar.

## Worked example

Three migration steps growing an `Item` record, with a recurring `Event` variant. Field types abbreviated.

### Vanilla (1.7.0)

```motoko
type Event__1 = {#added : Nat; #removed : Nat};
type Event__2 = {#added : Nat; #removed : Nat};
type Event__3 = {#added : Nat; #removed : Nat};

type Item__1 = { id : Nat; name : Text; value : Nat };
type Item__2 = { id : Nat; name : Text; value : Nat;
                 derived5 : Nat; tag2 : Text };
type Item__3 = { id : Nat; name : Text; value : Nat;
                 derived5 : Nat; tag2 : Text;
                 score : Int; flag : Bool };
type State__1 = { events : List<Event__1>;
                  items : Map<Nat, Item__1> };
type State__2 = { events : List<Event__2>;
                  items : Map<Nat, Item__2> };
type State__3 = { events : List<Event__3>;
                  items : Map<Nat, Item__3> };
```

### After Stage 1 (dedup, ≈ what #6074 produces)

```motoko
type Event__1 = {#added : Nat; #removed : Nat};

type Item__1 = { id : Nat; name : Text; value : Nat };
type Item__2 = { id : Nat; name : Text; value : Nat;
                 derived5 : Nat; tag2 : Text };
type Item__3 = { id : Nat; name : Text; value : Nat;
                 derived5 : Nat; tag2 : Text;
                 score : Int; flag : Bool };
// State__N still differ by Item__N parameter
type State__1 = { events : List<Event__1>;
                  items : Map<Nat, Item__1> };
type State__2 = { events : List<Event__1>;
                  items : Map<Nat, Item__2> };
type State__3 = { events : List<Event__1>;
                  items : Map<Nat, Item__3> };
```

### After Stage 1 + Stage 2 (this PR)

```motoko
type Event__1   = {#added : Nat; #removed : Nat};

type Base__a    = { id : Nat; name : Text; value : Nat };
type Base__b    = { derived5 : Nat; tag2 : Text };

type Item__1 = Base__a;
type Item__2 = Base__a and Base__b;
type Item__3 = Base__a and Base__b and { score : Int; flag : Bool };

type State__1 = { events : List<Event__1>; items : Map<Nat, Item__1> };
type State__2 = { events : List<Event__1>; items : Map<Nat, Item__2> };
type State__3 = { events : List<Event__1>; items : Map<Nat, Item__3> };
```

A real factored line from the long-rich `.most`:

```motoko
type Base__10 = {id : Nat; name : Text; value : Nat};
type Base__22 = { count527 : Nat; count587 : Nat; ... };
type Item__105463158 = Base__10 and Base__22
  and {derived770 : Nat; renamed779 : Nat};
```

## Impact (internal `enhanced-migrations/long-rich`, 1150 migrations)

A/B `mops build` of the same project, same source:

| moc                          | `backend.most`           | reduction | build time |
| ---------------------------- | ------------------------ | --------- | ---------- |
| `1.7.0` (vanilla)            | 4,654,621 B (4.44 MiB)   | —         | ~21 s      |
| #6074 (dedup only)           | 1,131,389 B (1.08 MiB)   | -75.7%    | ~21 s      |
| **#6081 (dedup + mining)**   | **792,768 B (775 KiB)**  | **-83.0%** | **~21 s** |

On the same project, **2135 / 2207 emitted record types (96.7%) factor through at least one synthetic `Base__N`**. Stage 2 contributes the additional ~30% on top of Stage 1 by collapsing field-set drift across `Item`/`Order`/`User` migrations that dedup couldn't touch.

In the previous DFX install A/B (#6074), the install ceiling moved from ~N=740 to ~N=1050. Extrapolating from byte ratios, this PR pushes the same ceiling well past N=1150 on the same project — though the gain is project-dependent (see caveats).

## Comparison with #6074

|                                    | #6074              | #6081 (this)        |
| ---------------------------------- | ------------------ | ------------------- |
| Wire-format change                 | None               | None                |
| Stable-sig compatibility check     | unchanged (struct) | unchanged (struct)  |
| Approach                           | type-level dedup   | dedup + record mining |
| Worst case (no shared fields)      | dedup only         | falls back to dedup |
| Best case observed                 | 4× compression     | 5.9× compression    |
| Mutates `Cons.t` in place          | yes                | yes (same dedup)    |
| Determinism                        | sub-optimal        | sub-optimal (Hashtbl iter order) |
| Code size (added)                  | ~150 LoC           | ~400 LoC            |

#6074 stays as the smaller, more conservative option if we want to land something soon. This PR strictly subsumes it on benefit but with more surface area to vet.

## Caveats

- **Experiment** — pending broader testing.
- **Determinism** — mining uses `Hashtbl`, so `.most` field order is iteration-order-dependent. Needs a sort by canonical key before this is reproducible-build-friendly.
- **`Cons.kind` mutation** — Stage 1 rewrites `Cons.kind` in place inside a `Cons.session` scope (inherited from #6074). Works for the signature path but is fragile if anything downstream caches kinds.
- **Project-dependent gain** — projects with little structural overlap will see less. We should A/B on a few more before drawing general conclusions.
- **Synthetic names in migration line** — `OldActor → NewActor` may surface as `NewActor_X → NewActor_X` after dedup; cosmetic but worth fixing before merge.

## Test plan

- [x] `dune build --profile=release` clean
- [x] `mops build` round-trip on long-rich (parses + validates compressed signature)
- [ ] `make -C test` full run
- [ ] Round-trip `dfx canister install --mode=upgrade` against an IC replica
- [ ] Determinism: byte-identical `.most` across two consecutive builds
- [ ] A/B on at least one project with low structural overlap