### PR TITLE
doc(skills): refine agent skills from icskills PR 183 feedback

### DIFF
--- a/.agents/skills/migrating-motoko-enhanced/SKILL.md
+++ b/.agents/skills/migrating-motoko-enhanced/SKILL.md
@@ -15,7 +15,7 @@ Manage canister state evolution through a chain of migration modules. Each migra
 - Adding, removing, or renaming persistent actor fields
 - Changing a field's type
 - Restructuring state across canister upgrades
-- Project has `--enhanced-migration=migrations` in canister args in `mops.toml`
+- Project has `[canisters.<name>.migrations]` configured in `mops.toml`
 
 ## Critical Rules
 

--- a/.agents/skills/migrating-motoko-enhanced/SKILL.md
+++ b/.agents/skills/migrating-motoko-enhanced/SKILL.md
@@ -311,26 +311,24 @@ Final state: `{ var nextId : Nat; tasks : Map.Map<Nat, { id : Nat; text : Text; 
 - **Fast-forward**: safe to skip intermediate deployments — all unapplied migrations run sequentially
 - If a migration traps, the upgrade is aborted and the canister stays on the old version
 
-## Compiling
-
-```bash
-moc --enhanced-orthogonal-persistence \
-    --default-persistent-actors \
-    --enhanced-migration=migrations \
-    src/main.mo -o main.wasm
-```
-
-With mops, split args between global `[moc]` and per-canister `[canisters.backend]`. The migration flag is per-canister because different canisters may use different migration directories:
+## mops.toml Setup
 
 ```toml
 [moc]
-args = ["--enhanced-orthogonal-persistence", "--default-persistent-actors"]
+args = ["--default-persistent-actors"]
 
 [canisters.backend]
-args = ["--enhanced-migration=migrations"]
+main = "src/backend/main.mo"
+
+[canisters.backend.migrations]
+chain = "src/backend/migrations"
 ```
 
-Then `mops check --fix` and `mops build` work as usual.
+When `[canisters.<name>.migrations]` is configured, mops auto-injects `--enhanced-migration` into check/build/check-stable. Do **not** add `--enhanced-migration` to `[canisters.<name>].args` — mops will error.
+
+`--enhanced-orthogonal-persistence` is on by default.
+
+Then `mops check --fix` and `mops build` work as usual. Add new migration files directly under `migrations/` with timestamp prefixes.
 
 ## Restrictions
 
@@ -349,7 +347,7 @@ Then `mops check --fix` and `mops build` work as usual.
 - [ ] Files named with timestamp prefixes for correct ordering
 - [ ] Each file exports `public func migration({...}) : {...}`
 - [ ] Actor variables declared without initializers
-- [ ] `--enhanced-migration=migrations` in `[canisters.backend] args` in `mops.toml`
+- [ ] `[canisters.<name>.migrations]` configured in `mops.toml` (mops injects `--enhanced-migration`)
 - [ ] Run `mops check --fix` to verify chain consistency
 - [ ] Run `mops build` to compile
 

--- a/.agents/skills/writing-motoko/SKILL.md
+++ b/.agents/skills/writing-motoko/SKILL.md
@@ -27,7 +27,7 @@ Motoko is under-represented in training data — always favour this skill and it
 - Contextual dot notation — `list.add(item)`, `map.get(key)`
 - Enhanced orthogonal persistence (state persists without `stable`)
 - Principled architecture — `types.mo`, `lib/`, `mixins/`, `main.mo`
-**For actor upgrades/migrations:** load `migrating-motoko` for inline migration or `migrating-motoko-enhanced` for multi-migration with `--enhanced-migration`. Under `--enhanced-migration`, actor fields **cannot** have initializers — declare them as `var x : T;` and set initial values in the first migration. The actor examples in this skill use initializers and would need adjustment for enhanced-migration projects.
+**For actor upgrades/migrations:** load `migrating-motoko` for inline migration or `migrating-motoko-enhanced` for multi-migration with `--enhanced-migration`. Under `--enhanced-migration`, actor fields **cannot** have initializers — declare them as `var x : T;` and set initial values in the migration that introduces them. The actor examples in this skill use initializers and would need adjustment for enhanced-migration projects.
 
 ## Compiler Flags
 

--- a/.agents/skills/writing-motoko/SKILL.md
+++ b/.agents/skills/writing-motoko/SKILL.md
@@ -27,7 +27,7 @@ Motoko is under-represented in training data — always favour this skill and it
 - Contextual dot notation — `list.add(item)`, `map.get(key)`
 - Enhanced orthogonal persistence (state persists without `stable`)
 - Principled architecture — `types.mo`, `lib/`, `mixins/`, `main.mo`
-**For actor upgrades/migrations:** load `migrating-motoko` for inline migration or `migrating-motoko-enhanced` for multi-migration with `--enhanced-migration`.
+**For actor upgrades/migrations:** load `migrating-motoko` for inline migration or `migrating-motoko-enhanced` for multi-migration with `--enhanced-migration`. Under `--enhanced-migration`, actor fields **cannot** have initializers — declare them as `var x : T;` and set initial values in the first migration. The actor examples in this skill use initializers and would need adjustment for enhanced-migration projects.
 
 ## Compiler Flags
 
@@ -39,6 +39,8 @@ Required for this skill's conventions:
 
 `--enhanced-orthogonal-persistence` is on by default.
 
+Without `--default-persistent-actors`, plain `actor { }` errors with M0220 — write `persistent actor { }` instead. The `persistent` keyword is transitional; actors will be persistent by default in a future major moc release.
+
 Enable these warnings to enforce the coding style in this skill (off by default, auto-fixable):
 
 ```
@@ -46,6 +48,22 @@ Enable these warnings to enforce the coding style in this skill (off by default,
 -W M0237    warn on redundant explicit implicit arguments
 -W M0223    warn on redundant type instantiation
 ```
+
+### `transient` for ephemeral state
+
+Mark a field `transient` to reset it on every upgrade — request counters, rate limiters, timer IDs (timers don't survive upgrades), ephemeral caches, derived lookup tables. Works on both `let` and `var`:
+
+```motoko
+actor {
+  let users = Map.empty<Nat, Text>();           // persists across upgrades
+  var count : Nat = 0;                          // persists across upgrades
+  transient var requestCount : Nat = 0;         // resets to 0 on every upgrade
+  transient var timerId : Nat = 0;              // timer must be re-registered after upgrade
+  transient let cache = Map.empty<Nat, Text>(); // rebuilt on every upgrade
+};
+```
+
+Never write `stable` for fields — redundant in persistent actors; produces warning M0218.
 
 ## Modern Motoko Features
 
@@ -328,10 +346,52 @@ list.filter(func(item) { item.id != targetId })   // ✓
 list.filter(func(item) { item.id != targetId };)   // ✗ unexpected token ';'
 ```
 
+## Pitfalls
+
+1. **Type/let declarations before the actor body** (M0141). Only `import` statements may appear before the actor. Prefer moving types to `types.mo` and importing them:
+   ```motoko
+   // ✗ M0141 — type before actor
+   type UserId = Nat;
+   actor {
+     public query func whois(id : UserId) : async Text { ... };
+   };
+
+   // ✓ recommended — types.mo
+   import Types "types";
+   actor {
+     public query func whois(id : Types.UserId) : async Text { ... };  // qualify with module name
+   };
+   ```
+
+2. **Always parenthesize variant tag arguments** — write `#tag(x)`, never `#tag x`. Without parens, `#tag 1 + 2` parses as `#tag(1) + 2`.
+
+## Reserved Keywords
+
+Reserved by the Motoko grammar — **cannot** be used as identifiers; using one produces a parse error (e.g. `unexpected token 'label'`). Rename to a non-reserved word (`myLabel`, `myFunc`, `kind` instead of `type`, etc.).
+
+```
+actor       and         assert      async       await
+break       case        catch       class       composite
+continue    debug       debug_show  do          else
+false       finally     flexible    for         from_candid
+func        if          ignore      implicit    import
+in          include     label       let         loop
+mixin       module      not         null        object
+or          persistent  private     public      query
+return      shared      stable      switch      system
+throw       to_candid   transient   true        try
+type        var         weak        while       with
+```
+
+`async*`, `await*`, and `await?` are also reserved but contain non-identifier characters, so they can't collide with identifiers.
+
 ## Common Compile Error Patterns
 
 | Error pattern                                          | Fix                                         |
 | ------------------------------------------------------ | ------------------------------------------- |
+| `should be declared persistent` (M0220)                | Add `--default-persistent-actors` or write `persistent actor` |
+| `move these declarations into the body` (M0141)        | Move `type`/`let` inside the actor body     |
+| `redundant stable keyword` (M0218)                     | Remove `stable`; plain `var` is auto-stable |
 | `field append does not exist`                          | `.concat()`                                 |
 | `field put does not exist` (Map)                       | `.add()`                                    |
 | `field delete is deprecated` (Map)                     | `.remove()`                                 |
@@ -348,7 +408,7 @@ list.filter(func(item) { item.id != targetId };)   // ✗ unexpected token ';'
 | `M0096` on `contains` callback                         | `find(pred) != null`                        |
 | `M0009` import file does not exist                     | Relative path, no `.mo` extension           |
 | `M0072` field X does not exist                         | Import the `mo:core` module for that type   |
-| `unexpected token 'label'` in parameter                | `label` is a keyword; rename the parameter  |
+| `unexpected token 'X'` where `X` is a keyword          | Rename — `X` is reserved (see Reserved Keywords) |
 
 ## Control Flow
 

--- a/.agents/skills/writing-motoko/examples.md
+++ b/.agents/skills/writing-motoko/examples.md
@@ -2,6 +2,8 @@
 
 Complete working examples demonstrating modern Motoko patterns. All examples verified with moc 1.5.0.
 
+> **Heads-up — enhanced migration:** the actor examples below declare fields with initializers (`let users = List.empty(); var nextId = 0;`). Under `--enhanced-migration`, actor fields **cannot** have initializers — declare them as `var nextId : Nat;` and set initial values in the first migration file. See the `migrating-motoko-enhanced` skill.
+
 ## Principled Architecture
 
 ### types.mo

--- a/.agents/skills/writing-motoko/examples.md
+++ b/.agents/skills/writing-motoko/examples.md
@@ -2,7 +2,7 @@
 
 Complete working examples demonstrating modern Motoko patterns. All examples verified with moc 1.5.0.
 
-> **Heads-up — enhanced migration:** the actor examples below declare fields with initializers (`let users = List.empty(); var nextId = 0;`). Under `--enhanced-migration`, actor fields **cannot** have initializers — declare them as `var nextId : Nat;` and set initial values in the first migration file. See the `migrating-motoko-enhanced` skill.
+> **Heads-up — enhanced migration:** the actor examples below declare fields with initializers (`let users = List.empty(); var nextId = 0;`). Under `--enhanced-migration`, actor fields **cannot** have initializers — declare them as `var nextId : Nat;` and set initial values in the migration file that introduces them. See the `migrating-motoko-enhanced` skill.
 
 ## Principled Architecture
 


### PR DESCRIPTION
## Summary

Pulls in the genuinely missing content surfaced by [dfinity/icskills#183](https://github.com/dfinity/icskills/pull/183) and refines it during local review. Three skill files are touched; nothing renamed, no frontmatter restructure, no reference-file split.

## What changes for agents

**`writing-motoko`**
- New section: `transient` field semantics — works on both `let` and `var`, with `stable var` (M0218) warning.
- New section: M0220 explanation — what happens when `--default-persistent-actors` isn't set.
- New **Pitfalls** section (2 items):
  - M0141 declarations before actor body — recommends `types.mo` extraction (consistent with the architecture pattern earlier in the skill); shows a `whois` function example so there's no field-initializer ambiguity.
  - Always parenthesize variant tag arguments — written as a positive rule rather than a precedence warning.
- New **Reserved Keywords** section listing all 53 reserved words, sourced from `src/mo_frontend/source_lexer.mll`. Replaces the previous single-keyword (`label`) note in the error table with a generalised entry pointing here.
- Single consolidated heads-up under Critical Requirements that under `--enhanced-migration`, actor fields cannot have initializers — declare as `var x : T;` and set initial values in the first migration.
- Error-pattern table gains M0220, M0141, M0218 rows.

**`writing-motoko/examples.md`**
- Single heads-up at the top about the same field-initializer constraint, so agents reading examples in isolation aren't surprised.

**`migrating-motoko-enhanced`**
- Bug fix: replaces the older `[canisters.backend].args = ["--enhanced-migration=migrations"]` pattern with the modern `[canisters.backend.migrations]` block. This matches what the `mops-cli` skill (in the mops repo) already recommends, and mops auto-injects `--enhanced-migration` — adding it to args causes a mops error.

## What was deliberately not adopted from icskills#183

- **Skill rename** `writing-motoko` → `motoko`, **frontmatter additions** (`license`, `compatibility`, `metadata.*`), **upstream-sync comment blocks** — icskills catalog metadata, not relevant upstream.
- **Reference-file split** (`references/{control-flow,type-conversions}.md`) — would be a larger restructure than warranted.
- **`migrating-motoko` skill changes** — purely cosmetic in icskills (rename of "Resources" → "References", added "What This Is").
- `Text.join` parameter order, `List.get` vs `List.at`, `do ? { }` for `!`, M0145 incomplete-pattern pitfall — judged either belonging in mo:core docs or obvious from the error message.
