### PR TITLE
chore: bump three `performance`-action pins

### DIFF
--- a/.github/actions/performance/action.yml
+++ b/.github/actions/performance/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
 
     - name: Commit `test/bench` changes
-      uses: EndBug/add-and-commit@v9
+      uses: EndBug/add-and-commit@0a145b91207725ab63102736ff2ddcf18f90cdb5 # v10.0.0
       with:
         default_author: github_actions
         author_name: Cycle and memory benchmark updater
@@ -68,7 +68,7 @@ runs:
 
     - name: Find performance comment
       if: ${{ inputs.is_fork == 'false' }}
-      uses: peter-evans/find-comment@v3
+      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
       id: fc
       with:
         issue-number: ${{ inputs.pr_number }}
@@ -79,7 +79,7 @@ runs:
     # motoko#2864.
     - name: Create or update performance comment
       if: ${{ inputs.is_fork == 'false' }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ inputs.pr_number }}


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 actions effective 2026-06-02 and removes Node 20 from runners 2026-09-16. The `tests` workflow's post-job log already emits a warning naming three actions in `.github/actions/performance/action.yml` that still run on Node 20:

| action | from | to (SHA + tag) |
| --- | --- | --- |
| `EndBug/add-and-commit` | `@v9` | `@0a145b91207725ab63102736ff2ddcf18f90cdb5 # v10.0.0` |
| `peter-evans/find-comment` | `@v3` | `@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0` |
| `peter-evans/create-or-update-comment` | `@v4` | `@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0` |

All three major bumps update only the runtime (Node 20 → 24); the input schemas of the actions are backwards-compatible with the params passed in `action.yml` (`default_author`, `github_token`, `committer_*`, `message`, `commit` for `add-and-commit`; `issue-number`, `comment-author`, `body-includes` for `find-comment`; `comment-id`, `issue-number`, `body`, `edit-mode` for `create-or-update-comment`).

Pinning by commit SHA + version comment matches the convention introduced in [#90](https://github.com/caffeinelabs/motoko/pull/90) (`chore: pin GitHub Actions to commit SHAs`) and already in use elsewhere under `.github/workflows/`.

## Test plan

- [x] CI green: the `tests` job's `Commit test/bench changes` step (uses `add-and-commit`) and the perf-comment update steps (`find-comment` + `create-or-update-comment`) all succeed on a real perf run.
- [x] The Node-20-deprecation warning at the end of the `tests` job log is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
