### PR TITLE
chore: serialise `tests` builds on `arm64-linux-16`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,12 @@ jobs:
       matrix:
         os: [ubuntu-24-large, arm64-linux-16]
         build_type: [release, debug]
+        include:
+          - os: ubuntu-24-large
+            max_jobs: auto
+          # arm64-linux-16 OOMs on three parallel ~3 GB derivation builds; serialise.
+          - os: arm64-linux-16
+            max_jobs: 1
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -73,6 +79,7 @@ jobs:
           test-target: ${{ matrix.build_type }}-systems-go
           test-name: ${{ matrix.os }}-${{ matrix.build_type }}-tests
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          max-jobs: ${{ matrix.max_jobs }}
 
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3


### PR DESCRIPTION
## Summary
Extends the same `max_jobs=1` workaround used by `gc-tests` in #6009 to the `tests` matrix on `arm64-linux-16`. `ubuntu-24-large` keeps `max-jobs=auto`.

## Why
`tests (arm64-linux-16, release)` and `tests (arm64-linux-16, debug)` have been OOM-killed by the runner whenever `nix-build-uncached --max-jobs auto` schedules three parallel ~3 GB derivation builds. Most recent observation: https://github.com/caffeinelabs/motoko/actions/runs/25409615273/job/74528169567 (initial CI on the `pocket-ic` bump PR #6088 — failure was unrelated to the bump itself).

## Why max-jobs=1 (not 2)
We probed a higher ceiling but it's not stable enough to ship:

- PR #6090 ran `gc-tests` and `tests` at `max-jobs=2` against a cache-busted `test-runner` and **appeared** to pass.
- PR #6088 with a *different* cache-buster (forcing a different content hash than #6090's, and therefore a real cold rebuild of the GC-variant derivations) hit OOM on `gc-tests (arm64-linux-16, 2)` after ~2.5 minutes:
  ```
  building 'test-drun-compacting-gc.drv'...
  building 'test-drun-generational-gc.drv'...
  Killed   nix-build-uncached -build-flags "--max-jobs 2"
  ```
  Run: https://github.com/caffeinelabs/motoko/actions/runs/25411132891/job/74532926605

The result depends on which derivations happen to be cachix-cached vs cold-rebuilt at any given moment. An asymmetric `gc-tests=1, tests=2` configuration would also be brittle: a future test addition could shift the memory profile of `release-systems-go` and silently reintroduce OOMs. Going uniform `max-jobs=1` is slower but stable.

## Test plan
- [x] CI green
- [x] No `tests (arm64-linux-16, *)` OOM on the resulting run

🤖 Generated with [Claude Code](https://claude.com/claude-code)