### PR TITLE
nix(flake): track `nixpkgs-unstable` instead of `nixos-unstable`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,16 +193,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "The Motoko compiler";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     flake-utils.url = "github:numtide/flake-utils";
 


### PR DESCRIPTION
## Summary

`nixos-unstable` is gated on hydra channel-bumps and lags `nixpkgs-unstable` by days, occasionally weeks. Switching the flake input to `nixpkgs-unstable` picks up package updates as soon as they land in the master branch.

## Concrete win

| channel | wabt |
|---|---|
| `nixpkgs-unstable` | 1.0.41 ✓ |
| `nixos-unstable` (today's snapshot) | 1.0.40 ✗ |

`wabt` 1.0.41 is the version we've been carrying via overlay (#5a8df27df, #38ba3e93a, #17e685f39 on the `gabor/wasm-exts-sync` branch — see project memory). Switching to `nixpkgs-unstable` makes the overlay redundant.

## Test plan

- [ ] CI green on the lock-refreshed flake
- [ ] After merge: drop the wabt overlay + `wabt-package-src` input on `gabor/wasm-exts-sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)