### PR TITLE
chore: revert `SKIP-SANITY-CHECKS` exclusions from #5074

### DIFF
--- a/test/run-drun/migration-paths.drun
+++ b/test/run-drun/migration-paths.drun
@@ -1,6 +1,5 @@
 # CLASSICAL-PERSISTENCE-ONLY
 # DEFAULT-GC-ONLY
-# SKIP-SANITY-CHECKS
 
 # Start with classical persistence
 install $ID migration-paths/old-installer.mo ""

--- a/test/run-drun/non-par.mo
+++ b/test/run-drun/non-par.mo
@@ -114,4 +114,3 @@ actor A {
 //CALL ingress test5 "DIDL\x00\x00"
 //CALL ingress test6 "DIDL\x00\x00"
 //CALL ingress test7 "DIDL\x00\x00"
-//SKIP-SANITY-CHECKS

--- a/test/run-drun/par-effects.mo
+++ b/test/run-drun/par-effects.mo
@@ -42,4 +42,3 @@ actor A {
 };
 
 A.go(); //OR-CALL ingress go "DIDL\x00\x00"
-//SKIP-SANITY-CHECKS

--- a/test/run-drun/par.mo
+++ b/test/run-drun/par.mo
@@ -174,4 +174,3 @@ actor A {
 //CALL ingress test10 "DIDL\x00\x00"
 //CALL ingress test11 "DIDL\x00\x00"
 //CALL ingress test12 "DIDL\x00\x00"
-//SKIP-SANITY-CHECKS

--- a/test/run-drun/stabilize-to-any.drun
+++ b/test/run-drun/stabilize-to-any.drun
@@ -1,5 +1,4 @@
 # ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
-# SKIP-SANITY-CHECKS
 
 install $ID stabilize-to-any/version0.mo ""
 ingress $ID check "DIDL\x00\x00"


### PR DESCRIPTION
## Summary

Removes the `SKIP-SANITY-CHECKS` directives that PR #5074 (rust-nightly bump to 2024-12-19) added to five drun-tests as a workaround for the cycle-limit issue tracked in #5665. CI confirms the underlying issue has been fixed by something that landed since — the un-excluded tests now run under sanity checks with zero failures.

Files un-excluded:

- `test/run-drun/non-par.mo`
- `test/run-drun/par.mo`
- `test/run-drun/par-effects.mo`
- `test/run-drun/migration-paths.drun`
- `test/run-drun/stabilize-to-any.drun`

The other three `SKIP-SANITY-CHECKS` files in the tree (`stabilization-authorization.mo`, `send-failure-example.mo`, `class-import.mo`) were excluded by other PRs and are out of scope here.

## Context

- #5665 — original issue (already closed) requesting investigation into the cycle-limit-busting behavior.
- #5074 — added the exclusions as a temporary workaround to land the rust-nightly bump.
- This PR — confirms the workaround is no longer needed.

## CI result

All 16 required checks SUCCESS, 0 failures.

## Test plan

- [x] CI green on all matrix configurations (incl. sanity-check pass)
- [ ] Optional follow-up: bisect to identify which intervening commit fixed the underlying issue, for the changelog