### PR TITLE
fix(test-runner): recognise `// CHECK` (space) as `FileCheck` directive

### DIFF
--- a/test-runner/src/run_test.rs
+++ b/test-runner/src/run_test.rs
@@ -280,7 +280,7 @@ fn parse_directives(src: &str, is_drun: bool) -> Directives {
             {
                 d.filter.insert(ext.to_string(), cmd.trim().to_string());
             }
-            d.check |= line.starts_with("//CHECK");
+            d.check |= re(r"^// *CHECK").is_match(line);
             d.no_force_gc |= tagged("MOC-NO-FORCE-GC");
             d.no_skip_gc_deprecation_warning |= tagged("NO-SKIP-GC-DEPRECATION-WARNING");
             d.generational_gc_only |= tagged("GENERATIONAL-GC-ONLY");
@@ -617,7 +617,8 @@ fn diff_variant(ctx: &mut Ctx, a: &str, b: &str, dst: &str) {
 
 fn filecheck(ctx: &mut Ctx, cli: &Cli, wasm: &Path, mangled: &Path) {
     let mangled_src = fs::read_to_string(mangled).unwrap_or_default();
-    if !mangled_src.lines().any(|l| l.starts_with("//CHECK")) {
+    let check_re = re(r"^// *CHECK");
+    if !mangled_src.lines().any(|l| check_re.is_match(l)) {
         return;
     }
     echo(cli, " [FileCheck]");


### PR DESCRIPTION
## Summary

Both FileCheck gates in `test-runner/src/run_test.rs` (`parse_directives:283` and `filecheck:620`) used `line.starts_with("//CHECK")` with **no space** — but 24 of the 27 FileCheck-annotated tests in `test/run/` use the conventional `// CHECK:` form. Result: FileCheck was silently skipped on the majority of would-be FileCheck tests. The `[FileCheck]` phase never appeared in their output, and `// CHECK` directives were unenforced.

Fix: trim leading `/` and whitespace before matching `CHECK`, so both `// CHECK` and `//CHECK` activate.

## Test plan

- [x] Manually invoked FileCheck on the 19 silenced classical-mode tests (the 5 EOP-only ones have no wasm under default classical mode) — all 19 pass; fix is risk-free.
- [x] `make -C test/run -j8 quick` still green.
- [x] After the fix, the phase line shows `[FileCheck]` for all `// CHECK` tests, e.g. `top-bit: [tc] [run] [run-ir] [run-low] [comp] [valid] [FileCheck] [wasm-run]`.