### PR TITLE
perf: peephole `if cond (br N) else ()` → `br_if (N-1)`

### DIFF
--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -62,8 +62,8 @@ let optimize : instr list -> instr list = fun is ->
       go l' r'
     | { it = GlobalGet n1; _} :: l', ({ it = GlobalSet n2; _ }) :: r' when n1 = n2 ->
       go l' r'
-    (* Code after Return, Br or Unreachable is dead *)
-    | _, ({ it = Return | Br _ | Unreachable; _ } as i) :: t ->
+    (* Code after Return, Br, BrTable or Unreachable is dead *)
+    | _, ({ it = Return | Br _ | BrTable _ | Unreachable; _ } as i) :: t ->
       (* see Note [funneling DIEs through Wasm.Ast] *)
       List.(rev (i :: l) @ find_all (fun instr -> Wasm_exts.Ast.is_dwarf_like instr.it) t)
     (* Equals zero has a dedicated operation (and works well with leg swapping) *)

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -124,15 +124,6 @@ let optimize : instr list -> instr list = fun is ->
        go l' ({i with it = Drop} :: r')
     | l', ({it = If (_, [{it = Br x; _}], []); _} as i) :: r' ->
       go l' ({i with it = BrIf {x with it = Int32.sub x.it 1l}} :: r')
-    (* Probe: `if (cond) (br N) else <non-empty>`. Would generalise the
-       rule above by wrapping the else body in a `block` to preserve the
-       if's implicit label (so `Br 0` inside the body still falls
-       through, and higher depths stay correct). Add the rewrite once
-       we've seen a concrete moc-emitted instance and confirmed the
-       block-type encoding is no longer than the if's. *)
-    | l', ({it = If (_, [{it = Br _; _}], _ :: _); _}) :: _ ->
-      failwith "instrList: probe — `If (_, [Br N], non-empty else)` seen; \
-                consider extending the BrIf rule with a block wrapper"
     (* `If` blocks with empty then after comparison can invert the comparison and swap legs *)
     | { it = Compare (I32 I32Op.Eq); _} as comp :: l', ({it = If (res,[],else_); _} as i) :: r' ->
       go ({comp with it = Compare (I32 I32Op.Ne)} :: l') ({i with it = If (res,else_,[])} :: r')

--- a/src/codegen/instrList.ml
+++ b/src/codegen/instrList.ml
@@ -119,9 +119,20 @@ let optimize : instr list -> instr list = fun is ->
     (* `If` blocks after negation can swap legs *)
     | { it = Test (I32 I32Op.Eqz); _} :: l', ({it = If (res,then_,else_); _} as i) :: r' ->
       go l' ({i with it = If (res,else_,then_)} :: r')
-    (* `If` blocks with empty legs just drop *)
-    | l', ({it = If (_,[],[]); _} as i) :: r' ->
+    (* `If` blocks with empty legs (or just a Br 0 fall-through) just drop *)
+    | l', ({it = If (_, ([] | [{it = Br {it = 0l; _}; _}]), []); _} as i) :: r' ->
        go l' ({i with it = Drop} :: r')
+    | l', ({it = If (_, [{it = Br x; _}], []); _} as i) :: r' ->
+      go l' ({i with it = BrIf {x with it = Int32.sub x.it 1l}} :: r')
+    (* Probe: `if (cond) (br N) else <non-empty>`. Would generalise the
+       rule above by wrapping the else body in a `block` to preserve the
+       if's implicit label (so `Br 0` inside the body still falls
+       through, and higher depths stay correct). Add the rewrite once
+       we've seen a concrete moc-emitted instance and confirmed the
+       block-type encoding is no longer than the if's. *)
+    | l', ({it = If (_, [{it = Br _; _}], _ :: _); _}) :: _ ->
+      failwith "instrList: probe — `If (_, [Br N], non-empty else)` seen; \
+                consider extending the BrIf rule with a block wrapper"
     (* `If` blocks with empty then after comparison can invert the comparison and swap legs *)
     | { it = Compare (I32 I32Op.Eq); _} as comp :: l', ({it = If (res,[],else_); _} as i) :: r' ->
       go ({comp with it = Compare (I32 I32Op.Ne)} :: l') ({i with it = If (res,else_,[])} :: r')


### PR DESCRIPTION
## Summary

moc's IR has no direct way to emit `br_if`, so conditional branches show up post-codegen as `if (cond) [br N] []`. This peephole recognises that shape and rewrites to a single `br_if` instruction, decrementing the target by 1 to compensate for the removed `if`'s implicit label. `Br 0` (no-op fall-through) becomes a plain `Drop` of the condition.

Also declares `BrTable` as terminator.

## Coverage

Fires on internal codegen with no-result blocks (e.g. `trans_state4`'s state-equality checks). Does **not** fire on user-level break/continue/let-else because those lower to `if [const 0; br N] []` — the target block expects a unit value pushed before the break, and rewriting that would need locals to stash the unit value (out of scope for the zipper).

## Probe (removed)

A `failwith` covers the `If (_, [Br N], non-empty else)` shape we haven't yet seen moc emit; rewriting it cleanly would need a wrapping `block` to preserve the if's implicit label. Left as a trap until we have a concrete instance to test against.

**Empirically not triggered by user-level break.** A natural-looking
`var t = true; label l loop if t { break l }` lowers to
`block (result i64) loop block (result i64) if (result i64) [i64.const 0; br 3] else [i64.const 0] end ...`
— both legs of the `if` start with a matching `i64.const 0` (the
result-typed scaffolding around the loop) and the then-leg is
`[const 0; br N]` rather than `[br N]`. So the probe doesn't fire,
and the simpler `[br N] []` rule doesn't fire either. Hoisting
matching push-like instructions out of both legs would expose the
`[br N] []` shape; out of scope here.

## Test plan

- [x] `make -C test/run` — green
- [x] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
