### PR TITLE
fix(ci): skip GitHub-App token + perf step on fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,10 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           max-jobs: ${{ matrix.max_jobs }}
 
+      # Secrets/vars are not exposed to fork PRs, so this step (and the perf
+      # step that consumes its output) is skipped on fork PRs.
       - name: Create GitHub App Token
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
@@ -89,7 +92,7 @@ jobs:
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
 
       - name: Run Performance Tests
-        if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && runner.os == 'Linux' && runner.arch == 'X64' && matrix.build_type == 'release'
+        if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && runner.os == 'Linux' && runner.arch == 'X64' && matrix.build_type == 'release'
         uses: ./.github/actions/performance
         with:
           head_sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Why

Every PR from a fork currently fails CI before tests even start. The `tests` matrix job dies at the `Create GitHub App Token` step because GitHub never exposes `vars.*` / `secrets.*` to fork workflows — `client-id` is empty and the action errors out. Since `tests` is a required check via `verify-main-tests`, no external contributor can land a change, regardless of what they touched. Concrete example: #6132.

This isn't a contributor-permission problem — there's no GitHub setting or org allowlist that hands secrets to fork workflows. The workflow itself has to handle it, the way the `artifacts` / `autoclose` / `approvals` jobs in this same file already do.

## What changes

Fork PRs now run the full test suite to completion and get a green check. They don't get the perf comment or the `test/bench` auto-commit, because those need to push to / comment on the PR — which the action genuinely can't do from a fork (it's also why the perf action already has `is_fork` gating internally).

Same-repo PRs and `master` are unchanged.

Made with [Cursor](https://cursor.com)