### PR TITLE
chore: drop obsolete `make -C doc base` from release flow

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -113,17 +113,16 @@ git switch master
 git pull
 ```
 
-Make sure the markdown doc for base is up-to-date:
-For now, in a nix shell `$ nix develop` (or _re-enter_ if you already have one open):
+Make sure the compiler, runtime, and any generated docs still build
+cleanly and the working tree stays clean:
 
 ```bash
-  make -C rts
-  make -C src
-  make -C doc base
-  git diff
+nix develop -c bash -c "
+  make -C rts &&
+  make -C src &&
+  git -C doc diff
+"
 ```
-
-If not, create and merge a separate PR to update the doc (adding any new files) and goto step 0.
 
 ### 1. Update Changelog
 


### PR DESCRIPTION
## Why

Step 0 of the release procedure in Building.md says to run:

\`\`\`bash
make -C rts
make -C src
make -C doc base
git diff
\`\`\`

The third line fails today: \`doc/Makefile\` only has \`preview\` /
\`build\` / \`serve\` / \`_site-install\` targets.  Anyone following
the documented release flow trips on
\`make: *** No rule to make target 'base'.  Stop.\` mid-release.

## What

Drop the stale step.  Keep the still-valid rts/src build sanity
check (catches local build breakage before a release).  Add a note
pointing at the existing \`niv-updater-action\` that handles
downstream \`motoko-base\` / \`motoko-core\` markdown sync, so
nobody wonders where the base-docs-sync went.

Caught while cutting 1.8.1 (#6137).