### PR TITLE
docs: extract sidebar to doc/md/sidebar.mjs, hide index stubs

### DIFF
--- a/doc/md/fundamentals/actors/index.md
+++ b/doc/md/fundamentals/actors/index.md
@@ -3,4 +3,5 @@ title: "Actors"
 sidebar:
   order: 3
   label: "Actors"
+  hidden: true
 ---

--- a/doc/md/fundamentals/actors/orthogonal-persistence/index.md
+++ b/doc/md/fundamentals/actors/orthogonal-persistence/index.md
@@ -3,4 +3,5 @@ title: "Orthogonal persistence"
 sidebar:
   order: 6
   label: "Orthogonal persistence"
+  hidden: true
 ---

--- a/doc/md/fundamentals/basic-syntax/index.md
+++ b/doc/md/fundamentals/basic-syntax/index.md
@@ -3,4 +3,5 @@ title: "Basic syntax"
 sidebar:
   order: 2
   label: "Basic syntax"
+  hidden: true
 ---

--- a/doc/md/fundamentals/control-flow/index.md
+++ b/doc/md/fundamentals/control-flow/index.md
@@ -3,4 +3,5 @@ title: "Control flow"
 sidebar:
   order: 6
   label: "Control flow"
+  hidden: true
 ---

--- a/doc/md/fundamentals/declarations/index.md
+++ b/doc/md/fundamentals/declarations/index.md
@@ -3,4 +3,5 @@ title: "Declarations"
 sidebar:
   order: 5
   label: "Declarations"
+  hidden: true
 ---

--- a/doc/md/fundamentals/types/index.md
+++ b/doc/md/fundamentals/types/index.md
@@ -3,4 +3,5 @@ title: "Types"
 sidebar:
   order: 4
   label: "Types"
+  hidden: true
 ---

--- a/doc/md/reference/changelog.md
+++ b/doc/md/reference/changelog.md
@@ -3,6 +3,7 @@ title: "Changelog"
 description: "Motoko compiler changelog."
 sidebar:
   order: 6
+  label: "Motoko changelog"
 ---
 
 ```md file=<motokoRoot>/Changelog.md

--- a/doc/md/sidebar.mjs
+++ b/doc/md/sidebar.mjs
@@ -1,0 +1,123 @@
+/**
+ * Motoko documentation sidebar — single source of truth.
+ *
+ * Consumed by two sites:
+ *   - doc/site/  (local Astro + Starlight preview)
+ *   - docs.internetcomputer.org  (consumer site syncs doc/md/ via rsync;
+ *     its sync script reads this file and prepends the "languages/motoko/"
+ *     path prefix to every slug and autogenerate.directory value)
+ *
+ * Maintenance: edit this file when pages are added, removed, or reordered.
+ * doc/site/astro.config.mjs imports this directly — no duplication.
+ */
+
+export const sidebar = [
+  { slug: "index", label: "Overview" },
+  {
+    label: "Fundamentals",
+    collapsed: false,
+    items: [
+      { slug: "fundamentals/hello-world" },
+      {
+        label: "Basic syntax",
+        collapsed: true,
+        items: [
+          { slug: "fundamentals/basic-syntax/defining-an-actor" },
+          { slug: "fundamentals/basic-syntax/imports" },
+          { slug: "fundamentals/basic-syntax/printing-values" },
+          { slug: "fundamentals/basic-syntax/numbers" },
+          { slug: "fundamentals/basic-syntax/characters-text" },
+          { slug: "fundamentals/basic-syntax/literals" },
+          { slug: "fundamentals/basic-syntax/identifiers" },
+          { slug: "fundamentals/basic-syntax/functions" },
+          { slug: "fundamentals/basic-syntax/operators" },
+          { slug: "fundamentals/basic-syntax/comments" },
+          { slug: "fundamentals/basic-syntax/whitespace" },
+          { slug: "fundamentals/basic-syntax/traps" },
+        ],
+      },
+      {
+        label: "Actors",
+        collapsed: true,
+        items: [
+          { slug: "fundamentals/actors/actors-async" },
+          { slug: "fundamentals/actors/state" },
+          { slug: "fundamentals/actors/data-persistence" },
+          { slug: "fundamentals/actors/compatibility" },
+          { slug: "fundamentals/actors/messaging" },
+          {
+            label: "Orthogonal persistence",
+            collapsed: true,
+            items: [
+              { slug: "fundamentals/actors/orthogonal-persistence/overview" },
+              { slug: "fundamentals/actors/orthogonal-persistence/enhanced" },
+              { slug: "fundamentals/actors/orthogonal-persistence/classical" },
+            ],
+          },
+          { slug: "fundamentals/actors/mixins" },
+          { slug: "fundamentals/actors/enhanced-multi-migration" },
+        ],
+      },
+      {
+        label: "Types",
+        collapsed: true,
+        items: [
+          { slug: "fundamentals/types/primitive-types" },
+          { slug: "fundamentals/types/shared-types" },
+          { slug: "fundamentals/types/function-types" },
+          { slug: "fundamentals/types/tuples" },
+          { slug: "fundamentals/types/records" },
+          { slug: "fundamentals/types/objects-classes" },
+          { slug: "fundamentals/types/variants" },
+          { slug: "fundamentals/types/immutable-arrays" },
+          { slug: "fundamentals/types/mutable-arrays" },
+          { slug: "fundamentals/types/options" },
+          { slug: "fundamentals/types/results" },
+          { slug: "fundamentals/types/advanced-types" },
+          { slug: "fundamentals/types/stable-types" },
+          { slug: "fundamentals/types/subtyping" },
+          { slug: "fundamentals/types/type-conversions" },
+        ],
+      },
+      {
+        label: "Declarations",
+        collapsed: true,
+        items: [
+          { slug: "fundamentals/declarations/variable-declarations" },
+          { slug: "fundamentals/declarations/function-declarations" },
+          { slug: "fundamentals/declarations/object-declaration" },
+          { slug: "fundamentals/declarations/class-declarations" },
+          { slug: "fundamentals/declarations/type-declarations" },
+          { slug: "fundamentals/declarations/expression-declarations" },
+          { slug: "fundamentals/declarations/module-declarations" },
+        ],
+      },
+      {
+        label: "Control flow",
+        collapsed: true,
+        items: [
+          { slug: "fundamentals/control-flow/basic-control-flow" },
+          { slug: "fundamentals/control-flow/loops" },
+          { slug: "fundamentals/control-flow/conditionals" },
+          { slug: "fundamentals/control-flow/blocks" },
+          { slug: "fundamentals/control-flow/switch" },
+        ],
+      },
+      { slug: "fundamentals/modules-imports" },
+      { slug: "fundamentals/pattern-matching" },
+      { slug: "fundamentals/error-handling" },
+      { slug: "fundamentals/contextual-dot" },
+      { slug: "fundamentals/implicit-parameters" },
+    ],
+  },
+  {
+    label: "ICP features",
+    collapsed: true,
+    autogenerate: { directory: "icp-features" },
+  },
+  {
+    label: "Reference",
+    collapsed: true,
+    autogenerate: { directory: "reference" },
+  },
+];

--- a/doc/site/astro.config.mjs
+++ b/doc/site/astro.config.mjs
@@ -5,6 +5,7 @@ import remarkIncludeFile from "./plugins/remark-include-file.mjs";
 import remarkHeadingId from "./plugins/remark-heading-id.mjs";
 import rehypeExternalLinks from "./plugins/rehype-external-links.mjs";
 import rehypeRewriteLinks from "./plugins/rehype-rewrite-links.mjs";
+import { sidebar } from "../md/sidebar.mjs";
 
 export default defineConfig({
   markdown: {
@@ -34,116 +35,7 @@ export default defineConfig({
           href: "https://github.com/caffeinelabs/motoko",
         },
       ],
-      sidebar: [
-        { slug: "index", label: "Overview" },
-        {
-          label: "Fundamentals",
-          collapsed: false,
-          items: [
-            { slug: "fundamentals/hello-world" },
-            {
-              label: "Basic syntax",
-              collapsed: true,
-              items: [
-                { slug: "fundamentals/basic-syntax/defining-an-actor" },
-                { slug: "fundamentals/basic-syntax/imports" },
-                { slug: "fundamentals/basic-syntax/printing-values" },
-                { slug: "fundamentals/basic-syntax/numbers" },
-                { slug: "fundamentals/basic-syntax/characters-text" },
-                { slug: "fundamentals/basic-syntax/literals" },
-                { slug: "fundamentals/basic-syntax/identifiers" },
-                { slug: "fundamentals/basic-syntax/functions" },
-                { slug: "fundamentals/basic-syntax/operators" },
-                { slug: "fundamentals/basic-syntax/comments" },
-                { slug: "fundamentals/basic-syntax/whitespace" },
-                { slug: "fundamentals/basic-syntax/traps" },
-              ],
-            },
-            {
-              label: "Actors",
-              collapsed: true,
-              items: [
-                { slug: "fundamentals/actors/actors-async" },
-                { slug: "fundamentals/actors/state" },
-                { slug: "fundamentals/actors/data-persistence" },
-                { slug: "fundamentals/actors/compatibility" },
-                { slug: "fundamentals/actors/messaging" },
-                {
-                  label: "Orthogonal persistence",
-                  collapsed: true,
-                  items: [
-                    { slug: "fundamentals/actors/orthogonal-persistence/overview" },
-                    { slug: "fundamentals/actors/orthogonal-persistence/enhanced" },
-                    { slug: "fundamentals/actors/orthogonal-persistence/classical" },
-                  ],
-                },
-                { slug: "fundamentals/actors/mixins" },
-                { slug: "fundamentals/actors/enhanced-multi-migration" },
-              ],
-            },
-            {
-              label: "Types",
-              collapsed: true,
-              items: [
-                { slug: "fundamentals/types/primitive-types" },
-                { slug: "fundamentals/types/shared-types" },
-                { slug: "fundamentals/types/function-types" },
-                { slug: "fundamentals/types/tuples" },
-                { slug: "fundamentals/types/records" },
-                { slug: "fundamentals/types/objects-classes" },
-                { slug: "fundamentals/types/variants" },
-                { slug: "fundamentals/types/immutable-arrays" },
-                { slug: "fundamentals/types/mutable-arrays" },
-                { slug: "fundamentals/types/options" },
-                { slug: "fundamentals/types/results" },
-                { slug: "fundamentals/types/advanced-types" },
-                { slug: "fundamentals/types/stable-types" },
-                { slug: "fundamentals/types/subtyping" },
-                { slug: "fundamentals/types/type-conversions" },
-              ],
-            },
-            {
-              label: "Declarations",
-              collapsed: true,
-              items: [
-                { slug: "fundamentals/declarations/variable-declarations" },
-                { slug: "fundamentals/declarations/function-declarations" },
-                { slug: "fundamentals/declarations/object-declaration" },
-                { slug: "fundamentals/declarations/class-declarations" },
-                { slug: "fundamentals/declarations/type-declarations" },
-                { slug: "fundamentals/declarations/expression-declarations" },
-                { slug: "fundamentals/declarations/module-declarations" },
-              ],
-            },
-            {
-              label: "Control flow",
-              collapsed: true,
-              items: [
-                { slug: "fundamentals/control-flow/basic-control-flow" },
-                { slug: "fundamentals/control-flow/loops" },
-                { slug: "fundamentals/control-flow/conditionals" },
-                { slug: "fundamentals/control-flow/blocks" },
-                { slug: "fundamentals/control-flow/switch" },
-              ],
-            },
-            { slug: "fundamentals/modules-imports" },
-            { slug: "fundamentals/pattern-matching" },
-            { slug: "fundamentals/error-handling" },
-            { slug: "fundamentals/contextual-dot" },
-            { slug: "fundamentals/implicit-parameters" },
-          ],
-        },
-        {
-          label: "ICP features",
-          collapsed: true,
-          autogenerate: { directory: "icp-features" },
-        },
-        {
-          label: "Reference",
-          collapsed: true,
-          autogenerate: { directory: "reference" },
-        },
-      ],
+      sidebar,
     }),
   ],
 });

--- a/doc/site/astro.config.mjs
+++ b/doc/site/astro.config.mjs
@@ -5,7 +5,7 @@ import remarkIncludeFile from "./plugins/remark-include-file.mjs";
 import remarkHeadingId from "./plugins/remark-heading-id.mjs";
 import rehypeExternalLinks from "./plugins/rehype-external-links.mjs";
 import rehypeRewriteLinks from "./plugins/rehype-rewrite-links.mjs";
-import { sidebar } from "../md/sidebar.mjs";
+import { sidebar } from "./sidebar.mjs";
 
 export default defineConfig({
   markdown: {

--- a/doc/site/sidebar.mjs
+++ b/doc/site/sidebar.mjs
@@ -2,13 +2,12 @@
  * Motoko documentation sidebar — single source of truth.
  *
  * Consumed by two sites:
- *   - doc/site/  (local Astro + Starlight preview)
- *   - docs.internetcomputer.org  (consumer site syncs doc/md/ via rsync;
- *     its sync script reads this file and prepends the "languages/motoko/"
+ *   - doc/site/astro.config.mjs  (local Astro + Starlight preview, imports directly)
+ *   - docs.internetcomputer.org  (reads this file from the pinned .sources/motoko
+ *     submodule at doc/site/sidebar.mjs and prepends the "languages/motoko/"
  *     path prefix to every slug and autogenerate.directory value)
  *
  * Maintenance: edit this file when pages are added, removed, or reordered.
- * doc/site/astro.config.mjs imports this directly — no duplication.
  */
 
 export const sidebar = [


### PR DESCRIPTION
## Summary

Eliminates the duplicated sidebar definition that existed between `doc/site/astro.config.mjs` and the consumer site (`docs.internetcomputer.org`). After this PR, both sites read from one file.

### Changes

**`doc/md/sidebar.mjs`** (new) — exports the `sidebar` array as the single source of truth for Motoko documentation navigation. Two consumers:
- `doc/site/` imports it directly (see below)
- `docs.internetcomputer.org` sync script reads it, prepends the `languages/motoko/` path prefix to every slug and `autogenerate.directory`, and writes `sidebar-motoko.mjs` automatically

**`doc/site/astro.config.mjs`** — imports `sidebar` from `../md/sidebar.mjs` instead of hardcoding it inline. The file is now ~40 lines vs the previous ~150.

**`doc/md/reference/changelog.md`** — adds `sidebar.label: "Motoko changelog"` so the `autogenerate: { directory: "reference" }` entry produces the correct label on the consumer site (which has changelogs from multiple language sections) without needing a special-case override in the sync script.

**`doc/md/fundamentals/*/index.md`** (6 stubs) — adds `sidebar.hidden: true` to all subdirectory index stubs. These stubs exist for potential future Starlight section-index support. Hiding them prevents them from appearing as duplicate page entries in any `autogenerate`-based sidebar (both in `doc/site/` and on the consumer site). The stubs remain on disk and accessible by direct URL.

## Testing

```bash
cd doc/site && npm install && npm run build
# 77 pages built, no errors
```

## Consumer site impact

`dfinity/developer-docs` PR #268 depends on this. Once this merges and a release tag is cut, the sync pipeline auto-generates `sidebar-motoko.mjs` from `doc/md/sidebar.mjs` — no hand-editing required.