### PR TITLE
fix(docs): remove stray Frontify logo from actors-async.md

### DIFF
--- a/doc/md/fundamentals/actors/actors-async.md
+++ b/doc/md/fundamentals/actors/actors-async.md
@@ -377,6 +377,3 @@ When `catch` is used, the `finally` clause is optional. The `catch` block only c
 1. Local traps.
 2. Pre-await traps in async functions.
 3. Traps after `await`.
-
-
-<img src="https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGZpbml0eVwvYWNjb3VudHNcLzAxXC80MDAwMzA0XC9wcm9qZWN0c1wvNFwvYXNzZXRzXC8zOFwvMTc2XC9jZGYwZTJlOTEyNDFlYzAzZTQ1YTVhZTc4OGQ0ZDk0MS0xNjA1MjIyMzU4LnBuZyJ9:dfinity:9Q2_9PEsbPqdJNAQ08DAwqOenwIo7A8_tCN4PSSWkAM?width=2400" alt="Logo" width="150" height="150" />


### PR DESCRIPTION
## Summary

Removes an auth-gated DFINITY Frontify brand asset URL accidentally left at the bottom of `doc/md/fundamentals/actors/actors-async.md`. The `<img>` tag points to a Frontify CDN URL.

No content change — just removes the stray 3-line `<img>` block after the `catch` limitations list.