### PR TITLE
fix: don't suggest M0236 dot notation when receiver isn't postfix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Motoko compiler changelog
 
+## Next
+
+* motoko (`moc`)
+
+  * bugfix: M0236 dot-notation suggestion no longer fires when the receiver argument is not already a postfix expression (e.g. `Nat.toText((x * a + b) % c)`). The compiler used to print the suggestion as `(<expr>).toText(...)` but emit no machine-applicable edits, leaving `mops check --fix` with nothing to do; suggesting `(complex).f()` over `Module.f(complex)` is also a debatable style change. Trivial-receiver cases (variables, literals, calls) are unaffected.
+
 ## 1.8.1 (2026-05-20)
 
 * motoko (`moc`)

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1997,12 +1997,9 @@ let check_can_dot env ctx_dot (exp : Syntax.exp) tys es at =
           DotE ({ it = VarE {it = mod_id1; note = (Const, _); _};_ } as old_receiver,
                 { it = id1; _},
                 _)  when mod_id0 = mod_id1 && id0 = id1 ->
-          (* Skip non-postfix receivers: `(complex).f()` is a debatable style change and we'd emit no autofix anyway. *)
-          if not (Syntax.is_postfix_exp e) then () else
-          (match
-             if e.at.left.line <> e.at.right.line then None
-             else read_region e.at
-           with
+          (* Skip non-postfix or multi-line receivers: `(complex).f()` is a debatable style change and we'd emit no autofix anyway. *)
+          if not (Syntax.is_postfix_exp e) || e.at.left.line <> e.at.right.line then () else
+          (match read_region e.at with
            | None -> ()
            | Some receiver_text ->
              let replace_receiver = edit old_receiver.at receiver_text in

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1997,25 +1997,24 @@ let check_can_dot env ctx_dot (exp : Syntax.exp) tys es at =
           DotE ({ it = VarE {it = mod_id1; note = (Const, _); _};_ } as old_receiver,
                 { it = id1; _},
                 _)  when mod_id0 = mod_id1 && id0 = id1 ->
-          let source =
-            if e.at.left.line <> e.at.right.line then None
-            else read_region e.at
-          in
-          let receiver_text, edits = match source with
-            | None -> "...", []
-            | Some receiver_text ->
-              if not (Syntax.is_postfix_exp e) then "(" ^ receiver_text ^ ")", [] else
-              let replace_receiver = edit old_receiver.at receiver_text in
-              let argument_edit = match es with
-                | [] when at.right = e.at.right -> edit e.at "()" (* unparenthesized single arg (`Module.f x`); preserve a `()` arg list *)
-                | [] -> edit e.at "" (* parenthesized single arg; remove the argument, keep the parens *)
-                | next :: _ -> edit { left = e.at.left; right = next.at.left } "" (* multi-arg; remove the argument + the comma *)
-              in receiver_text, [replace_receiver; argument_edit]
-          in
-          warn env at "M0236" "You can use the dot notation `%s.%s(...)` here"
-            ~edits
-            receiver_text
-            id.it
+          (* Skip non-postfix receivers: `(complex).f()` is a debatable style change and we'd emit no autofix anyway. *)
+          if not (Syntax.is_postfix_exp e) then () else
+          (match
+             if e.at.left.line <> e.at.right.line then None
+             else read_region e.at
+           with
+           | None -> ()
+           | Some receiver_text ->
+             let replace_receiver = edit old_receiver.at receiver_text in
+             let argument_edit = match es with
+               | [] when at.right = e.at.right -> edit e.at "()" (* unparenthesized single arg (`Module.f x`); preserve a `()` arg list *)
+               | [] -> edit e.at "" (* parenthesized single arg; remove the argument, keep the parens *)
+               | next :: _ -> edit { left = e.at.left; right = next.at.left } "" (* multi-arg; remove the argument + the comma *)
+             in
+             warn env at "M0236" "You can use the dot notation `%s.%s(...)` here"
+               ~edits:[replace_receiver; argument_edit]
+               receiver_text
+               id.it)
         | _ -> ())
     | _, _, _ -> ()
 

--- a/test/fail/contextual-dot-suggest.mo
+++ b/test/fail/contextual-dot-suggest.mo
@@ -79,8 +79,8 @@ persistent actor {
   ignore Text.compare("", ""); // no-warn
   ignore Text.equal("", ""); // no-warn
 
-  ignore Odd.equal(#odd); // warn non-binary
-  ignore Odd.compare(#odd, #odd, #odd); // warn non-binary
+  ignore Odd.equal(#odd); // no-warn — non-postfix receiver, no clean autofix
+  ignore Odd.compare(#odd, #odd, #odd); // no-warn — non-postfix receiver, no clean autofix
 
   // get
   ignore Map.get(peopleMap, Nat.compare, 1); // warn

--- a/test/fail/edit-suggestions.mo
+++ b/test/fail/edit-suggestions.mo
@@ -159,3 +159,15 @@ do {
   // single arg, no parens, with type instantiation
   ignore Map.size<Nat, Text> m; // warn M0236
 };
+
+// --- M0236: non-postfix receiver -> no warning (no clean autofix) ---
+
+do {
+  // BinE receiver: `Nat.toText((x * 6364136223846793005 + 1442695040888963407) % 4294967296)`
+  // would rewrite to `(...).toText()` adding outer parens; suppress instead.
+  let pos = 1;
+  ignore Nat.toText((pos * 6364136223846793005 + 1442695040888963407) % 4294967296); // no-warn
+
+  // IfE receiver — likewise.
+  ignore Nat.toText(if (pos == 0) 1 else 2); // no-warn
+};

--- a/test/fail/ok/contextual-dot-suggest.tc-human.ok
+++ b/test/fail/ok/contextual-dot-suggest.tc-human.ok
@@ -1,11 +1,3 @@
-warning[M0236]: You can use the dot notation `(#odd).equal(...)` here
-    ┌─ contextual-dot-suggest.mo:82:10
- 82 │    ignore Odd.equal(#odd); // warn non-binary
-    │           ^^^^^^^^^^^^^^^ 
-warning[M0236]: You can use the dot notation `(#odd).compare(...)` here
-    ┌─ contextual-dot-suggest.mo:83:10
- 83 │    ignore Odd.compare(#odd, #odd, #odd); // warn non-binary
-    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 warning[M0236]: You can use the dot notation `peopleMap.get(...)` here
     ┌─ contextual-dot-suggest.mo:86:10
  86 │    ignore Map.get(peopleMap, Nat.compare, 1); // warn

--- a/test/fail/ok/contextual-dot-suggest.tc.ok
+++ b/test/fail/ok/contextual-dot-suggest.tc.ok
@@ -1,5 +1,3 @@
-contextual-dot-suggest.mo:82.10-82.25: warning [M0236], You can use the dot notation `(#odd).equal(...)` here
-contextual-dot-suggest.mo:83.10-83.39: warning [M0236], You can use the dot notation `(#odd).compare(...)` here
 contextual-dot-suggest.mo:86.10-86.44: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
 contextual-dot-suggest.mo:87.10-87.31: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
 contextual-dot-suggest.mo:88.10-88.29: warning [M0236], You can use the dot notation `peopleMap.size(...)` here


### PR DESCRIPTION
## What changes for users

Compiling

```motoko
ignore Nat.toText((pos * 6364136223846793005 + 1442695040888963407) % 4294967296);
```

with `-W M0236` (e.g. via `mops check`) used to print

```
warning[M0236]: You can use the dot notation `((pos * 6364136223846793005 + 1442695040888963407) % 4294967296).toText(...)` here
```

with no machine-applicable edits attached, so `mops check --fix` could
not apply it. The suggestion itself was also debatable — the rewrite
adds synthetic outer parens (`(expr).toText()`) purely to satisfy the
parser, which is at best a wash against the original `Module.f(expr)`
form.

After this PR, M0236 only fires when the receiver is already a
postfix expression (variable, literal, call, indexing, `.field`,
`!`, array literal), i.e. exactly the cases where the rewrite is a
clear readability win **and** we can hand `mops check --fix` an edit
it can apply. Every emitted M0236 now carries machine-applicable
edits.

Likewise gone: `Odd.equal(#odd)` / `Odd.compare(#odd, #odd, #odd)`
(TagE receivers) used to warn `(#odd).equal(...)` with no fix; they
now warn-free.

Trivial-receiver cases (`Map.size(m)`, `Map.get(m, …)`,
`Map.clone(x).size(...)`, etc.) are unchanged.

## Why

Two complaints conflated into one fix:

1. The warning is meant to be machine-applicable (it's how `mops
   check --fix` enforces dot-notation style). Emitting it without an
   edit defeats the workflow.
2. For non-postfix receivers the rewrite arguably hurts readability
   — `Module.f(<complex>)` reads better than `(<complex>).f()`
   because the verb (`f`) shows up before you've finished scanning
   the long expression.

The cutoff is `Syntax.is_postfix_exp`, which is exactly "can appear
to the left of `.` without parenthesization" (matches the
`exp_post` parser rule). That's the right invariant for both
points.

## Test plan

- [x] `test-runner -baf contextual-dot` — passes; two snapshot lines removed.
- [x] `test-runner -baf edit-suggestions` — passes; added a `BinE` and `IfE` receiver case as negative regression tests.
- [x] `test-runner -bf fail/` — only pre-existing unrelated failure (`implicit-derivation-deep` whitespace, present on master too).


Made with [Cursor](https://cursor.com)