### PR TITLE
chore: pin `nixpkgs` to `release-26.05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,16 +193,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778274207,
-        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "lastModified": 1779641195,
+        "narHash": "sha256-MH/26qn0HrXrnQTD8ZHsGO4k976I2Bidhw1AxnWsYck=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "rev": "77d41323e7a7f6a3635a2272d2fcc6af4f3c120a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "release-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "The Motoko compiler";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-26.05";
 
     flake-utils.url = "github:numtide/flake-utils";
 


### PR DESCRIPTION
Park on the new stable channel.  Pure flake update — only the input URL changes from `github:NixOS/nixpkgs/nixpkgs-unstable` to `github:NixOS/nixpkgs/release-26.05`; the lock advances to the matching pinned revision.

> **Note: 26.05 is the last NixOS release to support `x86_64-darwin`.**  The next bump (to `nixpkgs/master` or `release-26.11`) drops the platform.  Before doing that, we'll need to drop `x86_64-darwin` from the moc release-build matrix.  Parking on 26.05 keeps the Intel Mac release artefacts buildable until we're ready to retire them.