### PR TITLE
fix: make M0254 an error by default (enhanced migration chain leaves stable fields uninitialized)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 * motoko (`moc`)
 
+  * bugfix: M0254 ("initial actor requires field") is now an _error_ by default. With `--enhanced-migration`, a chain that does not initialize all of the actor's stable fields previously compiled with only a warning, shipping a wasm that is guaranteed to trap on fresh installation (`stable variable ... not found in persisted state`). Pass `-W M0254` to demote it back to a warning if needed.
+
   * feat: M0218 ("redundant `stable` keyword") now ships a machine-applicable edit, so `mops check --fix` removes the explicit `stable` keyword on fields of a `persistent actor` (#6175).
 
   * bugfix: Diagnostic columns now count Unicode codepoints (matching editor displays and `rustc`), and JSON diagnostics gain `byte_start`/`byte_end` for encoding-independent edit anchors. Previously `mops check --fix` over-deleted on multi-byte lines (e.g. `Char.toNat32('京')` trimmed the trailing `)`) (#6168).

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -96,6 +96,9 @@ let default_warning_levels = M.empty
   |> M.add "M0235" Allow (* don't deprecate for non-caffeine *)
   |> M.add "M0236" Allow (* don't suggest contextual dot notation *)
   |> M.add "M0237" Allow (* don't report redundant explicit arguments *)
+  |> M.add "M0254" (Error : lint_level) (* an enhanced migration chain that leaves stable fields
+                            uninitialized traps on fresh installation; demote with
+                            -W M0254 if needed. *)
 
 let warning_levels = ref default_warning_levels
 

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -4502,11 +4502,15 @@ and check_enhanced_migration_chain env chain stab_tfs at =
    let rec check_mfs at post mfs =
      match mfs with
      | [] ->
-       (* issue warnings if we infer the initial actor in the chain requires any fields *)
+       (* report if we infer the initial actor in the chain requires any fields;
+          such fields are not initialized by any migration, so a fresh installation
+          would trap at runtime (level Error by default, demotable with -W M0254) *)
        List.iter (fun tf ->
          warn env at "M0254"
-           "initial actor requires field `%s` of type%a"
-           tf.T.lab display_typ tf.T.typ)
+           "initial actor requires field `%s` of type%a\n%s\n%s"
+           tf.T.lab display_typ tf.T.typ
+           "The migration chain does not initialize this field, so a fresh installation will trap at runtime."
+           "Initialize the field in a migration function, or pass `-W M0254` to demote this error to a warning if you are upgrading a canister whose persisted state already contains the field.")
          post
      | (file, _, typ)::mfs1 ->
         let file_at = let file_pos = { no_pos with file = file} in {left = file_pos; right=file_pos} in

--- a/test/fail/enhanced-migration-empty-dir.mo
+++ b/test/fail/enhanced-migration-empty-dir.mo
@@ -1,0 +1,11 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-empty
+//MOC-FLAG -A=M0194
+
+// The migrations directory exists but contains no .mo files: the chain is
+// literally empty and must be rejected (M0251), since the actor's stable
+// fields could never be initialized.
+
+actor {
+    var name : Text;
+    var balance : Nat;
+};

--- a/test/fail/enhanced-migration-ok-chain-M0254.mo
+++ b/test/fail/enhanced-migration-ok-chain-M0254.mo
@@ -1,5 +1,10 @@
 //MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-test2
 //MOC-FLAG -A=M0194
+//MOC-FLAG -W M0254
+
+// Field `x` is not initialized by the chain: it can only come from the
+// persisted state of an already-deployed canister. M0254 is an error by
+// default; `-W M0254` demotes it to a warning to allow deployment.
 
 actor {
     let a : Float;

--- a/test/fail/enhanced-migration-uninitialized-chain.mo
+++ b/test/fail/enhanced-migration-uninitialized-chain.mo
@@ -1,0 +1,12 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-noop
+//MOC-FLAG -A=M0194,M0244
+
+// The migration chain composes fine but initializes none of the actor's
+// stable fields. Since stable fields cannot have initializers under
+// --enhanced-migration, a fresh installation would trap at runtime.
+// M0254 is an error by default, so this must be rejected statically.
+
+actor {
+    var name : Text;
+    var balance : Nat;
+};

--- a/test/fail/enhanced-migration/enh-mig-empty/README
+++ b/test/fail/enhanced-migration/enh-mig-empty/README
@@ -1,0 +1,3 @@
+Placeholder so git tracks this directory. Only `.mo` files count as
+migration modules, so for the compiler this directory is an empty
+migration chain (see enhanced-migration-empty-dir.mo).

--- a/test/fail/enhanced-migration/enh-mig-noop/m1.mo
+++ b/test/fail/enhanced-migration/enh-mig-noop/m1.mo
@@ -1,0 +1,4 @@
+module {
+    // A no-op migration: consumes nothing, produces nothing.
+    public func migration(_ : {}) : {} { {} };
+};

--- a/test/fail/ok/enhanced-migration-empty-dir.tc-human.ok
+++ b/test/fail/ok/enhanced-migration-empty-dir.tc-human.ok
@@ -1,0 +1,9 @@
+error[M0251]: --enhanced-migration: no valid migration modules found (migration modules must export a public `migration` function)
+    ┌─ enhanced-migration-empty-dir.mo:8:1
+  7 │    
+  8 │ ╭  actor {
+  9 │ │      var name : Text;
+ 10 │ │      var balance : Nat;
+ 11 │ │  };
+    │ ╰──^ 
+ 12 │    

--- a/test/fail/ok/enhanced-migration-empty-dir.tc-human.ret.ok
+++ b/test/fail/ok/enhanced-migration-empty-dir.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/enhanced-migration-empty-dir.tc.ok
+++ b/test/fail/ok/enhanced-migration-empty-dir.tc.ok
@@ -1,0 +1,1 @@
+enhanced-migration-empty-dir.mo:8.1-11.2: type error [M0251], --enhanced-migration: no valid migration modules found (migration modules must export a public `migration` function)

--- a/test/fail/ok/enhanced-migration-empty-dir.tc.ret.ok
+++ b/test/fail/ok/enhanced-migration-empty-dir.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/enhanced-migration-ok-chain-M0254.tc-human.ok
+++ b/test/fail/ok/enhanced-migration-ok-chain-M0254.tc-human.ok
@@ -1,5 +1,7 @@
 warning[M0254]: initial actor requires field `x` of type
   {#X}
+The migration chain does not initialize this field, so a fresh installation will trap at runtime.
+Initialize the field in a migration function, or pass `-W M0254` to demote this error to a warning if you are upgrading a canister whose persisted state already contains the field.
     ┌─ enhanced-migration/enh-mig-test2/m1.mo:1:1
   1 │  module {
     │  ^ 

--- a/test/fail/ok/enhanced-migration-ok-chain-M0254.tc.ok
+++ b/test/fail/ok/enhanced-migration-ok-chain-M0254.tc.ok
@@ -1,2 +1,4 @@
 enhanced-migration/enh-mig-test2/m1.mo:0.1: warning [M0254], initial actor requires field `x` of type
   {#X}
+The migration chain does not initialize this field, so a fresh installation will trap at runtime.
+Initialize the field in a migration function, or pass `-W M0254` to demote this error to a warning if you are upgrading a canister whose persisted state already contains the field.

--- a/test/fail/ok/enhanced-migration-uninitialized-chain.tc-human.ok
+++ b/test/fail/ok/enhanced-migration-uninitialized-chain.tc-human.ok
@@ -1,0 +1,14 @@
+error[M0254]: initial actor requires field `balance` of type
+  var Nat
+The migration chain does not initialize this field, so a fresh installation will trap at runtime.
+Initialize the field in a migration function, or pass `-W M0254` to demote this error to a warning if you are upgrading a canister whose persisted state already contains the field.
+    ┌─ enhanced-migration/enh-mig-noop/m1.mo:1:1
+  1 │  module {
+    │  ^ 
+error[M0254]: initial actor requires field `name` of type
+  var Text
+The migration chain does not initialize this field, so a fresh installation will trap at runtime.
+Initialize the field in a migration function, or pass `-W M0254` to demote this error to a warning if you are upgrading a canister whose persisted state already contains the field.
+    ┌─ enhanced-migration/enh-mig-noop/m1.mo:1:1
+  1 │  module {
+    │  ^ 

--- a/test/fail/ok/enhanced-migration-uninitialized-chain.tc-human.ret.ok
+++ b/test/fail/ok/enhanced-migration-uninitialized-chain.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/enhanced-migration-uninitialized-chain.tc.ok
+++ b/test/fail/ok/enhanced-migration-uninitialized-chain.tc.ok
@@ -1,0 +1,8 @@
+enhanced-migration/enh-mig-noop/m1.mo:0.1: type error [M0254], initial actor requires field `balance` of type
+  var Nat
+The migration chain does not initialize this field, so a fresh installation will trap at runtime.
+Initialize the field in a migration function, or pass `-W M0254` to demote this error to a warning if you are upgrading a canister whose persisted state already contains the field.
+enhanced-migration/enh-mig-noop/m1.mo:0.1: type error [M0254], initial actor requires field `name` of type
+  var Text
+The migration chain does not initialize this field, so a fresh installation will trap at runtime.
+Initialize the field in a migration function, or pass `-W M0254` to demote this error to a warning if you are upgrading a canister whose persisted state already contains the field.

--- a/test/fail/ok/enhanced-migration-uninitialized-chain.tc.ret.ok
+++ b/test/fail/ok/enhanced-migration-uninitialized-chain.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/warn-help.tc-human.ok
+++ b/test/fail/ok/warn-help.tc-human.ok
@@ -39,6 +39,6 @@ M0241 (W) Unused field in shared pattern warning
 M0242 (W) Implicit oneway declaration
 M0243 (W) Unreachable else in let-else
 M0244 (W) Mutable variable is never reassigned
-M0254 (W) Initial actor requires field
+M0254 (E) Initial actor requires field
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/fail/ok/warn-help.tc.ok
+++ b/test/fail/ok/warn-help.tc.ok
@@ -39,6 +39,6 @@ M0241 (W) Unused field in shared pattern warning
 M0242 (W) Implicit oneway declaration
 M0243 (W) Unreachable else in let-else
 M0244 (W) Mutable variable is never reassigned
-M0254 (W) Initial actor requires field
+M0254 (E) Initial actor requires field
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/run-drun/multi-migration-bad-chain/version2.mo
+++ b/test/run-drun/multi-migration-bad-chain/version2.mo
@@ -1,5 +1,5 @@
-// enable -E M0254 to reject non-empty initial actor (pre)
-//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration multi-migration-bad-chain/bad-chain -E M0254
+// M0254 (non-empty initial actor) is an error by default
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration multi-migration-bad-chain/bad-chain
 
 import Prim "mo:prim";
 

--- a/test/run-drun/ok/multi-migration-bad-chain.version2.drun.comp.ok
+++ b/test/run-drun/ok/multi-migration-bad-chain.version2.drun.comp.ok
@@ -1,2 +1,4 @@
 multi-migration-bad-chain/bad-chain/Init.mo:0.1: type error [M0254], initial actor requires field `five` of type
   var Text
+The migration chain does not initialize this field, so a fresh installation will trap at runtime.
+Initialize the field in a migration function, or pass `-W M0254` to demote this error to a warning if you are upgrading a canister whose persisted state already contains the field.


### PR DESCRIPTION
With `--enhanced-migration`, a chain that composes but does not initialize all of the actor's stable fields compiled with only a warning (M0254), shipping a wasm that is guaranteed to trap on fresh installation (`stable variable ... not found in persisted state`).

- Flip M0254's default lint level to **Error**; `-W M0254` demotes it back for upgrading an already-deployed canister whose persisted state contains the fields.
- Extend the M0254 message with the consequence and remedies.
- New `test/fail/enhanced-migration-uninitialized-chain.mo` (default → error); `enhanced-migration-ok-chain-M0254.mo` now covers the `-W M0254` demotion path; dropped redundant `-E M0254` from `multi-migration-bad-chain/version2.mo`.

Fixes [LANG-1328](https://linear.app/caffeinelabs/issue/LANG-1328/moc-enhanced-migration-chain-that-initializes-nothing-compiles-then)

Made with [Cursor](https://cursor.com)