### PR TITLE
fix(typing): derive implicits for covariant-only result type variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 * motoko (`moc`)
 
+  * bugfix: Implicit argument derivation now resolves type variables that occur only in a covariant result position (e.g. JSON-style decoders `Text -> ?T`). Previously such a variable was solved to `None` (bottom), so the implicit had to be passed explicitly (#6186).
+
   * feat: M0218 ("redundant `stable` keyword") now ships a machine-applicable edit, so `mops check --fix` removes the explicit `stable` keyword on fields of a `persistent actor` (#6175).
 
   * bugfix: Diagnostic columns now count Unicode codepoints (matching editor displays and `rustc`), and JSON diagnostics gain `byte_start`/`byte_end` for encoding-independent edit anchors. Previously `mops check --fix` over-deleted on multi-byte lines (e.g. `Char.toNat32('京')` trimmed the trailing `)`) (#6168).

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1649,7 +1649,7 @@ end
 
 (** Checks [args -> rets  <:  req_args -> req_rets] via subtyping or
     bidirectional matching when [tbs] are present. Returns [Some inst] or [None].
-    
+
     [inst] is the maximal solution, s.t [?A -> ?B  <:  ?Nat -> ?Int] solves [Nat <: A <: Any] and [Non <: B <: Int] as [A := Nat, B := Int]:
     To achieve this, we treat [args] as covariant and [rets] as contravariant.
     *)

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1647,8 +1647,12 @@ module SynthesizeWrapper = struct
     combiner_wrapper ~name combiner_path params entries
 end
 
-(** Checks [args -> rets <: req_args -> req_rets] via subtyping or
-    bidirectional matching when [tbs] are present. Returns [Some inst] or [None]. *)
+(** Checks [args -> rets  <:  req_args -> req_rets] via subtyping or
+    bidirectional matching when [tbs] are present. Returns [Some inst] or [None].
+    
+    [inst] is the maximal solution, s.t [?A -> ?B  <:  ?Nat -> ?Int] solves [Nat <: A <: Any] and [Non <: B <: Int] as [A := Nat, B := Int]:
+    To achieve this, we treat [args] as covariant and [rets] as contravariant.
+    *)
 let sub_or_bimatch_func tbs args rets req_args req_rets =
   assert (List.length args = List.length req_args);
   assert (List.length rets = List.length req_rets);
@@ -1659,8 +1663,9 @@ let sub_or_bimatch_func tbs args rets req_args req_rets =
   else
     let arg_subs = List.map2 (fun ra ea -> (ra, ea, no_region)) req_args args in
     let ret_subs = List.map2 (fun cr rr -> (cr, rr, no_region)) rets req_rets in
+    let ret_opt = Some (T.Func (T.Local, T.Returns, [], rets, args)) in (* Note: Flipped to get the maximal solution! *)
     try
-      let (inst, c) = Bi_match.bi_match_subs None tbs None (arg_subs @ ret_subs) ~must_solve:[] in
+      let (inst, c) = Bi_match.bi_match_subs None tbs ret_opt (arg_subs @ ret_subs) ~must_solve:[] in
       ignore (Bi_match.finalize inst c []);
       Some inst
     with Bi_match.Bimatch _ -> None

--- a/test/fail/implicit-derivation-bimatch.mo
+++ b/test/fail/implicit-derivation-bimatch.mo
@@ -1,7 +1,7 @@
 // Tests for bi-matching limits in implicit candidate selection.
 
-// B is fully phantom (no bounds at all); C has an upper bound from ret_subs
-// (C ≤ Nat) but no lower bound — bivariant solver still picks lb = None for both.
+// C is in `rets` (contravariant): the maximal solution picks its upper bound, C := Nat.
+// B is phantom (in neither args nor rets): solved to its lower bound None — phantom B fails derivation.
 module Pipeline {
   public func chain<A, B, C>(
     x : A,
@@ -21,3 +21,15 @@ module Wrapper {
 
 func needsWrap(x : Nat, wrap : (implicit : Nat -> Bool)) : Bool { wrap(x) };
 ignore needsWrap(42);
+
+// T is in `args` ([T]) (covariant): the maximal solution picks its lower bound, T := Nat.
+// So the `Text -> T` hole is `Text -> Nat` — correctly unresolved, not widened to `Text -> Any`.
+module Maker {
+  public func weird<T>(self : [T], mk : (implicit : Text -> T)) : Text {
+    ignore (self, mk);
+    "";
+  };
+};
+
+func needsWeird(self : [Nat], weird : (implicit : ([Nat]) -> Text)) : Text { weird(self) };
+ignore needsWeird([42]);

--- a/test/fail/implicit-derivation-bimatch.mo
+++ b/test/fail/implicit-derivation-bimatch.mo
@@ -21,15 +21,3 @@ module Wrapper {
 
 func needsWrap(x : Nat, wrap : (implicit : Nat -> Bool)) : Bool { wrap(x) };
 ignore needsWrap(42);
-
-// T is in `args` ([T]) (covariant): the maximal solution picks its lower bound, T := Nat.
-// So the `Text -> T` hole is `Text -> Nat` — correctly unresolved, not widened to `Text -> Any`.
-module Maker {
-  public func weird<T>(self : [T], mk : (implicit : Text -> T)) : Text {
-    ignore (self, mk);
-    "";
-  };
-};
-
-func needsWeird(self : [Nat], weird : (implicit : ([Nat]) -> Text)) : Text { weird(self) };
-ignore needsWeird([42]);

--- a/test/fail/ok/implicit-derivation-bimatch.tc-human.ok
+++ b/test/fail/ok/implicit-derivation-bimatch.tc-human.ok
@@ -5,10 +5,17 @@ error[M0230]: Cannot determine implicit argument `chain` of type
     │         ^^^^^^^^^^^^^^ 
     = note: Implicit derivation failed:
                  `step : Nat -> None` not found
-                 `finish : None -> None` not found
+                 `finish : None -> Nat` not found
 error[M0230]: Cannot determine implicit argument `wrap` of type
   Nat -> Bool
     ┌─ implicit-derivation-bimatch.mo:23:8
  23 │  ignore needsWrap(42);
     │         ^^^^^^^^^^^^^ 
     = note: If you're trying to omit an implicit argument named `wrap` you need to have a matching declaration named `wrap` in scope.
+error[M0230]: Cannot determine implicit argument `weird` of type
+  [Nat] -> Text
+    ┌─ implicit-derivation-bimatch.mo:35:8
+ 35 │  ignore needsWeird([42]);
+    │         ^^^^^^^^^^^^^^^^ 
+    = note: Implicit derivation failed:
+                 `mk : Text -> Nat` not found

--- a/test/fail/ok/implicit-derivation-bimatch.tc-human.ok
+++ b/test/fail/ok/implicit-derivation-bimatch.tc-human.ok
@@ -12,10 +12,3 @@ error[M0230]: Cannot determine implicit argument `wrap` of type
  23 │  ignore needsWrap(42);
     │         ^^^^^^^^^^^^^ 
     = note: If you're trying to omit an implicit argument named `wrap` you need to have a matching declaration named `wrap` in scope.
-error[M0230]: Cannot determine implicit argument `weird` of type
-  [Nat] -> Text
-    ┌─ implicit-derivation-bimatch.mo:35:8
- 35 │  ignore needsWeird([42]);
-    │         ^^^^^^^^^^^^^^^^ 
-    = note: Implicit derivation failed:
-                 `mk : Text -> Nat` not found

--- a/test/fail/ok/implicit-derivation-bimatch.tc.ok
+++ b/test/fail/ok/implicit-derivation-bimatch.tc.ok
@@ -6,7 +6,3 @@ note: Implicit derivation failed:
 implicit-derivation-bimatch.mo:23.8-23.21: type error [M0230], Cannot determine implicit argument `wrap` of type
   Nat -> Bool
 note: If you're trying to omit an implicit argument named `wrap` you need to have a matching declaration named `wrap` in scope.
-implicit-derivation-bimatch.mo:35.8-35.24: type error [M0230], Cannot determine implicit argument `weird` of type
-  [Nat] -> Text
-note: Implicit derivation failed:
-  `mk : Text -> Nat` not found

--- a/test/fail/ok/implicit-derivation-bimatch.tc.ok
+++ b/test/fail/ok/implicit-derivation-bimatch.tc.ok
@@ -2,7 +2,11 @@ implicit-derivation-bimatch.mo:14.8-14.22: type error [M0230], Cannot determine 
   Nat -> Nat
 note: Implicit derivation failed:
   `step : Nat -> None` not found
-  `finish : None -> None` not found
+  `finish : None -> Nat` not found
 implicit-derivation-bimatch.mo:23.8-23.21: type error [M0230], Cannot determine implicit argument `wrap` of type
   Nat -> Bool
 note: If you're trying to omit an implicit argument named `wrap` you need to have a matching declaration named `wrap` in scope.
+implicit-derivation-bimatch.mo:35.8-35.24: type error [M0230], Cannot determine implicit argument `weird` of type
+  [Nat] -> Text
+note: Implicit derivation failed:
+  `mk : Text -> Nat` not found

--- a/test/run/implicit-derivation.mo
+++ b/test/run/implicit-derivation.mo
@@ -400,3 +400,22 @@ do {
   // Derives Array.decode, whose inner `Text -> ?Text` hole resolves to Text.decode.
   assert decodeField<[Text]>("a") == ?["a"];
 };
+
+// The `?A -> ?B  <:  ?Nat -> ?Int` example from `sub_or_bimatch_func`: one type
+// variable in a (contravariant) argument, another in the (covariant) result. The
+// maximal solution picks `A := Nat` (lower bound) and `B := Int` (upper bound), so
+// the inner `A -> B = Nat -> Int` hole resolves (to `None` before, failing).
+do {
+  module Int {
+    public func coerce(n : Nat) : Int = n;
+  };
+
+  module Opt {
+    public func coerce<A, B>(x : ?A, coerce : (implicit : A -> B)) : ?B =
+      do ? { coerce(x!) };
+  };
+
+  func useCoerce(x : ?Nat, coerce : (implicit : ?Nat -> ?Int)) : ?Int = coerce(x);
+
+  assert useCoerce(?5) == ?(5 : Int);
+};

--- a/test/run/implicit-derivation.mo
+++ b/test/run/implicit-derivation.mo
@@ -380,3 +380,23 @@ do {
   assert needsNatArrayCompare([1, 2], [1, 3]) == #less;
   assert intCompareCalled;
 };
+
+// Derivation when the type variable occurs only in the (covariant) result, e.g.
+// JSON-style decoders `Text -> ?T`. The variable must be solved to the required
+// type, not bottom (`None`).
+do {
+  module Text {
+    public func decode(s : Text) : ?Text { ?s };
+  };
+
+  module Array {
+    public func decode<T>(s : Text, decode : (implicit : Text -> ?T)) : ?[T] =
+      do ? { [decode(s)!] };
+  };
+
+  func decodeField<T>(s : Text, decode : (implicit : Text -> ?T)) : ?T = decode(s);
+
+  assert decodeField<Text>("a") == ?"a";
+  // Derives Array.decode, whose inner `Text -> ?Text` hole resolves to Text.decode.
+  assert decodeField<[Text]>("a") == ?["a"];
+};

--- a/test/run/implicit-derivation.mo
+++ b/test/run/implicit-derivation.mo
@@ -401,10 +401,8 @@ do {
   assert decodeField<[Text]>("a") == ?["a"];
 };
 
-// The `?A -> ?B  <:  ?Nat -> ?Int` example from `sub_or_bimatch_func`: one type
-// variable in a (contravariant) argument, another in the (covariant) result. The
-// maximal solution picks `A := Nat` (lower bound) and `B := Int` (upper bound), so
-// the inner `A -> B = Nat -> Int` hole resolves (to `None` before, failing).
+// `?A -> ?B  <:  ?Nat -> ?Int` should pick the maximal solution
+// `A := Nat` (lower bound) and `B := Int` (upper bound).
 do {
   module Int {
     public func coerce(n : Nat) : Int = n;


### PR DESCRIPTION
Implicit derivation failed when a candidate's type variable occurred only in a covariant result position (e.g. decoders `Text -> ?T`): the variable was solved to `None` (bottom) instead of the required type, so the implicit had to be passed explicitly.

Solving `?A -> ?B  <:  ?Nat -> ?Int`, when instantiating candidates, should pick the maximal solution.
So `Nat <: A <: Any` and `None <: B <: Int` should solve as `A := Nat, B := Int` — i.e. lower bound for argument vars, upper bound for result vars.

Without a polarity witness `ret_opt`, a result-only var like `B` was treated as bivariant and collapsed to its lower bound `None`. Passing a flipped function type as the witness treats `args` as covariant and `rets` as contravariant, recovering the maximal solution.