### PR TITLE
chore: fix a nix warning

### DIFF
--- a/nix/rts.nix
+++ b/nix/rts.nix
@@ -59,7 +59,7 @@ let
       rust-bindgen
       python3
       wabt
-    ] ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
+    ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
       libiconv
     ];
 


### PR DESCRIPTION
This fixes these warnings I've been getting in my nix shell recently

```
evaluation warning: Dependency of package 'moc-rts' uses a nested list in attribute 'buildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
evaluation warning: Dependency of package 'motoko-shell' uses a nested list in attribute 'propagatedBuildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
```