### PR TITLE
ci: silence M0223 in nightly `motoko-core` tests until core is cleaned

### DIFF
--- a/.github/workflows/nightly-macos-test.yml
+++ b/.github/workflows/nightly-macos-test.yml
@@ -75,6 +75,14 @@ jobs:
       - name: Build `moc`
         run: |
           nix build .#moc --print-out-paths
+      - name: Build M0223-silenced `moc`
+        # CI-only: `.#moc-M0223` wraps moc to force M0223 off, so motoko-core's
+        # `-E=M0223` (mops.toml) doesn't fail the build on its ~2871 redundant
+        # `<T>`s. Built here (before the motoko-core checkout replaces the
+        # working dir) and its store path stashed for the fixup step. Drop once
+        # #6199 cleans core up.
+        run: |
+          echo "MOC_M0223=$(nix build .#moc-M0223 --print-out-paths)" >> "$GITHUB_ENV"
       - name: Save the `test-blueprint` action
         # This is needed by the "Post Populate `moc`" step (cleanup)
         # but since the checkout of `motoko-core` destroys the `pwd` contents
@@ -95,7 +103,11 @@ jobs:
           npx ${DFX_MOC_PATH} --version
       - name: Fixup `mops` cache
         run: |
-          ln -sf /nix/store/*-moc/bin/moc $(cat .mops/moc-*)
+          # Point mops at the M0223-silenced moc wrapper (.#moc-M0223, built
+          # before the checkout). Its store path is used explicitly rather than
+          # the `*-moc` glob, since the wrapper and the real moc both end in
+          # `-moc`. Remove once motoko-core is cleaned up — see #6199.
+          ln -sf "$MOC_M0223/bin/moc" "$(cat .mops/moc-*)"
           npx ${DFX_MOC_PATH} --version
       - name: Run `motoko-core` Tests
         run: npm test

--- a/flake.nix
+++ b/flake.nix
@@ -293,6 +293,14 @@
 
         inherit (debug) moc;
 
+        # CI-only wrapper: `moc` with M0223 (redundant type instantiation)
+        # forced off, to silence the storm on `motoko-core` (which promotes it
+        # via `-E=M0223` in its mops.toml) until #6199 cleans it up. The trailing
+        # `-A M0223` wins (last-one-wins); `-E=M0154` etc. are preserved.
+        moc-M0223 = pkgs.writeShellScriptBin "moc" ''
+          exec ${debug.moc}/bin/moc "$@" -A M0223
+        '';
+
         default = release-systems-go;
       };
 


### PR DESCRIPTION
The `motoko-core-tests` job in `nightly-macos-test` has failed for ≥2 nights with ~2871 **M0223 "redundant type instantiation"** errors against `dfinity/motoko-core`.

**Cause:** moc #6166 (M0237 fix) reworked the shared call-instantiation path so M0223 now fires comprehensively; `motoko-core` promotes it to an error via `-E=M0223` in its `mops.toml`. moc's verdicts are *correct* (verified — it spares return-only `<T>`s), so the instantiations really are redundant. This is a core cleanup → tracked in #6199.

**This PR (interim, CI-only):** instead of symlinking `moc` for `mops`, install a one-line wrapper that appends a trailing `-A M0223` — last-wins, so it overrides core's `-E=M0223` while leaving `-E=M0154` intact. No `moc` or `motoko-core` source change.

Remove the wrapper once #6199 lands (core de-redundified).