### PR TITLE
feat: emit standardized `target_features` Wasm custom section

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,12 @@
 # Motoko compiler changelog
 
-## 1.10.1 (2026-06-24)
-
 * motoko (`moc`)
 
   * feat: `moc` now emits the standardized `target_features` Wasm custom section, so Binaryen-based tools (`wasm-opt`, `ic-wasm optimize`, `dfx`'s `optimize`) accept and optimize Motoko output without per-tool feature flags. Previously these tools defaulted to MVP and rejected the `multivalue`/`bulk-memory`/`memory64` features moc relies on (#6213).
+
+## 1.10.1 (2026-06-24)
+
+* motoko (`moc`)
 
   * bugfix: M0223 ("redundant type instantiation") and M0237 ("implicit argument can be omitted") no longer emit suggestions that are individually valid but break compilation when applied together. In nested calls where an inner instantiation or implicit is only inferable thanks to an outer one (e.g. `List.fromArray(Array.tabulate(...))`), only a jointly-applicable subset is now suggested, so `mops check --fix` no longer rewrites the code into an M0098 type error. The check is conservative: a few genuinely-redundant cases may go unreported in exchange for soundness (#6209).
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 * motoko (`moc`)
 
-  * feat: `moc` now emits the standardized `target_features` Wasm custom section, so Binaryen-based tools (`wasm-opt`, `ic-wasm optimize`, `dfx`'s `optimize`) accept and optimize Motoko output without per-tool feature flags. Previously these tools defaulted to MVP and rejected the `multivalue`/`bulk-memory`/`memory64` features moc relies on (#6213).
+  * feat: `moc` now emits the standardized `target_features` Wasm custom section, so Binaryen-based tools (`wasm-opt`, `ic-wasm optimize`, `dfx`'s `optimize`) accept and optimize Motoko output without per-tool feature flags. Previously these tools defaulted to MVP and rejected the `multivalue`/`bulk-memory`/`memory64` features moc relies on (#6214).
 
 ## 1.10.1 (2026-06-24)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * feat: `moc` now emits the standardized `target_features` Wasm custom section, so Binaryen-based tools (`wasm-opt`, `ic-wasm optimize`, `dfx`'s `optimize`) accept and optimize Motoko output without per-tool feature flags. Previously these tools defaulted to MVP and rejected the `multivalue`/`bulk-memory`/`memory64` features moc relies on (#6213).
+
 ## 1.10.0 (2026-06-19)
 
 * motoko (`moc`)

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -13732,6 +13732,12 @@ and conclude_module env set_serialization_globals start_fi_o =
       };
       source_mapping_url = None;
       wasm_features = E.get_features env;
+      (* See `compile_enhanced.ml` for rationale. Classical persistence uses a
+         32-bit main memory, so no `memory64`. *)
+      target_features =
+        [ "bulk-memory"; "bulk-memory-opt"; "nontrapping-fptoint"; "sign-ext" ]
+        @ (if !Flags.multi_value then ["multivalue"] else [])
+        @ (if List.mem "multi-memory" (E.get_features env) then ["multimemory"] else []);
     } in
 
   match E.get_rts env with

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -14095,6 +14095,16 @@ and conclude_module env set_serialization_globals start_fi_o =
       };
       source_mapping_url = None;
       wasm_features = E.get_features env;
+      (* Wasm features used by the emitted code and the linked RTS, in Binaryen
+         names. Empirically validated as the minimal set that lets a bare
+         `wasm-opt` (MVP by default) validate the module: the RTS contributes
+         sign-ext / nontrapping-fptoint / bulk-memory(-opt), enhanced orthogonal
+         persistence uses a 64-bit main memory, and WASI/Wasm stable-memory
+         emulation adds a second memory (`multimemory`, tracked dynamically). *)
+      target_features =
+        [ "bulk-memory"; "bulk-memory-opt"; "memory64"; "nontrapping-fptoint"; "sign-ext" ]
+        @ (if !Flags.multi_value then ["multivalue"] else [])
+        @ (if List.mem "multi-memory" (E.get_features env) then ["multimemory"] else []);
     } in
 
   (* For debugging *)

--- a/src/wasm-exts/customModule.ml
+++ b/src/wasm-exts/customModule.ml
@@ -83,4 +83,7 @@ type extended_module = {
   (* source map section *)
   source_mapping_url : string option;
   wasm_features : string list;
+  (* standardized `target_features` section (Binaryen/LLVM feature names),
+     read by Binaryen-based tools (wasm-opt, ic-wasm) to auto-enable features *)
+  target_features : string list;
 }

--- a/src/wasm-exts/customModuleDecode.ml
+++ b/src/wasm-exts/customModuleDecode.ml
@@ -929,6 +929,11 @@ let wasm_features_section s =
   custom_section is_wasm_features
     (fun sec_end s -> let t = utf8 sec_end s in String.split_on_char ',' t) [] s
 
+let is_target_features n = (n = Utf8.decode "target_features")
+let target_features_section s =
+  custom_section is_target_features
+    (fun _sec_end s -> vec (fun s -> ignore (u8 s) (* '+'/'-' prefix *); string s) s) [] s
+
 let is_unknown n = not (
   is_dylink0 n ||
   is_name n ||
@@ -936,7 +941,8 @@ let is_unknown n = not (
   is_icp candid_service_name n ||
   is_icp candid_args_name n ||
   is_icp motoko_stable_types_name n ||
-  is_wasm_features n)
+  is_wasm_features n ||
+  is_target_features n)
 
 let skip_custom sec_end s =
   skip (sec_end - pos s) s;
@@ -991,6 +997,12 @@ let module_ s =
   iterate skip_custom_section s;
   let wasm_features = wasm_features_section s in
   iterate skip_custom_section s;
+  (* Decode is order-sensitive: known sections must appear in this order, with
+     only `is_unknown` sections skippable between them. Holds because `lld`
+     emits `target_features` last; if a future toolchain placed it earlier,
+     it would no longer be skipped and decode would fail here. *)
+  let target_features = target_features_section s in
+  iterate skip_custom_section s;
   require (pos s = len s) s (len s) "junk after last section";
   require (List.length func_types = List.length func_bodies)
     s (len s) "function and code section have inconsistent lengths";
@@ -1009,6 +1021,7 @@ let module_ s =
     candid;
     source_mapping_url = None;
     wasm_features = wasm_features;
+    target_features = target_features;
   }
 
 

--- a/src/wasm-exts/customModuleEncode.ml
+++ b/src/wasm-exts/customModuleEncode.ml
@@ -940,6 +940,13 @@ let encode (em : extended_module) =
       let text = String.concat "," wasm_features in
       custom_section "wasm_features" utf8 text (text <> "")
 
+    (* Standardized `target_features` section, cf.
+       https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#target-features-section
+       Each entry is prefixed with '+' (0x2b), marking the feature as used. *)
+    let target_features_section features =
+      custom_section "target_features"
+        (vec (fun feat -> u8 0x2b; string feat)) features (features <> [])
+
     let uleb128 n = vu64 (Int64.of_int n)
     let sleb128 n = vs64 (Int64.of_int n)
     let close_section () = u8 0x00
@@ -1311,6 +1318,7 @@ let encode (em : extended_module) =
       motoko_sections em.motoko;
       enhanced_orthogonal_persistence_section em.enhanced_orthogonal_persistence;
       wasm_features_section em.wasm_features;
+      target_features_section em.target_features;
       source_mapping_url_section em.source_mapping_url;
       if !Mo_config.Flags.debug_info then
         begin


### PR DESCRIPTION
Binaryen-based tools (`wasm-opt`, `ic-wasm optimize`, `dfx`'s `optimize`) default to the MVP feature set when a module carries no `target_features` section. Motoko output uses `multivalue`, `bulk-memory`, `sign-ext`, `nontrapping-fptoint` (and `memory64` under enhanced orthogonal persistence), so these tools rejected it outright — and `ic-wasm optimize` has no flag to override, making the optimization unrecoverable.

`moc` now emits the standardized [`target_features`](https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#target-features-section) custom section listing exactly the features the emitted code and linked RTS use. Binaryen reads it and self-configures, so optimizing Motoko output needs no per-tool feature flags.

### Before / After

```console
$ moc -o canister.wasm canister.mo
$ wasm-opt -O3 canister.wasm -o opt.wasm
# Before: [wasm-validator error] ... memory.copy requires bulk memory [--enable-bulk-memory-opt]
# After:  ok
```

The declared set is empirically minimal: stripping the section makes the same module fail MVP validation again. It adapts to the build mode — `memory64` only under enhanced orthogonal persistence (classical is 32-bit), `multivalue` gated on `--multi-value`, and `multimemory` only in WASI/Wasm modes that emulate stable memory with a second linear memory (kept in sync with the existing dynamic `wasm_features` set).

## Scope

- Fully unblocks classical (32-bit) Motoko output for current `ic-wasm` (0.9.11).
- For enhanced-persistence (64-bit) output, the section is a prerequisite but not sufficient for `ic-wasm` 0.9.11: it bundles Binaryen 116, and 64-bit tables need Binaryen ≥118. That's a downstream toolchain bump tracked in [dfinity/ic-wasm#102](https://github.com/dfinity/ic-wasm/pull/102), not fixable here.

Closes #6213.

Made with [Cursor](https://cursor.com)