### PR TITLE
refactor: simplifies bounds checks for candid decoding in the RTS

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 * motoko (`moc`)
 
+  * refactor: simplifies bounds checks for candid decoding in the RTS (#6240).
   * fix: fix codegen for nested mixins (#6223).
   * deprecation: removed the legacy `-multi-value`/`-no-multi-value` flags; `--experimental-multi-value` and
     `--no-experimental-multi-value` now warn as deprecated — multi-value Wasm codegen is the default (#6206).

--- a/rts/motoko-rts/src/buf.rs
+++ b/rts/motoko-rts/src/buf.rs
@@ -19,12 +19,16 @@ impl Buf {
     /// Restrict the read area
     #[cfg(feature = "ic")]
     pub(crate) unsafe fn limit_size(self: *mut Self, lim: usize) -> *mut u8 {
-        let limit_ptr = (*self).ptr.add(lim);
         let prev = (*self).end;
-        if limit_ptr < prev {
-            (*self).end = limit_ptr;
+        if lim < self.size() {
+            (*self).end = (*self).ptr.add(lim);
         }
         prev
+    }
+
+    #[cfg(feature = "ic")]
+    pub(crate) unsafe fn size(self: *const Self) -> usize {
+        (*self).end.offset_from_unsigned((*self).ptr)
     }
 }
 
@@ -46,7 +50,7 @@ pub(crate) unsafe fn read_word(buf: *mut Buf) -> u32 {
     // IDL buffer is still 32-bit-based.
     const WORD_SIZE: usize = core::mem::size_of::<u32>();
 
-    if (*buf).ptr.add(WORD_SIZE) > (*buf).end {
+    if WORD_SIZE > buf.size() {
         idl_trap_with("word read out of buffer");
     }
 
@@ -62,7 +66,7 @@ pub(crate) unsafe fn read_word(buf: *mut Buf) -> u32 {
 
 #[cfg(feature = "ic")]
 unsafe fn advance(buf: *mut Buf, n: usize) {
-    if (*buf).ptr.add(n) > (*buf).end {
+    if n > buf.size() {
         idl_trap_with("advance out of buffer");
     }
 

--- a/rts/motoko-rts/src/idl.rs
+++ b/rts/motoko-rts/src/idl.rs
@@ -202,7 +202,7 @@ unsafe fn parse_idl_header<M: Memory>(
     let n_types = leb128_decode(buf);
 
     // Early sanity check
-    if (*buf).ptr.add(n_types as usize) >= (*buf).end {
+    if n_types as usize > buf.size() {
         idl_trap_with("too many types");
     }
 

--- a/test/bench/ok/bignum.drun-run.ok
+++ b/test/bench/ok/bignum.drun-run.ok
@@ -2,6 +2,6 @@ ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a000000000000000001
 ingress Completed: Reply: 0x4449444c0000
 debug.print: {cycles = 2_464_049; size = +25_528}
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 54_911_823; size = +830_464}
+debug.print: {cycles = 54_911_849; size = +830_464}
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/candid-subtype-cost.drun-run.ok
+++ b/test/bench/ok/candid-subtype-cost.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 1_118_504; heap_bytes = +33_888}
+debug.print: {cycles = 1_119_725; heap_bytes = +33_888}
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/typtbl.drun-run.ok
+++ b/test/bench/ok/typtbl.drun-run.ok
@@ -1,9 +1,9 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 debug.print: {bias = 1_024; scalar = 16}
-debug.print: {cycles = 175_473}
-debug.print: {cycles = 175_741}
-debug.print: {cycles = 354_173}
-debug.print: {cycles = 532_605}
-debug.print: {cycles = 711_037}
-debug.print: {cycles = 262_499}
+debug.print: {cycles = 178_057}
+debug.print: {cycles = 178_325}
+debug.print: {cycles = 359_317}
+debug.print: {cycles = 540_309}
+debug.print: {cycles = 721_301}
+debug.print: {cycles = 265_083}
 ingress Completed: Reply: 0x4449444c0000


### PR DESCRIPTION
Just making things a bit easier to understand.

~TODO:~
- [x] Changelog entry