### PR TITLE
docs: fix old link in changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -965,7 +965,7 @@
     ensures that no cleanup is required.
 
     The relevant security best practices are accessible at
-    https://internetcomputer.org/docs/current/developer-docs/security/security-best-practices/inter-canister-calls#recommendation
+    https://docs.internetcomputer.org/guides/security/inter-canister-calls/#recommendation
 
     BREAKING CHANGE (Minor): `finally` is now a reserved keyword,
     programs using this identifier will break.


### PR DESCRIPTION
Fixes a stale security-best-practices link in `Changelog.md` (old `internetcomputer.org/docs/current/...` → current `docs.internetcomputer.org/guides/...`).

Authored by **@marc0olo** (Marco Walz) — this is a same-repo re-submission of #6180 with authorship preserved (cherry-pick of the original commit).

**Why re-submitted:** #6180 is a fork PR, and GitHub withholds repo secrets from fork PRs, so its CI could not authenticate to the private nix build cache and cold-built the whole toolchain until the runner hit its timeout (SIGTERM/143) — never a problem with the one-line diff. Running the identical change from a same-repo branch lets CI use the warm cache and pass. Supersedes #6180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)