### PR TITLE
perf: short-circuit Text equality on differing byte lengths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * perf: Text equality (`==`/`!=`) now short-circuits when the operands have different byte lengths, avoiding a UTF-8/rope scan; ordering (`<`, `<=`, `>`, `>=`) is unchanged (#6257).
+
 ## 1.11.2 (2026-07-22)
 
 * motoko (`moc`)

--- a/rts/motoko-rts-tests/src/text.rs
+++ b/rts/motoko-rts-tests/src/text.rs
@@ -4,7 +4,7 @@ use crate::memory::{initialize_test_memory, reset_test_memory};
 
 use motoko_rts::memory::Memory;
 use motoko_rts::text::{
-    blob_of_text, decode_code_point, text_compare, text_concat, text_len, text_of_str,
+    blob_of_text, decode_code_point, text_compare, text_concat, text_eq, text_len, text_of_str,
     text_singleton, text_size,
 };
 use motoko_rts::text_iter::{text_iter, text_iter_done, text_iter_next};
@@ -99,9 +99,53 @@ pub unsafe fn test() {
         ],
     );
 
+    println!("  Testing text_eq");
+    text_eq_test(&mut mem);
+
     drop(mem);
 
     reset_test_memory();
+}
+
+unsafe fn text_eq_test<M: Memory>(mem: &mut M) {
+    let eq = |mem: &mut M, a: &str, b: &str| {
+        let a = text_of_str(mem, a);
+        let b = text_of_str(mem, b);
+        text_eq(a, b)
+    };
+
+    // Unequal lengths are decided without needing equal prefixes.
+    assert!(!eq(mem, "a", "aa"));
+    assert!(!eq(mem, "", "x"));
+    assert!(!eq(mem, "DE", "DEU"));
+
+    // Equal length, equal content.
+    assert!(eq(mem, "", ""));
+    assert!(eq(mem, "abc", "abc"));
+
+    // Equal length, different content.
+    assert!(!eq(mem, "ab", "ac"));
+
+    // Same (forwarded) object.
+    let shared = text_of_str(mem, "shared");
+    assert!(text_eq(shared, shared));
+
+    // Concat nodes compare equal to the equivalent blob.
+    let ab = text_of_str(mem, "ab");
+    let cd = text_of_str(mem, "cd");
+    let concat = text_concat(mem, ab, cd);
+    let abcd = text_of_str(mem, "abcd");
+    let abce = text_of_str(mem, "abce");
+    let abcde = text_of_str(mem, "abcde");
+    assert!(text_eq(concat, abcd));
+    assert!(!text_eq(concat, abce));
+    assert!(!text_eq(concat, abcde));
+
+    // Ordering is *not* decided by length alone: an equal prefix still compares by length.
+    let ab = text_of_str(mem, "ab");
+    let abc = text_of_str(mem, "abc");
+    assert_eq!(text_compare(ab, abc), -1);
+    assert_eq!(text_compare(abc, ab), 1);
 }
 
 unsafe fn concat1<M: Memory>(mem: &mut M) {

--- a/rts/motoko-rts/src/text.rs
+++ b/rts/motoko-rts/src/text.rs
@@ -343,6 +343,20 @@ pub unsafe extern "C" fn text_compare(s1: Value, s2: Value) -> isize {
     }
 }
 
+/// Equality on texts. Unlike ordering, equality is decided by byte length: texts of different
+/// `text_size` cannot be equal, so we short-circuit without walking the UTF-8 / rope payloads.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn text_eq(s1: Value, s2: Value) -> bool {
+    // Same (forwarded) object.
+    if s1 == s2 {
+        return true;
+    }
+    if text_size(s1) != text_size(s2) {
+        return false;
+    }
+    text_compare(s1, s2) == 0
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn blob_compare(s1: Value, s2: Value) -> isize {
     let n1 = text_size(s1);

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -1133,6 +1133,7 @@ module RTS = struct
     add_rts_import "continuation_table_size" [] [I32Type];
     add_rts_import "blob_of_text" [I32Type] [I32Type];
     add_rts_import "text_compare" [I32Type; I32Type] [I32Type];
+    add_rts_import "text_eq" [I32Type; I32Type] [I32Type];
     add_rts_import "text_concat" [I32Type; I32Type] [I32Type];
     add_rts_import "text_iter_done" [I32Type] [I32Type];
     add_rts_import "text_iter" [I32Type] [I32Type];
@@ -4696,14 +4697,18 @@ module Text = struct
     Func.share_code2 Func.Never env name (("x", I32Type), ("y", I32Type)) [I32Type] (fun env get_x get_y ->
       get_x ^^ Tagged.load_forwarding_pointer env ^^
       get_y ^^ Tagged.load_forwarding_pointer env ^^
-      E.call_rts env "text_compare" ^^
-      compile_unboxed_const 0l ^^
       match op with
-        | LtOp -> G.i (Compare (Wasm.Values.I32 I32Op.LtS))
-        | LeOp -> G.i (Compare (Wasm.Values.I32 I32Op.LeS))
-        | GtOp -> G.i (Compare (Wasm.Values.I32 I32Op.GtS))
-        | GeOp -> G.i (Compare (Wasm.Values.I32 I32Op.GeS))
-        | EqOp -> G.i (Compare (Wasm.Values.I32 I32Op.Eq))
+        (* Equality is decided by length, so `text_eq` short-circuits on differing sizes. *)
+        | EqOp -> E.call_rts env "text_eq"
+        | LtOp | LeOp | GtOp | GeOp ->
+          E.call_rts env "text_compare" ^^
+          compile_unboxed_const 0l ^^
+          (match op with
+            | LtOp -> G.i (Compare (Wasm.Values.I32 I32Op.LtS))
+            | LeOp -> G.i (Compare (Wasm.Values.I32 I32Op.LeS))
+            | GtOp -> G.i (Compare (Wasm.Values.I32 I32Op.GtS))
+            | GeOp -> G.i (Compare (Wasm.Values.I32 I32Op.GeS))
+            | _ -> assert false)
         | NeqOp -> assert false
     )
 

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -1217,6 +1217,7 @@ module RTS = struct
     add_rts_import "continuation_table_size" [] [I64Type];
     add_rts_import "blob_of_text" [I64Type] [I64Type];
     add_rts_import "text_compare" [I64Type; I64Type] [I64Type];
+    add_rts_import "text_eq" [I64Type; I64Type] [I32Type];
     add_rts_import "text_concat" [I64Type; I64Type] [I64Type];
     add_rts_import "text_iter_done" [I64Type] [I64Type];
     add_rts_import "text_iter" [I64Type] [I64Type];
@@ -4431,14 +4432,18 @@ module Text = struct
     Func.share_code2 Func.Never env name (("x", I64Type), ("y", I64Type)) [I64Type] (fun env get_x get_y ->
       get_x ^^ Tagged.load_forwarding_pointer env ^^
       get_y ^^ Tagged.load_forwarding_pointer env ^^
-      E.call_rts env "text_compare" ^^
-      compile_unboxed_const 0L ^^
       match op with
-        | LtOp -> compile_comparison I64Op.LtS
-        | LeOp -> compile_comparison I64Op.LeS
-        | GtOp -> compile_comparison I64Op.GtS
-        | GeOp -> compile_comparison I64Op.GeS
-        | EqOp -> compile_comparison I64Op.Eq
+        (* Equality is decided by length, so `text_eq` short-circuits on differing sizes. *)
+        | EqOp -> E.call_rts env "text_eq" ^^ Bool.from_rts_int32
+        | LtOp | LeOp | GtOp | GeOp ->
+          E.call_rts env "text_compare" ^^
+          compile_unboxed_const 0L ^^
+          (match op with
+            | LtOp -> compile_comparison I64Op.LtS
+            | LeOp -> compile_comparison I64Op.LeS
+            | GtOp -> compile_comparison I64Op.GtS
+            | GeOp -> compile_comparison I64Op.GeS
+            | _ -> assert false)
         | NeqOp -> assert false
     )
 

--- a/test/run/text-op.mo
+++ b/test/run/text-op.mo
@@ -30,6 +30,14 @@ assert (not ("a" == "ä"));
 assert (not ("a" >= "ä"));
 assert (not ("a" >  "ä"));
 
+// Equality short-circuits on differing byte lengths; ordering must not.
+assert (    ("DE" == "DE"));
+assert (not ("DE" == "D"));
+assert (not ("DE" == "DEU"));
+assert (    ("DE" != "DEU"));
+assert (    ("ab" <  "abc"));
+assert (not ("z"  <  "aaa"));
+
 assert textCompare("", "a") == -1;
 assert textCompare("b", "a") == 1;
 assert textCompare("a", "") == 1;


### PR DESCRIPTION
Text equality (`==` / `!=`) always dispatched to the RTS `text_compare`, which scans `min(n1, n2)` payload bytes (a `memcmp` per blob segment, walking concat ropes) before ever looking at length. But unlike ordering, equality is fully decided by byte length: two texts of different `text_size` cannot be equal. That size lives in the object header and is O(1) for both `BLOB` and `CONCAT`, so the payload walk on length-mismatched operands was pure waste.

A dedicated RTS `text_eq` now short-circuits: same forwarded pointer → equal, differing `text_size` → not equal, otherwise fall back to the full compare. Both the enhanced (EOP) and classical codegen `Text.compare` `EqOp` paths call it; `!=` negates it for free.

## What is unchanged

Ordering (`<`, `<=`, `>`, `>=`) still goes through `text_compare` untouched — length alone does not decide order (`"ab" < "abc"`, but `"z" < "aaa"` is false), so those paths must keep comparing the common prefix first.

Blob equality has the same "prefix then length" shape and could get the same treatment; left out of scope here.
