### PR TITLE
feat: warn on excess precision in `Float` literals (M0266)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 * motoko (`moc`)
 
   * feat: the excess-precision warning (M0266) now also covers `Float` (F64) literals, not just
-    `Float32`, suggesting the shortest round-trip equivalent (#5973).
+    `Float32`, suggesting the shortest round-trip equivalent (#6261).
 
   * feat: `--stable-baseline <file.most>` with `--enhanced-migration` escalates unexplained
     "initial actor requires field" cases to error M0267; fields whose baseline type is a

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,10 +3,7 @@
 * motoko (`moc`)
 
   * feat: the excess-precision warning (M0266) now also covers `Float` (F64) literals, not just
-    `Float32`. A literal with more significant digits than F64 can hold warns and suggests the
-    shortest round-trip equivalent — e.g. `0.12345678901234567890 : Float`. Minimal literals like
-    `0.1`/`3.14` stay quiet, and because bare float literals default to `Float`, unannotated
-    literals are covered too (#5973).
+    `Float32`, suggesting the shortest round-trip equivalent (#5973).
 
   * feat: `--stable-baseline <file.most>` with `--enhanced-migration` escalates unexplained
     "initial actor requires field" cases to error M0267; fields whose baseline type is a

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,12 @@
 
 * motoko (`moc`)
 
+  * feat: the excess-precision warning (M0266) now also covers `Float` (F64) literals, not just
+    `Float32`. A literal with more significant digits than F64 can hold warns and suggests the
+    shortest round-trip equivalent — e.g. `0.12345678901234567890 : Float`. Minimal literals like
+    `0.1`/`3.14` stay quiet, and because bare float literals default to `Float`, unannotated
+    literals are covered too (#5973).
+
   * feat: `--stable-baseline <file.most>` with `--enhanced-migration` escalates unexplained
     "initial actor requires field" cases to error M0267; fields whose baseline type is a
     stable subtype of the required type keep warning M0254 (prototype for legacy→EM

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -270,7 +270,7 @@ let warning_codes = [
   "M0244", None, "Mutable variable is never reassigned";
   "M0254", None, "Initial actor requires field";
   "M0265", None, "The `system` capability is not required by this mixin";
-  "M0266", None, "Float32 literal has more precision than Float32 can represent"
+  "M0266", None, "floating-point literal has more precision than its type can represent"
   ]
 
 let try_find_explanation code =

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1336,20 +1336,36 @@ let decimal_sig_digits (s : string) : int option =
     Some (if !j >= !i then !j - !i + 1 else 0)
   end
 
-(* Warn (M0266) when a Float32 literal carries more significant digits than the
-   value can hold — i.e. the surplus digits are silently discarded by rounding.
-   Fires only on genuine excess: a minimally-written literal equals its own
-   shortest round-trip form, so 0.1, 3.14, 1.5 etc. stay quiet. *)
-let check_float32_precision env at s v =
+(* Shortest decimal (<= 17 significant digits — always enough to round-trip an
+   F64) that parses back to the same Float [v]. Same synthesis as
+   [float32_shortest], widened to F64's 17-digit ceiling. *)
+let float_shortest (v : Numerics.Float.t) : string =
+  let f = Numerics.Float.to_float v in
+  let rec go n =
+    let cand = Printf.sprintf "%.*g" n f in
+    if n >= 17 || (try Numerics.Float.eq (Numerics.Float.of_string cand) v
+                   with _ -> false)
+    then cand
+    else go (n + 1)
+  in
+  go 1
+
+(* Warn (M0266) when a float literal carries more significant digits than its
+   type [ty] can hold — the surplus is silently discarded by rounding. Fires
+   only on genuine excess: a minimally-written literal is its own shortest
+   round-trip form, so 0.1, 3.14, 1.5 etc. stay quiet. [shortest] yields the
+   type-specific shortest round-trip decimal (Float32: <=9 sig digits;
+   Float: <=17). *)
+let check_float_precision env at ty shortest s =
   match decimal_sig_digits s with
   | None -> ()
   | Some used ->
-    let short = float32_shortest v in
+    let short = shortest () in
     (match decimal_sig_digits short with
      | Some need when used > need ->
        warn env at "M0266"
-         "literal %s has more precision than Float32 can represent; it rounds to %s (the surplus digits are discarded)"
-         s short
+         "literal %s has more precision than %s can represent; it rounds to %s (the surplus digits are discarded)"
+         s (T.string_of_typ (T.Prim ty)) short
      | _ -> ())
 
 let check_text env at s =
@@ -1385,8 +1401,11 @@ let infer_lit env lit at : T.prim =
       lit := IntLit (check_int env at s); (* default *)
     T.Int
   | PreLit (s, T.Float) ->
-    if not env.pre then
-      lit := FloatLit (check_float env at s); (* default *)
+    if not env.pre then begin
+      let v = check_float env at s in
+      check_float_precision env at T.Float (fun () -> float_shortest v) s;
+      lit := FloatLit v (* default *)
+    end;
     T.Float
   | PreLit (s, T.Text) ->
     if not env.pre then
@@ -1420,10 +1439,12 @@ let check_lit env t lit at suggest =
   | Prim Int64, PreLit (s, (Nat | Int)) ->
     lit := Int64Lit (check_int64 env at s)
   | Prim Float, PreLit (s, (Nat | Int | Float)) ->
-    lit := FloatLit (check_float env at s)
+    let v = check_float env at s in
+    check_float_precision env at T.Float (fun () -> float_shortest v) s;
+    lit := FloatLit v
   | Prim Float32, PreLit (s, (Nat | Int | Float)) ->
     let v = check_float32 env at s in
-    check_float32_precision env at s v;
+    check_float_precision env at T.Float32 (fun () -> float32_shortest v) s;
     lit := Float32Lit v
   | Prim Blob, PreLit (s, Text) ->
     lit := BlobLit s

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1352,10 +1352,8 @@ let float_shortest (v : Numerics.Float.t) : string =
 
 (* Warn (M0266) when a float literal carries more significant digits than its
    type [ty] can hold — the surplus is silently discarded by rounding. Fires
-   only on genuine excess: a minimally-written literal is its own shortest
-   round-trip form, so 0.1, 3.14, 1.5 etc. stay quiet. [shortest] yields the
-   type-specific shortest round-trip decimal (Float32: <=9 sig digits;
-   Float: <=17). *)
+   only on genuine excess: a minimal literal equals its own shortest round-trip
+   form ([shortest]), so 0.1, 3.14, 1.5 etc. stay quiet. *)
 let check_float_precision env at ty shortest s =
   match decimal_sig_digits s with
   | None -> ()

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1315,8 +1315,8 @@ let shortest_roundtrip (cap, to_float, eq, of_string) v : string =
   in
   go 1
 
-let float32_shortest v = shortest_roundtrip Numerics.Float32.(9, to_float, eq, of_string) v
-let float_shortest   v = shortest_roundtrip Numerics.Float.(17, to_float, eq, of_string) v
+let float32_shortest = shortest_roundtrip Numerics.Float32.(9, to_float, eq, of_string)
+let float_shortest   = shortest_roundtrip Numerics.Float.(17, to_float, eq, of_string)
 
 (* Significant digits of a decimal float/int literal lexeme; [None] for a hex
    float (which we don't analyse). Strips digit separators, the exponent, the

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1301,19 +1301,22 @@ let check_float env = check_lit_val env T.Float Numerics.Float.of_string
 let check_float32 env at s =
   check_lit_val env T.Float32 Numerics.Float32.of_string at s
 
-(* Shortest decimal (<= 9 significant digits — always enough to round-trip an
-   F32) that parses back to the same Float32 [v]. Synthesised from the printer
-   and parser we already have, so no shortest-float dependency is needed. *)
-let float32_shortest (v : Numerics.Float32.t) : string =
-  let f = Numerics.Float32.to_float v in
+(* Shortest decimal that round-trips to the float [v]: try 1..[cap] significant
+   digits with the printer + parser we already have (no shortest-float dep).
+   The tuple is the type's round-trip ceiling and its to_float / eq / of_string
+   (F32: cap 9, F64: cap 17). *)
+let shortest_roundtrip (cap, to_float, eq, of_string) v : string =
+  let f = to_float v in
   let rec go n =
     let cand = Printf.sprintf "%.*g" n f in
-    if n >= 9 || (try Numerics.Float32.eq (Numerics.Float32.of_string cand) v
-                  with _ -> false)
+    if n >= cap || (try eq (of_string cand) v with _ -> false)
     then cand
     else go (n + 1)
   in
   go 1
+
+let float32_shortest v = shortest_roundtrip Numerics.Float32.(9, to_float, eq, of_string) v
+let float_shortest   v = shortest_roundtrip Numerics.Float.(17, to_float, eq, of_string) v
 
 (* Significant digits of a decimal float/int literal lexeme; [None] for a hex
    float (which we don't analyse). Strips digit separators, the exponent, the
@@ -1335,20 +1338,6 @@ let decimal_sig_digits (s : string) : int option =
     let j = ref (n - 1) in while !j >= !i && digits.[!j] = '0' do decr j done;
     Some (if !j >= !i then !j - !i + 1 else 0)
   end
-
-(* Shortest decimal (<= 17 significant digits — always enough to round-trip an
-   F64) that parses back to the same Float [v]. Same synthesis as
-   [float32_shortest], widened to F64's 17-digit ceiling. *)
-let float_shortest (v : Numerics.Float.t) : string =
-  let f = Numerics.Float.to_float v in
-  let rec go n =
-    let cand = Printf.sprintf "%.*g" n f in
-    if n >= 17 || (try Numerics.Float.eq (Numerics.Float.of_string cand) v
-                   with _ -> false)
-    then cand
-    else go (n + 1)
-  in
-  go 1
 
 (* Warn (M0266) when a float literal carries more significant digits than its
    type [ty] can hold — the surplus is silently discarded by rounding. Fires

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1302,9 +1302,7 @@ let check_float32 env at s =
   check_lit_val env T.Float32 Numerics.Float32.of_string at s
 
 (* Shortest decimal that round-trips to the float [v]: try 1..[cap] significant
-   digits with the printer + parser we already have (no shortest-float dep).
-   The tuple is the type's round-trip ceiling and its to_float / eq / of_string
-   (F32: cap 9, F64: cap 17). *)
+   digits with the printer + parser we already have (no shortest-float dep). *)
 let shortest_roundtrip (cap, to_float, eq, of_string) v : string =
   let f = to_float v in
   let rec go n =

--- a/test/fail/ok/warn-help.tc-human.ok
+++ b/test/fail/ok/warn-help.tc-human.ok
@@ -41,6 +41,6 @@ M0243 (W) Unreachable else in let-else
 M0244 (W) Mutable variable is never reassigned
 M0254 (W) Initial actor requires field
 M0265 (W) The `system` capability is not required by this mixin
-M0266 (W) Float32 literal has more precision than Float32 can represent
+M0266 (W) floating-point literal has more precision than its type can represent
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/fail/ok/warn-help.tc.ok
+++ b/test/fail/ok/warn-help.tc.ok
@@ -41,6 +41,6 @@ M0243 (W) Unreachable else in let-else
 M0244 (W) Mutable variable is never reassigned
 M0254 (W) Initial actor requires field
 M0265 (W) The `system` capability is not required by this mixin
-M0266 (W) Float32 literal has more precision than Float32 can represent
+M0266 (W) floating-point literal has more precision than its type can represent
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/run/float-fmt.mo
+++ b/test/run/float-fmt.mo
@@ -1,3 +1,6 @@
+//MOC-FLAG -A M0266
+// This test deliberately writes an over-precise Float literal (a 19-digit pi)
+// to exercise float formatting, so silence the excess-precision warning.
 import Prim "mo:⛔";
 
 let pi = 3.141592653589793238;

--- a/test/run/float-ops.mo
+++ b/test/run/float-ops.mo
@@ -1,3 +1,6 @@
+//MOC-FLAG -A M0266
+// This test exercises float ops with deliberately over-precise literals
+// (a 19-digit pi, ~10^101 magnitudes), so silence the excess-precision warning.
 import Prim "mo:⛔";
 
 func isNegative(number: Float): Bool {

--- a/test/run/float-precision.mo
+++ b/test/run/float-precision.mo
@@ -1,0 +1,14 @@
+// M0266 (shared by Float32 and Float): a floating-point literal with more
+// significant digits than the type can hold warns (and suggests the shortest
+// round-trip form); minimal literals stay quiet. For Float both the
+// `: Float`-annotated site and the unannotated (inferred, defaults to Float)
+// site are covered.
+let excess : Float32 = 0.123456789;  // warns: rounds to 0.12345679
+let minimal : Float32 = 0.1;         // no warning
+let exact : Float32 = 1.0;           // no warning
+let excessF : Float = 0.12345678901234567890;  // warns (annotated : Float)
+let inferredF = 0.12345678901234567890;         // warns (unannotated, defaults to Float)
+let minimalF : Float = 0.1;                      // no warning
+let exactF = 1.0;                                // no warning (unannotated)
+assert (excess != minimal and minimal != exact);
+assert (excessF != minimalF and minimalF != exactF and inferredF == excessF);

--- a/test/run/float32-precision.mo
+++ b/test/run/float32-precision.mo
@@ -1,6 +1,0 @@
-// M0266: a Float32 literal with more significant digits than F32 can hold
-// warns (and suggests the shortest round-trip form); minimal literals do not.
-let excess : Float32 = 0.123456789;  // warns: rounds to 0.12345679
-let minimal : Float32 = 0.1;         // no warning
-let exact : Float32 = 1.0;           // no warning
-assert (excess != minimal and minimal != exact);

--- a/test/run/ok/float-precision.tc.ok
+++ b/test/run/ok/float-precision.tc.ok
@@ -1,0 +1,3 @@
+float-precision.mo:6.24-6.35: warning [M0266], literal 0.123456789 has more precision than Float32 can represent; it rounds to 0.12345679 (the surplus digits are discarded)
+float-precision.mo:9.23-9.45: warning [M0266], literal 0.12345678901234567890 has more precision than Float can represent; it rounds to 0.12345678901234568 (the surplus digits are discarded)
+float-precision.mo:10.17-10.39: warning [M0266], literal 0.12345678901234567890 has more precision than Float can represent; it rounds to 0.12345678901234568 (the surplus digits are discarded)

--- a/test/run/ok/float32-precision.tc.ok
+++ b/test/run/ok/float32-precision.tc.ok
@@ -1,1 +1,0 @@
-float32-precision.mo:3.24-3.35: warning [M0266], literal 0.123456789 has more precision than Float32 can represent; it rounds to 0.12345679 (the surplus digits are discarded)


### PR DESCRIPTION
Closes #5973.

Generalises the `Float32` excess-precision warning from #6198 to **`Float` (F64)**. A literal written with more significant digits than F64 can hold has those digits **silently discarded** by rounding; the type checker now warns and suggests the shortest equivalent:

```
0.12345678901234567890 : Float   →  M0266, rounds to 0.12345678901234568
0.1  /  3.14  /  1.0             →  (no warning)
```

## Design

- **Reuses warning code M0266** (no new code) — as agreed. The per-literal diagnostic now names the concrete type via `T.string_of_typ`, so a single parameterised `check_float_precision env at ty shortest s` serves **both** widths (the two type-specific `float32_shortest` / `float_shortest` differ only in their significant-digit ceiling — 9 for F32, 17 for F64). The code-catalogue description in `error_codes.ml` is generalised to be type-agnostic ("floating-point literal has more precision than its type can represent"), since that listing has no literal/type in scope.
- **Both literal sites are hooked.** Unlike `Float32` (which is always ascribed, so #6198 only needed `check_lit`), a bare float literal **defaults to `Float`**, so the check runs at both the ascribed site (`check_lit`, `Prim Float`) and the inferred/default site (`infer_lit`, `PreLit … Float`). The excess-only criterion (shortest-round-trip vs. written digits) is unchanged, so minimal literals stay quiet — no false-positive storm.

## Tests

- `test/run/float32-precision.mo` → **renamed** to `float-precision.mo` and extended to cover `Float` at **both** the `: Float`-annotated and the unannotated (inferred) sites, alongside the original `Float32` cases. `.tc.ok` shows all three excess literals warning; the minimal/exact literals stay clean.
- `test/run/float-fmt.mo` (a deliberate 19-digit pi) guarded with `//MOC-FLAG -A M0266`, mirroring the `float32.mo` guard #6198 added. No other in-repo test writes an over-precise F64 literal (`compact-float.mo`'s boundary values are already at their shortest form).