### PR TITLE
chore: always multi-value — remove `multi_value` flag, rename `FakeMultiVal` → `MultiVal`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Motoko compiler changelog
 
+* motoko (`moc`)
+
+  * chore: multi-value Wasm codegen is now always on;
+    `--(no-)experimental-multi-value` are kept for CLI compatibility but have
+    no effect (#6266).
+
 ## 1.12.0 (2026-07-30)
 
 * motoko (`moc`)

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -876,7 +876,7 @@ let from_m_to_n env m mk_body =
 (* Expects a number on the stack. Iterates from zero to below that number. *)
 let from_0_to_n env mk_body = from_m_to_n env 0l mk_body
 
-module FakeMultiVal = struct
+module MultiVal = struct
   (* Multi-value codegen is always on, so these are transparent wrappers:
      [ty] is the identity and [store]/[load] are no-ops (values stay on the
      Wasm stack). [if_]/[block_] remain drop-in replacements for E.if_/E.block_. *)
@@ -898,7 +898,7 @@ module FakeMultiVal = struct
     )) ^^
     load env bt
 
-end (* FakeMultiVal *)
+end (* MultiVal *)
 
 module Func = struct
   (* This module contains basic bookkeeping functionality to define functions,
@@ -909,9 +909,9 @@ module Func = struct
   let of_body env params retty mk_body =
     let env1 = E.mk_fun_env env (Int32.of_int (List.length params)) (List.length retty) in
     List.iteri (fun i (n,_t) -> E.add_local_name env1 (Int32.of_int i) n) params;
-    let ty = FuncType (List.map snd params, FakeMultiVal.ty retty) in
+    let ty = FuncType (List.map snd params, MultiVal.ty retty) in
     let body = G.to_instr_list (
-      mk_body env1 ^^ FakeMultiVal.store env1 retty
+      mk_body env1 ^^ MultiVal.store env1 retty
     ) in
     (nr { ftype = nr (E.func_type env ty);
           locals = E.get_locals env1;
@@ -941,7 +941,7 @@ module Func = struct
       in
       define_built_in env name params retty (fun env -> mk_body env getters);
       G.i (Call (nr (E.built_in env name))) ^^
-      FakeMultiVal.load env retty
+      MultiVal.load env retty
     else begin
       assert (sharing = Never);
       let locals =
@@ -952,8 +952,8 @@ module Func = struct
       let set_locals = List.fold_right (fun (set, get, _) is-> is ^^ set) locals G.nop in
       let getters = List.map (fun (set, get, _) -> get) locals in
       set_locals ^^
-      mk_body env getters ^^ FakeMultiVal.store env retty ^^
-      FakeMultiVal.load env retty
+      mk_body env getters ^^ MultiVal.store env retty ^^
+      MultiVal.load env retty
    end
 
   (* Shorthands for various arities *)
@@ -2510,14 +2510,14 @@ module Closure = struct
        An extra first argument for the closure! *)
     let ty = E.func_type env (FuncType (
       I32Type :: Lib.List.make n_args I32Type,
-      FakeMultiVal.ty (Lib.List.make n_res I32Type))) in
+      MultiVal.ty (Lib.List.make n_res I32Type))) in
     (* get the table index *)
     Tagged.load_forwarding_pointer env ^^
     Tagged.load_field env (funptr_field env) ^^
     (* All done: Call! *)
     let table_index = 0l in
     G.i (CallIndirect (nr table_index, nr ty)) ^^
-    FakeMultiVal.load env (Lib.List.make n_res I32Type)
+    MultiVal.load env (Lib.List.make n_res I32Type)
 
   let static_closure env fi : int32 =
     Tagged.shared_static_obj env Tagged.Closure StaticBytes.[
@@ -5801,7 +5801,7 @@ module Cycles = struct
        end)
 
   (* takes a bignum from the stack, traps if ≥2^128, and leaves two 64bit words on the stack *)
-  (* only used twice, so ok to not use share_code1; that would require I64Type support in FakeMultiVal *)
+  (* only used twice, so ok to not use share_code1; that would require I64Type support in MultiVal *)
   let to_two_word64 env =
     let (set_val, get_val) = new_local env "cycles" in
     set_val ^^
@@ -9202,7 +9202,7 @@ module StackRep = struct
 
   (* The env looks unused, but will be needed once we can use multi-value, to register
      the complex types in the environment.
-     For now, multi-value block returns are handled via FakeMultiVal. *)
+     For now, multi-value block returns are handled via MultiVal. *)
   let to_block_type env = function
     | Vanilla -> [I32Type]
     | UnboxedWord64 _ -> [I64Type]
@@ -11263,7 +11263,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
          compile_unboxed_zero ^^ (* A dummy closure *)
          compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^ (* the args *)
          G.i (Call (nr (mk_fi ()))) ^^
-         FakeMultiVal.load env (Lib.List.make return_arity I32Type)
+         MultiVal.load env (Lib.List.make return_arity I32Type)
       | _, Type.Local ->
          let (set_clos, get_clos) = new_local env "clos" in
 
@@ -11411,7 +11411,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
   | RetPrim, [e] ->
     SR.Unreachable,
     compile_exp_as env ae (StackRep.of_arity (E.get_return_arity env)) e ^^
-    FakeMultiVal.store env (Lib.List.make (E.get_return_arity env) I32Type) ^^
+    MultiVal.store env (Lib.List.make (E.get_return_arity env) I32Type) ^^
     G.i Return
 
   (* Numeric conversions *)
@@ -12799,7 +12799,7 @@ and compile_exp_with_hint (env : E.t) ae sr_hint exp =
     in
     sr,
     code_scrut ^^
-    FakeMultiVal.if_ env
+    MultiVal.if_ env
       (StackRep.to_block_type env sr)
       (code1 ^^ StackRep.adjust env sr1 sr)
       (code2 ^^ StackRep.adjust env sr2 sr)
@@ -12842,7 +12842,7 @@ and compile_exp_with_hint (env : E.t) ae sr_hint exp =
 
     final_sr,
     (* Run rest in block to exit from *)
-    FakeMultiVal.block_ env (StackRep.to_block_type env final_sr) (fun branch_code ->
+    MultiVal.block_ env (StackRep.to_block_type env final_sr) (fun branch_code ->
        orsPatternFailure env (List.map (fun (sr, c) ->
           c ^^^ CannotFail (StackRep.adjust env sr final_sr ^^ branch_code)
        ) [sr, CannotFail code1 ^^^ pat_code ^^^ CannotFail rhs_code]) ^^
@@ -12870,7 +12870,7 @@ and compile_exp_with_hint (env : E.t) ae sr_hint exp =
     (* Run scrut *)
     code1 ^^ set_i ^^
     (* Run rest in block to exit from *)
-    FakeMultiVal.block_ env (StackRep.to_block_type env final_sr) (fun branch_code ->
+    MultiVal.block_ env (StackRep.to_block_type env final_sr) (fun branch_code ->
        orsPatternFailure env (List.map (fun (sr, c) ->
           c ^^^ CannotFail (StackRep.adjust env sr final_sr ^^ branch_code)
        ) codes) ^^

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -877,38 +877,14 @@ let from_m_to_n env m mk_body =
 let from_0_to_n env mk_body = from_m_to_n env 0l mk_body
 
 module FakeMultiVal = struct
-  (* For some use-cases (e.g. processing the compiler output with analysis
-     tools) it is useful to avoid the multi-value extension.
+  (* Multi-value codegen is always on, so these are transparent wrappers:
+     [ty] is the identity and [store]/[load] are no-ops (values stay on the
+     Wasm stack). [if_]/[block_] remain drop-in replacements for E.if_/E.block_. *)
+  let ty tys = tys
 
-     This module provides mostly transparent wrappers that put multiple values
-     in statically allocated globals and pull them off again.
+  let store _env _tys = G.nop
 
-     So far only does I32Type (but that could be changed).
-
-     If the multi_value flag is on, these do not do anything.
-  *)
-  let ty tys =
-    if !Flags.multi_value || List.length tys <= 1
-    then tys
-    else []
-
-  let global env i =
-    E.get_global32_lazy env (Printf.sprintf "multi_val_%d" i) Mutable 0l
-
-  let store env tys =
-    if !Flags.multi_value || List.length tys <= 1 then G.nop else
-    G.concat_mapi (fun i ty ->
-      assert(ty = I32Type);
-      G.i (GlobalSet (nr (global env i)))
-    ) tys
-
-  let load env tys =
-    if !Flags.multi_value || List.length tys <= 1 then G.nop else
-    let n = List.length tys - 1 in
-    G.concat_mapi (fun i ty ->
-      assert(ty = I32Type);
-      G.i (GlobalGet (nr (global env (n - i))))
-    ) tys
+  let load _env _tys = G.nop
 
   (* A drop-in replacement for E.if_ *)
   let if_ env bt thn els =
@@ -13736,7 +13712,7 @@ and conclude_module env set_serialization_globals start_fi_o =
          32-bit main memory, so no `memory64`. *)
       target_features =
         [ "bulk-memory"; "bulk-memory-opt"; "nontrapping-fptoint"; "sign-ext" ]
-        @ (if !Flags.multi_value then ["multivalue"] else [])
+        @ ["multivalue"]
         @ (if List.mem "multi-memory" (E.get_features env) then ["multimemory"] else []);
     } in
 

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -971,7 +971,7 @@ let narrow_to_32 env get_value =
   get_value ^^
   G.i (Convert (Wasm_exts.Values.I32 I32Op.WrapI64))
 
-module FakeMultiVal = struct
+module MultiVal = struct
   (* Multi-value codegen is always on, so these are transparent wrappers:
      [ty] is the identity and [store]/[load] are no-ops (values stay on the
      Wasm stack). [if_]/[block_] remain drop-in replacements for E.if_/E.block_. *)
@@ -993,7 +993,7 @@ module FakeMultiVal = struct
     )) ^^
     load env bt
 
-end (* FakeMultiVal *)
+end (* MultiVal *)
 
 module Func = struct
   (* This module contains basic bookkeeping functionality to define functions,
@@ -1004,9 +1004,9 @@ module Func = struct
   let of_body env params retty mk_body =
     let env1 = E.mk_fun_env env (Int32.of_int (List.length params)) (List.length retty) in
     List.iteri (fun i (n,_t) -> E.add_local_name env1 (Int32.of_int i) n) params;
-    let ty = FuncType (List.map snd params, FakeMultiVal.ty retty) in
+    let ty = FuncType (List.map snd params, MultiVal.ty retty) in
     let body = G.to_instr_list (
-      mk_body env1 ^^ FakeMultiVal.store env1 retty
+      mk_body env1 ^^ MultiVal.store env1 retty
     ) in
     (nr { ftype = nr (E.func_type env ty);
           locals = E.get_locals env1;
@@ -1036,7 +1036,7 @@ module Func = struct
       in
       define_built_in env name params retty (fun env -> mk_body env getters);
       G.i (Call (nr (E.built_in env name))) ^^
-      FakeMultiVal.load env retty
+      MultiVal.load env retty
     else begin
       assert (sharing = Never);
       let locals =
@@ -1047,8 +1047,8 @@ module Func = struct
       let set_locals = List.fold_right (fun (set, get, _) is-> is ^^ set) locals G.nop in
       let getters = List.map (fun (set, get, _) -> get) locals in
       set_locals ^^
-      mk_body env getters ^^ FakeMultiVal.store env retty ^^
-      FakeMultiVal.load env retty
+      mk_body env getters ^^ MultiVal.store env retty ^^
+      MultiVal.load env retty
    end
 
   (* Shorthands for various arities *)
@@ -2427,14 +2427,14 @@ module Closure = struct
        An extra first argument for the closure! *)
     let ty = E.func_type env (FuncType (
       I64Type :: Lib.List.make n_args I64Type,
-      FakeMultiVal.ty (Lib.List.make n_res I64Type))) in
+      MultiVal.ty (Lib.List.make n_res I64Type))) in
     (* get the table index *)
     Tagged.load_forwarding_pointer env ^^
     Tagged.load_field env funptr_field ^^
     (* All done: Call! *)
     let table_index = 0l in
     G.i (CallIndirect (nr table_index, nr ty)) ^^
-    FakeMultiVal.load env (Lib.List.make n_res I64Type)
+    MultiVal.load env (Lib.List.make n_res I64Type)
 
   let constant env get_fi =
     let fi = Wasm.I64_convert.extend_i32_u (E.add_fun_ptr env (get_fi ())) in
@@ -5637,7 +5637,7 @@ module Cycles = struct
        end)
 
   (* takes a bignum from the stack, traps if ≥2^128, and leaves two 64bit words on the stack *)
-  (* only used twice, so ok to not use share_code1; that would require I64Type support in FakeMultiVal *)
+  (* only used twice, so ok to not use share_code1; that would require I64Type support in MultiVal *)
   let to_two_word64 env =
     let (set_val, get_val) = new_local env "cycles" in
     set_val ^^
@@ -6562,7 +6562,7 @@ module StackRep = struct
 
   (* The env looks unused, but will be needed once we can use multi-value, to register
      the complex types in the environment.
-     For now, multi-value block returns are handled via FakeMultiVal. *)
+     For now, multi-value block returns are handled via MultiVal. *)
   let to_block_type env = function
     | Vanilla -> [I64Type]
     | UnboxedWord64 _ -> [I64Type]
@@ -11646,7 +11646,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
          compile_unboxed_zero ^^ (* A dummy closure *)
          compile_exp_as env ae (StackRep.of_arity n_args) e2 ^^ (* the args *)
          G.i (Call (nr (mk_fi()))) ^^
-         FakeMultiVal.load env (Lib.List.make return_arity I64Type)
+         MultiVal.load env (Lib.List.make return_arity I64Type)
       | _, Type.Local ->
          let (set_clos, get_clos) = new_local env "clos" in
 
@@ -11795,7 +11795,7 @@ and compile_prim_invocation (env : E.t) ae p es at =
   | RetPrim, [e] ->
     SR.Unreachable,
     compile_exp_as env ae (StackRep.of_arity (E.get_return_arity env)) e ^^
-    FakeMultiVal.store env (Lib.List.make (E.get_return_arity env) I64Type) ^^
+    MultiVal.store env (Lib.List.make (E.get_return_arity env) I64Type) ^^
     G.i Return
 
   (* Numeric conversions *)
@@ -13139,7 +13139,7 @@ and compile_exp_with_hint (env : E.t) ae sr_hint exp =
     in
     sr,
     code_scrut ^^
-    FakeMultiVal.if_ env
+    MultiVal.if_ env
       (StackRep.to_block_type env sr)
       (code1 ^^ StackRep.adjust env sr1 sr)
       (code2 ^^ StackRep.adjust env sr2 sr)
@@ -13182,7 +13182,7 @@ and compile_exp_with_hint (env : E.t) ae sr_hint exp =
 
     final_sr,
     (* Run rest in block to exit from *)
-    FakeMultiVal.block_ env (StackRep.to_block_type env final_sr) (fun branch_code ->
+    MultiVal.block_ env (StackRep.to_block_type env final_sr) (fun branch_code ->
        orsPatternFailure env (List.map (fun (sr, c) ->
           c ^^^ CannotFail (StackRep.adjust env sr final_sr ^^ branch_code)
        ) [sr, CannotFail code1 ^^^ pat_code ^^^ CannotFail rhs_code]) ^^
@@ -13210,7 +13210,7 @@ and compile_exp_with_hint (env : E.t) ae sr_hint exp =
     (* Run scrut *)
     code1 ^^ set_i ^^
     (* Run rest in block to exit from *)
-    FakeMultiVal.block_ env (StackRep.to_block_type env final_sr) (fun branch_code ->
+    MultiVal.block_ env (StackRep.to_block_type env final_sr) (fun branch_code ->
        orsPatternFailure env (List.map (fun (sr, c) ->
           c ^^^ CannotFail (StackRep.adjust env sr final_sr ^^ branch_code)
        ) codes) ^^

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -972,38 +972,14 @@ let narrow_to_32 env get_value =
   G.i (Convert (Wasm_exts.Values.I32 I32Op.WrapI64))
 
 module FakeMultiVal = struct
-  (* For some use-cases (e.g. processing the compiler output with analysis
-     tools) it is useful to avoid the multi-value extension.
+  (* Multi-value codegen is always on, so these are transparent wrappers:
+     [ty] is the identity and [store]/[load] are no-ops (values stay on the
+     Wasm stack). [if_]/[block_] remain drop-in replacements for E.if_/E.block_. *)
+  let ty tys = tys
 
-     This module provides mostly transparent wrappers that put multiple values
-     in statically allocated globals and pull them off again.
+  let store _env _tys = G.nop
 
-     So far only does I64Type (but that could be changed).
-
-     If the multi_value flag is on, these do not do anything.
-  *)
-  let ty tys =
-    if !Flags.multi_value || List.length tys <= 1
-    then tys
-    else []
-
-  let global env i =
-    E.get_global64_lazy env (Printf.sprintf "multi_val_%d" i) Mutable 0L
-
-  let store env tys =
-    if !Flags.multi_value || List.length tys <= 1 then G.nop else
-    G.concat_mapi (fun i ty ->
-      assert(ty = I64Type);
-      G.i (GlobalSet (nr (global env i)))
-    ) tys
-
-  let load env tys =
-    if !Flags.multi_value || List.length tys <= 1 then G.nop else
-    let n = List.length tys - 1 in
-    G.concat_mapi (fun i ty ->
-      assert(ty = I64Type);
-      G.i (GlobalGet (nr (global env (n - i))))
-    ) tys
+  let load _env _tys = G.nop
 
   (* A drop-in replacement for E.if_ *)
   let if_ env bt thn els =
@@ -14103,7 +14079,7 @@ and conclude_module env set_serialization_globals start_fi_o =
          emulation adds a second memory (`multimemory`, tracked dynamically). *)
       target_features =
         [ "bulk-memory"; "bulk-memory-opt"; "memory64"; "nontrapping-fptoint"; "sign-ext" ]
-        @ (if !Flags.multi_value then ["multivalue"] else [])
+        @ ["multivalue"]
         @ (if List.mem "multi-memory" (E.get_features env) then ["multimemory"] else []);
     } in
 

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -129,14 +129,12 @@ let argspec =
       " use the reference implementation of the Internet Computer system API (ic-ref-run)";
   "--experimental-multi-value",
   Arg.Unit (fun () ->
-    eprintf "moc: --experimental-multi-value is deprecated; multi-value codegen is the default.\n";
-    Flags.multi_value := true),
-  " (deprecated) multi-value codegen is the default";
+    eprintf "moc: --experimental-multi-value has no effect; multi-value codegen is always on.\n"),
+  " (deprecated, no effect) multi-value codegen is always on";
   "--no-experimental-multi-value",
   Arg.Unit (fun () ->
-    eprintf "moc: --no-experimental-multi-value is deprecated; the `FakeMultiVal` emulation fallback is being retired.\n";
-    Flags.multi_value := false),
-  " (deprecated) force `FakeMultiVal` emulation, opting out of multi-value codegen";
+    eprintf "moc: --no-experimental-multi-value has no effect; multi-value codegen is always on.\n"),
+  " (deprecated, no effect) multi-value codegen can no longer be disabled";
 
   "-dp", Arg.Set Flags.dump_parse, " dump parse";
   "-dt", Arg.Set Flags.dump_tc, " dump type-checked AST";

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -30,7 +30,6 @@ let print_depth = ref 2
 let release_mode = ref false
 let compile_mode = ref ICMode
 let debug_info = ref false
-let multi_value = ref true
 let await_lowering = ref true
 let async_lowering = ref true
 let dump_parse = ref false


### PR DESCRIPTION
Real multi-value Wasm codegen has been the default since **1.10.0** (#6165), and the `FakeMultiVal` emulation fallback has been unreachable ever since (unless the user forced it). This retires it.

## Commits

1. **Remove the internal `multi_value` flag (always on).** Drop `Flags.multi_value` and collapse every use to its `true` branch:
   - In both backends (`compile_classical`, `compile_enhanced`) `MultiVal.ty` becomes the identity and `store`/`load` become no-ops (values stay on the Wasm stack); the now-dead `global` spill helper is removed.
   - The emitted Wasm feature list unconditionally includes `multivalue`.
   - `--experimental-multi-value` / `--no-experimental-multi-value` are kept for CLI compatibility but are now **no-ops** that print a *"has no effect; multi-value codegen is always on"* notice.

2. **Rename `FakeMultiVal` → `MultiVal`** (pure rename, no logic change). With the emulation gone, it's a transparent wrapper over real multi-value, so the "Fake" qualifier is misleading. 16 sites per backend.

## Behavior

No change versus the shipping default (`multi_value` was already `true` in 1.9-era→1.12 releases as of #6165). Only the unreachable emulation path and the internal flag are gone. `MultiVal.block_` still provides its `with_current_depth`/`branch_to_` glue; `MultiVal.ty`/`store`/`load` are retained as transparent wrappers so the ~26 call sites are untouched.

## Verification

Built clean (both commits); `test/run/multi-value-block.mo` and `nested-multi-value.mo` pass all phases including `wasm-run`. No test passes `--no-experimental-multi-value` via `MOC-FLAG`, so no golden relied on the emulation. Full suite via CI.

## Future

The CLI flag is marked for removal in v2.0: #6231.
