### PR TITLE
chore: bump `rustc-nightly` to 2026-07-25

### DIFF
--- a/.agents/skills/bump-rust-nightly/SKILL.md
+++ b/.agents/skills/bump-rust-nightly/SKILL.md
@@ -21,6 +21,18 @@ the Motoko RTS.
 git checkout gabor/bump-nightly-rustc
 git rebase origin/master
 ```
+Note: the previous bump usually lands on `master` via **squash-merge**, which
+leaves this branch's old bump commit orphaned (present locally, not an ancestor
+of `origin/master`, and often carrying a nightly date `master` already has). In
+that case don't rebase onto the stale commit — hard-reset the branch to master
+and redo the bump fresh:
+```sh
+git fetch origin master
+git checkout -B gabor/bump-nightly-rustc origin/master
+```
+(Check first with `git merge-base --is-ancestor gabor/bump-nightly-rustc
+origin/master` — if it says the branch has unmerged commits *and* they're a real
+WIP, keep them; if they're just the last, already-merged bump, reset.)
 
 ### 2. Update rust-overlay
 ```sh
@@ -87,8 +99,10 @@ The vendored std deps are stale — re-run the `rustStdDepsHash` probe (step 4).
   wasm memory ops). Triggered in CI by the `nightly-macos-test` workflow's
   `rts-checked` job; not normally needed locally.
 
-**Local bump loop:** `nix build .#rts` until green. Push and let CI's
-`rts-checked` exercise the slow path on macOS.
+**Local bump loop:** `nix build .#rts` until green. Then push and **manually
+dispatch** `nightly-macos-test` to exercise the slow `rts-checked` path — it
+triggers **only** on `schedule` + `workflow_dispatch`, so a branch push does NOT
+run it automatically (see step 9).
 
 **If `nightly-macos-test` jobs fail or time out**, re-trigger — each run
 caches more derivations, so subsequent runs make progress:
@@ -119,7 +133,17 @@ chore: bump rustc-nightly to YYYY-MM-DD
 ### 9. Push and watch CI
 ```sh
 git push --force-with-lease origin gabor/bump-nightly-rustc
+# nightly-macos-test does NOT run on push — dispatch it explicitly:
+gh workflow run nightly-macos-test.yml --ref gabor/bump-nightly-rustc
 gh run watch <run-id> --repo caffeinelabs/motoko
+```
+Gotcha — **first push after a reset (step 1)**: if the old remote branch was
+deleted when the previous bump merged, `--force-with-lease` fails with
+`! [rejected] ... (stale info)` because your local `origin/gabor/bump-nightly-rustc`
+tracking ref is stale (points at a branch that no longer exists remotely). Fix:
+```sh
+git remote prune origin
+git push -u origin gabor/bump-nightly-rustc   # plain push re-creates the branch
 ```
 
 ## Makefile Structure (as of 2026-04-01)

--- a/.agents/skills/bump-rust-nightly/SKILL.md
+++ b/.agents/skills/bump-rust-nightly/SKILL.md
@@ -18,7 +18,7 @@ the Motoko RTS.
 
 ### 1. Switch branch and rebase
 ```sh
-git checkout gabor/bump-nightly-rustc
+git checkout $USER/bump-nightly-rustc
 git rebase origin/master
 ```
 Note: the previous bump usually lands on `master` via **squash-merge**, which
@@ -28,9 +28,9 @@ that case don't rebase onto the stale commit — hard-reset the branch to master
 and redo the bump fresh:
 ```sh
 git fetch origin master
-git checkout -B gabor/bump-nightly-rustc origin/master
+git checkout -B $USER/bump-nightly-rustc origin/master
 ```
-(Check first with `git merge-base --is-ancestor gabor/bump-nightly-rustc
+(Check first with `git merge-base --is-ancestor $USER/bump-nightly-rustc
 origin/master` — if it says the branch has unmerged commits *and* they're a real
 WIP, keep them; if they're just the last, already-merged bump, reset.)
 

--- a/.agents/skills/bump-rust-nightly/SKILL.md
+++ b/.agents/skills/bump-rust-nightly/SKILL.md
@@ -132,18 +132,18 @@ chore: bump rustc-nightly to YYYY-MM-DD
 
 ### 9. Push and watch CI
 ```sh
-git push --force-with-lease origin gabor/bump-nightly-rustc
+git push --force-with-lease origin $USER/bump-nightly-rustc
 # nightly-macos-test does NOT run on push — dispatch it explicitly:
-gh workflow run nightly-macos-test.yml --ref gabor/bump-nightly-rustc
+gh workflow run nightly-macos-test.yml --ref $USER/bump-nightly-rustc
 gh run watch <run-id> --repo caffeinelabs/motoko
 ```
 Gotcha — **first push after a reset (step 1)**: if the old remote branch was
 deleted when the previous bump merged, `--force-with-lease` fails with
-`! [rejected] ... (stale info)` because your local `origin/gabor/bump-nightly-rustc`
+`! [rejected] ... (stale info)` because your local `origin/$USER/bump-nightly-rustc`
 tracking ref is stale (points at a branch that no longer exists remotely). Fix:
 ```sh
 git remote prune origin
-git push -u origin gabor/bump-nightly-rustc   # plain push re-creates the branch
+git push -u origin $USER/bump-nightly-rustc   # plain push re-creates the branch
 ```
 
 ## Makefile Structure (as of 2026-04-01)

--- a/flake.lock
+++ b/flake.lock
@@ -247,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785562362,
-        "narHash": "sha256-J15aBa3d6B1SUUAQydQ06wFjPzrrcVceb6jkdfwfGls=",
+        "lastModified": 1785648791,
+        "narHash": "sha256-4wZa7NDOxbcm9pTNNcg88nvvPb9uVcWsJ+Ncil8eB1I=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5f29c219a7655519f8a9f8c6968064b82c17cc93",
+        "rev": "32346a8154e65fa10bac36f7b476a5294cb8b150",
         "type": "github"
       },
       "original": {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -45,7 +45,7 @@
     (self: super: {
       # When you change the rust-nightly version,
       # make sure to change the rustStdDepsHash in ./rts.nix accordingly.
-      rust-nightly = self.rust-bin.nightly."2026-06-01".default.override {
+      rust-nightly = self.rust-bin.nightly."2026-07-25".default.override {
         extensions = [ "rust-src" ];
         targets = [ "wasm32-wasip1" ];
       };

--- a/nix/rts.nix
+++ b/nix/rts.nix
@@ -13,7 +13,7 @@ let
   vendorRustStdDeps = "${cargoVendorTools}/bin/vendor-rust-std-deps";
 
   # SHA256 of Rust std deps
-  rustStdDepsHash = "sha256-HfTizTBQZW4t2vDjYatn4RXzSbSzJiYbNU+yRnyVpFk=";
+  rustStdDepsHash = "sha256-OTZ3LG84PNaPTbckD062aXpbXly07iTnIg00nQZD7Mw=";
 
   # Vendor directory for Rust std deps
   rustStdDeps = pkgs.stdenvNoCC.mkDerivation {

--- a/rts/motoko-rts-tests/Cargo.lock
+++ b/rts/motoko-rts-tests/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "byteorder"
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -121,18 +121,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core",
 ]
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -187,18 +187,18 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rts/motoko-rts/Cargo.lock
+++ b/rts/motoko-rts/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -34,27 +34,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/test/bench/ok/candid-subtype-cost.drun-run.ok
+++ b/test/bench/ok/candid-subtype-cost.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 1_119_725; heap_bytes = +33_888}
+debug.print: {cycles = 1_119_260; heap_bytes = +33_888}
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/typtbl.drun-run.ok
+++ b/test/bench/ok/typtbl.drun-run.ok
@@ -1,9 +1,9 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 debug.print: {bias = 1_024; scalar = 16}
-debug.print: {cycles = 178_057}
-debug.print: {cycles = 178_325}
-debug.print: {cycles = 359_317}
-debug.print: {cycles = 540_309}
-debug.print: {cycles = 721_301}
-debug.print: {cycles = 265_083}
+debug.print: {cycles = 178_054}
+debug.print: {cycles = 178_322}
+debug.print: {cycles = 359_314}
+debug.print: {cycles = 540_306}
+debug.print: {cycles = 721_298}
+debug.print: {cycles = 265_074}
 ingress Completed: Reply: 0x4449444c0000


### PR DESCRIPTION
Bumps the rustc-nightly toolchain that compiles the Motoko RTS from **2026-06-01 → 2026-07-25** (Rust 1.99.0-nightly), following `.agents/skills/bump-rust-nightly`.

## Changes
- `nix/pkgs.nix` — nightly date `2026-06-01` → `2026-07-25`
- `nix/rts.nix` — `rustStdDepsHash` refreshed for the new std deps
- `flake.lock` — `rust-overlay` input updated (→ 2026-08-02)
- `rts/motoko-rts/Cargo.lock` — `cargo update`: libc 0.2.186→0.2.189, proc-macro2 1.0.106→1.0.107, quote 1.0.45→1.0.47, syn 2.0.118→2.0.119
- `rts/motoko-rts-tests/Cargo.lock` — `cargo update`: + bitflags 2.13.0→2.13.1, rand 0.8.6→0.8.7, zerocopy(+derive) 0.8.52→0.8.55

Clean bump — `nix build .#rts` green with **no** Makefile/target-spec workarounds required.

## Skill doc fixes (second commit)
While running the bump I hit three divergences from the recipe and corrected `.agents/skills/bump-rust-nightly/SKILL.md`:
- Step 1: the prior bump squash-merges to master, orphaning the branch's old bump commit — hard-reset `git checkout -B … origin/master` instead of rebasing onto it.
- Step 7/9: `nightly-macos-test` triggers only on `schedule`/`workflow_dispatch`, so a push does not auto-run `rts-checked`; dispatch it explicitly.
- Step 9: first push after the reset fails `--force-with-lease` with "stale info"; `git remote prune origin` + plain `git push -u`.

## CI
Manually dispatched `nightly-macos-test` on this branch (run 30760398482, testing the bump commit) — **all jobs green**: rts-checked ✅, common-tests ✅, gc-tests ✅, systems-go-tests (debug + release) ✅, motoko-core-tests ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)