### PR TITLE
chore(ci): fail hung nixbuild.net builds fast, bound all test.yml jobs

### DIFF
--- a/.github/actions/test-blueprint/action.yml
+++ b/.github/actions/test-blueprint/action.yml
@@ -75,6 +75,12 @@ runs:
       with:
         nixbuild_token: ${{ inputs.nixbuild_token }}
         generate_summary_for: 'workflow'
+        # Fail hung builds fast: our derivations stream output continuously, so
+        # prolonged silence means a wedged build. nixbuild.net's defaults
+        # (6 h silence / 12 h total) let hangs burn runners for hours.
+        settings: |
+          max-silent-time = 1800
+          timeout = 7200
 
     - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
       with:
         nixbuild_token: ${{ secrets.NIXBUILD_TOKEN }}
         generate_summary_for: 'workflow'
+        # Fail hung builds fast (see .github/actions/test-blueprint/action.yml).
+        settings: |
+          max-silent-time = 1800
+          timeout = 7200
     - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
       with:
         name: ic-hs-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
         with:
           nixbuild_token: ${{ secrets.NIXBUILD_TOKEN }}
           generate_summary_for: 'workflow'
+          # Fail hung builds fast (see .github/actions/test-blueprint/action.yml).
+          settings: |
+            max-silent-time = 1800
+            timeout = 7200
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ic-hs-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ jobs:
         os: [ubuntu-latest, ubuntu-26.04-arm]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    # Cold-cache runs have been observed at ~85 min; the default 6 h limit only
+    # bounds hung nixbuild.net sessions long after they stopped making progress.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -46,6 +49,8 @@ jobs:
         os: [ubuntu-latest, ubuntu-26.04-arm]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    # Slowest job of the workflow: cold-cache runs reach ~105 min.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -70,6 +75,8 @@ jobs:
         build_type: [release, debug]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    # Cold-cache runs reach ~50 min; extra headroom for the perf step on PRs.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -118,6 +125,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-26.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
+    # Local `nix build` of moc; generous bound for cold-cache macOS builds.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
@@ -141,6 +150,7 @@ jobs:
     needs: [common-tests, gc-tests]
     if: ${{ always() }} # run even if dependencies failed/skipped/cancelled
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Show dependency results
         run: |
@@ -160,6 +170,7 @@ jobs:
     needs: tests
     if: ${{ always() }} # run even if dependencies failed/skipped/cancelled
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Show dependency results
         run: |
@@ -178,6 +189,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref == 'master' && contains(github.event.pull_request.labels.*.name, 'autoclose')
     needs: [verify-common-gc, verify-main-tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -192,6 +204,7 @@ jobs:
   approvals:
     if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref == 'master' && github.event.pull_request.changed_files == 1
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
A hung nixbuild.net build currently burns runners for hours: nixbuild.net kills a silent build only after **6 h** (\`max-silent-time\`) with a **12 h** per-build cap, and every job in \`test.yml\` ran under GitHub's 6-hour default. In [run 30773582420](https://github.com/caffeinelabs/motoko/actions/runs/30773582420) five jobs spent 110–153 min each inside a wedged \`nix build\` before dying.

Two complementary bounds:

- **nixbuild.net settings** (\`max-silent-time = 1800\`, \`timeout = 7200\`), passed via the \`nixbuild-action\` \`settings\` input in \`test-blueprint\`, \`build.yml\`, and \`release.yml\`. Our derivations stream test/compile output continuously, so 30 min of silence reliably means a hang — this turns a multi-hour burn into a 30-min failure. (The nix client's \`--timeout\` doesn't propagate over \`ssh-ng://\`, so the action's settings input is the only place this can live.)
- **\`timeout-minutes\` on every \`test.yml\` job** as the backstop: 150 min for the test jobs (slowest observed cold-cache success is a ~106 min \`gc-tests\`), 120 for label-gated \`artifacts\`, 10 for the echo/\`gh\` jobs.

## What is unchanged

This came out of an automated CI-health scan of \`test.yml\`. Its other two findings need no workflow change:

- *"no caching"* — false positive: caching is Cachix + nixbuild.net remote builders (the scanner only recognizes \`actions/cache\`).
- *"20% failure rate"* — real failures, not flaky infra: mostly in-development PR pushes, plus the daily \`flake.lock\` trial PRs failing on six genuine \`test-candid\` principal/service subtype traps introduced by a dependency bump. That incompatibility blocks the daily update from landing and is tracked separately as its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)